### PR TITLE
Full update to buffer functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added `Buffer_Name` to `AFC.cfg`
     - this allows the code base to have a name for the buffer to reference.
     - The name must match how buffer is defined in `[AFC_buffer *Buffer_Name*]`
+    - ^^^This has to be manually updated^^^
   -  Additions to `AFC.py`
     - establish Buffer name
     - With buffer set up

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added `Buffer_Name` to `AFC.cfg`
     - this allows the code base to have a name for the buffer to reference.
     - The name must match how buffer is defined in `[AFC_buffer *Buffer_Name*]`
-    - ^^^This has to be manually updated^^^
+    - ^^^This has to be manually updated and must be uncommented/added to AFC.cfg file^^^
   -  Additions to `AFC.py`
     - establish Buffer name
     - With buffer set up

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Sample configuration files for the most popular boards are located in the `Klipper_cfg_example/AFC` directory.
 
-## [Unreleased]
+## [2024-10-24]
 
 ### Added
 
@@ -39,6 +39,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - If using sensor after gears `[filament_switch_sensor extruder]` updaste to `[filament_switch_sensor tool_end]`
 
 ### Fixed
+### Removed
 
+## [2024-10-24]
+
+### Added
+
+  - Added `Buffer_Name` to `AFC.cfg`
+    - this allows the code base to have a name for the buffer to reference.
+    - The name must match how buffer is defined in `[AFC_buffer *Buffer_Name*]`
+  -  Additions to `AFC.py`
+    - establish Buffer name
+    - With buffer set up
+      - Enable during `PREP`
+      - Enable during `tool_load`
+      - Disable during `tool_unload`
+  - Added `SET_ROTATION_FACTOR` that uses variable `FACTOR`
+    - if a turtleneck style buffer is enabled it will change the current rotation distance of the AFC stepper,
+    - Values greater than 0
+    - Values greater than 1 will cause more filament to be fed
+    - Values Less than 1 greater than 0 will cause less filament to be fed
+
+### Changed
+
+  - Full functionality change for Turtleneck/ Turtleneck 2.0 style buffers
+  - Changed buffer configuration examples, new configuration is required for full functionality!
+    - `multiplier_high` controls the speed up of filament being fed
+    - `multiplier_low` controls the slow down of filament being fed
+  - `QUERY_BUFFER` will output rotation distance if applicable
+
+### Fixed
+  - minor adjustments to the use of single sensor buffers, retaining functionality for Belay
 ### Removed
 

--- a/config/AFC.cfg
+++ b/config/AFC.cfg
@@ -2,7 +2,9 @@
 #--=================================================================================--#
 ######### Unit Type ###################################################################
 #--=================================================================================--#
-Type: Box_Turtle            
+Type: Box_Turtle
+
+# Buffer_Name: TN2              # This name must match name of Buffer in mcu config, ex.TN2, TN or Belay.
 
 VarFile: ../printer_data/config/AFC/AFC.var   # Path to the variables file for AFC configuration.
 

--- a/config/AFC.cfg
+++ b/config/AFC.cfg
@@ -4,6 +4,7 @@
 #--=================================================================================--#
 Type: Box_Turtle
 
+# Uncomment and set to name of your buffer
 # Buffer_Name: TN2              # This name must match name of Buffer in mcu config, ex.TN2, TN or Belay.
 
 VarFile: ../printer_data/config/AFC/AFC.var   # Path to the variables file for AFC configuration.

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -534,8 +534,6 @@ class afc:
                 self.toolhead.wait_moves()
                 self.printer.lookup_object('AFC_stepper ' + CUR_LANE.name).status = 'tool'
                 self.lanes[CUR_LANE.unit][CUR_LANE.name]['tool_loaded'] = True
-                self.lanes[CUR_LANE.unit][CUR_LANE.name]['hub_loaded'] = CUR_LANE.hub_load
-                self.save_vars()
 
                 self.current = CUR_LANE.name
                 if self.buffer_name != None:

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -5,7 +5,6 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import os
 import json
-from . import AFC_hub_cut
 
 from configparser import Error as error
 class afc:

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -17,6 +17,7 @@ class afc:
         self.gcode = self.printer.lookup_object('gcode')
         self.VarFile = config.get('VarFile')
         self.Type = config.get('Type')
+        self.buffer_name = config.get('Buffer_Name', None)
         self.current = None
         self.failure = False
         self.lanes = {}
