### PR TITLE
Fix: Adding protection to renaming macros if users call BT_PREP again from command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,3 +183,8 @@ gcode:
 ### Added
 
 - `generate_docs.py` utility in the `utilities` folder to auto-generate some basic documentation in the `docs/command_reference.md` file.
+
+## [2024-11-27]]
+
+### Fixed
+- Klipper erroring out when renaming `RESUME` macro when a user call's `BT_PREP` within the same reboot of klipper

--- a/config/macros/AFC_macros.cfg
+++ b/config/macros/AFC_macros.cfg
@@ -43,15 +43,6 @@ description: Run the AFC PREP sequence
 gcode:
   PREP
 
-[gcode_macro BT_RESUME]
-description: Resume the print after an error
-gcode:
-    {% if not printer.pause_resume.is_paused %}
-        RESPOND MSG="Print is not paused. Resume ignored"
-    {% else %}
-        AFC_RESUME
-    {% endif %}
-
 [gcode_macro T0]
 description: Change to tool 0
 gcode:

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -20,21 +20,30 @@ class afcPrep:
         self.gcode.register_command('PREP', self.PREP, desc=None)
         self.enable = config.getboolean("enable", False)
 
+        # Flag to set once resume rename as occured for the first time
+        self.rename_occured = False
+
+    def _rename_resume(self):
+        # Checking to see if rename has already been done, don't want to rename again if prep was already ran
+        if not self.rename_occured:
+            self.rename_occured = True
+            # Renaming users Resume macro so that RESUME calls AFC_Resume function instead
+            base_resume_name = "RESUME"
+            prev_cmd = self.gcode.register_command(base_resume_name, None)
+            if prev_cmd is not None:
+                pdesc = "Renamed builtin of '%s'" % (base_resume_name,)
+                self.gcode.register_command(self.AFC.AFC_RENAME_RESUME_NAME, prev_cmd, desc=pdesc)
+            else:
+                self.gcode.respond_info("{}Existing command {} not found in gcode_macros{}".format("<span class=warning--text>", base_resume_name, "</span>",))
+
+            self.gcode.register_command(base_resume_name, self.AFC.cmd_AFC_RESUME, desc=self.AFC.cmd_AFC_RESUME_help)
+
     def PREP(self, gcmd):
         self.AFC = self.printer.lookup_object('AFC')
         while self.printer.state_message != 'Printer is ready':
             self.reactor.pause(self.reactor.monotonic() + 1)
 
-        # Renaming users Resume macro so that RESUME calls AFC_Resume function instead
-        base_resume_name = "RESUME"
-        prev_cmd = self.gcode.register_command(base_resume_name, None)
-        if prev_cmd is not None:
-            pdesc = "Renamed builtin of '%s'" % (base_resume_name,)
-            self.gcode.register_command(self.AFC.AFC_RENAME_RESUME_NAME, prev_cmd, desc=pdesc)
-        else:
-            self.gcode.respond_info("{}Existing command {} not found in gcode_macros{}".format("<span class=warning--text>", base_resume_name, "</span>",))
-
-        self.gcode.register_command(base_resume_name, self.AFC.cmd_AFC_RESUME, desc=self.AFC.cmd_AFC_RESUME_help)
+        self._rename_resume()
 
         ## load Unit variables
         if os.path.exists(self.AFC.VarFile + '.unit') and os.stat(self.AFC.VarFile + '.unit').st_size > 0:
@@ -200,6 +209,7 @@ class afcPrep:
                 self.gcode.respond_raw(logo)
             else:
                 self.gcode.respond_raw(logo_error)
+
     def error_tool_unload(self, CUR_LANE):
         self.gcode.respond_info('Error on filament trying to correct')
         while CUR_LANE.load_state == True:

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -24,6 +24,11 @@ class afcPrep:
         self.rename_occured = False
 
     def _rename_resume(self):
+        """
+            Helper function to check if renaming RESUME macro has occured and renames RESUME.
+            Addes a new RESUME macro that points to AFC resume function
+        """
+
         # Checking to see if rename has already been done, don't want to rename again if prep was already ran
         if not self.rename_occured:
             self.rename_occured = True


### PR DESCRIPTION
- Fixes issue where klipper errors out when renaming resume macro if prep is called twice after a reboot 
- Adds a flag that get set when prep is called the first time so the renaming of resume macro can only happen once per reboot