### PR TITLE
handle previous lane being current but not loaded during prep

### DIFF
--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -356,7 +356,7 @@ class afc:
                     self.reactor.pause(self.reactor.monotonic() + 1)
                     CUR_LANE.move( 5, self.short_moves_speed, self.short_moves_accel, True)
                     # create T codes for macro use
-                    
+
                     if CUR_LANE.prep_state == False: self.afc_led(self.led_not_ready, CUR_LANE.led_index)
                     CUR_LANE.hub_load = self.lanes[UNIT][LANE]['hub_loaded'] # Setting hub load state so it can be retained between restarts
 
@@ -792,7 +792,7 @@ class afc:
         CUR_LANE.color = '#' + color
         self.lanes[CUR_LANE.unit][CUR_LANE.name]['color'] ='#'+ color
         self.save_vars()
-        
+
     def get_status(self, eventtime):
         str = {}
         # Try to get hub filament sensor, if lookup fails default to None

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -449,7 +449,11 @@ class afc:
                         CUR_LANE.do_enable(True)
                         CUR_EXTRUDER = self.printer.lookup_object('AFC_extruder ' + CUR_LANE.extruder_name)
                         if self.current == CUR_LANE.name:
-                            if CUR_EXTRUDER.tool_start_state == False and CUR_HUB.state == True:
+                            if CUR_EXTRUDER.tool_start_state == False and CUR_HUB.state == False:
+                                if CUR_LANE.load_state == False and CUR_LANE.prep_state == False:
+                                    CUR_LANE.status = None
+                                    self.current = None
+                            elif CUR_EXTRUDER.tool_start_state == False and CUR_HUB.state == True:
                                 untool_attempts = 0
                                 while CUR_LANE.load_state == True:
                                     CUR_LANE.move( CUR_HUB.move_dis * -1, self.short_moves_speed, self.short_moves_accel)


### PR DESCRIPTION
This is an unlikely state but still possible. This will help to cover all possible states during PREP more thoroughly