@@ -429,6 +430,9 @@ class afc:
 
         if check_success == True:
             self.gcode.respond_info(logo)
+            if self.buffer_name != None:
+                self.buffer = self.printer.lookup_object('AFC_buffer {}'.format(self.buffer_name))
+                self.buffer.enable_buffer()
         else:
             self.gcode.respond_info(logo_error)
         # Call out if all lanes are clear but hub is not
@@ -530,7 +534,13 @@ class afc:
                 self.toolhead.wait_moves()
                 self.printer.lookup_object('AFC_stepper ' + CUR_LANE.name).status = 'tool'
                 self.lanes[CUR_LANE.unit][CUR_LANE.name]['tool_loaded'] = True
+                self.lanes[CUR_LANE.unit][CUR_LANE.name]['hub_loaded'] = CUR_LANE.hub_load
+                self.save_vars()
+
                 self.current = CUR_LANE.name
+                if self.buffer_name != None:
+                    self.buffer.enable_buffer()
+
                 self.afc_led(self.led_tool_loaded, CUR_LANE.led_index)
                 if self.poop:
                     self.gcode.run_script_from_command(self.poop_cmd)
@@ -574,6 +584,10 @@ class afc:
         extruder = self.toolhead.get_extruder() #Get extruder
         self.heater = extruder.get_heater() #Get extruder heater
         CUR_LANE.status = 'unloading'
+
+        if self.buffer_name != None:
+            self.buffer.disable_buffer()
+
         self.afc_led(self.led_unloading, CUR_LANE.led_index)
         CUR_LANE.extruder_stepper.sync_to_extruder(CUR_LANE.extruder_name)
         extruder = self.printer.lookup_object('toolhead').get_extruder()

--- a/extras/AFC_buffer.py
+++ b/extras/AFC_buffer.py
@@ -76,7 +76,7 @@ class AFCtrigger:
     # Belay Call back
     def belay_sensor_callback(self, state):
         self.last_state = state
-        if self.printer.state_message == 'Printer is ready' and self.enable:
+        if self.printer.state_message == 'Printer is ready':
             if self.AFC.tool_start.filament_present:
                 if self.AFC.current != None:
                     tool_loaded = self.AFC.current

--- a/extras/AFC_buffer.py
+++ b/extras/AFC_buffer.py
@@ -3,47 +3,223 @@
 # Copyright (C) 2024 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from configparser import Error as error
+
+ADVANCE_STATE_NAME = "Advance"
+TRAILING_STATE_NAME = "Trailing"
 
 class AFCtrigger:
-    def __init__(self, config):
-      self.printer = config.get_printer()
-      self.reactor = self.printer.get_reactor()
-      self.name = config.get_name().split(' ')[-1]
-      self.pin = config.get('pin')
-      self.buffer_distance = config.getfloat('distance', 0)
-      self.velocity = config.getfloat('velocity', 0)
-      self.accel = config.getfloat('accel', 0)
-      self.last_state = False
-      self.current = ''
-      self.AFC = self.printer.lookup_object('AFC')
-      self.debug = config.getboolean("debug", False)
-      buttons = self.printer.load_object(config, "buttons")
-      buttons.register_buttons([self.pin], self.sensor_callback)
-      self.gcode = self.printer.lookup_object('gcode')
-      self.printer.register_event_handler("klippy:ready", self._handle_ready)
-      self.gcode.register_mux_command("QUERY_BUFFER","BUFFER", self.name,self.cmd_QUERY_BUFFER,desc=self.cmd_QUERY_BUFFER_help)
-    cmd_QUERY_BUFFER_help = "Report Buffer sensor state"
 
