### PR TITLE
Miscellaneous fixes/updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,3 +232,13 @@ gcode:
 Optional:  
 `trsync_timeout: 0.05`  
 `TRSYNC_SINGLE_MCU_TIMEOUT: 0.5` 
+
+## [2024-12-07]
+
+### Updated
+- When BT_TOOL_UNLOAD us used, spoolman active spool is set to None
+- When spool is ejected from Box Turtle spoolman spool is removed from variables
+- Activated espooler when user calls LANE_MOVE
+
+### Fixed
+- Fixed places where gcode was not referencing AFC and would cause crashes

--- a/README.md
+++ b/README.md
@@ -189,6 +189,10 @@ If your leds are not displaying the correct color update the following value und
 ### Filament pulling past extruder during unloads
 During unloads if your filament retracts too much and goes past the lanes extruder then decrease your `afc_bowden_length` value in `~/printer_data/config/AFC/AFC.cfg` file
 
+### Timer too close (TTC) error
+If you keep getting TTC errors start by adding the following to `AFC/AFC.cfg` file under `[AFC]` section  
+- `trsync_update: True`
+
 ## Removing Plugin
 
 To remove the plugin, you can use the following commands:

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -487,6 +487,10 @@ class afc:
             self.lanes[CUR_LANE.unit][CUR_LANE.name]['hub_loaded'] = CUR_LANE.hub_load
             self.save_vars()
             CUR_LANE.status = None
+
+            # Removing spool from vars since it was ejected
+            self.SPOOL.set_spoolID( CUR_LANE, "")
+
         else:
             self.gcode.respond_info('LANE ' + CUR_LANE.name + ' IS TOOL LOADED')
 
@@ -683,6 +687,9 @@ class afc:
             return
         CUR_LANE = self.printer.lookup_object('AFC_stepper '+ lane)
         self.TOOL_UNLOAD(CUR_LANE)
+
+        # User manually unloaded spool from toolhead, remove spool from active status
+        self.SPOOL.set_active_spool( None )
 
     def TOOL_UNLOAD(self, CUR_LANE):
         """

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -108,7 +108,7 @@ class afc:
                 trsync_value = config.getfloat("trsync_timeout", 0.05)
                 trsync_single_value = config.getfloat("trsync_single_timeout", 0.5)
 
-                # Making sure value exists as danker klipper does not have TRSYNC_TIMEOUT value
+                # Making sure value exists as kalico(danger klipper) does not have TRSYNC_TIMEOUT value
                 if( hasattr(mcu, "TRSYNC_TIMEOUT")): mcu.TRSYNC_TIMEOUT = max(mcu.TRSYNC_TIMEOUT, trsync_value)
                 else : self.gcode.respond_info("TRSYNC_TIMEOUT does not exist in mcu file, not updating")
 

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -107,6 +107,7 @@ class afc:
                 import mcu
                 trsync_value = config.getfloat("trsync_timeout", 0.05)
                 trsync_single_value = config.getfloat("trsync_single_timeout", 0.5)
+                self.gcode.respond_info("Applying TRSYNC update")
 
                 # Making sure value exists as kalico(danger klipper) does not have TRSYNC_TIMEOUT value
                 if( hasattr(mcu, "TRSYNC_TIMEOUT")): mcu.TRSYNC_TIMEOUT = max(mcu.TRSYNC_TIMEOUT, trsync_value)

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -284,7 +284,7 @@ class afc:
         lane = gcmd.get('LANE', None)
         distance = gcmd.get_float('DISTANCE', 0)
         CUR_LANE = self.printer.lookup_object('AFC_stepper ' + lane)
-        CUR_LANE.move(distance, self.short_moves_speed, self.short_moves_accel)
+        CUR_LANE.move(distance, self.short_moves_speed, self.short_moves_accel, True)
 
     def save_pos(self):
         # Only save previous location on the first toolchange call to keep an error state from overwriting the location

--- a/extras/AFC_NightOwl.py
+++ b/extras/AFC_NightOwl.py
@@ -11,13 +11,13 @@ class afcNightOwl:
         """
         self.AFC = self.printer.lookup_object('AFC')
 
