### PR TITLE
Updates that were missed from main to DEV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+ - Added `loaded_to_hub` parameter to get_status so users can see if filament is loaded to  their hub
+
 ### Changed
 
  - Revamped `install-afc.sh` script to be interactive and provide more configuration options for the user.
  - Updated `ruff` GHA to only scan for changed files.
+ - Updates to AFC.cfg file. Be sure to backup current file and replace with new version, then update values from backed up file.
+ - Manually changes needed to AFC_hardware.cfg
+    - `[filament_switch_sensor tool]` update to `[filament_switch_sensor tool_start]`
+    - If using sensor after gears `[filament_switch_sensor extruder]` updaste to `[filament_switch_sensor tool_end]`
+
 ### Fixed
 
 ### Removed

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -508,8 +508,6 @@ class afc:
                 self.toolhead.wait_moves()
                 self.printer.lookup_object('AFC_stepper ' + CUR_LANE.name).status = 'tool'
                 self.lanes[CUR_LANE.unit][CUR_LANE.name]['tool_loaded'] = True
-                self.lanes[CUR_LANE.unit][CUR_LANE.name]['hub_loaded'] = CUR_LANE.hub_load
-                self.save_vars()
                 self.current = CUR_LANE.name
                 self.afc_led(self.led_tool_loaded, CUR_LANE.led_index)
                 if self.poop:
@@ -520,6 +518,9 @@ class afc:
                     self.gcode.run_script_from_command(self.kick_cmd)
                 if self.wipe:
                     self.gcode.run_script_from_command(self.wipe_cmd)
+            # Setting hub loaded outside of failure check since this could be true
+            self.lanes[CUR_LANE.unit][CUR_LANE.name]['hub_loaded'] = CUR_LANE.hub_load
+            self.save_vars() # Always save variables even if a failure happens
             if self.failure:
                 self.pause_print()
                 self.afc_led(self.led_fault, CUR_LANE.led_index)
@@ -673,9 +674,11 @@ class afc:
                 str[UNIT][NAME]['LANE'] = LANE.index
                 str[UNIT][NAME]['load'] = bool(LANE.load_state)
                 str[UNIT][NAME]["prep"]=bool(LANE.prep_state)
+                str[UNIT][NAME]["loaded_to_hub"] = self.lanes[UNIT][NAME]['hub_loaded']
                 str[UNIT][NAME]["material"]=self.lanes[UNIT][NAME]['material']
                 str[UNIT][NAME]["spool_id"]=self.lanes[UNIT][NAME]['spool_id']
                 str[UNIT][NAME]["color"]=self.lanes[UNIT][NAME]['color']
+                
                 numoflanes +=1
         str["system"]={}
         str["system"]['current_load']= self.current

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -249,6 +249,7 @@ class afc:
                     #self.gcode.register_mux_command('T' + str(CUR_LANE.index - 1), "LANE", CUR_LANE.name, self.cmd_CHANGE_TOOL, desc=self.cmd_CHANGE_TOOL_help)
                     #$self.gcode.respond_info('Addin T' + str(CUR_LANE.index - 1) + ' with Lane defined as ' + CUR_LANE.name)
                     if CUR_LANE.prep_state == False: self.afc_led(self.led_not_ready, CUR_LANE.led_index)
+                    CUR_LANE.hub_load = self.lanes[UNIT][LANE]['hub_loaded'] # Setting hub load state so it can be retained between restarts
 
             error_string = "Error: Filament switch sensor {} not found in config file"
             try: self.hub = self.printer.lookup_object('filament_switch_sensor hub').runout_helper

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -678,7 +678,7 @@ class afc:
                 str[UNIT][NAME]["material"]=self.lanes[UNIT][NAME]['material']
                 str[UNIT][NAME]["spool_id"]=self.lanes[UNIT][NAME]['spool_id']
                 str[UNIT][NAME]["color"]=self.lanes[UNIT][NAME]['color']
-                
+
                 numoflanes +=1
         str["system"]={}
         str["system"]['current_load']= self.current
@@ -688,7 +688,7 @@ class afc:
         str["system"]['num_units'] = len(self.lanes)
         str["system"]['num_lanes'] = numoflanes
         return str
-    
+
     def is_homed(self):
         curtime = self.reactor.monotonic()
         kin_status = self.toolhead.get_kinematics().get_status(curtime)


### PR DESCRIPTION
Updating code that was missed when doing main->dev merge, updates are mainly for hub loading and have been tested.
- Adding back setting hub_load for each lane from variable file after restart
- Moving updating hub_loaded out if statement since this variable was not getting updated if a tool load failed but the hub load was successfull
- Moved saving variables outside of if statement so that this would updated even if a failure happened
- Added loaded_to_hub parameter to get_status so users can see if filament is loaded to hub
- Updated changelog