-    def cmd_QUERY_BUFFER(self, gcmd):
-        if self.last_state:
-            state_info = "compressed"
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.reactor = self.printer.get_reactor()
+        self.gcode = self.printer.lookup_object('gcode')
+        self.name = config.get_name().split(' ')[-1]
+        self.turtleneck = False
+        self.belay = False
+        self.last_state = False
+        self.enable = False
+        self.current = ''
+        self.AFC = self.printer.lookup_object('AFC')
+        self.debug = config.getboolean("debug", False)
+        self.buttons = self.printer.load_object(config, "buttons")
+
+        # Try and get one of each pin to see how user has configured buffer
+        self.advance_pin = config.get('advance_pin', None)
+        self.buffer_distance = config.getfloat('distance', None)
+
+        if self.advance_pin is not None and self.buffer_distance is not None:
+            # Throw an error as this is not a valid configuration, only Turtle neck or buffer can be configured not both
+            msg = "Turtle neck or buffer can be configured not both, please fix buffer configuration"
+            self.gcode._respond_error( msg )
+            raise error( msg )
+
+        # Pull config for Turtleneck style buffer (advance and training switches)
+        if self.advance_pin is not None:
+            self.turtleneck = True
+            self.advance_pin = config.get('advance_pin')
+            self.trailing_pin = config.get('trailing_pin')
+            self.multiplier_high = config.getfloat("multiplier_high", default=1.1, minval=1.0)
+            self.multiplier_low = config.getfloat("multiplier_low", default=0.9, minval=0.0, maxval=1.0)
+
+        # Pull config for Belay style buffer (single switch)
+        elif self.buffer_distance is not None:
+            self.belay = True
+            self.pin = config.get('pin')
+            self.buffer_distance = config.getfloat('distance', 0)
+            self.velocity = config.getfloat('velocity', 0)
+            self.accel = config.getfloat('accel', 0)
+
+        # Error if buffer is not configured correctly
         else:
-            state_info = "expanded"
-        self.gcode.respond_info("{} : {}".format(self.name, state_info))
+            msg = "Buffer is not configured correctly, please fix configuration"
+            self.gcode._respond_error( msg )
+            raise error( msg )
+
+        self.printer.register_event_handler("klippy:ready", self._handle_ready)
+
+        self.gcode.register_mux_command("QUERY_BUFFER", "BUFFER", self.name, self.cmd_QUERY_BUFFER, desc=self.cmd_QUERY_BUFFER_help) 
+
+        # Belay Buffer 
+        if self.belay:
+            self.buttons.register_buttons([self.pin], self.belay_sensor_callback)
+
+        # Turtleneck Buffer
+        if self.turtleneck:
+            self.buttons.register_buttons([self.advance_pin], self.advance_callback)
+            self.buttons.register_buttons([self.trailing_pin], self.trailing_callback)
+            self.gcode.register_mux_command("SET_ROTATION_FACTOR", "AFC_trigger", None, self.cmd_SET_ROTATION_FACTOR, desc=self.cmd_LANE_ROT_FACTOR_help)
 
     def _handle_ready(self):
         self.min_event_systime = self.reactor.monotonic() + 2.
 
-    def sensor_callback(self, eventtime, state):
+    # Belay Call back
+    def belay_sensor_callback(self, state):
         self.last_state = state
-        if self.printer.state_message == 'Printer is ready':
-            if self.printer.lookup_object('filament_switch_sensor tool_start').runout_helper.filament_present == True:
-                if self.printer.lookup_object('AFC').current != None:
-                    tool_loaded=self.printer.lookup_object('AFC').current
+        if self.printer.state_message == 'Printer is ready' and self.enable:
+            if self.AFC.tool_start.filament_present:
+                if self.AFC.current != None:
+                    tool_loaded = self.AFC.current
                     LANE = self.printer.lookup_object('AFC_stepper ' + tool_loaded)
                     if LANE.status != 'unloading':
-                        if self.debug == True: self.gcode.respond_info("Buffer Triggered, State: {}".format(state))
+                        if self.debug: self.gcode.respond_info("Buffer Triggered, State: {}".format(state))
                         LANE.move(self.buffer_distance, self.velocity ,self.accel)
