### PR TITLE
Remove old toolhead pin assignment in Hardware cfg to make it generic

### DIFF
--- a/Klipper_cfg_example/AFC/AFC_Hardware.cfg
+++ b/Klipper_cfg_example/AFC/AFC_Hardware.cfg
@@ -106,13 +106,15 @@ uart_pin: AFC:M4_UART
 uart_address: 0
 run_current: 0.8
 
+# Tool head sensor located before the extruder gears
 [filament_switch_sensor tool]
-switch_pin: ^toolhead:TOOLHEAD_SENSOR
+switch_pin: enter_tool_pin
 pause_on_runout: False
 
-[filament_switch_sensor extruder]
-switch_pin: ^toolhead:EXTRUDER_SENSOR
-pause_on_runout: False
+# Tool head sensor located after the extruder gears
+#[filament_switch_sensor extruder]
+#switch_pin: enter_extruder_pin
+#pause_on_runout: False
 
 [filament_switch_sensor hub]
 switch_pin: AFC:HUB #^AFC:HUB       # AFC_Lite


### PR DESCRIPTION
Removed personal config pins from AFC_Hardware.cfg