### PR TITLE
Fixes link extension function

### DIFF
--- a/install-afc.sh
+++ b/install-afc.sh
@@ -44,7 +44,7 @@ function check_existing() {
 function link_extensions() {
     echo "Linking extensions to Klipper..."
     for extension in ${EXTENSION_LIST}; do
-        ln -sf "${SRCDIR}/${extension}.py" "${KLIPPER_PATH}/klippy/extras/${extension}.py"
+        ln -sf "${SRCDIR}/${BASE_PATH}/${extension}.py" "${KLIPPER_PATH}/klippy/extras/${extension}.py"
     done
 }
 


### PR DESCRIPTION
The current install script does not create the symlinks correctly, its missing the git folder name.

Fixed function to add BASE_PATH so when adding the symlinks the git folder is included in the path.

Current Script results:
![image](https://github.com/user-attachments/assets/b0da3f5c-5138-4ffb-8588-7e0b59417f95)

Symlinks with this fix:
![image](https://github.com/user-attachments/assets/bc2fba8f-1262-4fe4-98c0-d5d54617be8e)

