### PR TITLE
Fixing errors where CUR_LANE is not passed in when calling ERROR.fix

### DIFF
--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -386,7 +386,7 @@ class afc:
         try:
             CUR_LANE = self.printer.lookup_object('AFC_stepper '+lane)
         except error:
-            self.ERROR.fix('could not find stepper ' + lane)  #send to error handling
+            self.ERROR.fix( 'could not find stepper {}'.format(lane), CUR_LANE )  #send to error handling
             return
         self.gcode.respond_info('Testing at full speed')
         CUR_LANE.assist(-1)
@@ -920,7 +920,7 @@ class afc:
                     if not self.TOOL_UNLOAD(CUR_LANE):
                         # Abort if the unloading process fails.
                         msg = (' UNLOAD ERROR NOT CLEARED')
-                        self.ERROR.fix(msg)  #send to error handling
+                        self.ERROR.fix(msg, CUR_LANE)  #send to error handling
                         return
 
                 # Switch to the new lane for loading.

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -20,7 +20,7 @@ class afcError:
         self.AFC.gcode.register_command('RESET_FAILURE', self.cmd_RESET_FAILURE, desc=self.cmd_RESET_FAILURE_help)
         self.AFC.gcode.register_command('AFC_RESUME', self.cmd_AFC_RESUME, desc=self.cmd_AFC_RESUME_help)
 
-    def fix(self, problem, LANE=None):
+    def fix(self, problem, LANE):
         self.pause= True
         self.AFC = self.printer.lookup_object('AFC')
         error_handled = False


### PR DESCRIPTION
## Major Changes in this PR
Fixing error where current lane was not passed in when calling ERROR.fix, removed default value of None since a lane should always be passed in.

## Notes to Code Reviewers

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
