### PR TITLE
Add catch to Calibration

### DIFF
--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1005,7 +1005,7 @@ class afc:
             CUR_EXTRUDER = self.printer.lookup_object('AFC_extruder ' + EXTRUDE)
             str["system"]["extruders"][EXTRUDE]['lane_loaded'] = self.extruders[LANE.extruder_name]['lane_loaded']
             if CUR_EXTRUDER.tool_start == "buffer":
-                if self.extruders[LANE.extruder_name]['lane_loaded'] == None:
+                if self.extruders[LANE.extruder_name]['lane_loaded'] == '':
                     str ["system"]["extruders"][EXTRUDE]['tool_start_sensor'] = False
                 else:
                     str["system"]["extruders"][EXTRUDE]['tool_start_sensor'] = True

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -133,6 +133,22 @@ class afcBoxTurtle:
 
         cal_msg = ''
 
+        def find_lane_to_calibrate(lane_name):
+            """
+            Search for the given lane across all units in the AFC system.
+
+            Args: lane_name: The name of the lane to search for
+
+            Returns: The lane name if found, otherwise None
+            """
+            for UNIT in self.AFC.lanes.keys():
+                if lane_name in self.AFC.lanes[UNIT]:
+                    return lane_name
+
+            # If the lane was not found
+            self.AFC.gcode.respond_info('{} not found in any unit.'.format(lane_name))
+            return None
+
         # Helper functions for movement and calibration
         def calibrate_hub(CUR_LANE, CUR_HUB):
             hub_pos = 0
@@ -192,18 +208,13 @@ class afcBoxTurtle:
             cal_msg += 'AFC Calibration distances +/-{}mm'.format(tol)
             cal_msg += '\n<span class=info--text>Update values in AFC_Hardware.cfg</span>'
             if lanes != 'all':
-                lane_to_calibrate = None
-                # Search for the lane within the units
-                for UNIT in self.AFC.lanes.keys():
-                    if lanes in self.AFC.lanes[UNIT]:
-                        lane_to_calibrate = lanes
-                        break
+                lane_to_calibrate = find_lane_to_calibrate(lanes)
+
                 if lane_to_calibrate is None:
-                    self.AFC.gcode.respond_info('{} not found in any unit.'.format(lanes))
                     return
 
                 # Calibrate the specific lane
-                checked, msg = calibrate_lane(lanes)
+                checked, msg = calibrate_lane(lane_to_calibrate)
                 if(not checked): return
                 cal_msg += msg
             else:
@@ -223,7 +234,13 @@ class afcBoxTurtle:
                 self.AFC.gcode.respond_info('Starting AFC distance Calibrations')
                 cal_msg += 'AFC Calibration distances +/-{}mm'.format(tol)
                 cal_msg += '\n<span class=info--text>Update values in AFC_Hardware.cfg</span>'
-            lane = afc_bl
+
+            lane_to_calibrate = find_lane_to_calibrate(afc_bl)
+
+            if lane_to_calibrate is None:
+                return
+
+            lane = lane_to_calibrate
             CUR_LANE = self.printer.lookup_object('AFC_stepper ' + lane)
             CUR_EXTRUDER = self.printer.lookup_object('AFC_extruder ' + CUR_LANE.extruder_name)
             CUR_HUB = self.printer.lookup_object('AFC_hub ' + CUR_LANE.unit)


### PR DESCRIPTION
## Major Changes in this PR
- add function to catch if a lane is given that is not in a unit
## Notes to Code Reviewers

## How the changes in this PR are tested
- call the calibration function with a lane that does not exist in your config
## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Sent notification to software-design channel requesting review