-        self.logo = 'Night Owl Ready'
+        self.logo = '<span class=success--text>Night Owl Ready</span>'
         self.logo ='R  ,     ,\n'
         self.logo+='E  )\___/(\n'
         self.logo+='A {(@)v(@)}\n'
         self.logo+='D  {|~~~|}\n'
         self.logo+='Y  {/^^^\}\n'
-        self.logo+='!   `m-m`\n'
+        self.logo+='!   `m-m`</span>\n'
 
         self.logo_error = '<span class=error--text>Night Owl Not Ready</span>\n'
 

--- a/extras/AFC_NightOwl.py
+++ b/extras/AFC_NightOwl.py
@@ -12,7 +12,7 @@ class afcNightOwl:
         self.AFC = self.printer.lookup_object('AFC')
 
         self.logo = '<span class=success--text>Night Owl Ready</span>'
-        self.logo ='R  ,     ,\n'
+        self.logo ='<span class=success--text>R  ,     ,\n'
         self.logo+='E  )\___/(\n'
         self.logo+='A {(@)v(@)}\n'
         self.logo+='D  {|~~~|}\n'

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -74,8 +74,8 @@ class afcError:
         pause_print function verifies that the printer is homed and not currently paused before calling
         the base pause command
         """
-        self.gcode.respond_info ('PAUSING')
-        self.gcode.run_script_from_command('PAUSE')
+        self.AFC.gcode.respond_info ('PAUSING')
+        self.AFC.gcode.run_script_from_command('PAUSE')
 
     def set_error_state(self, state):
         # Only save position on first error state call

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -153,7 +153,7 @@ class afcPrep:
             try:
                 bypass = self.printer.lookup_object('filament_switch_sensor bypass').runout_helper
                 if bypass.filament_present == True:
-                    self.gcode.respond_info("Filament loaded in bypass, not doing toolchange")
+                    self.AFC.gcode.respond_info("Filament loaded in bypass, not doing toolchange")
             except: bypass = None
 
             for EXTRUDE in self.AFC.extruders.keys():

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -31,7 +31,6 @@ class afcPrep:
         """
         self.AFC = self.printer.lookup_object('AFC')
         self.AFC.gcode.register_command('PREP', self.PREP, desc=None)
