### PR TITLE
Change tool recovery

### DIFF
--- a/AFC.py
+++ b/AFC.py
@@ -461,7 +461,8 @@ class afc:
                 if hub_attempts > 10:
                     message = (' PAST HUB, CHECK FILAMENT PATH\n||=====||==>--||-----||\nTRG   LOAD   HUB   TOOL')
                     self.handle_lane_failure(CUR_LANE, message)
-                    break
+                    self.pause_print()
+                    return
             CUR_LANE.move( self.afc_bowden_length, self.long_moves_speed, self.long_moves_accel)
             CUR_LANE.extruder_stepper.sync_to_extruder(CUR_LANE.extruder_name)
             tool_attempts = 0

--- a/AFC.py
+++ b/AFC.py
@@ -608,6 +608,14 @@ class afc:
                 msg = (' HUB NOT CLEARING' + '\n||=====||====|x|-----||\nTRG   LOAD   HUB   TOOL')
                 self.handle_lane_failure(CUR_LANE, msg)
                 return
+
+        # retract a little more...helps to clear strings from the hub
+        # ...until either we've moved park_dist OR we passed the load switch
+        move_dist = 0
+        while CUR_LANE.load_state == True and move_dist < CUR_LANE.park_dist:
+            move_dist += min(self.short_move_dis, CUR_LANE.park_dist - move_dist)
+            CUR_LANE.move(self.short_move_dis * -1, self.short_moves_speed, self.short_moves_accel, True)
+
         CUR_LANE.hub_load = True
         self.lanes[CUR_LANE.unit][CUR_LANE.name]['tool_loaded'] = False
         self.save_vars()

--- a/AFC_stepper.py
+++ b/AFC_stepper.py
@@ -72,6 +72,8 @@ class AFCExtruderStepper:
             self.index = 0
         self.hub_dist = config.getfloat('hub_dist',20)
         self.dist_hub = config.getfloat('dist_hub', 60)
+        # distance to retract filament from the hub
+        self.park_dist = config.getfloat('park_dist', 10)
         self.led_index = config.get('led_index')
         # lane triggers
         buttons = self.printer.load_object(config, "buttons")
@@ -143,6 +145,10 @@ class AFCExtruderStepper:
            value = speed * -1
         else:
             value = speed
+        # TODO: 500 here is too slow for me. 100 works but may be faster than it needs to be.
+        #       The trouble is the "just right" speed would also vary based on how full the
+        #       spool is and perhaps variance in N20 motors and the voltage they are receiving.
+        #       Perhaps the speed ratio should be configurable?
         value /= 500
         if value > 1: value = 1
         if assist_active: self.assist(value)

--- a/Klipper_cfg_example/AFC/AFC_Hardware.cfg
+++ b/Klipper_cfg_example/AFC/AFC_Hardware.cfg
@@ -27,6 +27,7 @@ enable_pin: !AFC:M1_EN
 microsteps: 16
 rotation_distance: 4.65
 hub_dist: 140
+park_dist: 10
 led_index: AFC_Indicator:1
 afc_motor_rwd: AFC:MOT1_RWD
 #afc_motor_fwd: AFC:MOT1_FWD        # AFC_Lite
@@ -49,6 +50,7 @@ enable_pin: !AFC:M2_EN
 microsteps: 16
 rotation_distance: 4.65
 hub_dist: 80
+park_dist: 10
 led_index: AFC_Indicator:2
 afc_motor_rwd: AFC:MOT2_RWD
 #afc_motor_fwd: AFC:MOT2_FWD        # AFC_Lite
@@ -71,6 +73,7 @@ enable_pin: !AFC:M3_EN
 microsteps: 16
 rotation_distance: 4.65
 hub_dist: 80
+park_dist: 10
 led_index: AFC_Indicator:3
 afc_motor_rwd: AFC:MOT3_RWD
 #afc_motor_fwd: AFC:MOT3_FWD        # AFC_Lite
@@ -93,6 +96,7 @@ enable_pin: !AFC:M4_EN
 microsteps: 16
 rotation_distance: 4.65
 hub_dist: 140
+park_dist: 10
 led_index: AFC_Indicator:4
 afc_motor_rwd: AFC:MOT4_RWD
 #afc_motor_fwd: AFC:MOT4_FWD        # AFC_Lite


### PR DESCRIPTION
These changes should help with less than ideal tool changes. In particular, I am testing on a setup without a cutter, so it relies on tip forming. The primary issue with tip forming is that the tips are inconsistent due to differences in temp, material, and whether you are looking at your printer funny. Because tips are inconsistent, it makes tool changes less reliable. These changes help with that in a few ways:

1. Configurable park distance so that you can have the filament parked further behind the hub (I'm using 30mm, but defaulting to 10mm for now).
2. Ensure the print is paused when something unexpected happens during a tool change.
3. Save the position of the toolhead (most important the Z position) at the start of the tool change and provide a way to restore that position when resuming. This requires the user updates the `RESUME` macro to call `RESTORE_CHANGE_TOOL_POS`.

With these changes I've successfully been able to do a test print doing 10 swaps and when it inevitably fails to do a tool change, I was able to recover and resume successfully.