+
+    # Turtleneck commands
+    def enable_buffer(self):
+        if self.turtleneck:
+            self._set_extruder_stepper()
+            multiplier = 1.0
+            if self.last_state == ADVANCE_STATE_NAME:
+                multiplier = self.multiplier_high
+            elif self.last_state == TRAILING_STATE_NAME:
+                multiplier = self.multiplier_low
+            self.set_multiplier( multiplier )
+        if self.debug: self.gcode.respond_info("{} buffer enabled".format(self.name.upper()))
+        self.enable = True
+
+    def disable_buffer(self):
+        self.enable = False
+        if self.debug: self.gcode.respond_info("{} buffer disabled".format(self.name.upper()))
+        if self.turtleneck:
+            self.reset_multiplier()
+
+    def _set_extruder_stepper(self):
+        if self.printer.state_message == 'Printer is ready' and self.AFC.current != None and not self.enable:
+            LANE = self.printer.lookup_object('AFC_stepper ' + self.AFC.current)
+            stepper = LANE.extruder_stepper.stepper
+            base_rotation_dist = stepper.get_rotation_distance()[0]
+            self.base_rotation_dist = base_rotation_dist
+            if self.debug: self.gcode.respond_info("Base rotation distance for {}: {}".format(LANE.name.upper(), base_rotation_dist))
+            self.update_rotation_distance = lambda m: stepper.set_rotation_distance(
+                base_rotation_dist / m
+            )
+        else:
+            return
+
+    def set_multiplier(self, multiplier):
+        if not self.enable: return
+        if self.AFC.current is None: return
+
+        self.update_rotation_distance( multiplier )
+        if self.debug:
+            stepper = self.printer.lookup_object('AFC_stepper ' + self.AFC.current).extruder_stepper.stepper
+            new_rotation_dist = stepper.get_rotation_distance()[0]
+            self.gcode.respond_info("New rotation distance after applying factor: {}".format(new_rotation_dist))
+
+    def reset_multiplier(self):
+        if self.debug: self.gcode.respond_info("Buffer multiplier reset")
+        self.update_rotation_distance(1.0)
+
+    def advance_callback(self, eventime, state):
+        self.last_state = state
+        if self.printer.state_message == 'Printer is ready' and self.enable and self.last_state != ADVANCE_STATE_NAME:
+            if self.AFC.tool_start.filament_present:
+                if self.AFC.current != None:
+                    self.set_multiplier( self.multiplier_high )
+                    if self.debug: self.gcode.respond_info("Buffer Triggered State: Advancing")
+        
+        self.last_state = ADVANCE_STATE_NAME
+
+    def trailing_callback(self, eventime, state):
+        self.last_state = state
+        if self.printer.state_message == 'Printer is ready' and self.enable and self.last_state != TRAILING_STATE_NAME:
+            if self.AFC.tool_start.filament_present:
+                if self.AFC.current != None:
+                    self.set_multiplier( self.multiplier_low )
+                    if self.debug: self.gcode.respond_info("Buffer Triggered State: Trailing")
+
+        self.last_state = TRAILING_STATE_NAME
+
+    cmd_LANE_ROT_FACTOR_help = "change rotation distance by factor specified"
+    def cmd_SET_ROTATION_FACTOR(self, gcmd):
+        """
+        Adjusts the rotation distance of the current AFC stepper motor by applying a 
+        specified factor. If no factor is provided, it defaults to 1.0, which resets 
+        the rotation distance to the base value.
+
+        Args:
+            gcmd: A G-code command object containing the parameters for the factor. 
+                The 'FACTOR' parameter is used to specify the multiplier for the 
+                rotation distance.
+
+        Behavior:
+            - The FACTOR must be greater than 0.
+            - If the buffer is enabled and active, and a valid factor is provided, 
+            the function adjusts the rotation distance for the current AFC stepper.
+            - If FACTOR is 1.0, the rotation distance is reset to the base value.
+            - If FACTOR is a valid non-zero number, the rotation distance is updated 
+            by the provided factor.
+            - If FACTOR is 0 or AFC is not enabled, an appropriate message is sent 
+            back through the G-code interface.
+        """
+        if self.turtleneck:
+            if self.AFC.current != None and self.enable:
+                change_factor = gcmd.get_float('FACTOR', 1.0)
+                if change_factor <= 0:
+                    self.gcode.respond_info("FACTOR must be greater than 0")
+                    return
+                elif change_factor == 1.0:
+                    stepper = self.printer.lookup_object('AFC_stepper ' + self.AFC.current).extruder_stepper.stepper
+                    stepper.set_rotation_distance(self.base_rotation_dist)
+                    self.gcode.respond_info("Rotation distance reset to base value: {}".format(self.base_rotation_dist))
+                else:
+                    self.set_multiplier(change_factor)
+            else:
+                self.gcode.respond_info("BUFFER {} NOT ENABLED".format(self.name.upper()))
+        else:
+            self.gcode.respond_info("BUFFER {} CAN'T CHANGE ROTATION DISTANCE".format(self.name.upper())) 
+
+    cmd_QUERY_BUFFER_help = "Report Buffer sensor state"
+    def cmd_QUERY_BUFFER(self, gcmd):
+        """
+        Reports the current state of the buffer sensor and, if applicable, the rotation 
+        distance of the current AFC stepper motor.
+
+        Behavior:
+            - If the `turtleneck` feature is enabled and a tool is loaded, the rotation 
+            distance of the current AFC stepper motor is reported, along with the 
+            current state of the buffer sensor.
+            - If the `turtleneck` feature is not enabled, only the buffer state is 
+            reported.
+            - The buffer state is reported as 'compressed' if the last state indicates 
+            compression, or 'expanded' otherwise.
+            - Both the buffer state and, if applicable, the stepper motor's rotation 
+            distance are sent back as G-code responses.
+        """
+        if self.turtleneck:
+            tool_loaded=self.AFC.current
+            LANE = self.printer.lookup_object('AFC_stepper ' + tool_loaded)
+            stepper = LANE.extruder_stepper.stepper
+            rotation_dist = stepper.get_rotation_distance()[0]
+            self.gcode.respond_info("{} Rotation distance: {}".format(LANE.name.upper(), rotation_dist))
+            state_info = self.last_state
+        else:
+            if self.last_state:
+                state_info = "compressed"
+            else:
+                state_info = "expanded"
+            self.gcode.respond_info("{} : {}".format(self.name, state_info))
 
 def load_config_prefix(config):
     return AFCtrigger(config)

