### PR TITLE
fix(form-tip): copy initial retration settings from happy hare

### DIFF
--- a/AFC.py
+++ b/AFC.py
@@ -771,9 +771,9 @@ class afc:
         total_retraction_distance = self.cooling_tube_position + self.cooling_tube_length - 15
         self.afc_extrude(-15, self.unloading_speed_start * 60)
         if total_retraction_distance > 0:
-            self.afc_extrude(.7 * total_retraction_distance, 1.0 * self.unloading_speed)
-            self.afc_extrude(.2 * total_retraction_distance, 0.5 * self.unloading_speed)
-            self.afc_extrude(.1 * total_retraction_distance, 0.3 * self.unloading_speed)
+            self.afc_extrude(-.7 * total_retraction_distance, 1.0 * self.unloading_speed * 60)
+            self.afc_extrude(-.2 * total_retraction_distance, 0.5 * self.unloading_speed * 60)
+            self.afc_extrude(-.1 * total_retraction_distance, 0.3 * self.unloading_speed * 60)
         
         if self.toolchange_temp > 0:
             if self.use_skinnydip:


### PR DESCRIPTION
It looks like the whole tip forming was ported from happy hare but these few lines did not appear to be ported correctly. Original found [here](https://github.com/moggieuk/Happy-Hare/blob/d70ff2096d45b2564cacc0d23139b127cb2c1bc1/config/base/mmu_form_tip.cfg#L99-L101).