### PR TITLE
Fix error logo

### DIFF
--- a/AFC.py
+++ b/AFC.py
@@ -286,7 +286,7 @@ class afc:
             logo_error ='E  _ _   _ _\n'
             logo_error+='R |_|_|_|_|_|\n'
             logo_error+='R |         \____\n'
-            logo_error+='O |              \\n'
+            logo_error+='O |              \ \n'
             logo_error+='R |          |\ X |\n'
             logo_error+='! \_________/ |___|\n'
 


### PR DESCRIPTION
\\n creates '\n' not '\' + newline.

This fixes to use same formatting as regular turtle logo.