### PR TITLE
Removed a redundant multiplacation for travel speed

### DIFF
--- a/Klipper_cfg_example/AFC/macros/Cut.cfg
+++ b/Klipper_cfg_example/AFC/macros/Cut.cfg
@@ -127,10 +127,10 @@ gcode:
 
     {% if ((printer.gcode_move.gcode_position.x - pin_park_x_loc)|abs < safe_margin_x) or ((printer.gcode_move.gcode_position.y - pin_park_y_loc)|abs < safe_margin_y) %}
         # Make a safe but slower travel move
-        G1 X{pin_park_x_loc} F{travel_speed * 60}
-        G1 Y{pin_park_y_loc} F{travel_speed * 60}
+        G1 X{pin_park_x_loc} F{travel_speed}
+        G1 Y{pin_park_y_loc} F{travel_speed}
     {% else %}
-        G1 X{pin_park_x_loc} Y{pin_park_y_loc} F{travel_speed * 60}
+        G1 X{pin_park_x_loc} Y{pin_park_y_loc} F{travel_speed}
     {% endif %}
 
 


### PR DESCRIPTION
An extra multiplication was calculating a move speed 60 times what it should be.  This could lead to skipped steps and other issues if a printer's max speed wasn't limited in the klipper configuration.