### PR TITLE
Force restart of klipper if not printing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,4 +213,11 @@ gcode:
 ### Changed
 
 - Adjusted load and unload to account for ram sensor
-- Adjusted Prep to accound for ram sensor
+- Adjusted Prep to account for ram sensor
+
+## [2024-12-03]
+
+### Added
+
+- The `install-afc.sh` script will now query the printer upon exit to see if it is actively printing. If it is not
+  printing, it will restart the `klipper` service.

--- a/include/check_commands.sh
+++ b/include/check_commands.sh
@@ -125,3 +125,25 @@ check_unzip() {
     exit 1
   fi
 }
+
+check_for_jq() {
+  if ! command -v jq &> /dev/null; then
+    print_msg INFO "  jq is not installed. Installing jq..."
+    sudo apt-get update &> /dev/null
+    sudo apt-get install -y jq &> /dev/null
+  fi
+}
+
+query_printer_status() {
+  local response
+  local state
+
+  response=$(curl -s http://localhost/printer/objects/query?idle_timeout)
+  state=$(echo "$response" | jq -r '.result.status.idle_timeout.state')
+
+  if [ "$state" == "Ready" ]; then
+    return 0
+  else
+    return 1
+  fi
+}

--- a/include/exit_routines.sh
+++ b/include/exit_routines.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Armored Turtle Automated Filament Changer
+#
+# Copyright (C) 2024 Armored Turtle
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+exit_afc_install() {
+  echo "AFC_INSTALL_VERSION=$CURRENT_INSTALL_VERSION" > "${AFC_CONFIG_PATH}/.afc-version"
+  restart_klipper
+  exit 0
+}

--- a/include/utils.sh
+++ b/include/utils.sh
@@ -160,3 +160,12 @@ exclude_from_klipper_git() {
     fi
   done
 }
+
+restart_klipper() {
+  if query_printer_status; then
+    print_msg INFO "  Restarting Klipper..."
+    restart_service klipper
+  else
+    print_msg ERROR "  Printer is not ready, most likely printing. Ensure you restart Klippers when the printer is idle."
+  fi
+}

--- a/install-afc.sh
+++ b/install-afc.sh
@@ -173,6 +173,7 @@ if [ "$UNINSTALL" = "True" ]; then
   print_msg INFO " 1. Review your printer.cfg to ensure the AFC configuration is removed."
   print_msg INFO " 2. Remove any AFC configuration from your moonraker config."
   print_msg INFO " 3. Restart your Klipper service."
+  restart_klipper
   exit 0
 fi
 
@@ -180,6 +181,7 @@ fi
 clone_repo
 check_existing_install
 check_old_config_version
+check_for_jq
 set_install_version_if_missing
 if [ "$FORCE_UPDATE_NO_VERSION" == "False" ]; then
   check_version_and_set_force_update
@@ -211,7 +213,7 @@ if [ "$PRIOR_INSTALLATION" = "True" ] && [ "$FORCE_UPDATE" = False ]; then
       UPDATE_CONFIG=True
     else
       print_msg INFO "  Skipping configuration update."
-      exit 0
+      exit_afc_install
     fi
   fi
 fi
@@ -222,8 +224,7 @@ if [ "$PRIOR_INSTALLATION" = "True" ] && [ "$AUTO_UPDATE_CONFIG" = True ]; then
   print_msg INFO "  Auto updating configuration files..."
   print_msg INFO "  Please review your configuration files for accuracy."
   auto_update
-  echo "AFC_INSTALL_VERSION=$CURRENT_INSTALL_VERSION" > "${AFC_CONFIG_PATH}/.afc-version"
-  exit 0
+  exit_afc_install
 fi
 
 # If an existing installation is found, and we want to force run configuration changes.
@@ -309,9 +310,6 @@ if [ "$PRIOR_INSTALLATION" = "False" ] || [ "$UPDATE_CONFIG" = "True" ]; then
 
   print_msg INFO "  Prior to starting Klipper, please review all files in the AFC directory to ensure they are correct."
   print_msg WARNING "  This includes especially the AFC_Macro_Vars.cfg file and the pins in AFC_Hardware.cfg"
-  print_msg INFO "  Once you have reviewed the files, restart Klipper to apply the changes."
+  exit_afc_install
 
 fi
-
-# Set the installed-version to the latest version run
-echo "AFC_INSTALL_VERSION=$CURRENT_INSTALL_VERSION" > "${AFC_CONFIG_PATH}/.afc-version"


### PR DESCRIPTION
## Major Changes in this PR

- Install jq if missing (used for checking printer status)
- Add normalized exit_afc_install function to minimize duplication
- Add restart_klipper function that checks if the printer is actively printing, and if not, restarts klipper. If it is printing, it will display a message instead.

## Notes to Code Reviewers

n/a

## How the changes in this PR are tested

- Local testing

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
