### PR TITLE
Update so RESUME calls AFC_Resume function, added check for buffer name before calling enable_buffer

### DIFF
--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -105,6 +105,9 @@ class afc:
         #self.debug = True == config.get('debug', 0)
         self.debug = False
 
+        # Constant variable for renaming RESUME macro
+        self.AFC_RENAME_RESUME_NAME = '_AFC_RENAMED_RESUME_'
+
     cmd_AFC_STATUS_help = "Return current status of AFC"
     def cmd_AFC_STATUS(self, gcmd):
         status_msg = ''
@@ -291,7 +294,7 @@ class afc:
     def cmd_AFC_RESUME(self, gcmd):
         self.set_error_state(False)
         self.in_toolchange = False
-        self.gcode.run_script_from_command('RESUME')
+        self.gcode.run_script_from_command(self.AFC_RENAME_RESUME_NAME)
         self.restore_pos()
 
     cmd_HUB_CUT_TEST_help = "Test the cutting sequence of the hub cutter, expects LANE=legN"

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -28,13 +28,12 @@ class afcPrep:
         # Renaming users Resume macro so that RESUME calls AFC_Resume function instead
         base_resume_name = "RESUME"
         prev_cmd = self.gcode.register_command(base_resume_name, None)
-        if prev_cmd is None:
-            raise self.printer.config_error(
-                "Existing command '%s' not found in gcode_macro rename"
-                % (base_resume_name,))
-        pdesc = "Renamed builtin of '%s'" % (base_resume_name,)
+        if prev_cmd is not None:
+            pdesc = "Renamed builtin of '%s'" % (base_resume_name,)
+            self.gcode.register_command(self.AFC.AFC_RENAME_RESUME_NAME, prev_cmd, desc=pdesc)
+        else:
+            self.gcode.respond_info("{}Existing command {} not found in gcode_macros{}".format("<span class=warning--text>", base_resume_name, "</span>",))
 
-        self.gcode.register_command(self.AFC.AFC_RENAME_RESUME_NAME, prev_cmd, desc=pdesc)
         self.gcode.register_command(base_resume_name, self.AFC.cmd_AFC_RESUME, desc=self.AFC.cmd_AFC_RESUME_help)
 
         ## load Unit variables


### PR DESCRIPTION
Renaming users base resume and replacing with AFC_RESUME macro so that users can use normal resume button and AFC will still restores last position correctly

- Added check to make sure buffer name is set before calling enable_buffer