### PR TITLE
Fixing minor errors found with loading to hub and errors in PREP function

### DIFF
--- a/AFC.py
+++ b/AFC.py
@@ -299,6 +299,7 @@ class afc:
                     CUR_LANE.move( -5, self.short_moves_speed, self.short_moves_accel, True)
                     CUR_LANE.move( 5, self.short_moves_speed, self.short_moves_accel, True)
                     if CUR_LANE.prep_state == False: self.afc_led(self.led_not_ready, CUR_LANE.led_index)
+                    CUR_LANE.hub_load = self.lanes[UNIT][LANE]['hub_loaded'] # Setting hub load state so it can be retained between restarts
             
             error_string = "Error: Filament switch sensor {} not found in config file"
             try: self.hub=self.printer.lookup_object('filament_switch_sensor hub').runout_helper
@@ -470,7 +471,8 @@ class afc:
             CUR_LANE.do_enable(True)
             while CUR_LANE.load_state == False:
                 CUR_LANE.move( self.hub_move_dis, self.short_moves_speed, self.short_moves_accel)
-        CUR_LANE.move(CUR_LANE.dist_hub, CUR_LANE.dist_hub_move_speed, CUR_LANE.dist_hub_move_accel)
+        if CUR_LANE.hub_load == False:
+            CUR_LANE.move(CUR_LANE.dist_hub, CUR_LANE.dist_hub_move_speed, CUR_LANE.dist_hub_move_accel)
         while self.hub.filament_present == False:
             CUR_LANE.move(self.hub_move_dis, self.short_moves_speed, self.short_moves_accel)
         while self.hub.filament_present == True:

--- a/AFC_stepper.py
+++ b/AFC_stepper.py
@@ -82,7 +82,7 @@ class AFCExtruderStepper:
         else:
             self.unit = 'Unknown'
             self.index = 0
-        self.hub_dist = config.getfloat('hub_dist')
+            
         self.dist_hub = config.getfloat('dist_hub', 60)
         self.led_index = config.get('led_index')
 
@@ -111,7 +111,11 @@ class AFCExtruderStepper:
             self.afc_motor_enb = AFC_assist.AFCassistMotor(config,'enb')
             
         self.AFC = self.printer.lookup_object('AFC')
-        self.gcode = self.printer.lookup_object('gcode')   
+        self.gcode = self.printer.lookup_object('gcode')  
+
+        # Set hub loading speed depending on distance between extruder and hub
+        self.dist_hub_move_speed = self.AFC.long_moves_speed if self.dist_hub >= 200 else self.AFC.short_moves_speed
+        self.dist_hub_move_accel = self.AFC.long_moves_accel if self.dist_hub >= 200 else self.AFC.short_moves_accel 
 
         # Defaulting to false so that extruder motors to not move until PREP has been called
         self._afc_prep_done = False

--- a/Klipper_cfg_example/AFC/AFC_Hardware.cfg
+++ b/Klipper_cfg_example/AFC/AFC_Hardware.cfg
@@ -26,7 +26,7 @@ dir_pin: AFC:M1_DIR
 enable_pin: !AFC:M1_EN
 microsteps: 16
 rotation_distance: 4.65
-hub_dist: 140
+dist_hub: 140
 led_index: AFC_Indicator:1
 afc_motor_rwd: AFC:MOT1_RWD
 #afc_motor_fwd: AFC:MOT1_FWD        # AFC_Lite
@@ -48,7 +48,7 @@ dir_pin: AFC:M2_DIR
 enable_pin: !AFC:M2_EN
 microsteps: 16
 rotation_distance: 4.65
-hub_dist: 80
+dist_hub: 80
 led_index: AFC_Indicator:2
 afc_motor_rwd: AFC:MOT2_RWD
 #afc_motor_fwd: AFC:MOT2_FWD        # AFC_Lite
@@ -70,7 +70,7 @@ dir_pin: AFC:M3_DIR
 enable_pin: !AFC:M3_EN
 microsteps: 16
 rotation_distance: 4.65
-hub_dist: 80
+dist_hub: 80
 led_index: AFC_Indicator:3
 afc_motor_rwd: AFC:MOT3_RWD
 #afc_motor_fwd: AFC:MOT3_FWD        # AFC_Lite
@@ -92,7 +92,7 @@ dir_pin: AFC:M4_DIR
 enable_pin: !AFC:M4_EN
 microsteps: 16
 rotation_distance: 4.65
-hub_dist: 140
+dist_hub: 140
 led_index: AFC_Indicator:4
 afc_motor_rwd: AFC:MOT4_RWD
 #afc_motor_fwd: AFC:MOT4_FWD        # AFC_Lite


### PR DESCRIPTION
PREP Function:
- Moved setting afc prep done function out of if check so its always called regardless of error.  Before if PREP had a problem with a lane the user would not be able to remove and then reinsert without restarting klipper or manually calling PREP.
- Fixing some errors paths messages and adding call to handle lane failure

Moving filament to hub updates:
- Added logic to set lane hub_load state between powercycles/klipper restarts, I think using `hub_loaded` values it what this was intended for.
- Fixed error found where the lanes `dist_hub` value was being written to False after a unload
- Added writing to vars file once filament was loaded to hub
- Added activating assist motors if `dist_hub` is over 200, so that filament would be rewound for longer paths.
- dist_hub loading/unloading speed is dependent of value, value over 200 uses long speed value
- Removed hub_dist value since its not being used anywhere
- Updated hub_dist to dist_hub in AFC_Hardware.cfg file ( users need to make this same change in their config )