### PR TITLE
AFC-21 Fixing error state and adding pause when prep goes false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,3 +242,8 @@ Optional:
 
 ### Fixed
 - Fixed places where gcode was not referencing AFC and would cause crashes
+
+## [2024-12-09]
+
+### Added
+- Added logic to pause print when filament goes past prep sensor. Verify that PAUSE macro move's toolhead off print when it's called.

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -17,7 +17,6 @@ class afc:
         self.ERROR = self.printer.load_object(config,'AFC_error')
         self.IDLE = self.printer.load_object(config,'idle_timeout')
         self.gcode = self.printer.lookup_object('gcode')
-        self.STATUS= self.IDLE.state
 
         self.gcode_move = self.printer.load_object(config, 'gcode_move')
         self.VarFile = config.get('VarFile')
@@ -875,7 +874,7 @@ class afc:
             None
         """
         if not self.is_homed():
-            self.ERROR.AFC_error("Please home printer before doing a toolchange")
+            self.ERROR.AFC_error("Please home printer before doing a toolchange", False)
             return
 
         cmd = gcmd.get_commandline()

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -92,7 +92,7 @@ class afcPrep:
                             self.AFC.lanes[LANE.unit][LANE.name]['color'] = '#' + result['filament']['color_hex']
                             if 'remaining_weight' in result: self.AFC.lanes[LANE.unit][LANE.name]['weight'] =  result['remaining_weight']
                         except:
-                            self.AFC.ERROR.AFC_error("Error when trying to get Spoolman data for ID:{}".format(self.AFC.lanes[LANE.unit][LANE.name]['spool_id']))
+                            self.AFC.ERROR.AFC_error("Error when trying to get Spoolman data for ID:{}".format(self.AFC.lanes[LANE.unit][LANE.name]['spool_id']), False)
 
                 if 'material' not in self.AFC.lanes[LANE.unit][LANE.name]: self.AFC.lanes[LANE.unit][LANE.name]['material']=''
                 if 'color' not in self.AFC.lanes[LANE.unit][LANE.name]: self.AFC.lanes[LANE.unit][LANE.name]['color']='#000000'

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -151,7 +151,7 @@ class afcSpool:
                     self.AFC.lanes[CUR_LANE.unit][CUR_LANE.name]['color'] = '#' + result['filament']['color_hex']
                     if 'remaining_weight' in result: self.AFC.lanes[CUR_LANE.unit][CUR_LANE.name]['weight'] =  result['remaining_weight']
                 except:
-                    self.AFC.ERROR.AFC_error("Error when trying to get Spoolman data for ID:{}".format(SpoolID))
+                    self.AFC.ERROR.AFC_error("Error when trying to get Spoolman data for ID:{}".format(SpoolID), False)
             else:
                 self.AFC.lanes[CUR_LANE.unit][CUR_LANE.name]['spool_id'] = ''
                 self.AFC.lanes[CUR_LANE.unit][CUR_LANE.name]['material'] = ''

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -228,7 +228,7 @@ class AFCExtruderStepper:
                     self.reactor.pause(self.reactor.monotonic() + 0.1)
                     if x> 40:
                         msg = (' FAILED TO LOAD, CHECK FILAMENT AT TRIGGER\n||==>--||----||------||\nTRG   LOAD   HUB    TOOL')
-                        self.AFC.AFC_error(msg)
+                        self.AFC.AFC_error(msg, False)
                         self.AFC.afc_led(self.AFC.led_fault, led)
                         self.status=''
                         break

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -237,14 +237,20 @@ class AFCExtruderStepper:
                 if self.load_state == True and self.prep_state == True:
                     self.status = 'Loaded'
                     self.AFC.afc_led(self.AFC.led_ready, led)
-            elif self.name == self.AFC.current and self.IDLE.state == 'Printing' and self.AFC.lanes[self.unit][self.name]['runout_lane'] != 'NONE':
-                self.status = None
-                self.AFC.afc_led(self.AFC.led_not_ready, led)
-                self.AFC.gcode.respond_info("Infinite Spool triggered")
-                empty_LANE = self.printer.lookup_object('AFC_stepper ' + self.AFC.current)
-                change_LANE = self.printer.lookup_object('AFC_stepper ' + self.AFC.lanes[self.unit][self.name]['runout_lane'])
-                self.gcode.run_script_from_command(change_LANE.map)
-                self.gcode.run_script_from_command('SET_MAP LANE=' + change_LANE.name + ' MAP=' + empty_LANE.map)
+            elif self.name == self.AFC.current and self.AFC.IDLE.state == 'Printing':
+                # Checking to make sure runout_lane is set and does not equal 'NONE'
+                if self.AFC.lanes[self.unit][self.name]['runout_lane'] and self.AFC.lanes[self.unit][self.name]['runout_lane'] != 'NONE':
+                    self.status = None
+                    self.AFC.afc_led(self.AFC.led_not_ready, led)
+                    self.AFC.gcode.respond_info("Infinite Spool triggered for {}".format(self.name))
+                    empty_LANE = self.printer.lookup_object('AFC_stepper ' + self.AFC.current)
+                    change_LANE = self.printer.lookup_object('AFC_stepper ' + self.AFC.lanes[self.unit][self.name]['runout_lane'])
+                    self.gcode.run_script_from_command(change_LANE.map)
+                    self.gcode.run_script_from_command('SET_MAP LANE=' + change_LANE.name + ' MAP=' + empty_LANE.map)
+                else:
+                    # Pause print
+                    self.AFC.gcode.respond_info("Runout triggered for lane {} and runout lane is not setup to switch to another lane".format(self.name))
+                    self.AFC.ERROR.pause_print()
             else:
                 self.status = None
                 self.AFC.afc_led(self.AFC.led_not_ready, led)


### PR DESCRIPTION
## Major Changes in this PR
- Fixing error state, error state will only be set to true when a pause is commanded. Made sure error state and pause variables get reset back to false when resume is called.
- Added logic to pause print when prep sensor goes false
- Had to add a check to make sure runout_lane was not blank
- Fixed other errors where functions were not referencing self.AFC

## Notes to Code Reviewers

## How the changes in this PR are tested
Tested with short filament so that it caused prep to de-active when filament passed the sensor
## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Sent notification to software-design channel requesting review
