### PR TITLE
Led fixes, misc fixes and merged main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,3 +225,10 @@ gcode:
 
 ### Fixed
 - Fixed issue with Turtleneck buffer pins not being assigned correctly when prompted during install
+- Fixed issue with LEDs not showing the right color when error happened during PREP
+- Changed error message when AFC.vars.unit lane showed loaded but AFC.vars.tool file didn't match
+- Added logic so that user could change trsync value. To set value add the following into `[AFC]` section in AFC.cfg file:  
+`trsync_update: True`  
+Optional:  
+`trsync_timeout: 0.05`  
+`TRSYNC_SINGLE_MCU_TIMEOUT: 0.5` 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,3 +221,7 @@ gcode:
 
 - The `install-afc.sh` script will now query the printer upon exit to see if it is actively printing. If it is not
   printing, it will restart the `klipper` service.
+## [2024-12-04]
+
+### Fixed
+- Fixed issue with Turtleneck buffer pins not being assigned correctly when prompted during install

--- a/config/mcu/AFC_Lite.cfg
+++ b/config/mcu/AFC_Lite.cfg
@@ -10,7 +10,7 @@ aliases:
     HUB=PC4 		, 
     TRG1=PC5  		, TRG2=PB0  	, TRG3=PB1 		, TRG4=PB2		,
     EXT1=PE8 		, EXT2=PE9	, EXT3=PE10		, EXT4=PE11		,
-
+    TN_ADV=PE12         , TN_TRL=PE13   ,
     # alternate names for endstop ports
     SW1=PC4 		, SW2=PC5 	, SW3=PB0  	, SW4=PB1 	, SW5=PB2	, SW6=PE7	,
     SW7=PE8 		, SW8=PE9	, SW9=PE10	, SW10=PE11	, SW11=PE12	, SW12=PE13	,

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -97,7 +97,7 @@ class afc:
         # Get debug and cast to boolean
         #self.debug = True == config.get('debug', 0)
         self.debug = False
-    
+
     def _update_trsync(self, config):
         # Logic to update trsync values
         update_trsync = config.getboolean("trsync_update", False)

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -107,6 +107,7 @@ class afc:
                 trsync_value = config.getfloat("trsync_timeout", 0.05)
                 trsync_single_value = config.getfloat("trsync_single_timeout", 0.5)
 
+                # Making sure value exists as danker klipper does not have TRSYNC_TIMEOUT value
                 if( hasattr(mcu, "TRSYNC_TIMEOUT")): mcu.TRSYNC_TIMEOUT = max(mcu.TRSYNC_TIMEOUT, trsync_value)
                 else : self.gcode.respond_info("TRSYNC_TIMEOUT does not exist in mcu file, not updating")
 

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -90,11 +90,28 @@ class afc:
         self.resume_speed =config.getfloat("resume_speed", 0)
         self.resume_z_speed = config.getfloat("resume_z_speed", 0)
 
+        self._update_trsync(config)
+
         self.VarFile = config.get('VarFile')
 
         # Get debug and cast to boolean
         #self.debug = True == config.get('debug', 0)
         self.debug = False
