### PR TITLE
Added global accel value to macros and cleaned up default values

### DIFF
--- a/config/AFC_Macro_Vars.cfg
+++ b/config/AFC_Macro_Vars.cfg
@@ -10,12 +10,13 @@ gcode: # Leave Empty
 # Set this to match your AFC_stepper base naming in AFC_Hardware.cfg
 variable_stepper_name             : 'leg'     # [AFC_stepper leg1] [AFC_stepper leg2]...
 
-variable_travel_speed             : 350        # Speed mm/s
-variable_z_travel_speed           : 100        # Speed mm/s
-variable_verbose                  : 1            # Console Output for macros
-                                            #  0 - None
-                                            #  1 - Limited
-                                            #  2 - All
+variable_travel_speed             : 120        # Speed mm/s
+variable_z_travel_speed           : 30         # Speed mm/s
+variable_accel                    : 2000       # Move accel for all macro moves
+variable_verbose                  : 1          # Console Output for macros
+                                               #  0 - None
+                                               #  1 - Limited
+                                               #  2 - All
 
 
 #--=================================================================================-
@@ -25,6 +26,28 @@ variable_verbose                  : 1            # Console Output for macros
 description: Toolhead tip cutting macro configuration variables
 gcode: # Leave empty
 
+# This should be the position of the toolhead where the cutter arm just
+# lightly touches the depressor pin
+variable_pin_loc_xy               : -1, -1    # x,y coordinates of depressor pin
+
+# Accel during cut. This will overwrite the global accel for this macro. Set to 0 to use global accel
+variable_cut_accel                : 0
+
+# Direction to make the cut move (left, right, front, back)
+variable_cut_direction            : "left"
+
+# This distance is used to move toolhead to cut filament
+# and to create a small saftely distance that aids in generating momentum
+variable_pin_park_dist            : 6.0        # Distance in mm
+
+# Position of the toolhead when the cutter is fully compressed.
+# Distnace the toolhead needs to travel to compress the cutter arm.
+# To calculate this distance start at the pin_loc_xy position and move
+# your toolhead till the cutter arm is completely compressed. Take 0.5mm off this distance
+# as a buffer. 
+# Ex pin_loc_x : 9, 310  fully compressed at 0, 310 set cut_move_dist to 8.5
+variable_cut_move_dist            : 8.5        # Distance in mm
+
 # Speed related settings for tip cutting
 # Note that if the cut speed is too fast, the steppers can lose steps.
 # Therefore, for a cut:
@@ -33,9 +56,9 @@ gcode: # Leave empty
 # - We then make a slow move for the actual cut to happen 
 variable_cut_fast_move_speed      : 32        # Speed mm/s
 variable_cut_slow_move_speed      : 10        # Speed mm/s
-variable_evacuate_speed           : 150        # Speed mm/s
+variable_evacuate_speed           : 150       # Speed mm/s
 variable_cut_dwell_time           : 50        # Time to dwell at the cut point in ms
-variable_cut_fast_move_fraction   : 0.85        # Fraction of the move that uses fast move 0.0 - 1.0
+variable_cut_fast_move_fraction   : 0.85      # Fraction of the move that uses fast move 0.0 - 1.0
 variable_extruder_move_speed      : 25        # Speed mm/s for all extruder movement
 
 # If the toolhead returns to initial position after the cut is complete.
@@ -49,27 +72,8 @@ variable_retract_length           : 20
 # This can help prevent cloggin of some toolheads by doing a quick tip from to reduce stringing
 variable_quick_tip_forming        : False
 
-# Direction to make the cut move (left, right, front, back)
-variable_cut_direction            : "left"
-
 # Number of times to run the cut movement
 variable_cut_count                : 2
