### PR TITLE
Set bowden length mux, adjust movement

### DIFF
--- a/AFC.py
+++ b/AFC.py
@@ -1,4 +1,4 @@
-.# 8 Track Automated Filament Changer
+# 8 Track Automated Filament Changer
 #
 # Copyright (C) 2024 Armored Turtle
 #

--- a/AFC.py
+++ b/AFC.py
@@ -480,7 +480,7 @@ class afc:
                     message = (' PAST HUB, CHECK FILAMENT PATH\n||=====||==>--||-----||\nTRG   LOAD   HUB   TOOL')
                     self.handle_lane_failure(CUR_LANE, message)
                     return
-            CUR_LANE.move( self.afc_bowden_length, self.long_moves_speed, self.long_moves_accel)
+            CUR_LANE.move(self.afc_bowden_length - (hub_attempts * self.short_move_dis), self.long_moves_speed, self.long_moves_accel)
             CUR_LANE.extruder_stepper.sync_to_extruder(CUR_LANE.extruder_name)
             tool_attempts = 0
             while self.tool.filament_present == False:

--- a/AFC.py
+++ b/AFC.py
@@ -106,10 +106,15 @@ class afc:
         self.gcode.register_command('LANE_MOVE', self.cmd_LANE_MOVE, desc=self.cmd_LANE_MOVE_help)
         self.gcode.register_command('TEST', self.cmd_TEST, desc=self.cmd_TEST_help)
         self.gcode.register_command('HUB_CUT_TEST', self.cmd_HUB_CUT_TEST, desc=self.cmd_HUB_CUT_TEST_help)
+        self.gcode.register_mux_command('SET_BOWDEN_LENGTH', self.cmd_SET_BOWDEN_LENGTH, desc=self.cmd_SET_BOWDEN_LENGTH_help)
         self.VarFile = config.get('VarFile')
         # Get debug and cast to boolean
         self.debug = True == config.get('debug', 0)
 
+    cmd_SET_BOWDEN_LENGTH_help = "Set length of bowden, hub to toolhead"
+    def cmd_SET_BOWDEN_LENGTH(self, gcmd):
+        pass
+        
     cmd_LANE_MOVE_help = "Lane Manual Movements"
     def cmd_LANE_MOVE(self, gcmd):
         lane = gcmd.get('LANE', None)

--- a/AFC.py
+++ b/AFC.py
@@ -106,19 +106,9 @@ class afc:
         self.gcode.register_command('LANE_MOVE', self.cmd_LANE_MOVE, desc=self.cmd_LANE_MOVE_help)
         self.gcode.register_command('TEST', self.cmd_TEST, desc=self.cmd_TEST_help)
         self.gcode.register_command('HUB_CUT_TEST', self.cmd_HUB_CUT_TEST, desc=self.cmd_HUB_CUT_TEST_help)
-        self.gcode.register_mux_command('SET_BOWDEN_LENGTH', 'LENGTH', self.cmd_SET_BOWDEN_LENGTH, desc=self.cmd_SET_BOWDEN_LENGTH_help)
         self.VarFile = config.get('VarFile')
         # Get debug and cast to boolean
         self.debug = True == config.get('debug', 0)
-
-    cmd_SET_BOWDEN_LENGTH_help = "Set length of bowden, hub to toolhead"
-    def cmd_SET_BOWDEN_LENGTH(self, gcmd):
-        config_bowden = self.afc_bowden_length
-        bowden_length = get_float('LENGTH', self.afc_bowden_length)
-        self.afc_bowden_length = bowden_length
-        msg = (f"Config Bowden length: {config_bowden}\n"
-               f"New Bowden Length: {bowden_length}")
-        self.respond_info(msg)
         
     cmd_LANE_MOVE_help = "Lane Manual Movements"
     def cmd_LANE_MOVE(self, gcmd):

--- a/AFC.py
+++ b/AFC.py
@@ -106,14 +106,19 @@ class afc:
         self.gcode.register_command('LANE_MOVE', self.cmd_LANE_MOVE, desc=self.cmd_LANE_MOVE_help)
         self.gcode.register_command('TEST', self.cmd_TEST, desc=self.cmd_TEST_help)
         self.gcode.register_command('HUB_CUT_TEST', self.cmd_HUB_CUT_TEST, desc=self.cmd_HUB_CUT_TEST_help)
-        self.gcode.register_mux_command('SET_BOWDEN_LENGTH', self.cmd_SET_BOWDEN_LENGTH, desc=self.cmd_SET_BOWDEN_LENGTH_help)
+        self.gcode.register_mux_command('SET_BOWDEN_LENGTH', 'LENGTH', self.cmd_SET_BOWDEN_LENGTH, desc=self.cmd_SET_BOWDEN_LENGTH_help)
         self.VarFile = config.get('VarFile')
         # Get debug and cast to boolean
         self.debug = True == config.get('debug', 0)
 
     cmd_SET_BOWDEN_LENGTH_help = "Set length of bowden, hub to toolhead"
     def cmd_SET_BOWDEN_LENGTH(self, gcmd):
-        pass
+        config_bowden = self.afc_bowden_length
+        bowden_length = get_float('LENGTH', self.afc_bowden_length)
+        self.afc_bowden_length = bowden_length
+        msg = (f"Config Bowden length: {config_bowden}\n"
+               f"New Bowden Length: {bowden_length}")
+        self.respond_info(msg)
         
     cmd_LANE_MOVE_help = "Lane Manual Movements"
     def cmd_LANE_MOVE(self, gcmd):

--- a/AFC.py
+++ b/AFC.py
@@ -1,4 +1,4 @@
-# 8 Track Automated Filament Changer
+.# 8 Track Automated Filament Changer
 #
 # Copyright (C) 2024 Armored Turtle
 #
@@ -467,6 +467,9 @@ class afc:
             CUR_LANE.do_enable(True)
             if CUR_LANE.hub_load == False:
                 CUR_LANE.move(CUR_LANE.dist_hub, self.short_moves_speed, self.short_moves_accel)
+            if self.hub.filament_present == False:
+                CUR_LANE.move(self.hub_dis + self.short_move_dis, self.short_moves_speed, self.short_moves_accel)
+                self.toolhead.wait_moves()
             hub_attempts = 0
             while self.hub.filament_present == False:
                 CUR_LANE.move( self.short_move_dis, self.short_moves_speed, self.short_moves_accel)
@@ -609,6 +612,9 @@ class afc:
             self.toolhead.wait_moves()
         CUR_LANE.extruder_stepper.sync_to_extruder(None)
         CUR_LANE.move( self.afc_bowden_length * -1, self.long_moves_speed, self.long_moves_accel, True)
+        if self.hub.filament_present == True:
+            CUR_LANE.move( self.hub_dis * -1, self.short_moves_speed, self.short_moves_accel, True)
+            self.toolhead.wait_moves()
         num_tries = 0
         while self.hub.filament_present == True:
             CUR_LANE.move(self.short_move_dis * -1, self.short_moves_speed, self.short_moves_accel, True)


### PR DESCRIPTION
- Added mux command to allow for Bowden length to be adjusted on the fly
- Adjusted `LANE_MOVE` re respool if distance is less than 0
- Added fail safe to `HUB_LOAD` so that it won't attempt if the hub switch is triggered
- fixed spacing
- Added respool to reverse filament moves