### PR TITLE
AFC-9 Manual main to dev merge, fixed resume code

### DIFF
--- a/docs/command_reference.md
+++ b/docs/command_reference.md
@@ -5,26 +5,6 @@
 The following commands are built-in the AFC-Klipper-Add-On and are available through 
 the Klipper console.
 
-### SET_MULTIPLIER
-_Description_: This function handles the adjustment of the buffer multipliers for the turtleneck buffer.
-It retrieves the multiplier type ('HIGH' or 'LOW') and the factor to be applied. The function
-ensures that the factor is valid and updates the corresponding multiplier.  
-Usage: `SET_BUFFER_MULTIPLIER MULTIPLIER=<HIGH/LOW> FACTOR=<factor>`  
-Example: `SET_BUFFER_MULTIPLIER MULTIPLIER=HIGH FACTOR=1.2`  
-
-### SET_ROTATION_FACTOR
-_Description_: Adjusts the rotation distance of the current AFC stepper motor by applying a
-specified factor. If no factor is provided, it defaults to 1.0, which resets
-the rotation distance to the base value.  
-Usage: `SET_ROTATION_FACTOR FACTOR=<factor>`  
-Example: `SET_ROTATION_FACTOR FACTOR=1.2`  
-
-### QUERY_BUFFER
-_Description_: Reports the current state of the buffer sensor and, if applicable, the rotation
-distance of the current AFC stepper motor.  
-Usage: `QUERY_BUFFER BUFFER=<buffer_name>`  
-Example: `QUERY_BUFFER BUFFER=TN2`  
-
 ### AFC_STATUS
 _Description_: This function generates a status message for each unit and lane, indicating the preparation,
 loading, hub, and tool states. The status message is formatted with HTML tags for display.  
@@ -38,17 +18,6 @@ by the 'LENGTH' parameter. If the hub is not specified and a lane is currently l
 it uses the hub of the current lane.  
 Usage: ``SET_BOWDEN_LENGTH HUB=<hub> LENGTH=<length>``  
 Example: ``SET_BOWDEN_LENGTH HUB=Turtle_1 LENGTH=100``  
-
-### CLEAR_ERROR
-_Description_: This function clears the error state of the AFC system by setting the error state to False.  
-Usage: ``RESET_FAILURE``  
-Example: ``RESET_FAILURE``  
-
-### AFC_RESUME
-_Description_: This function clears the error state of the AFC system, sets the in_toolchange flag to False,
-runs the resume script, and restores the toolhead position to the last saved position.  
-Usage: ``AFC_RESUME``  
-Example: ``AFC_RESUME``  
 
 ### HUB_CUT_TEST
 _Description_: This function tests the cutting sequence of the hub cutter for a specified lane.
@@ -112,6 +81,37 @@ based on the information retrieved from the Spoolman API.
 Usage: ``SET_SPOOLID LANE=<lane> SPOOL_ID=<spool_id>``  
 Example: ``SET_SPOOLID LANE=leg1 SPOOL_ID=12345``  
 
+### SET_MULTIPLIER
+_Description_: This function handles the adjustment of the buffer multipliers for the turtleneck buffer.
+It retrieves the multiplier type ('HIGH' or 'LOW') and the factor to be applied. The function
+ensures that the factor is valid and updates the corresponding multiplier.  
+Usage: `SET_BUFFER_MULTIPLIER MULTIPLIER=<HIGH/LOW> FACTOR=<factor>`  
+Example: `SET_BUFFER_MULTIPLIER MULTIPLIER=HIGH FACTOR=1.2`  
+
+### SET_ROTATION_FACTOR
+_Description_: Adjusts the rotation distance of the current AFC stepper motor by applying a
+specified factor. If no factor is provided, it defaults to 1.0, which resets
+the rotation distance to the base value.  
+Usage: `SET_ROTATION_FACTOR FACTOR=<factor>`  
+Example: `SET_ROTATION_FACTOR FACTOR=1.2`  
+
+### QUERY_BUFFER
+_Description_: Reports the current state of the buffer sensor and, if applicable, the rotation
+distance of the current AFC stepper motor.  
+Usage: `QUERY_BUFFER BUFFER=<buffer_name>`  
+Example: `QUERY_BUFFER BUFFER=TN2`  
+
+### CLEAR_ERROR
+_Description_: This function clears the error state of the AFC system by setting the error state to False.  
+Usage: ``RESET_FAILURE``  
+Example: ``RESET_FAILURE``  
+
+### AFC_RESUME
+_Description_: This function clears the error state of the AFC system, sets the in_toolchange flag to False,
+runs the resume script, and restores the toolhead position to the last saved position.  
+Usage: ``AFC_RESUME``  
+Example: ``AFC_RESUME``  
+
 ## AFC Macros
 
 The following macros are defined in the `config/macros/AFC_macros.cfg` file.
@@ -130,8 +130,6 @@ _Description_: Move the specified lane the specified amount
 _Description_: Resume the print after an error
 ### BT_PREP
 _Description_: Run the AFC PREP sequence
-### BT_RESUME
-_Description_: Resume the print after an error
 ### T0
 _Description_: Change to tool 0
 ### T1

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -104,9 +104,6 @@ class afc:
         #self.debug = True == config.get('debug', 0)
         self.debug = False
 
