### PR TITLE
Various fixes and small enhancements

### DIFF
--- a/AFC.py
+++ b/AFC.py
@@ -139,9 +139,9 @@ class afc:
     cmd_LANE_MOVE_help = "Lane Manual Movements"
     def cmd_LANE_MOVE(self, gcmd):
         lane = gcmd.get('LANE', None)
-        distance = gcmd.get('DISTANCE', 0)
+        distance = gcmd.get_float('DISTANCE', 0)
         CUR_LANE = self.printer.lookup_object('AFC_stepper ' + lane)
-        CUR_LANE.move(int(distance), self.short_moves_speed, self.short_moves_accel)
+        CUR_LANE.move(distance, self.short_moves_speed, self.short_moves_accel)
 
     def respond_info(self, msg):
         """

--- a/AFC.py
+++ b/AFC.py
@@ -616,7 +616,7 @@ class afc:
         else:
             #callout if hub is triggered when trying to load
             if self.hub.filament_present == True:
-                msg = ('HUB NOT CLEAR TRYING TO LOAD ' + CUR_LANE,name.upper() + '\n||-----||----|x|-----||\nTRG   LOAD   HUB   TOOL')
+                msg = ('HUB NOT CLEAR TRYING TO LOAD ' + CUR_LANE.name.upper() + '\n||-----||----|x|-----||\nTRG   LOAD   HUB   TOOL')
                 self.respond_error(msg, raise_error=False)
                 self.gcode.run_script_from_command('PAUSE')
                 self.afc_led(self.led_ready, CUR_LANE.led_index)

--- a/AFC.py
+++ b/AFC.py
@@ -521,8 +521,12 @@ class afc:
             if self.hub_cut_active:
                 self.hub_cut(CUR_LANE.name)
             if not self.heater.can_extrude: #Heat extruder if not at min temp 
-                self.gcode.respond_info('Extruder below min_extrude_temp, heating to 5 degrees above min')
-                self.gcode.run_script_from_command('M109 S' + str((self.heater.min_extrude_temp) + 5))
+                if self.heater.target_temp >= self.heater.min_extrude_temp:
+                    self.gcode.respond_info('Extruder temp is still below min_extrude_temp, waiting for it to finish heating.')
+                    self.gcode.run_script_from_command('M109 S' + str((self.heater.target_temp)))
+                else:
+                    self.gcode.respond_info('Extruder below min_extrude_temp, heating to 5 degrees above min')
+                    self.gcode.run_script_from_command('M109 S' + str((self.heater.min_extrude_temp) + 5))
             CUR_LANE.do_enable(True)
             if CUR_LANE.hub_load == False:
                 CUR_LANE.move(CUR_LANE.dist_hub, CUR_LANE.dist_hub_move_speed, CUR_LANE.dist_hub_move_accel)

--- a/AFC.py
+++ b/AFC.py
@@ -405,6 +405,7 @@ class afc:
                                 x = 0
                                 while CUR_LANE.load_state == False:
                                     CUR_LANE.move( self.hub_move_dis, self.short_moves_speed, self.short_moves_accel)
+                                    x += 1
                                     if x > 20:
                                         message = (' FAILED TO LOAD, CHECK FILAMENT AT TRIGGER\n||==>--||----||-----||\nTRG   LOAD   HUB   TOOL')
                                         self.handle_lane_failure(CUR_LANE, message)
@@ -422,12 +423,13 @@ class afc:
                             #   far enough in for the gears to grab the filament
                             if CUR_LANE.prep_state == True and CUR_LANE.load_state == False:
                                 num_tries = 0
-                                while CUR_LANE.load_state == False and num_tries < 20:
+                                while CUR_LANE.load_state == False:
                                     CUR_LANE.move( self.hub_move_dis, self.short_moves_speed, self.short_moves_accel)
                                     num_tries += 1
                                     if num_tries > 20:
                                         message = (' FAILED TO LOAD, CHECK FILAMENT AT TRIGGER\n||==>--||----||-----||\nTRG   LOAD   HUB   TOOL')
                                         self.handle_lane_failure(CUR_LANE, message)
+                                        break
 
                             if CUR_LANE.prep_state == True and CUR_LANE.load_state == True:
                                 self.afc_led(self.led_ready, CUR_LANE.led_index)

--- a/AFC.py
+++ b/AFC.py
@@ -207,17 +207,17 @@ class afc:
             return
         self.gcode.respond_info('Testing at full speed')
         CUR_LANE.assist(-1)
-        time.sleep(1)
+        self.reactor.pause(self.reactor.monotonic() + 1)
         if CUR_LANE.afc_motor_rwd.is_pwm:
             self.gcode.respond_info('Testing at 50 percent speed')
             CUR_LANE.assist(-.5)
-            time.sleep(1)
+            self.reactor.pause(self.reactor.monotonic() + 1)
             self.gcode.respond_info('Testing at 30 percent speed')
             CUR_LANE.assist(-.3)
-            time.sleep(1)
+            self.reactor.pause(self.reactor.monotonic() + 1)
             self.gcode.respond_info('Testing at 10 percent speed')
             CUR_LANE.assist(-.1)
-            time.sleep(1)
+            self.reactor.pause(self.reactor.monotonic() + 1)
             
         self.gcode.respond_info('Test routine complete')
         CUR_LANE.assist(0)

--- a/AFC_stepper.py
+++ b/AFC_stepper.py
@@ -217,7 +217,7 @@ class AFCExtruderStepper:
                     x += 1
                     self.do_enable(True)
                     self.move(10,500,400)
-                    time.sleep(0.1)
+                    self.reactor.pause(self.reactor.monotonic() + 0.1)
                     if x> 40:
                         msg = (' FAILED TO LOAD, CHECK FILAMENT AT TRIGGER\n||==>--||----||------||\nTRG   LOAD   HUB    TOOL')
                         self.AFC.respond_error(msg, raise_error=False)


### PR DESCRIPTION
Contains the following updates:

* [feat: wait for existing temp if target would allow extruding](https://github.com/ArmoredTurtle/AFC-Klipper-Add-On/commit/069fa9992c499c946595d9b2593307197b3d0919)
  * Covers an edge case where perhaps the user has set the temperature already and while it was still heating attempted to load the lane. Previously it would override the existing target temp, but now it will just wait for the existing target temp to finish.
* [fix: correct typo (comma vs period)](https://github.com/ArmoredTurtle/AFC-Klipper-Add-On/commit/052526a9a4c3a14592d46c4ad4c7c874df51e769)
* [feat: limit number of attempts to unload toolhead](https://github.com/ArmoredTurtle/AFC-Klipper-Add-On/commit/c32bb19e8c99739cca3c64da056100ebd929829b)
* [fix: accept float distances when doing LANE_MOVE](https://github.com/ArmoredTurtle/AFC-Klipper-Add-On/commit/6fb60514a4ae03b45f2e82c97f9306bfcf6e0da5)
* [fix: replace more time.sleep with reactor pause](https://github.com/ArmoredTurtle/AFC-Klipper-Add-On/commit/7b5d871e3079eb8bfac26c7f8644339950ab2490)
  * Now the assist motor test seems to actually spend a full second on each speed where before it never seemed to actually have a wait.
* [fix: infinite loop in PREP when prepping lane that is the one that is supposed to be loaded](https://github.com/ArmoredTurtle/AFC-Klipper-Add-On/pull/55/commits/9c2d461b071b2a9c49ed86bb4e1cb121f7a02ad9)
  * Also more/less reverted a previous fix that was believed to cause an infinite loop but it was not. Basically that change moved that message to a place where it could never actually execute. This was verified by ejecting a lane and then calling PREP. Regardless it stops trying after 20 attempts, however with that code indented we no longer get the message because it is unreachable.