### PR TITLE
Add Set bowden length command

### DIFF
--- a/AFC.py
+++ b/AFC.py
@@ -6,8 +6,8 @@
 import os
 import json
 from . import AFC_hub_cut
-
 from configparser import Error as error
+
 class afc:
     def __init__(self, config):
         self.printer = config.get_printer()

--- a/AFC.py
+++ b/AFC.py
@@ -65,6 +65,7 @@ class afc:
         self.tool_stn = config.getfloat("tool_stn", 120)
         self.tool_stn_unload = config.getfloat("tool_stn_unload", self.tool_stn)
         self.afc_bowden_length = config.getfloat("afc_bowden_length", 900)
+        self.config_bowden_length = self.afc_bowden_length
 
         # MOVE SETTINGS
         self.tool_sensor_after_extruder = config.getfloat("tool_sensor_after_extruder", 0)

--- a/AFC.py
+++ b/AFC.py
@@ -111,9 +111,9 @@ class afc:
             else:
                 bowden_length = float(length_param)
         self.afc_bowden_length = bowden_length
-        msg = (f"Config Bowden Length: {self.config_bowden_length}\n"
-               f"Previous Bowden Length: {config_bowden}\n"
-               f"New Bowden Length: {bowden_length}")
+        msg = ("Config Bowden Length: {}\n".format(self.config_bowden_length) +
+               "Previous Bowden Length: {}\n".format(config_bowden) +
+               "New Bowden Length: {}".format(bowden_length))
         self.respond_info(msg)
 
     cmd_LANE_MOVE_help = "Lane Manual Movements"

--- a/AFC.py
+++ b/AFC.py
@@ -114,7 +114,7 @@ class afc:
         msg = ("Config Bowden Length: {}\n".format(self.config_bowden_length) +
                "Previous Bowden Length: {}\n".format(config_bowden) +
                "New Bowden Length: {}".format(bowden_length))
-        self.respond_info(msg)
+        self.gcode.respond_info(msg)
 
     cmd_LANE_MOVE_help = "Lane Manual Movements"
     def cmd_LANE_MOVE(self, gcmd):

--- a/AFC.py
+++ b/AFC.py
@@ -91,10 +91,29 @@ class afc:
         self.gcode.register_command('TEST', self.cmd_TEST, desc=self.cmd_TEST_help)
         self.gcode.register_command('HUB_CUT_TEST', self.cmd_HUB_CUT_TEST, desc=self.cmd_HUB_CUT_TEST_help)
         self.gcode.register_command('RESET_FAILURE', self.cmd_CLEAR_ERROR, desc=self.cmd_CLEAR_ERROR_help)
+        self.gcode.register_mux_command('SET_BOWDEN_LENGTH', 'AFC', None, self.cmd_SET_BOWDEN_LENGTH, desc=self.cmd_SET_BOWDEN_LENGTH_help)
         self.VarFile = config.get('VarFile')
         # Get debug and cast to boolean
         #self.debug = True == config.get('debug', 0)
         self.debug = False
+
+    cmd_SET_BOWDEN_LENGTH_help = "Set length of bowden, hub to toolhead"
+    def cmd_SET_BOWDEN_LENGTH(self, gcmd):
+        config_bowden = self.afc_bowden_length
+        length_param = gcmd.get('LENGTH', None)
+        if length_param is None or length_param.strip() == '':
+            bowden_length = self.config_bowden_length
+        else:
+            if length_param[0] in ('+', '-'):
+                bowden_value = float(length_param)
+                bowden_length = config_bowden + bowden_value
+            else:
+                bowden_length = float(length_param)
+        self.afc_bowden_length = bowden_length
+        msg = (f"Config Bowden Length: {self.config_bowden_length}\n"
+               f"Previous Bowden Length: {config_bowden}\n"
+               f"New Bowden Length: {bowden_length}")
+        self.respond_info(msg)
 
     cmd_LANE_MOVE_help = "Lane Manual Movements"
     def cmd_LANE_MOVE(self, gcmd):


### PR DESCRIPTION
This addition will allow for an on-demand change to the Bowden length. This will help dial in the distance as the AFC is feeding to the tool head.

Add `self.config_bowden_length = self.afc_bowden_length` to be referenced by the function later, this stores the variable even if it's changed.
`SET_BOWDEN_LENGTH` takes one input `LENGTH`
Length can be changed in 3 ways:
- An exact value can be set. `SET_BOWDEN_LENGTH LENGTH=955` will set the Bowden length to 955mm
- Current value can be incremented positive or negative.
    - `SET_BOWDEN_LENGTH LENGTH=+100` if the original length was 955 it will be changed to 1055
    - `SET_BOWDEN_LENGTH LENGTH=-100` if the original length was 955 it will be changed to 855
- if `SET_BOWDEN_LENGTH` is called without a length then the value will be reset back to the configured length