### PR TITLE
Update AFC.py

### DIFF
--- a/AFC.py
+++ b/AFC.py
@@ -337,7 +337,7 @@ class afc:
                 if 'tool_loaded' not in self.lanes[LANE.name]:
                     self.lanes[LANE.name]['tool_loaded']=False
                 if self.lanes[LANE.name]['tool_loaded'] == True:
-                    self.current = 'LANE.name'
+                    self.current = LANE.name
         tmp=[]
 
         for lanecheck in self.lanes.keys():


### PR DESCRIPTION
self.current needs to equal LANE.name not 'LANE.name'. At boot, the current loaded lane won't be recognized without this. 

This causes an error after boot if you try to do a tool change without unloading the tool loaded lane first.

There might be other reasons to change it to 'Lane.name' but everything works currently in my testing with Lane.name.