--- a/extras/AFC_buffer.py
+++ b/extras/AFC_buffer.py
@@ -58,9 +58,9 @@ class AFCtrigger:
 
         self.printer.register_event_handler("klippy:ready", self._handle_ready)
 
-        self.gcode.register_mux_command("QUERY_BUFFER", "BUFFER", self.name, self.cmd_QUERY_BUFFER, desc=self.cmd_QUERY_BUFFER_help) 
+        self.gcode.register_mux_command("QUERY_BUFFER", "BUFFER", self.name, self.cmd_QUERY_BUFFER, desc=self.cmd_QUERY_BUFFER_help)
 
-        # Belay Buffer 
+        # Belay Buffer
         if self.belay:
             self.buttons.register_buttons([self.pin], self.belay_sensor_callback)
 
@@ -138,7 +138,7 @@ class AFCtrigger:
                 if self.AFC.current != None:
                     self.set_multiplier( self.multiplier_high )
                     if self.debug: self.gcode.respond_info("Buffer Triggered State: Advancing")
-        
+
         self.last_state = ADVANCE_STATE_NAME
 
     def trailing_callback(self, eventime, state):
@@ -154,23 +154,23 @@ class AFCtrigger:
     cmd_LANE_ROT_FACTOR_help = "change rotation distance by factor specified"
     def cmd_SET_ROTATION_FACTOR(self, gcmd):
         """
-        Adjusts the rotation distance of the current AFC stepper motor by applying a 
-        specified factor. If no factor is provided, it defaults to 1.0, which resets 
+        Adjusts the rotation distance of the current AFC stepper motor by applying a
+        specified factor. If no factor is provided, it defaults to 1.0, which resets
         the rotation distance to the base value.
 
         Args:
-            gcmd: A G-code command object containing the parameters for the factor. 
-                The 'FACTOR' parameter is used to specify the multiplier for the 
+            gcmd: A G-code command object containing the parameters for the factor.
+                The 'FACTOR' parameter is used to specify the multiplier for the
                 rotation distance.
 
         Behavior:
             - The FACTOR must be greater than 0.
-            - If the buffer is enabled and active, and a valid factor is provided, 
+            - If the buffer is enabled and active, and a valid factor is provided,
             the function adjusts the rotation distance for the current AFC stepper.
             - If FACTOR is 1.0, the rotation distance is reset to the base value.
-            - If FACTOR is a valid non-zero number, the rotation distance is updated 
+            - If FACTOR is a valid non-zero number, the rotation distance is updated
             by the provided factor.
-            - If FACTOR is 0 or AFC is not enabled, an appropriate message is sent 
+            - If FACTOR is 0 or AFC is not enabled, an appropriate message is sent
             back through the G-code interface.
         """
         if self.turtleneck:

--- a/extras/AFC_buffer.py
+++ b/extras/AFC_buffer.py
@@ -188,23 +188,23 @@ class AFCtrigger:
             else:
                 self.gcode.respond_info("BUFFER {} NOT ENABLED".format(self.name.upper()))
         else:
