### PR TITLE
fix: use reactor to pause instead of time.sleep

### DIFF
--- a/AFC.py
+++ b/AFC.py
@@ -194,8 +194,16 @@ class afc:
     cmd_TEST_help = "Test Assist Motors"
     def cmd_TEST(self, gcmd):
         lane = gcmd.get('LANE', None)
+        if lane == None:
+            self.respond_error('Must select LANE')
+            return
+        
         self.gcode.respond_info('TEST ROUTINE')
-        CUR_LANE = self.printer.lookup_object('AFC_stepper '+lane)
+        try:
+            CUR_LANE = self.printer.lookup_object('AFC_stepper '+lane)
+        except error as e:
+            self.respond_error(str(e))
+            return
         self.gcode.respond_info('Testing at full speed')
         CUR_LANE.assist(-1)
         time.sleep(1)

--- a/AFC.py
+++ b/AFC.py
@@ -244,7 +244,7 @@ class afc:
     cmd_PREP_help = "Prep AFC"
     def cmd_PREP(self, gcmd):
         while self.printer.state_message != 'Printer is ready':
-            time.sleep(1)
+            self.reactor.pause(self.reactor.monotonic() + 1)
         if os.path.exists(self.VarFile) and os.stat(self.VarFile).st_size > 0:
             try: self.lanes=json.load(open(self.VarFile))
             except IOError: self.lanes={}
@@ -826,9 +826,9 @@ class afc:
         if self.use_skinnydip:
             self.gcode.respond_info('AFC-TIP-FORM: Step ' + str(step) + ': Skinny Dipping')
             self.afc_extrude(self.skinnydip_distance, self.dip_insertion_speed * 60)
-            time.sleep(self.melt_zone_pause)
+            self.reactor.pause(self.reactor.monotonic() + self.melt_zone_pause)
             self.afc_extrude(self.skinnydip_distance * -1, self.dip_extraction_speed * 60)
-            time.sleep(self.cooling_zone_pause)
+            self.reactor.pause(self.reactor.monotonic() + self.cooling_zone_pause)
 
 def load_config(config):         
     return afc(config)

--- a/Klipper_cfg_example/AFC/AFC.cfg
+++ b/Klipper_cfg_example/AFC/AFC.cfg
@@ -87,8 +87,8 @@ use_skinnydip: False            # Enable skinny dip moves (for burning off filam
 skinnydip_distance: 30          # Distance to reinsert the filament, starting at the end of the cooling tube in mm.
 dip_insertion_speed: 30         # Insertion speed for burning off filament hairs in mm/s.
 dip_extraction_speed: 70        # Extraction speed (set to around 2x the insertion speed) in mm/s.
-melt_zone_pause: 0              # Pause time in the melt zone in ms.
-cooling_zone_pause: 0           # Pause time in the cooling zone after the dip in ms.
+melt_zone_pause: 0              # Pause time in the melt zone in seconds.
+cooling_zone_pause: 0           # Pause time in the cooling zone after the dip in seconds.
 
 
 #--=================================================================================--#


### PR DESCRIPTION
Based this (https://discord.com/channels/431557959978450984/801826273227177984/1287375872432803872) comment, I am guessing time.sleep may be blocking the main thread and I have a hunch that perhaps may be a source for "Timer too close" errors that I (and I think others) are seeing? However I am still getting "Timer too close" way too often even after changing this 🤷🏻‍♂️ 

Also made the `TEST` macro a little more user friendly...it won't crash klipper if you omit the lane or give it the wrong lane name.