### PR TITLE
Added Z-Hop moves to the pause/resume

### DIFF
--- a/config/AFC.cfg
+++ b/config/AFC.cfg
@@ -16,9 +16,9 @@ short_move_dis: 10              # Move distance for failsafe moves. Default is 1
 #--=================================================================================-
 #------- Pause/Resume ---------------------------------------------------------------
 #--=================================================================================-
-xy_resume: False                # Enable to have position return to previous x,y coords after tool change
-resume_speed: 0                 # Speed of resume move. Leave 0 to use current printer speed
-resume_z_speed: 0               # Speed of resume move in Z. Leave 0 to use current printer speed
+z_hop: 5                        # Height to move up before and after a tool change completes
+resume_speed: 350               # Speed mm/s of resume move. Set to 0 to use gcode speed
+resume_z_speed: 100             # Speed mm/s of resume move in Z. Set to 0 to use gcode speed
 
 
 #--=================================================================================-
@@ -56,27 +56,27 @@ led_buffer_disable: 0,0,0,0.25  # Buffer disable color    (R,G,B,W) 0 = off, 1 =
 #   - Print            |
 
 # TOOL Cutting Settings
-tool_cut: True # Enable Cut macro.
+tool_cut: True                  # Enable Cut macro.
 tool_cut_cmd: AFC_CUT           # Cut macro name.
 
 # Park Settings
-park: True # Enable Park.
+park: True                      # Enable Park.
 park_cmd: AFC_PARK              # Park macro name.
 
 # Poop Settings
-poop: True # Enable Poop.
+poop: True                      # Enable Poop.
 poop_cmd: AFC_POOP              # Poop macro name.
 
 # Kick Settings
-kick: True # Enable Kick.
+kick: True                      # Enable Kick.
 kick_cmd: AFC_KICK              # Kick macro name.
 
 # Wipe Settings
-wipe: True # Enable Wipe.
+wipe: True                      # Enable Wipe.
 wipe_cmd: AFC_BRUSH             # Wipe macro name.
 
 # Form Tip Settings
-form_tip: False # Enable Tip Form.
+form_tip: False                 # Enable Tip Form.
 form_tip_cmd: AFC               # AFC is default routine. Name to custom macro if you prefer
 
 

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -205,12 +205,12 @@ class afc:
                 self.homing_position = self.gcode_move.homing_position
                 self.speed = self.gcode_move.speed
 
-    def restore_pos(self, justz=False):
+    def restore_pos(self):
         newpos = self.toolhead.get_position()
-        newpos[2] = self.last_gcode_position[2]
+        newpos[2] = self.last_gcode_position[2] + self.z_hop
 
-        speed = self.resume_speed if self.resume_speed > 0 else self.speed
-        speedz = self.resume_z_speed if self.resume_z_speed > 0 else self.speed
+        speed = self.resume_speed * 60 if self.resume_speed > 0 else self.speed
+        speedz = self.resume_z_speed * 60 if self.resume_z_speed > 0 else self.speed
         # Update GCODE STATE variables
         self.gcode_move.base_position = self.base_position
         self.gcode_move.last_position[:3] = self.last_gcode_position[:3]
@@ -220,13 +220,16 @@ class afc:
         e_diff = newpos[3] - self.last_gcode_position[3]
         self.gcode_move.base_position[3] += e_diff
 
-        # Move toolhead to previous z location
+        # Move toolhead to previous z location with zhop added
         self.gcode_move.move_with_transform(newpos, speedz)
 
-        # If this is a full pos restore move to the previous x,y after moving to previous z
-        if justz == False or self.xy_resume == True:
-            newpos[:2] = self.last_gcode_position[:2]
-            self.gcode_move.move_with_transform(newpos, speed)
+        # Move to previous x,y location
+        newpos[:2] = self.last_gcode_position[:2]
+        self.gcode_move.move_with_transform(newpos, speed)
+        
+        # Drop to previous z
+        newpos[2] = self.last_gcode_position[2]
+        self.gcode_move.move_with_transform(newpos, speedz)
 
     def pause_print(self):
         if self.is_homed() and not self.is_paused():
@@ -594,7 +597,7 @@ class afc:
                 self.TOOL_LOAD(CUR_LANE)
                 # Restore state
             if self.failure == False:
-                self.restore_pos(True)
+                self.restore_pos()
                 self.in_toolchange = False
 
     cmd_SET_COLOR_help = "change filaments color"


### PR DESCRIPTION
Added the zhop variable to the resume move. After the change is completed it will move to the previous z-height + the zhop height then move to the previous x,y. Finally, it drops back down to the pre-change z-height.