### PR TITLE
Update so printer does not issue pause when ejecting filament

### DIFF
--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -468,6 +468,10 @@ class afc:
         CUR_LANE = self.printer.lookup_object('AFC_stepper '+ lane)
         CUR_HUB = self.printer.lookup_object('AFC_hub '+ CUR_LANE.unit)
         if CUR_LANE.name != self.current:
+            # Setting status as ejecting so if filament is removed and de-activates the prep sensor while
+            # extruder motors are still running it does not trigger infinite spool or pause logic
+            # once user removes filament lanes status will go to None
+            CUR_LANE.status = 'ejecting'
             CUR_LANE.do_enable(True)
             if CUR_LANE.hub_load:
                 CUR_LANE.move(CUR_LANE.dist_hub * -1, CUR_LANE.dist_hub_move_speed, CUR_LANE.dist_hub_move_accel, True if CUR_LANE.dist_hub > 200 else False)
@@ -478,7 +482,6 @@ class afc:
             CUR_LANE.do_enable(False)
             self.lanes[CUR_LANE.unit][CUR_LANE.name]['hub_loaded'] = CUR_LANE.hub_load
             self.save_vars()
-            CUR_LANE.status = None
 
             # Removing spool from vars since it was ejected
             self.SPOOL.set_spoolID( CUR_LANE, "")

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -237,7 +237,7 @@ class AFCExtruderStepper:
                 if self.load_state == True and self.prep_state == True:
                     self.status = 'Loaded'
                     self.AFC.afc_led(self.AFC.led_ready, led)
-            elif self.name == self.AFC.current and self.AFC.IDLE.state == 'Printing':
+            elif self.name == self.AFC.current and self.AFC.IDLE.state == 'Printing' and self.load_state and self.status != 'ejecting':
                 # Checking to make sure runout_lane is set and does not equal 'NONE'
                 if self.AFC.lanes[self.unit][self.name]['runout_lane'] and self.AFC.lanes[self.unit][self.name]['runout_lane'] != 'NONE':
                     self.status = None


### PR DESCRIPTION
## Major Changes in this PR
- Setting lane status to ejecting and making sure status is not ejecting when going into infinite spool and pause logic
## Notes to Code Reviewers

## How the changes in this PR are tested
Pause is not issued when spools are ejected
## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