-        # Constant variable for renaming RESUME macro
-        self.AFC_RENAME_RESUME_NAME = '_AFC_RENAMED_RESUME_'
-
     cmd_AFC_STATUS_help = "Return current status of AFC"
     def cmd_AFC_STATUS(self, gcmd):
         """

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -357,7 +357,7 @@ class afc:
         self.gcode.respond_info('TEST ROUTINE')
         try:
             CUR_LANE = self.printer.lookup_object('AFC_stepper '+lane)
-        except error as e:
+        except error:
             self.ERROR.fix('could not find stepper ' + lane)  #send to error handling
             return
         self.gcode.respond_info('Testing at full speed')

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -51,7 +51,7 @@ class afcError:
 
             else:
                 self.PauseUserIntervention('Filament not loaded in Lane')
-    
+
     def PauseUserIntervention(self,message):
         #pause for user intervention
         self.gcode.respond_info(message)
@@ -69,7 +69,7 @@ class afcError:
     def AFC_error(self, msg, pause=True):
         # Handle AFC errors
         self.gcode._respond_error( msg )
-        
+
 
     cmd_CLEAR_ERROR_help = "CLEAR STATUS ERROR"
     def cmd_CLEAR_ERROR(self, gcmd):
@@ -86,7 +86,7 @@ class afcError:
             None
         """
         self.set_error_state(False)
-    
+
     cmd_AFC_RESUME_help = "Clear error state and restores position before resuming the print"
     def cmd_AFC_RESUME(self, gcmd):
         """
@@ -114,7 +114,7 @@ class afcError:
         msg = (CUR_LANE.name.upper() + ' NOT READY' + message)
         self.AFC_error(msg, pause)
         self.afc_led(self.led_fault, CUR_LANE.led_index)
-            
+
 def load_config(config):
     return afcError(config)
 

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -11,6 +11,9 @@ class afcError:
         self.gcode.register_command('RESET_FAILURE', self.cmd_CLEAR_ERROR, desc=self.cmd_CLEAR_ERROR_help)
         self.gcode.register_command('AFC_RESUME', self.cmd_AFC_RESUME, desc=self.cmd_AFC_RESUME_help)
 
+        # Constant variable for renaming RESUME macro
+        self.AFC_RENAME_RESUME_NAME = '_AFC_RENAMED_RESUME_'
+
     def fix(self, problem, LANE=None):
         self.pause= True
         self.set_error_state(True)
@@ -70,13 +73,38 @@ class afcError:
 
     cmd_CLEAR_ERROR_help = "CLEAR STATUS ERROR"
     def cmd_CLEAR_ERROR(self, gcmd):
+        """
+        This function clears the error state of the AFC system by setting the error state to False.
+
+        Usage: `RESET_FAILURE`
+        Example: `RESET_FAILURE`
+
+        Args:
+            gcmd: The G-code command object containing the parameters for the command.
+
+        Returns:
+            None
+        """
         self.set_error_state(False)
     
     cmd_AFC_RESUME_help = "Clear error state and restores position before resuming the print"
     def cmd_AFC_RESUME(self, gcmd):
+        """
+        This function clears the error state of the AFC system, sets the in_toolchange flag to False,
+        runs the resume script, and restores the toolhead position to the last saved position.
+
+        Usage: `AFC_RESUME`
+        Example: `AFC_RESUME`
+
+        Args:
+            gcmd: The G-code command object containing the parameters for the command.
+
+        Returns:
+            None
+        """
         self.set_error_state(False)
         self.in_toolchange = False
-        self.gcode.run_script_from_command('RESUME')
+        self.gcode.run_script_from_command(self.AFC_RENAME_RESUME_NAME)
         self.restore_pos()
 
     handle_lane_failure_help = "Get load errors, stop stepper and respond error"

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -38,11 +38,11 @@ class afcPrep:
             prev_cmd = self.gcode.register_command(base_resume_name, None)
             if prev_cmd is not None:
                 pdesc = "Renamed builtin of '%s'" % (base_resume_name,)
-                self.gcode.register_command(self.AFC.AFC_RENAME_RESUME_NAME, prev_cmd, desc=pdesc)
+                self.gcode.register_command(self.ERROR.AFC_RENAME_RESUME_NAME, prev_cmd, desc=pdesc)
             else:
                 self.gcode.respond_info("{}Existing command {} not found in gcode_macros{}".format("<span class=warning--text>", base_resume_name, "</span>",))
 
-            self.gcode.register_command(base_resume_name, self.AFC.cmd_AFC_RESUME, desc=self.AFC.cmd_AFC_RESUME_help)
+            self.gcode.register_command(base_resume_name, self.ERROR.cmd_AFC_RESUME, desc=self.ERROR.cmd_AFC_RESUME_help)
 
     def PREP(self, gcmd):
         self.AFC = self.printer.lookup_object('AFC')


### PR DESCRIPTION
- Manually merged main into DEV to sync up commits
- Added docstrings back for MACRO function that moved to AFC_error.py
- Updated prep rename resume function to use AFC_RESUME from AFC_error
- Updated command reference document