### PR TITLE
Update to prep function and buffer enable/disable logic

### DIFF
--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -388,8 +388,8 @@ class afc:
                 self.lanes[CUR_LANE.unit][CUR_LANE.name]['tool_loaded'] = True
 
                 self.current = CUR_LANE.name
-                if self.buffer != None:
-                    self.buffer.enable_buffer()
+                if CUR_EXTRUDER.buffer_name != None:
+                    CUR_EXTRUDER.buffer.enable_buffer()
 
                 self.afc_led(self.led_tool_loaded, CUR_LANE.led_index)
                 if self.poop:
@@ -434,8 +434,8 @@ class afc:
         self.heater = extruder.get_heater() #Get extruder heater
         CUR_LANE.status = 'unloading'
 
-        if self.buffer != None:
-            self.buffer.disable_buffer()
+        if CUR_EXTRUDER.buffer_name != None:
+            CUR_EXTRUDER.buffer.disable_buffer()
 
         self.afc_led(self.led_unloading, CUR_LANE.led_index)
         CUR_LANE.extruder_stepper.sync_to_extruder(CUR_LANE.extruder_name)
@@ -569,9 +569,6 @@ class afc:
     def get_status(self, eventtime):
         str = {}
         
-        # Try to get buffer, if lookup fails default to None
-        try: self.buffer = self.printer.lookup_object('AFC_buffer {}'.format(self.buffer_name))
-        except: self.buffer = None
         numoflanes = 0
         for UNIT in self.lanes.keys():
             try:
@@ -607,9 +604,8 @@ class afc:
             CUR_EXTRUDER = self.printer.lookup_object('AFC_extruder ' + EXTRUDE)
             str["system"][EXTRUDE]['tool_start_sensor'] = True == CUR_EXTRUDER.tool_start_state if CUR_EXTRUDER.tool_start is not None else False
             str["system"][EXTRUDE]['tool_end_sensor']   = True == CUR_EXTRUDER.tool_end_state   if CUR_EXTRUDER.tool_end   is not None else False
-            if CUR_EXTRUDER.buffer_name !=None:
-                CUR_EXTRUDER.buffer = self.printer.lookup_object('AFC_buffer ' + CUR_EXTRUDER.buffer_name)
-                str["system"][EXTRUDE]['buffer']   = CUR_EXTRUDER.buffer.last_state
+            if CUR_EXTRUDER.buffer_name != None:
+                str["system"][EXTRUDE]['buffer']   = CUR_EXTRUDER.buffer.buffer_status()
             else:
                 str["system"][EXTRUDE]['buffer']   = 'None'
 

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -326,7 +326,7 @@ class afc:
         if CUR_LANE == None:
             return
         # Try to get bypass filament sensor, if lookup fails default to None
-        try: 
+        try:
             bypass = self.printer.lookup_object('filament_switch_sensor bypass').runout_helper
             if bypass.filament_present == True:
                 return
@@ -514,12 +514,12 @@ class afc:
     def cmd_CHANGE_TOOL(self, gcmd):
         lane = gcmd.get('LANE', None)
         # Try to get bypass filament sensor, if lookup fails default to None
-        try: 
+        try:
             bypass = self.printer.lookup_object('filament_switch_sensor bypass').runout_helper
             if bypass.filament_present == True:
                 return
         except: bypass = None
-        
+
         if lane != self.current:
             # Create save state
             self.save_pos()
@@ -565,10 +565,10 @@ class afc:
         CUR_LANE.spool_id = ID
         self.lanes[CUR_LANE.unit][CUR_LANE.name]['spool_id'] = ID
         self.save_vars()
-        
+
     def get_status(self, eventtime):
         str = {}
-        
+
         numoflanes = 0
         for UNIT in self.lanes.keys():
             try:

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -56,7 +56,7 @@ class afcPrep:
                     self.AFC.AFC_error(error_string, False)
                     return
                 self.gcode.respond_info(CUR_HUB.type + ' ' + UNIT +' Prepping lanes')
-                
+
                 if CUR_HUB.type == 'Box_Turtle':
                     firstLeg = '<span class=warning--text>|</span><span class=error--text>_</span>'
                     secondLeg = firstLeg + '<span class=warning--text>|</span>'
@@ -85,7 +85,7 @@ class afcPrep:
                     logo+='Y  {/^^^\}\n'
                     logo+='!   `m-m`\n'
                     logo+='  ' + UNIT + '\n'
-                
+
                 if self.AFC.current != None:
                     CUR_LANE = self.printer.lookup_object('AFC_stepper ' + self.AFC.current)
                     CUR_EXTRUDER = self.printer.lookup_object('AFC_extruder ' + CUR_LANE.extruder_name)