-        
 
     def _rename_resume(self):
         """
@@ -71,7 +70,7 @@ class afcPrep:
             self.AFC.extruders={}
 
         temp=[]
-        
+
         self.AFC.tool_cmds={}
         for PO in self.printer.objects:
             if 'AFC_stepper' in PO and 'tmc' not in PO:

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -162,6 +162,10 @@ class afcPrep:
                     if not self.AFC.extruders[EXTRUDE]['lane_loaded']:
                         self.AFC.gcode.respond_info("<span class=error--text>{} loaded with out identifying lane in AFC.vars.tool file<span>".format(EXTRUDE))
 
+        # Defaulting to no active spool, putting at end so endpoint has time to register
+        if self.AFC.current is None:
+            self.AFC.SPOOL.set_active_spool( None )
+
 def load_config(config):
     return afcPrep(config)
 

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -138,7 +138,7 @@ class afcSpool:
                 return
             SpoolID = gcmd.get('SPOOL_ID', '')
             CUR_LANE = self.printer.lookup_object('AFC_stepper ' + lane)
-            self.set_spoolID(CURLANE, SpoolID)
+            self.set_spoolID(CUR_LANE, SpoolID)
 
     def set_spoolID(self, CUR_LANE, SpoolID):
         if self.AFC.spoolman_ip !=None:

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -26,6 +26,8 @@ class afcSpool:
         self.gcode.register_mux_command('SET_RUNOUT',None,None, self.cmd_SET_RUNOUT, desc=self.cmd_SET_RUNOUT_help)
         self.gcode.register_mux_command('SET_MAP',None,None, self.cmd_SET_MAP, desc=self.cmd_SET_MAP_help)
 
+        self.URL = 'http://{}:{}/api/v1/spool/'.format(self.AFC.spoolman_ip, self.AFC.spoolman_port)
+
 
     cmd_SET_MAP_help = "change filaments color"
     def cmd_SET_MAP(self, gcmd):
@@ -99,14 +101,16 @@ class afcSpool:
     def set_active_spool(self, ID):
         webhooks = self.printer.lookup_object('webhooks')
         if self.AFC.spoolman_ip != None:
-            if ID:
-                args = {'spool_id' : int(ID)}
-                try:
-                    webhooks.call_remote_method("spoolman_set_active_spool", **args)
-                except self.printer.command_error:
-                    self.gcode._respond_error("Error trying to set active spool")
+            if ID and ID is not None:
+                id = int(ID)
             else:
-                self.gcode.respond_info("Spool ID not set, cannot update spoolman with active spool")
+                id = None
+
+            args = {'spool_id' : id }
+            try:
+                webhooks.call_remote_method("spoolman_set_active_spool", **args)
+            except self.printer.command_error as e:
+                self.gcode._respond_error("Error trying to set active spool \n{}".format(e))
 
     cmd_SET_SPOOLID_help = "change filaments ID"
     def cmd_SET_SPOOLID(self, gcmd):
@@ -134,14 +138,18 @@ class afcSpool:
                 return
             SpoolID = gcmd.get('SPOOL_ID', '')
             CUR_LANE = self.printer.lookup_object('AFC_stepper ' + lane)
+            self.set_spoolID(CURLANE, SpoolID)
+
+    def set_spoolID(self, CUR_LANE, SpoolID):
+        if self.AFC.spoolman_ip !=None:
             if SpoolID !='':
                 try:
-                    url = 'http://' + self.AFC.spoolman_ip + ':'+ self.AFC.spoolman_port +"/api/v1/spool/" + SpoolID
+                    url =  "{}{}".format(self.URL, SpoolID)
                     result = json.load(urlopen(url))
                     self.AFC.lanes[CUR_LANE.unit][CUR_LANE.name]['spool_id'] = SpoolID
                     self.AFC.lanes[CUR_LANE.unit][CUR_LANE.name]['material'] = result['filament']['material']
                     self.AFC.lanes[CUR_LANE.unit][CUR_LANE.name]['color'] = '#' + result['filament']['color_hex']
-                    self.AFC.lanes[CUR_LANE.unit][CUR_LANE.name]['weight'] =  result['remaining_weight']
+                    if 'remaining_weight' in result: self.AFC.lanes[CUR_LANE.unit][CUR_LANE.name]['weight'] =  result['remaining_weight']
                 except:
                     self.AFC.ERROR.AFC_error("Error when trying to get Spoolman data for ID:{}".format(SpoolID))
             else:

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -66,7 +66,6 @@ class AFCExtruderStepper:
         self.stepper_kinematics = ffi_main.gc(
             ffi_lib.cartesian_stepper_alloc(b'x'), ffi_lib.free)
         self.assist_activate=False
-        self.gcode = self.printer.lookup_object('gcode')
         # Units
         unit = config.get('unit', None)
         if unit != None:
@@ -241,7 +240,7 @@ class AFCExtruderStepper:
             elif self.name == self.AFC.current and self.IDLE.state == 'Printing' and self.AFC.lanes[self.unit][self.name]['runout_lane'] != 'NONE':
                 self.status = None
                 self.AFC.afc_led(self.AFC.led_not_ready, led)
-                self.AFC.gcode.respond_info("Infinete Spool triggered")
+                self.AFC.gcode.respond_info("Infinite Spool triggered")
                 empty_LANE = self.printer.lookup_object('AFC_stepper ' + self.AFC.current)
                 change_LANE = self.printer.lookup_object('AFC_stepper ' + self.AFC.lanes[self.unit][self.name]['runout_lane'])
                 self.gcode.run_script_from_command(change_LANE.map)

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -248,7 +248,7 @@ class AFCExtruderStepper:
             else:
                 self.status = None
                 self.AFC.afc_led(self.AFC.led_not_ready, led)
-                
+
     def do_enable(self, enable):
         self.sync_print_time()
         stepper_enable = self.printer.lookup_object('stepper_enable')


### PR DESCRIPTION
## Major Changes in this PR
- Fixed errors where gcode.respond_info was not using AFC.gcode
- Added removing active spool when users use `BT_TOOL_UNLOAD`
- Added removing spool from variables when user eject spool from BT
- Added troubleshooting for TTC to turn on TRSYNC
- Added turning on espooler when using LANE_MOVE macro
## Notes to Code Reviewers

## How the changes in this PR are tested
Ejected lanes and used `BT_TOOL_UNLOAD`
## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