-
-# This should be the position of the toolhead where the cutter arm just
-# lightly touches the depressor pin
-variable_pin_loc_xy               : 9, 310    # x,y coordinates of depressor pin
-
-# This distance is used to move toolhead to cut filament
-# and to create a small saftely distance that aids in generating momentum
-variable_pin_park_dist            : 6.0        # Distance in mm
-
-# Position of the toolhead when the cutter is fully compressed.
-# Distnace the toolhead needs to travel to compress the cutter arm.
-# To calculate this distance start at the pin_loc_xy position and move
-# your toolhead till the cutter arm is completely compressed. Take 0.5mm off this distance
-# as a buffer. 
-# Ex pin_loc_x : 9, 310  fully compressed at 0, 310 set cut_move_dist to 8.5
-variable_cut_move_dist            : 8.5        # Distance in mm
 
 # Retract length and speed after the cut so that the cutter can go back 
 # into its origin position
@@ -95,7 +99,7 @@ variable_safe_margin_xy           : 30, 30    # Approx toolhead width +5mm, heig
 description: Poop macro configuration variables
 gcode: # Leave empty
 # (x,y) Location of where to purge
-variable_purge_loc_xy             : 297, 290
+variable_purge_loc_xy             : -1, -1
 
 # Speed, in mm/s, of the purge.
 variable_purge_spd                : 6.5
@@ -152,11 +156,14 @@ variable_purge_length_minimum     : 60.999
 description: Kick macro configuration variables
 gcode: # Leave empty
 # Location to move before kick
-variable_kick_start_loc           : 250, 300, 10
+variable_kick_start_loc           : -1, -1, 10
 
 variable_kick_z                   : 1.5 # Height to drop to for kick move
 
 variable_kick_speed               : 150 # Speed of kick movement
+
+# Accel of kick moves. This will overwrite the global accel for this macro. Set to 0 to use global accel
+variable_kick_accel               : 0
 
 # Direction to make the kick move (left, right, front, back)
 variable_kick_direction           : "right"
@@ -173,13 +180,13 @@ variable_z_after_kick             : 10 # Height of z after kick move
 description: Brush macro configuration variables
 gcode: # Leave empty
 # Position of the center of the brush (Set z to -1 if you dont want a z move)
-variable_brush_loc                : 217, 310, -1
+variable_brush_loc                : -1, -1, -1
 
 # Speed of cleaning moves when brushing
 variable_brush_clean_speed        : 150
 
-# Accel of cleaning moves when brushing
-variable_brush_clean_accel        : 1500
+# Accel of cleaning moves when brushing. This will overwrite the global accel for this macro. Set to 0 to use global accel
+variable_brush_clean_accel        : 0
 
 # Total width in mm of the brush in the X direction
 variable_brush_width              : 30
@@ -200,7 +207,7 @@ variable_brush_count              : 4 # Number of passes to make on the brush.
 description: Park macro configuration variables
 gcode: # Leave empty
 # Position to park the toolhead
-variable_park_loc_xy              : 270, 310
+variable_park_loc_xy              : -1, -1
 
 # Height to raise Z when moving to park. Leave 0 to disable
 # If you want z_hop during toolchanges please set the value in the AFC.cfg

--- a/config/macros/AFC_macros.cfg
+++ b/config/macros/AFC_macros.cfg
@@ -42,35 +42,3 @@ gcode:
 description: Run the AFC PREP sequence
 gcode:
   PREP
-
-[gcode_macro T0]
-description: Change to tool 0
-gcode:
-  {% set stepper = printer['gcode_macro _AFC_GLOBAL_VARS'].stepper_name|string %}
-  {% set ln = stepper ~ "1" %}
-  
-  CHANGE_TOOL LANE={ln}
-
-[gcode_macro T1]
-description: Change to tool 1
-gcode:
-  {% set stepper = printer['gcode_macro _AFC_GLOBAL_VARS'].stepper_name|string %}
-  {% set ln = stepper ~ "2" %}
-  
-  CHANGE_TOOL LANE={ln}
-   
-[gcode_macro T2]
-description: Change to tool 2
-gcode:
-  {% set stepper = printer['gcode_macro _AFC_GLOBAL_VARS'].stepper_name|string %}
-  {% set ln = stepper ~ "3" %}
-  
-  CHANGE_TOOL LANE={ln}
-
-[gcode_macro T3]
-description: Change to tool 3
-gcode:
-  {% set stepper = printer['gcode_macro _AFC_GLOBAL_VARS'].stepper_name|string %}
-  {% set ln = stepper ~ "4" %}
-  
-  CHANGE_TOOL LANE={ln}