-            self.gcode.respond_info("BUFFER {} CAN'T CHANGE ROTATION DISTANCE".format(self.name.upper())) 
+            self.gcode.respond_info("BUFFER {} CAN'T CHANGE ROTATION DISTANCE".format(self.name.upper()))
 
     cmd_QUERY_BUFFER_help = "Report Buffer sensor state"
     def cmd_QUERY_BUFFER(self, gcmd):
         """
-        Reports the current state of the buffer sensor and, if applicable, the rotation 
+        Reports the current state of the buffer sensor and, if applicable, the rotation
         distance of the current AFC stepper motor.
 
         Behavior:
-            - If the `turtleneck` feature is enabled and a tool is loaded, the rotation 
-            distance of the current AFC stepper motor is reported, along with the 
+            - If the `turtleneck` feature is enabled and a tool is loaded, the rotation
+            distance of the current AFC stepper motor is reported, along with the
             current state of the buffer sensor.
-            - If the `turtleneck` feature is not enabled, only the buffer state is 
+            - If the `turtleneck` feature is not enabled, only the buffer state is
             reported.
-            - The buffer state is reported as 'compressed' if the last state indicates 
+            - The buffer state is reported as 'compressed' if the last state indicates
             compression, or 'expanded' otherwise.
-            - Both the buffer state and, if applicable, the stepper motor's rotation 
+            - Both the buffer state and, if applicable, the stepper motor's rotation
             distance are sent back as G-code responses.
         """
         if self.turtleneck:

--- a/templates/AFC_Hardware-AFC.cfg
+++ b/templates/AFC_Hardware-AFC.cfg
@@ -143,8 +143,20 @@ initial_WHITE: 0.0
 #color_order: RGBW
 
 # if equipped with buffer
-[AFC_buffer neck]
-pin: mcu:BUFFER
-distance: 25
-velocity: 1000
-accel: 1000
+# [AFC_buffer TN2]
+# advance_pin:     !PB1
+# trailing_pin:    !PB2
+# multiplier_high: 1.1   # default 1.1, factor to feed more filament
+# multiplier_low:  0.9   # default 0.9, factor to feed less filament
+
+# [AFC_buffer TN]
+# advance_pin:     # set advance pin
+# trailing_pin:    # set trailing pin
+# multiplier_high: 1.1   # default 1.1, factor to feed more filament
+# multiplier_low:  0.9   # default 0.9, factor to feed less filament
+
+# [AFC_buffer Belay]
+# pin: mcu:BUFFER
+# distance: 25
+# velocity: 1000
+# accel: 1000

--- a/templates/AFC_Hardware-MMB.cfg
+++ b/templates/AFC_Hardware-MMB.cfg
@@ -120,8 +120,20 @@ initial_BLUE: 0.0
 initial_WHITE: 0.0
 
 # if equipped with buffer
-[AFC_buffer neck]
-pin: mcu:BUFFER
-distance: 25
-velocity: 1000
-accel: 1000
+# [AFC_buffer TN2]
+# advance_pin:     !PB1
+# trailing_pin:    !PB2
+# multiplier_high: 1.1   # default 1.1, factor to feed more filament
+# multiplier_low:  0.9   # default 0.9, factor to feed less filament
+
+# [AFC_buffer TN]
+# advance_pin:     # set advance pin
+# trailing_pin:    # set trailing pin
+# multiplier_high: 1.1   # default 1.1, factor to feed more filament
+# multiplier_low:  0.9   # default 0.9, factor to feed less filament
+
+# [AFC_buffer Belay]
+# pin: mcu:BUFFER
+# distance: 25
+# velocity: 1000
+# accel: 1000


### PR DESCRIPTION
Functionality was added for two sensor buffers, Specifically Turtleneck and Turtleneck 2.0. see [TurtleNeck2.0](https://github.com/ArmoredTurtle/TurtleNeck2.0)

When the tool is loaded, the buffer gets enabled. Enabling happens during `PREP` or during `TOOL_LOAD`. Buffer is disabled during `TOOL_UNLOAD`.

- Rotation distance is decreased when the trailing sensor is `True` putting the system into an `advancing` state. This will push the filament faster to the tool head.
- Rotation distance is increased when the advance sensor is `True` putting the system into a trailing state. This will slow down the filament being fed to the tool head.

***Manual updates are required in a few locations.***

1. `ACF.cfg` `Buffer_Name` must be updated to match the configured name in the hardware template i.e `[AFC_buffer *Buffer_Name*]`
2. Example Buffer configs have been changed, TurtleNeck users will have to define the correct MCU pin,
3. `multipier_high` and `multiplier_low` can be changed to further fine-tune buffers functionality