### PR TITLE
Added Hub-Cut Operations.

### DIFF
--- a/AFC.py
+++ b/AFC.py
@@ -128,6 +128,7 @@ class afc:
         self.gcode.register_command('PREP', self.cmd_PREP, desc=self.cmd_PREP_help)
 
         self.gcode.register_command('TEST', self.cmd_TEST, desc=self.cmd_TEST_help)
+        self.gcode.register_command('HUB_CUT_TEST', self.cmd_HUB_CUT_TEST, desc=self.cmd_HUB_CUT_TEST_help)
 
         self.VarFile = config.get('VarFile')
         
@@ -517,16 +518,25 @@ class afc:
             if self.current != '':
                 self.gcode.run_script_from_command('TOOL_UNLOAD LANE=' + self.current)
             if self.hub_cut_active == 1 and self.current== '':
-                self.gcode.run_script_from_command('SET_SERVO SERVO=cut ANGLE=' + str(self.hub_cut_servo_prep_angle))
-                while self.hub.filament_present == False:
-                    self.afc_move(lane, self.hub_move_dis, self.short_moves_speed, self.short_moves_accel)
-                self.afc_move(lane, self.hub_cut_dist, self.short_moves_speed, self.short_moves_accel)
-                time.sleep(2)
-                self.gcode.run_script_from_command('SET_SERVO SERVO=cut ANGLE=' + str(self.hub_cut_servo_clip_angle))
-                time.sleep(2)
-                self.gcode.run_script_from_command('SET_SERVO SERVO=cut ANGLE=' + str(self.hub_cut_servo_pass_angle))
-                time.sleep(2)
+                self.hub_cut(lane)
             self.gcode.run_script_from_command('TOOL_LOAD LANE=' + lane)
+
+    def hub_cut(self, lane):
+        self.gcode.run_script_from_command('SET_SERVO SERVO=cut ANGLE=' + str(self.hub_cut_servo_prep_angle))
+        while self.hub.filament_present == False:
+            self.afc_move(lane, self.hub_move_dis, self.short_moves_speed, self.short_moves_accel)
+        self.afc_move(lane, self.hub_cut_dist, self.short_moves_speed, self.short_moves_accel)
+        time.sleep(2)
+        self.gcode.run_script_from_command('SET_SERVO SERVO=cut ANGLE=' + str(self.hub_cut_servo_clip_angle))
+        time.sleep(2)
+        self.gcode.run_script_from_command('SET_SERVO SERVO=cut ANGLE=' + str(self.hub_cut_servo_pass_angle))
+        time.sleep(2)
+
+    cmd_HUB_CUT_TEST_help = "Test the cutting sequence of the hub cutter, expects LANE=legN"
+    def cmd_HUB_CUT_TEST(self, gcmd):
+        lane = gcmd.get('LANE', None)
+        self.gcode.respond_info('Testing Hub Cut on Lane: ' + lane)
+        self.hub_cut(lane)
         
     def get_status(self, eventtime):
         str={}

--- a/AFC.py
+++ b/AFC.py
@@ -526,17 +526,20 @@ class afc:
         while self.hub.filament_present == False:
             self.afc_move(lane, self.hub_move_dis, self.short_moves_speed, self.short_moves_accel)
         self.afc_move(lane, self.hub_cut_dist, self.short_moves_speed, self.short_moves_accel)
-        time.sleep(2)
+        self.sleepCmd(1.5)
         self.gcode.run_script_from_command('SET_SERVO SERVO=cut ANGLE=' + str(self.hub_cut_servo_clip_angle))
-        time.sleep(2)
+        self.sleepCmd(1.5)
         self.gcode.run_script_from_command('SET_SERVO SERVO=cut ANGLE=' + str(self.hub_cut_servo_pass_angle))
-        time.sleep(2)
+        self.afc_move(lane, -self.hub_cut_clear, self.short_moves_speed, self.short_moves_accel)
 
     cmd_HUB_CUT_TEST_help = "Test the cutting sequence of the hub cutter, expects LANE=legN"
     def cmd_HUB_CUT_TEST(self, gcmd):
         lane = gcmd.get('LANE', None)
         self.gcode.respond_info('Testing Hub Cut on Lane: ' + lane)
         self.hub_cut(lane)
+
+    def sleepCmd(self, timeSeconds):
+        self.gcode.run_script_from_command('G4 P' + str(timeSeconds * 1000))
         
     def get_status(self, eventtime):
         str={}

--- a/AFC.py
+++ b/AFC.py
@@ -517,14 +517,14 @@ class afc:
             if self.current != '':
                 self.gcode.run_script_from_command('TOOL_UNLOAD LANE=' + self.current)
             if self.hub_cut_active == 1 and self.current== '':
-                self.gcode.run_script_from_command('SET_SERVO SERVO=cut ANGLE=' + self.hub_cut_servo_prep_angle)
+                self.gcode.run_script_from_command('SET_SERVO SERVO=cut ANGLE=' + str(self.hub_cut_servo_prep_angle))
                 while self.hub.filament_present == False:
                     self.afc_move(lane, self.hub_move_dis, self.short_moves_speed, self.short_moves_accel)
                 self.afc_move(lane, self.hub_cut_dist, self.short_moves_speed, self.short_moves_accel)
                 time.sleep(2)
-                self.gcode.run_script_from_command('SET_SERVO SERVO=cut ANGLE='+self.hub_cut_servo_clip_angle)
+                self.gcode.run_script_from_command('SET_SERVO SERVO=cut ANGLE=' + str(self.hub_cut_servo_clip_angle))
                 time.sleep(2)
-                self.gcode.run_script_from_command('SET_SERVO SERVO=cut ANGLE='+self.hub_cut_servo_pass_angle)
+                self.gcode.run_script_from_command('SET_SERVO SERVO=cut ANGLE=' + str(self.hub_cut_servo_pass_angle))
                 time.sleep(2)
             self.gcode.run_script_from_command('TOOL_LOAD LANE=' + lane)
         

--- a/Klipper_cfg_example/AFC/AFC.cfg
+++ b/Klipper_cfg_example/AFC/AFC.cfg
@@ -25,12 +25,12 @@ hub_clear: 140
 
 # HUB Cutting Settings
 hub_cut_active: 0
-hub_cut_dist: 200
-hub_cut_clear: 120
+hub_cut_dist: 200                 # How much filament do you want to cut off? (in MM)
+hub_cut_clear: 120                # How far should the filament be retracted back from the hub (in MM)
 hub_cut_min_length: 300.0
-hub_cut_servo_pass_angle: 10
-hub_cut_servo_clip_angle: 180
-hub_cut_servo_prep_angle: 80
+hub_cut_servo_pass_angle: 10      # Bowden Aligned with the hole, able to load the toolhead.
+hub_cut_servo_clip_angle: 180     # Cutting action angle.
+hub_cut_servo_prep_angle: 80      # Align exit hole for cutting.
 
 # TOOL Cutting Settings
 tool_cut_active: 1


### PR DESCRIPTION
Changes:
- Moved Hub Cutting to its own method `hub_cut()`
- Replaced `time.sleep()` in hub_cut() with `sleepCmd()` which accepts a seconds integer and sleeps using Gcode G4.
- Added `HUB_CUT_TEST` which accepts `LANE=legN` to test cutting actions.
- Removed hub-cutting code from `CHANGE_TOOL` and referenced the new `hub_cut()` method instead.
- Added comments to Hub Cutting Settings in AFC.cfg