### PR TITLE
Added support for hubs that are not located in box turtle and backwards compatible called to older klipper for setting led color

### DIFF
--- a/AFC.py
+++ b/AFC.py
@@ -510,12 +510,12 @@ class afc:
             CUR_LANE.do_enable(True)
             
             # Do a fast unload first with assist if needed
-            LANE.retreat_from_hub()
+            CUR_LANE.retreat_from_hub()
 
             while CUR_LANE.load_state == True:
                CUR_LANE.move( self.hub_move_dis * -1, self.short_moves_speed, self.short_moves_accel)
             CUR_LANE.move( self.hub_move_dis * -5, self.short_moves_speed, self.short_moves_accel)
-            CUR_LANEE.do_enable(False)
+            CUR_LANE.do_enable(False)
         else:
             self.gcode.respond_info('LANE ' + CUR_LANE.name + ' IS TOOL LOADED')
 
@@ -680,6 +680,7 @@ class afc:
             self.toolhead.wait_moves()
             
         CUR_LANE.extruder_stepper.sync_to_extruder(None)
+        CUR_LANE.assist(-1)
         CUR_LANE.move( self.afc_bowden_length * -1, self.long_moves_speed, self.long_moves_accel)
         x = 0
         while self.hub.filament_present == True:
@@ -687,9 +688,11 @@ class afc:
             x += 1
             # callout if while unloading, filament doesn't move past HUB
             if x > (self.afc_bowden_length/self.short_move_dis):
+                CUR_LANE.assist(-1)
                 msg = ('HUB NOT CLEARING ' + CUR_LANE.name.upper() + '\n||=====||====|x|-----||\nTRG   LOAD   HUB   TOOL')
                 self.respond_error(msg, raise_error=False)
                 return
+        CUR_LANE.assist(-1)
         self.lanes[CUR_LANE.unit][CUR_LANE.name]['tool_loaded'] = False
         self.save_vars()
         self.printer.lookup_object('AFC_stepper ' + CUR_LANE.name).status = 'tool'

--- a/Klipper_cfg_example/AFC/AFC_Hardware.cfg
+++ b/Klipper_cfg_example/AFC/AFC_Hardware.cfg
@@ -34,6 +34,9 @@ afc_motor_rwd: AFC:MOT1_RWD
 pwm: True
 prep: !AFC:TRG1 #^!AFC:TRG1         # AFC_Lite
 load: AFC:EXT1  #^AFC:EXT1          # AFC_Lite
+using_passthrough: False            # Set to True if using passthrough skirts and hub has been moved closer to toolhead,
+                                    #   make sure hub_dist is set to the correct length minus ~100mm for the distance between the
+                                    #   extruder and the hub
 
 [tmc2209 AFC_stepper leg1]
 uart_pin: AFC:M1_UART
@@ -56,6 +59,9 @@ afc_motor_rwd: AFC:MOT2_RWD
 #pwm: True                          # AFC_Lite
 prep: !AFC:TRG2 #^!AFC:TRG2         # AFC_Lite
 load: AFC:EXT2  #^AFC:EXT2          # AFC_Lite
+using_passthrough: False            # Set to True if using passthrough skirts and hub has been moved closer to toolhead,
+                                    #   make sure hub_dist is set to the correct length minus ~100mm for the distance between the
+                                    #   extruder and the hub
 
 [tmc2209 AFC_stepper leg2]
 uart_pin: AFC:M2_UART
@@ -78,6 +84,9 @@ afc_motor_rwd: AFC:MOT3_RWD
 #pwm: True                          # AFC_Lite
 prep: !AFC:TRG3 #^!AFC:TRG3         # AFC_Lite
 load: AFC:EXT3  #^AFC:EXT3          # AFC_Lite
+using_passthrough: False            # Set to True if using passthrough skirts and hub has been moved closer to toolhead,
+                                    #   make sure hub_dist is set to the correct length minus ~100mm for the distance between the
+                                    #   extruder and the hub
 
 [tmc2209 AFC_stepper leg3]
 uart_pin: AFC:M3_UART
@@ -100,6 +109,9 @@ afc_motor_rwd: AFC:MOT4_RWD
 #pwm: True                          # AFC_Lite
 prep: !AFC:TRG4 #^!AFC:TRG4         # AFC_Lite
 load: AFC:EXT4  #^AFC:EXT4          # AFC_Lite
+using_passthrough: False            # Set to True if using passthrough skirts and hub has been moved closer to toolhead,
+                                    #   make sure hub_dist is set to the correct length minus ~100mm for the distance between the
+                                    #   extruder and the hub
 
 [tmc2209 AFC_stepper leg4]
 uart_pin: AFC:M4_UART


### PR DESCRIPTION
Added support for using hubs that are located closer to toolhead. Before this update loading to toolhead would timeout. Enable this feature by setting `using_passthrough` to True in AFC_hardware.cfg for each stepper

Updates:
- After filament is loaded, performs a fast load to load filament into bowden up to the hub
- When ejecting filament, fast unloads with motors to aid in a speedier unload
- Fixed some errors in PREP function for failure conditions
- Updated AFC_Hardware.cfg file to reflect using passthrough skirts with hub closer to toolhead by setting using_passthrough to True
- Some code cleanup, created common function for generating message that is displayed to user during PREP
- Added common timeout constant so that this could be easier to change in the future in one place
- Added back turning on assist motors when unloading from toolhead

Led support for older klipper versions
- Added backwards compatible function calls for setting led color and transmit.

Testing:
I tested as much as I could for the failure cases in the PREP call to make sure filament didn't go past hub during failure conditions.