### PR TITLE
Fixing indent for if statement that is supposed to be inside a while loop

### DIFF
--- a/AFC.py
+++ b/AFC.py
@@ -416,9 +416,9 @@ class afc:
                                 while CUR_LANE.load_state == False and num_tries < 20:
                                     CUR_LANE.move( self.hub_move_dis, self.short_moves_speed, self.short_moves_accel)
                                     num_tries += 1
-                                if num_tries > 20:
-                                    message = (' FAILED TO LOAD, CHECK FILAMENT AT TRIGGER\n||==>--||----||-----||\nTRG   LOAD   HUB   TOOL')
-                                    self.handle_lane_failure(CUR_LANE, message)
+                                    if num_tries > 20:
+                                        message = (' FAILED TO LOAD, CHECK FILAMENT AT TRIGGER\n||==>--||----||-----||\nTRG   LOAD   HUB   TOOL')
+                                        self.handle_lane_failure(CUR_LANE, message)
 
                             if CUR_LANE.prep_state == True and CUR_LANE.load_state == True:
                                 self.afc_led(self.led_ready, CUR_LANE.led_index)


### PR DESCRIPTION
Found and fixed a if statement that should of been inside a while loop so that it does not get stuck in an infinite loop when `PREP` is called.