+    
+    def _update_trsync(self, config):
+        # Logic to update trsync values
+        update_trsync = config.getboolean("trsync_update", False)
+        if update_trsync:
+            try:
+                import mcu
+                trsync_value = config.getfloat("trsync_timeout", 0.05)
+                trsync_single_value = config.getfloat("trsync_single_timeout", 0.5)
+                if( hasattr(mcu, "TRSYNC_TIMEOUT")): mcu.TRSYNC_TIMEOUT = max(mcu.TRSYNC_TIMEOUT, trsync_value)
+                else : self.gcode.respond_info("TRSYNC_TIMEOUT does not exist in mcu file, not updating")
+                if( hasattr(mcu, "TRSYNC_SINGLE_MCU_TIMEOUT")): mcu.TRSYNC_SINGLE_MCU_TIMEOUT = max(mcu.TRSYNC_SINGLE_MCU_TIMEOUT, trsync_single_value)
+                else : self.gcode.respond_info("TRSYNC_SINGLE_MCU_TIMEOUT does not exist in mcu file, not updating")
+            except Exception as e:
+                self.gcode.respond_info("Unable to update TRSYNC_TIMEOUT: {}".format(e))
 
     def handle_connect(self):
         """

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -106,8 +106,10 @@ class afc:
                 import mcu
                 trsync_value = config.getfloat("trsync_timeout", 0.05)
                 trsync_single_value = config.getfloat("trsync_single_timeout", 0.5)
+
                 if( hasattr(mcu, "TRSYNC_TIMEOUT")): mcu.TRSYNC_TIMEOUT = max(mcu.TRSYNC_TIMEOUT, trsync_value)
                 else : self.gcode.respond_info("TRSYNC_TIMEOUT does not exist in mcu file, not updating")
+
                 if( hasattr(mcu, "TRSYNC_SINGLE_MCU_TIMEOUT")): mcu.TRSYNC_SINGLE_MCU_TIMEOUT = max(mcu.TRSYNC_SINGLE_MCU_TIMEOUT, trsync_single_value)
                 else : self.gcode.respond_info("TRSYNC_SINGLE_MCU_TIMEOUT does not exist in mcu file, not updating")
             except Exception as e:

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -80,7 +80,7 @@ class afcBoxTurtle:
                                 CUR_EXTRUDER.enable_buffer()
                         else:
                             if CUR_EXTRUDER.tool_start_state == True:
-                                msg +="<span class=error--text> error in ToolHead. \nLane identified as loaded in AFC.vars.unit \nfile but not identified as loaded in AFC.var.tool file</span>"
+                                msg +="<span class=error--text> error in ToolHead. \nLane identified as loaded in AFC.vars.unit file\n but not identified as loaded in AFC.var.tool file</span>"
                                 succeeded = False
                     else:
                         lane_check=self.AFC.ERROR.fix('toolhead',CUR_LANE)  #send to error handling

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -46,10 +46,11 @@ class afcBoxTurtle:
                 self.AFC.afc_led(self.AFC.led_not_ready, CUR_LANE.led_index)
                 msg += 'EMPTY READY FOR SPOOL'
             else:
+                self.AFC.afc_led(self.AFC.led_fault, CUR_LANE.led_index)
                 CUR_LANE.status = None
                 msg +="<span class=error--text> NOT READY</span>"
                 CUR_LANE.do_enable(False)
-                msg = '<span class=secondary--text>CHECK FILAMENT Prep: False - Load: True</span>'
+                msg = '<span class=error--text>CHECK FILAMENT Prep: False - Load: True</span>'
 
         else:
             CUR_LANE.hub_load = self.AFC.lanes[UNIT][LANE]['hub_loaded'] # Setting hub load state so it can be retained between restarts
@@ -57,6 +58,7 @@ class afcBoxTurtle:
             msg +="<span class=success--text>LOCKED</span>"
             if CUR_LANE.load_state == False:
                 msg +="<span class=error--text> NOT LOADED</span>"
+                self.AFC.afc_led(self.AFC.led_not_ready, CUR_LANE.led_index)
             else:
                 CUR_LANE.status = 'Loaded'
                 msg +="<span class=success--text> AND LOADED</span>"
@@ -65,7 +67,7 @@ class afcBoxTurtle:
                     if CUR_EXTRUDER.tool_start_state == True or CUR_EXTRUDER.tool_start == "buffer":
                         if self.AFC.extruders[CUR_LANE.extruder_name]['lane_loaded'] == CUR_LANE.name:
                             CUR_LANE.extruder_stepper.sync_to_extruder(CUR_LANE.extruder_name)
-                            msg +="\n in ToolHead"
+                            msg +="<span class=primary--text> in ToolHead</span>"
                             if CUR_EXTRUDER.tool_start == "buffer":
                                 msg += "<span class=warning--text>\n Ram sensor enabled, confirm tool is loaded</span>"
                             self.AFC.SPOOL.set_active_spool(self.AFC.lanes[CUR_LANE.unit][CUR_LANE.name]['spool_id'])

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -80,13 +80,13 @@ class afcBoxTurtle:
                                 CUR_EXTRUDER.enable_buffer()
                         else:
                             if CUR_EXTRUDER.tool_start_state == True:
-                                if self.AFC.extruders[CUR_LANE.extruder_name]['lane_loaded'] == CUR_LANE.name:
-                                    msg +="<span class=error--text> error in ToolHead. Extruder loaded with no lane identified in AFC.vars.tool file</span>"
-                                    succeeded = False
+                                msg +="<span class=error--text> error in ToolHead. \nLane identified as loaded in AFC.vars.unit \nfile but not identified as loaded in AFC.var.tool file</span>"
+                                succeeded = False
                     else:
                         lane_check=self.AFC.ERROR.fix('toolhead',CUR_LANE)  #send to error handling
                         if not lane_check:
                             return False
+
         self.AFC.TcmdAssign(CUR_LANE)
         CUR_LANE.do_enable(False)
         self.AFC.gcode.respond_info( '{lane_name} tool cmd: {tcmd:3} {msg}'.format(lane_name=CUR_LANE.name.upper(), tcmd=CUR_LANE.map, msg=msg))

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -91,7 +91,7 @@ class afcBoxTurtle:
         CUR_LANE.do_enable(False)
         self.AFC.gcode.respond_info( '{lane_name} tool cmd: {tcmd:3} {msg}'.format(lane_name=CUR_LANE.name.upper(), tcmd=CUR_LANE.map, msg=msg))
         CUR_LANE.set_afc_prep_done()
-        
+
         return succeeded
 
 def load_config(config):

--- a/extras/AFC_NightOwl.py
+++ b/extras/AFC_NightOwl.py
@@ -75,7 +75,7 @@ class afcNightOwl:
                                 CUR_EXTRUDER.enable_buffer()
                         else:
                             if CUR_EXTRUDER.tool_start_state == True:
-                                msg +="<span class=error--text> error in ToolHead. \nLane identified as loaded in AFC.vars.unit \nfile but not identified as loaded in AFC.var.tool file</span>"
+                                msg +="<span class=error--text> error in ToolHead. \nLane identified as loaded in AFC.vars.unit file\n but not identified as loaded in AFC.var.tool file</span>"
                                 succeeded = False
                     else:
                         lane_check=self.AFC.ERROR.fix('toolhead',CUR_LANE)  #send to error handling

--- a/extras/AFC_NightOwl.py
+++ b/extras/AFC_NightOwl.py
@@ -41,10 +41,11 @@ class afcNightOwl:
                 self.AFC.afc_led(self.AFC.led_not_ready, CUR_LANE.led_index)
                 msg += 'EMPTY READY FOR SPOOL'
             else:
+                self.AFC.afc_led(self.AFC.led_fault, CUR_LANE.led_index)
                 CUR_LANE.status = None
                 msg +="<span class=error--text> NOT READY</span>"
                 CUR_LANE.do_enable(False)
-                msg = '<span class=secondary--text>CHECK FILAMENT Prep: False - Load: True</span>'
+                msg = '<span class=error--text>CHECK FILAMENT Prep: False - Load: True</span>'
 
         else:
             CUR_LANE.hub_load = self.AFC.lanes[UNIT][LANE]['hub_loaded'] # Setting hub load state so it can be retained between restarts
@@ -52,6 +53,7 @@ class afcNightOwl:
             msg +="<span class=success--text>LOCKED</span>"
             if CUR_LANE.load_state == False:
                 msg +="<span class=error--text> NOT LOADED</span>"
+                self.AFC.afc_led(self.AFC.led_not_ready, CUR_LANE.led_index)
             else:
                 CUR_LANE.status = 'Loaded'
                 msg +="<span class=success--text> AND LOADED</span>"
@@ -60,7 +62,7 @@ class afcNightOwl:
                     if CUR_EXTRUDER.tool_start_state == True or CUR_EXTRUDER.tool_start == "buffer":
                         if self.AFC.extruders[CUR_LANE.extruder_name]['lane_loaded'] == CUR_LANE.name:
                             CUR_LANE.extruder_stepper.sync_to_extruder(CUR_LANE.extruder_name)
-                            msg +="\n in ToolHead"
+                            msg +="<span class=primary--text> in ToolHead</span>"
                             if CUR_EXTRUDER.tool_start == "buffer":
                                 msg += "<span class=warning--text>\n Ram sensor enabled, confirm tool is loaded</span>"
                             self.AFC.SPOOL.set_active_spool(self.AFC.lanes[CUR_LANE.unit][CUR_LANE.name]['spool_id'])

--- a/extras/AFC_NightOwl.py
+++ b/extras/AFC_NightOwl.py
@@ -19,10 +19,11 @@ class afcNightOwl:
         self.logo+='Y  {/^^^\}\n'
         self.logo+='!   `m-m`\n'
 
-        self.logo_error = 'Night Owl Not Ready\n'
+        self.logo_error = '<span class=error--text>Night Owl Not Ready</span>\n'
 
     def system_Test(self, UNIT, LANE, delay):
         msg = ''
+        succeeded = True
         CUR_LANE = self.printer.lookup_object('AFC_stepper ' + LANE)
         try: CUR_EXTRUDER = self.printer.lookup_object('AFC_extruder ' + CUR_LANE.extruder_name)
         except:
@@ -46,6 +47,7 @@ class afcNightOwl:
                 msg +="<span class=error--text> NOT READY</span>"
                 CUR_LANE.do_enable(False)
                 msg = '<span class=error--text>CHECK FILAMENT Prep: False - Load: True</span>'
+                succeeded = False
 
         else:
             CUR_LANE.hub_load = self.AFC.lanes[UNIT][LANE]['hub_loaded'] # Setting hub load state so it can be retained between restarts
@@ -54,6 +56,7 @@ class afcNightOwl:
             if CUR_LANE.load_state == False:
                 msg +="<span class=error--text> NOT LOADED</span>"
                 self.AFC.afc_led(self.AFC.led_not_ready, CUR_LANE.led_index)
+                succeeded = False
             else:
                 CUR_LANE.status = 'Loaded'
                 msg +="<span class=success--text> AND LOADED</span>"
@@ -71,19 +74,19 @@ class afcNightOwl:
                                 self.AFC.current = CUR_LANE.name
                                 CUR_EXTRUDER.enable_buffer()
                         else:
-                            lane_check=self.AFC.ERROR.fix('toolhead',CUR_LANE)  #send to error handling
-                            if not lane_check:
-                                return False
+                            if CUR_EXTRUDER.tool_start_state == True:
+                                msg +="<span class=error--text> error in ToolHead. \nLane identified as loaded in AFC.vars.unit \nfile but not identified as loaded in AFC.var.tool file</span>"
+                                succeeded = False
                     else:
-                        if CUR_EXTRUDER.tool_start_state == True:
-                            if self.AFC.extruders[CUR_LANE.extruder_name]['lane_loaded'] == CUR_LANE.name:
-                                msg +="\n<span class=error--text> error in ToolHead. Extruder loaded with no lane identified</span>"
+                        lane_check=self.AFC.ERROR.fix('toolhead',CUR_LANE)  #send to error handling
+                        if not lane_check:
+                            return False
 
         self.AFC.TcmdAssign(CUR_LANE)
         CUR_LANE.do_enable(False)
-        self.AFC.gcode.respond_info(CUR_LANE.name.upper() + ' ' + msg + ' ' + CUR_LANE.map)
+        self.AFC.gcode.respond_info( '{lane_name} tool cmd: {tcmd:3} {msg}'.format(lane_name=CUR_LANE.name.upper(), tcmd=CUR_LANE.map, msg=msg))
         CUR_LANE.set_afc_prep_done()
-        return True
+        return succeeded
 
 def load_config(config):
     return afcNightOwl(config)

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -67,6 +67,7 @@ class afcPrep:
             self.AFC.extruders=json.load(open(self.AFC.VarFile + '.tool'))
         else:
             self.AFC.extruders={}
+
         temp=[]
         self.AFC.tool_cmds={}
         for PO in self.printer.objects:
@@ -137,8 +138,10 @@ class afcPrep:
                 logo_error=CUR_HUB.unit.logo_error
                 logo_error+='  ' + UNIT + '\n'
 
+                LaneCheck = True
                 for LANE in self.AFC.lanes[UNIT].keys():
-                    LaneCheck=CUR_HUB.unit.system_Test(UNIT,LANE, self.delay)
+                    if not CUR_HUB.unit.system_Test(UNIT,LANE, self.delay):
+                        LaneCheck = False
 
                 if LaneCheck:
                     self.AFC.gcode.respond_raw(logo)
@@ -154,7 +157,7 @@ class afcPrep:
                 CUR_EXTRUDER = self.printer.lookup_object('AFC_extruder ' + EXTRUDE)
                 if CUR_EXTRUDER.tool_start_state == True and bypass != True:
                     if not self.AFC.extruders[EXTRUDE]['lane_loaded']:
-                        self.AFC.gcode.respond_info(EXTRUDE + ' loaded with out knowing Lane')
+                        self.AFC.gcode.respond_info("<span class=error--text>{} loaded with out identifying lane in AFC.vars.tool file<span>".format(EXTRUDE))
 
 def load_config(config):
     return afcPrep(config)

--- a/include/buffer_configurations.sh
+++ b/include/buffer_configurations.sh
@@ -12,12 +12,12 @@ append_buffer_config() {
   local hardware_config_path="${AFC_CONFIG_PATH}/AFC_Hardware.cfg"
   local buffer_config=""
   local buffer_name=""
-  local tn_advance_pin=$2
-  local tn_trailing_pin=$3
+  tn_advance_pin=$2
+  tn_trailing_pin=$3
 
   case "$buffer_system" in
     "TurtleNeck")
-      buffer_config=$(cat <<'EOF'
+      buffer_config=$(cat <<EOF
 [AFC_buffer TN]
 advance_pin: ${tn_advance_pin}    # set advance pin
 trailing_pin: ${tn_trailing_pin}  # set trailing pin
@@ -122,14 +122,15 @@ query_tn_pins() {
   # Arguments:
   #   $1: buffer_name - The name of the buffer to be added.
   local buffer_name="$1"
-  local tn_advance_pin="UNKNOWN"
-  local tn_trailing_pin="UNKNOWN"
   local input
+  tn_advance_pin="^AFC:TN_ADV"
+  tn_trailing_pin="^AFC:TN_TRL"
 
   print_msg INFO "  \n  Please enter the pin numbers for the TurtleNeck buffer '$buffer_name':"
   print_msg INFO "  (Leave blank to use the default values)"
-  print_msg INFO "  (Example: turtleneck:ADVANCE)"
-  print_msg INFO "  (Example: turtleneck:TRAILING)"
+  print_msg INFO "  Ensure you use a pull-up '^' if you are using a AFC end stop pin."
+  print_msg INFO "  (Example: ^AFC:TN_ADV)"
+  print_msg INFO "  (Example: ^AFC:TN_TRL)"
 
   read -p "  Enter the advance pin (default: $tn_advance_pin): " -r input
   if [ -n "$input" ]; then

--- a/install-afc.sh
+++ b/install-afc.sh
@@ -289,7 +289,7 @@ if [ "$PRIOR_INSTALLATION" = "False" ] || [ "$UPDATE_CONFIG" = "True" ]; then
   # Update buffer configuration
   if [ "$BUFFER_SYSTEM" == "TurtleNeck" ]; then
     query_tn_pins "TN"
-    append_buffer_config "TurtleNeck"
+    append_buffer_config "TurtleNeck" "$tn_advance_pin" "$tn_trailing_pin"
     add_buffer_to_extruder "${AFC_CONFIG_PATH}/AFC_Hardware.cfg" "TN"
   elif [ "$BUFFER_SYSTEM" == "TurtleNeckV2" ]; then
     append_buffer_config "TurtleNeckV2"


### PR DESCRIPTION
## Major Changes in this PR
- Merging in recent changes from main
- Fixed issue where LEDs were not getting set correctly in failure states
- Updated some error wording so it was clearer to users on what the error is
- Reversed else logic on lines 76-83 for AFC_BoxTurtle and 71-78 for NightOwl as the logic was backwards
- Fixed issue where dead turtle does not print when errors occurred during system_test
- Added logic for changing trsync

## Notes to Code Reviewers
Since I also merged in the recent changes from main, some of erics changes show in this PR as well

## How the changes in this PR are tested
LED Status
![PXL_20241204_233053640 NIGHT](https://github.com/user-attachments/assets/283b17cd-938b-4b14-9e80-19461c12ae84)

Dead Turtle and updated wording
![image](https://github.com/user-attachments/assets/a71a3280-5a49-4336-86ee-4abfc491c6f7)

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [ ] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Sent notification to software-design channel requesting review
