### PR TITLE
Remove _set_extruder_stepper call from AFC_buffer.py

### DIFF
--- a/extras/AFC_buffer.py
+++ b/extras/AFC_buffer.py
@@ -103,7 +103,6 @@ class AFCtrigger:
 
     def enable_buffer(self):
         if self.turtleneck:
-            self._set_extruder_stepper()
             self.enable = True
             multiplier = 1.0
             if self.last_state == ADVANCE_STATE_NAME:


### PR DESCRIPTION
Function call was missed when moving stepper control to AFC_stepper.py