@@ -97,7 +97,7 @@ class afcPrep:
                         self.gcode.respond_info( "{} Currently Loaded".format(self.AFC.current.upper()) )
                     else:
                         if CUR_LANE.load_state == True and CUR_EXTRUDER.tool_start_state == False:
-                            self.gcode.respond_info( " Not in Tool Head".format(self.AFC.current.upper()) )
+                            self.gcode.respond_info( "{} Not in Tool Head".format(self.AFC.current.upper()) )
                             return
                 for LANE in self.AFC.lanes[UNIT].keys():
                     if self.AFC.current != LANE:
@@ -119,7 +119,7 @@ class afcPrep:
                             CUR_LANE.move( 5, self.AFC.short_moves_speed, self.AFC.short_moves_accel, True)
                             self.reactor.pause(self.reactor.monotonic() + 1)
                             CUR_LANE.move( -5, self.AFC.short_moves_speed, self.AFC.short_moves_accel, True)
-                    
+
                             if CUR_LANE.prep_state == False:
                                 self.AFC.afc_led(self.AFC.led_not_ready, CUR_LANE.led_index)
 

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -87,13 +87,17 @@ class afcPrep:
                     logo+='  ' + UNIT + '\n'
                 
                 if self.AFC.current != None:
-                    CUR_LANE = self.printer.lookup_object('AFC_stepper ' + self.current)
+                    CUR_LANE = self.printer.lookup_object('AFC_stepper ' + self.AFC.current)
                     CUR_EXTRUDER = self.printer.lookup_object('AFC_extruder ' + CUR_LANE.extruder_name)
                     if CUR_HUB.state == True and CUR_LANE.load_state == True and CUR_EXTRUDER.tool_start_state == True:
-                        self.gcode.respond_info(self.current + " Currently Loaded")
+                        if CUR_EXTRUDER.buffer_name !=None:
+                            CUR_EXTRUDER.buffer = self.printer.lookup_object('AFC_buffer ' + CUR_EXTRUDER.buffer_name)
+                        self.AFC.afc_led(self.AFC.led_tool_loaded, CUR_LANE.led_index)
+                        CUR_EXTRUDER.buffer.enable_buffer()
+                        self.gcode.respond_info( "{} Currently Loaded".format(self.AFC.current.upper()) )
                     else:
                         if CUR_LANE.load_state == True and CUR_EXTRUDER.tool_start_state == False:
-                            self.gcode.respond_info(self.current + " Not in Tool Head")
+                            self.gcode.respond_info( " Not in Tool Head".format(self.AFC.current.upper()) )
                             return
                 for LANE in self.AFC.lanes[UNIT].keys():
                     if self.AFC.current != LANE:
@@ -105,6 +109,8 @@ class afcPrep:
                             error_string = 'Error: No config found for extruder: ' + CUR_LANE.extruder_name + ' in [AFC_stepper ' + CUR_LANE.name + ']. Please make sure [AFC_extruder ' + CUR_LANE.extruder_name + '] config exists in AFC_Hardware.cfg'
                             self.AFC.AFC_error(error_string, False)
                             check_success = False
+                            break
+
                         if CUR_EXTRUDER.buffer_name !=None:
                             CUR_EXTRUDER.buffer = self.printer.lookup_object('AFC_buffer ' + CUR_EXTRUDER.buffer_name)
                         # Run test reverse/forward on each lane
@@ -116,9 +122,11 @@ class afcPrep:
                     
                             if CUR_LANE.prep_state == False:
                                 self.AFC.afc_led(self.AFC.led_not_ready, CUR_LANE.led_index)
-                            elif CUR_HUB.state == True:
+
+                            elif CUR_LANE.prep_state == True and CUR_LANE.load_state == True:
                                 CUR_LANE.hub_load = self.AFC.lanes[UNIT][LANE]['hub_loaded'] # Setting hub load state so it can be retained between restarts
                                 self.AFC.afc_led(self.AFC.led_ready, CUR_LANE.led_index)
+
                             msg = ''
                             if CUR_LANE.prep_state == True:
                                 msg +="LOCKED"
@@ -138,6 +146,7 @@ class afcPrep:
                             CUR_LANE.do_enable(False)
                             self.gcode.respond_info(CUR_LANE.name.upper() + ' ' + msg)
                             CUR_LANE.set_afc_prep_done()
+
                 if check_success == True:
                     self.gcode.respond_raw(logo)
                 else:


### PR DESCRIPTION
When testing found and fixed the following:
AFC_prep updates
- Fixed error when getting  and printing current lane
- Added setting led to tool loaded when a lane is loaded to the toolhead
- Added enabling buffer when toolhead is loaded
- Fixed check for lane ready, now leds and hub_load state get set correctly
- 
AFC buffer updates
- Fixing code that needed to be updated to reference buffers in the extruder class
- Changed getting status to use the `buffer_status` function for buffer