### PR TITLE
fix: use gcode save/restore

### DIFF
--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -20,8 +20,9 @@ class afc:
         self.current = None
         self.failure = False
         self.lanes = {}
-        # tool position when tool change was requested
-        self.change_tool_pos = None
+        # whether we failed during a tool change. used to determine if the restore position macro
+        # should actually restore gcode state
+        self.failed_in_toolchange = False
         self.tool_start = None
 
         # SPOOLMAN
@@ -651,10 +652,10 @@ class afc:
     cmd_CHANGE_TOOL_help = "change filaments in tool head"
     def cmd_CHANGE_TOOL(self, gcmd):
         lane = gcmd.get('LANE', None)
+        self.failed_in_toolchange = False
         if lane != self.current:
-            store_pos = self.toolhead.get_position()
-            if self.is_homed() and not self.is_paused():
-                self.change_tool_pos = store_pos
+            # Create save state
+            self.gcode.run_script_from_command("SAVE_GCODE_STATE NAME=_AFC_CHANGE_TOOL")
             self.gcode.respond_info(" Tool Change - " + str(self.current) + " -> " + lane)
             if self.current != None:
                 CUR_LANE = self.printer.lookup_object('AFC_stepper ' + self.current)
@@ -665,19 +666,17 @@ class afc:
                     return
             CUR_LANE = self.printer.lookup_object('AFC_stepper ' + lane)
             self.TOOL_LOAD(CUR_LANE)
-            newpos = self.toolhead.get_position()
-            newpos[2] = store_pos[2]
-            self.toolhead.manual_move(newpos, self.tool_unload_speed)
-            self.toolhead.wait_moves()
-            if self.is_printing() and not self.is_paused():
-                self.change_tool_pos = None
+            # Restore state
+            self.gcode.run_script_from_command("RESTORE_GCODE_STATE NAME=_AFC_CHANGE_TOOL MOVE=1 MOVE_SPEED={}".format(self.tool_unload_speed))
+            if self.is_printing() and self.is_paused():
+                self.failed_in_toolchange = True
 
     cmd_RESTORE_CHANGE_TOOL_POS_help = "change filaments in tool head"
     def cmd_RESTORE_CHANGE_TOOL_POS(self, gcmd):
-        if self.change_tool_pos:
-            restore_pos = self.change_tool_pos[:3]
-            self.toolhead.manual_move(restore_pos, self.tool_start_unload_speed)
-            self.toolhead.wait_moves()
+        if self.failed_in_toolchange:
+            # Restore previous state
+            self.failed_in_toolchange = False
+            self.gcode.run_script_from_command("RESTORE_GCODE_STATE NAME=_AFC_CHANGE_TOOL MOVE=1 MOVE_SPEED={}".format(self.tool_unload_speed))
 
     def get_status(self, eventtime):
         str = {}


### PR DESCRIPTION
This change is similar to #60, but replaces the existing save/restore position with the gcode save/restore. When doing my cereal print I noticed that the first few layers (without any tool changes) my layer stacking was good. Then once I got to layers that had tool changes the layers were not great.

So I added this macro:

```
[gcode_macro CORRECT_Z_POS]
description: Checks Z position against the expected Z position and corrects if necessary
gcode:
  {% set actual = printer.toolhead.position.z|float %}
  {% set expected = params.HEIGHT|float %}
  {% set speed = 60 * 60 %}
  {% if actual == expected %}
    RESPOND MSG="Actual Z position {actual} matches expected Z position {expected}. Yay!"
  {% else %}
    RESPOND MSG="Actual Z position {actual} does not match expected Z position {expected}. Where did we go wrong?"
    G1 Z{expected} F{speed}
  {% endif %}
```

And updated my tool change gcode in Orca to the following:
```gcode
T{next_extruder}
CORRECT_Z_POS HEIGHT={z_after_toolchange}
```

What I found was after each tool change I would get something like this:

```
Actual Z position 1.9813329873150878 does not match expected Z position 2.0. Where did we go wrong?
```

The difference varied a bit on each tool change with a range of ~0.02 to ~0.06. I'm 99% sure that the difference is because of the bed mesh. I believe getting the toolhead position is getting the position after applying the bed mesh, so the z position we are restoring to may be off slightly. Though there is also a flaw in my test because the "actual" position I have there is also using toolhead position, so the value difference there may be doubly off. Later I found that I can use `printer.gcode_move.gcode_position.z` to get the gcode position, to get the actual position in my macro, though I haven't verified this yet. But using these changes my layer heights are back to normal through tool changes.

Here's what my cereal turtle looks like:
![PXL_20241007_221844609](https://github.com/user-attachments/assets/8dc732e2-737b-415c-a387-56c5f2d5b3bf)

Here's test half a turtle after adding the `CORRECT_Z_POS` macro, which helped the z position.

![PXL_20241008_175119575 MP](https://github.com/user-attachments/assets/3b8db860-a681-4d4d-87f4-1aaa66c1df0f)

Here's after changing to save/restore gcode.

![PXL_20241008_174814466](https://github.com/user-attachments/assets/819d212b-eb6e-4605-bf71-b21ec9e1cd22)

Here's top layer view of with `CORRECT_Z_POS` on the left and save/restore gcode state on the right.


![PXL_20241008_175240081](https://github.com/user-attachments/assets/999cb705-db0e-4074-887e-cc3a1e48e776)
