### PR TITLE
Fixing error in AFC_STATUS when filament is loaded in toolhead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,24 @@ gcode:
 
 ### Added
 - New variable `cut_servo_name` for AFC_hub configuration to specify which servo to use
+- AFC_STATUS macro call, will print out what the current status is for each lane
+  
+  ex. 
+  ```
+  Turtle_1 Status
+  LANE | Prep | Load | Hub | Tool |
+  LEG1 |  xx  |  xx  |  x  |  xx  |
+  LEG2 |  xx  |  xx  |  x  |  xx  |
+  LEG3 |  xx  |  xx  |  x  |  xx  |
+  LEG4 |  xx  |  xx  |  x  |  xx  |
+  
+  Turtle_2 Status
+  LANE | Prep | Load | Hub | Tool |
+  LEG5 |  xx  |  xx  |  x  |  xx  |
+  LEG6 |  xx  |  xx  |  x  |  xx  |
+  LEG7 |  xx  |  xx  |  x  |  xx  |
+  LEG8 | <--> | <--> | <-> | <--> |
+  ```
 
 ### Fixed
 - Fixed hub_cut function to work with new structure

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -115,7 +115,7 @@ class afc:
                 CUR_EXTRUDER = self.printer.lookup_object('AFC_extruder ' + CUR_LANE.extruder_name)
                 if self.current != None:
                     if self.current == CUR_LANE.name:
-                        if not CUR_EXTRUDER.tool_start.filament_present or not CUR_HUB.filament_present:
+                        if not CUR_EXTRUDER.tool_start_state or not CUR_HUB.state:
                             lane_msg += '<span class=warning--text>{} </span>'.format(CUR_LANE.name.upper())
                         else:
                             lane_msg += '<span class=success--text>{} </span>'.format(CUR_LANE.name.upper())

--- a/templates/AFC_Hardware-AFC.cfg
+++ b/templates/AFC_Hardware-AFC.cfg
@@ -133,6 +133,7 @@ cut: False                     # Hub has Cutter
 cut_cmd: AFC                   # CMD to use
 cut_dist: 200                  # How much filament to cut off (in mm).
 cut_clear: 120                 # How far the filament should retract back from the hub (in mm).
+cut_servo_name: cut            # Servos name in configuration to use
 cut_min_length: 300.0
 cut_servo_pass_angle: 10       # Servo angle to align the Bowden tube with the hole for loading the toolhead.
 cut_servo_clip_angle: 180      # Servo angle for cutting the filament.

--- a/templates/AFC_Hardware-MMB.cfg
+++ b/templates/AFC_Hardware-MMB.cfg
@@ -125,6 +125,7 @@ cut: False                      # Hub has Cutter
 cut_cmd: AFC                    # CMD to use
 cut_dist: 200                   # How much filament to cut off (in mm).
 cut_clear: 120                  # How far the filament should retract back from the hub (in mm).
+cut_servo_name: cut             # Servos name in configuration to use
 cut_min_length: 300.0
 cut_servo_pass_angle: 10        # Servo angle to align the Bowden tube with the hole for loading the toolhead.
 cut_servo_clip_angle: 180       # Servo angle for cutting the filament.


### PR DESCRIPTION
- Fixed error when filament was loaded
- Added `cut_servo_name` to templates
- Updated changelog

AFC_STATUS working with filament loaded:
![image](https://github.com/user-attachments/assets/7ed09124-9690-4670-8360-9dad6596cc48)
