### PR TITLE
AFC-23 Distance calibration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -255,4 +255,14 @@ Optional:
 - When updating the AFC software, the `install-afc.sh` script will now remove any instances of `[gcode_macro T#]` found in the `AFC_Macros.cfg`
 file as the code now generates them automatically.
 
+## [Unreleased]
+
+### Added
+- **New Command: CALIBRATE_AFC**  
+    Allows calibration of the hub position and Bowden length in the Automated Filament Changer (AFC) system.  
+    Supports calibration for a specific lane or all lanes (LANES parameter).  
+    Provides options for distance and tolerance during calibration:
+    - `DISTANCE=<distance>`: Optional distance parameter for lane movement during calibration (default is 25mm).
+    - `TOLERANCE=<tolerance>`: Optional tolerance for fine-tuning adjustments during calibration (default is 5mm).  
+    - Bowden Calibration: Added functionality to calibrate Bowden length for individual lanes using the `BOWDEN` parameter.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -258,7 +258,7 @@ file as the code now generates them automatically.
 ## [Unreleased]
 
 ### Added
-- **New Command: CALIBRATE_AFC**  
+- **New Command: `CALIBRATE_AFC`**  
     Allows calibration of the hub position and Bowden length in the Automated Filament Changer (AFC) system.  
     Supports calibration for a specific lane or all lanes (LANES parameter).  
     Provides options for distance and tolerance during calibration:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -255,12 +255,12 @@ Optional:
 - When updating the AFC software, the `install-afc.sh` script will now remove any instances of `[gcode_macro T#]` found in the `AFC_Macros.cfg`
 file as the code now generates them automatically.
 
-## [Unreleased]
+## [2024-12-09]
 
 ### Added
 - **New Command: `CALIBRATE_AFC`**  
     Allows calibration of the hub position and Bowden length in the Automated Filament Changer (AFC) system.  
-    Supports calibration for a specific lane or all lanes (LANES parameter).  
+    Supports calibration for a specific lane or all lanes (`LANES` parameter).  
     Provides options for distance and tolerance during calibration:
     - `DISTANCE=<distance>`: Optional distance parameter for lane movement during calibration (default is 25mm).
     - `TOLERANCE=<tolerance>`: Optional tolerance for fine-tuning adjustments during calibration (default is 5mm).  

--- a/docs/command_reference.md
+++ b/docs/command_reference.md
@@ -79,6 +79,15 @@ current lane and loading the new lane.
 Usage: ``CHANGE_TOOL LANE=<lane>``  
 Example: ``CHANGE_TOOL LANE=leg1``  
 
+### CALIBRATE_AFC
+_Description_: This function performs the calibration of the hub and Bowden length for one or more lanes within an AFC
+(Automated Filament Changer) system. The function uses precise movements to adjust the positions of the
+steppers, check the state of the hubs and tools, and calculate distances for calibration based on the
+user-provided input. If no specific lane is provided, the function defaults to notifying the user that no lane has been selected. The function also includes
+the option to calibrate the Bowden length for a particular lane, if specified.
+Usage: ``CALIBRATE_AFC LANES=<lane> DISTANCE=<distance> TOLERANCE=<tolerance> BOWDEN=<lane>``  
+Example: `CALIBRATE_AFC LANES=all Bowden=leg1`  
+
 ### SET_MULTIPLIER
 _Description_: This function handles the adjustment of the buffer multipliers for the turtleneck buffer.
 It retrieves the multiplier type ('HIGH' or 'LOW') and the factor to be applied. The function

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -162,7 +162,7 @@ class afc:
             status_msg += '<span class=info--text>{} Status</span>\n'.format(UNIT)
 
             # Create a dynamic format string that adjusts based on lane name length
-            header_format = '{:<{}} | Prep | Load | Hub | Tool |\n'
+            header_format = '{:<{}} | Prep | Load |\n'
             status_msg += header_format.format("LANE", max_lane_length)
 
             for LANE in self.lanes[UNIT].keys():
@@ -186,27 +186,20 @@ class afc:
                 else:
                     lane_msg += '|  <span class=error--text>xx</span>  |'
                 if CUR_LANE.load_state == True:
-                    lane_msg += ' <span class=success--text><--></span> |'
+                    lane_msg += ' <span class=success--text><--></span> |\n'
                 else:
-                    lane_msg += '  <span class=error--text>xx</span>  |'
-
-                if self.current != None:
-                    if self.current == CUR_LANE.name:
-                        if CUR_HUB.state == True:
-                            lane_msg += ' <span class=success--text><-></span> |'
-                        else:
-                            lane_msg += '  <span class=error--text>xx</span>  |'
-                        if CUR_EXTRUDER.tool_start_state == True:
-                            lane_msg += ' <span class=success--text><--></span> |\n'
-                        else:
-                            lane_msg += '  <span class=error--text>xx</span>  |\n'
-                    else:
-                        lane_msg += '  <span class=error--text>x</span>  |'
-                        lane_msg += '  <span class=error--text>xx</span>  |\n'
-                else:
-                    lane_msg += '  <span class=error--text>x</span>  |'
                     lane_msg += '  <span class=error--text>xx</span>  |\n'
                 status_msg += lane_msg
+            if CUR_HUB.state == True:
+                status_msg += 'HUB: <span class=success--text><-></span>'
+            else:
+                status_msg += 'HUB: <span class=error--text>x</span>'
+            if CUR_EXTRUDER.tool_start_state == True:
+                status_msg += '  Tool: <span class=success--text><-></span>'
+            else:
+                status_msg += '  Tool: <span class=error--text>x</span>'
+            if CUR_EXTRUDER.tool_start == 'buffer':
+                status_msg += '\n<span class=info--text>Ram sensor enabled</span>'
         self.gcode.respond_raw(status_msg)
 
     cmd_SET_BOWDEN_LENGTH_help = "Helper to dynamically set length of bowden between hub and toolhead. Pass in HUB if using multiple box turtles"

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -174,13 +174,11 @@ class afcBoxTurtle:
             cal_msg += 'AFC Calibration distances +/-{}mm'.format(tol)
             cal_msg += '\n<span class=info--text>Update values in AFC_Hardware.cfg</span>'
             if lanes != 'all':
-                units = [unit for unit in self.AFC.lanes.keys()]
                 lane_to_calibrate = None
                 # Search for the lane within the units
-                for UNIT in units:
+                for UNIT in self.AFC.lanes.keys():
                     if lanes in self.AFC.lanes[UNIT]:
                         lane_to_calibrate = lanes
-                        unit = UNIT
                         break
                 if lane_to_calibrate is None:
                     self.AFC.gcode.respond_info('{} not found in any unit.'.format(lanes))

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -230,7 +230,8 @@ class afcBoxTurtle:
         if afc_bl is not None:
             if lanes is None:
                 self.AFC.gcode.respond_info('Starting AFC distance Calibrations')
-                cal_msg += 'AFC Calibration distances +/-{}mm\nUpdate values in AFC_Hardware.cfg'.format(tol)
+                cal_msg += 'AFC Calibration distances +/-{}mm'.format(tol)
+                cal_msg += '\n<span class=info--text>Update values in AFC_Hardware.cfg</span>'
             lane = afc_bl
             CUR_LANE = self.printer.lookup_object('AFC_stepper ' + lane)
             CUR_EXTRUDER = self.printer.lookup_object('AFC_extruder ' + CUR_LANE.extruder_name)


### PR DESCRIPTION
## Major Changes in this PR

- Added `CALIBRATE_AFC` function
  - Users can use this function to find `dist_hub` values as well as their `afc_bowden_length`
 
![image](https://github.com/user-attachments/assets/2c985134-092c-4670-8010-c9dea7c5139b)

- Update to AFC_STATUS
  - Simplified so that hub and tool are not shown for all lanes
  - hub and tool are now shown separately and will report current status
![image](https://github.com/user-attachments/assets/f98fea9d-6591-4efa-b5a6-979481e2c433)


 
## Notes to Code Reviewers
- expected functionality:
  - when a lane is selected using the variable `LANES` AFC will move than lane past the load sensor, bring it back forward until it finds the sensor to the tolerance set (default 5mm)
  - the lane will then be loaded to the hub sensor and the same check is performed.
  - specifying `LANES=all` will run the check for all lanes
  - calling out a lane to check bowden length using the variable `BOWDEN` will move to the hub and do it's check there and then make moves to the toolhead
      - once the checks at the toolhead are complete it will retract back the measured distance and reset it self at the hub
  - ALL VALUES MUST BE UPDATED IN CONFIG FILE

## How the changes in this PR are tested
- Run through different variations of the `CALIBRATE_AFC` command and confirm functionality.
## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