--- a/config/macros/Brush.cfg
+++ b/config/macros/Brush.cfg
@@ -2,6 +2,7 @@
 description: Wipe the nozzle on the brush
 gcode:
     {% set gVars = printer['gcode_macro _AFC_GLOBAL_VARS'] %}
+    {% set accel = gVars['accel']|float %}
     {% set travel_speed = gVars['travel_speed'] * 60|float %}
     {% set z_travel_speed = gVars['z_travel_speed'] * 60|float %}
     {% set verbose = gVars['verbose']|int %}
@@ -28,7 +29,15 @@ gcode:
 
     # Set the cleaning acceleration prior to any movement
     {% set saved_accel = printer.toolhead.max_accel %}
-    SET_VELOCITY_LIMIT ACCEL={brush_clean_accel}
+
+    # Check if macro accel is defined
+    {% if brush_clean_accel > 0 %}
+        {% set selected_accel = brush_clean_accel %}
+    {% else %}
+        {% set selected_accel = accel %}
+    {% endif %}
+    
+    SET_VELOCITY_LIMIT ACCEL={selected_accel}
 
     {% if verbose > 0 %}
       RESPOND TYPE=command MSG='AFC_Brush: Clean Nozzle'

--- a/config/macros/Cut.cfg
+++ b/config/macros/Cut.cfg
@@ -2,6 +2,7 @@
 description: Cut filament by pressing the cutter on a pin
 gcode:
     {% set gVars = printer['gcode_macro _AFC_GLOBAL_VARS'] %}
+    {% set accel = gVars['accel']|float %}
     {% set travel_speed = gVars['travel_speed'] * 60|float %}
     {% set verbose = gVars['verbose']|int %}
     {% set vars = printer['gcode_macro _AFC_CUT_TIP_VARS'] %}
@@ -11,6 +12,7 @@ gcode:
     {% set quick_tip_forming = vars['quick_tip_forming']|default(true)|lower == 'true' %}
     {% set rip_length = vars['rip_length']|float %}
     {% set cut_direction = vars['cut_direction']|default('')|lower %}
+    {% set cut_accel = vars['cut_accel']|float %}
     {% set pushback_length = vars['pushback_length']|float %}
     {% set pushback_dwell_time = vars['pushback_dwell_time']|int %}
     {% set extruder_move_speed = vars['extruder_move_speed'] * 60|float %}
@@ -48,6 +50,18 @@ gcode:
     {% endif %}
 
     SAVE_GCODE_STATE NAME=_AFC_CUT
+
+    # Save current Accel   
+    {% set saved_accel = printer.toolhead.max_accel %}
+
+    # Check if macro accel is defined
+    {% if cut_accel > 0 %}
+        {% set selected_accel = cut_accel %}
+    {% else %}
+        {% set selected_accel = accel %}
+    {% endif %}
+
+    SET_VELOCITY_LIMIT ACCEL={selected_accel}
 
     {% set prev_pa = printer.extruder.pressure_advance %}  # Save current PA
     SET_PRESSURE_ADVANCE ADVANCE=0  # Temporarily disable PA
@@ -90,6 +104,7 @@ gcode:
     {% if verbose > 1 %}
           RESPOND TYPE=command MSG='AFC_Cut: Final Cut...'
     {% endif %}
+
     # Do a rip on final cut pass
     _DO_CUT_MOTION PIN_PARK_X_LOC={pin_park_x_loc} PIN_PARK_Y_LOC={pin_park_y_loc} RIP_LENGTH={rip_length}
     
@@ -108,6 +123,9 @@ gcode:
     {% endif %}
 
     SET_PRESSURE_ADVANCE ADVANCE={prev_pa}  # Restore PA
+
+    # Reset acceleration values to what it was before
+    SET_VELOCITY_LIMIT ACCEL={saved_accel}
 
     # Restore state and optionally position
     RESTORE_GCODE_STATE NAME=_AFC_CUT MOVE={1 if restore_position else 0} MOVE_SPEED={travel_speed}
@@ -184,7 +202,9 @@ gcode:
     		{% if rip_length > 0 %}
     			G1 E-{rip_length} F{rip_speed}
     		{% endif %}
+            G4 P200
     		G1 X{pin_park_x_loc} F{evacuate_speed} # Evacuate
+            G4 P200
         {% endif %}
     {% elif cut_direction == "front" or cut_direction == "back" %}
         {% set fast_slow_transition_loc_y = pin_park_y_loc + location_factor[cut_direction].y * (cut_dist * cut_fast_move_fraction)| float %}
@@ -199,7 +219,9 @@ gcode:
     		{% if rip_length > 0 %}
     			G1 E-{rip_length} F{rip_speed}
     		{% endif %}
+            G4 P200
     		G1 Y{pin_park_y_loc} F{evacuate_speed} # Evacuate
+            G4 P200
         {% endif %}
     {% else %}
         { action_raise_error("Invalid cut direction. Check the cut_direction in your AFC_Macro_Vars.cfg file!") }

--- a/config/macros/Kick.cfg
+++ b/config/macros/Kick.cfg
@@ -1,22 +1,36 @@
 [gcode_macro AFC_KICK]
 gcode:
   {% set gVars = printer['gcode_macro _AFC_GLOBAL_VARS'] %}
+  {% set accel = gVars['accel']|float %}
   {% set travel_speed = gVars['travel_speed'] * 60|float %}
   {% set z_travel_speed = gVars['z_travel_speed'] * 60|float %}
   {% set verbose = gVars['verbose']|int %}
   {% set vars = printer['gcode_macro _AFC_KICK_VARS'] %}
   {% set kick_start_x, kick_start_y, kick_start_z = vars.kick_start_loc|map('float') %}
   {% set kick_z = vars['kick_z']|float %}
-  {% set kick_direction = vars['kick_direction']|default('')|lower %} %}
+  {% set kick_direction = vars['kick_direction']|default('')|lower %}
   {% set kick_move_dist = vars['kick_move_dist']|float %}
   {% set z_after_kick = vars['z_after_kick']|float %}
   {% set kick_speed = vars['kick_speed'] * 60|float %}
+  {% set kick_accel = vars['kick_accel']|float %}
 
   # Get printer bounds to make sure none of our kick moves fall outside of them
   {% set x_max = printer.toolhead.axis_maximum.x %}
   {% set x_min = printer.toolhead.axis_minimum.x %}
   {% set y_max = printer.toolhead.axis_maximum.y %}
   {% set y_min = printer.toolhead.axis_minimum.y %}
+
+  # Save current Accel
+  {% set saved_accel = printer.toolhead.max_accel %}
+
+    # Check if macro accel is defined
+  {% if kick_accel > 0 %}
+      {% set selected_accel = kick_accel %}
+  {% else %}
+      {% set selected_accel = accel %}
+  {% endif %}
+
+  SET_VELOCITY_LIMIT ACCEL={selected_accel}
 
   {% if verbose > 0 %}
     RESPOND TYPE=command MSG='AFC_Kick: Starting Filament Kick'
@@ -65,3 +79,6 @@ gcode:
   {% endif %}
   
   G1 Z{z_after_kick} F{z_travel_speed}
+
+  # Reset acceleration values to what it was before
+  SET_VELOCITY_LIMIT ACCEL={saved_accel}


### PR DESCRIPTION
## Major Changes in this PR
- Added global accel value to macros
- Added per macro accel value to Brush, Cut, and Kick that will overwrite the global if set 
- Removed T macro from AFC_macros
- Set all macro position default values to (x,y) -1,-1 to catch a user not defining them for their setup

## Notes to Code Reviewers

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [ ] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Sent notification to software-design channel requesting review
