### PR TITLE
Fixing misc errors and errors found from users on discord and adding support for spoolman multicolors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,17 +243,12 @@ Optional:
 ### Fixed
 - Fixed places where gcode was not referencing AFC and would cause crashes
 
-
-## [2024-12-09]
-
-### Added
-- Added logic to pause print when filament goes past prep sensor. Verify that PAUSE macro move's toolhead off print when it's called.
-=======
 ## [2024-12-08]
 
 ### Added
 - When updating the AFC software, the `install-afc.sh` script will now remove any instances of `[gcode_macro T#]` found in the `AFC_Macros.cfg`
 file as the code now generates them automatically.
+- Added logic to pause print when filament goes past prep sensor. Verify that PAUSE macro move's toolhead off print when it's called.
 
 ## [2024-12-09]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -266,3 +266,11 @@ file as the code now generates them automatically.
 ### Updated
 - Updated Cut.cfg macro to have the ability to up stepper current when doing filament cutting, 
   see layer shift troubleshooting section on what values need to be set
+
+## [2024-12-20]
+
+### Added
+- More error printouts to aid users
+
+### Fixes
+- Misc error fixes

--- a/config/macros/Cut.cfg
+++ b/config/macros/Cut.cfg
@@ -191,6 +191,8 @@ description: Helper to do a single horizontal cut movement
 gcode:
     {% set pin_park_x_loc = params.PIN_PARK_X_LOC|float %}
     {% set pin_park_y_loc = params.PIN_PARK_Y_LOC|float %}
+    {% set rip_length = params.RIP_LENGTH|float %}
+
     {% set vars = printer['gcode_macro _AFC_CUT_TIP_VARS'] %}
     {% set cut_move_dist = vars['cut_move_dist']|float %}
     {% set cut_direction = vars['cut_direction']|default('')|lower %}
@@ -200,7 +202,6 @@ gcode:
     {% set cut_slow_move_speed = vars['cut_slow_move_speed'] * 60|float %}
     {% set cut_dwell_time = vars['cut_dwell_time']|float %}
     {% set evacuate_speed = vars['evacuate_speed'] * 60|float %}
-    {% set rip_length = vars['rip_length']|float %}
     {% set rip_speed = vars['rip_speed'] * 60|float %}
 
     # Get printer bounds to make sure none of our cut moves fall outside of them

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -532,7 +532,7 @@ class afc:
         if lane not in self.stepper:
             self.gcode.respond_info('{} Unknown'.format(lane.upper()))
             return
-        
+
         if self.current is not None:
             self.ERROR.AFC_error("Cannot load {}, {} currently loaded".format(lane.upper(), self.current.upper()), pause=False)
             return

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -850,6 +850,9 @@ class afc:
         # Clear toolhead's loaded state for easier error handling later.
         CUR_LANE.tool_loaded = False
         self.extruders[CUR_LANE.extruder_name]['lane_loaded'] = ''
+        CUR_LANE.status = None
+        self.current = None
+
         self.save_vars()
 
         # Ensure filament is fully cleared from the hub.
@@ -873,14 +876,15 @@ class afc:
             else:
                 self.gcode.run_script_from_command(CUR_HUB.cut_cmd)
 
-        # Confirm the hub is clear after the cut.
-        while CUR_HUB.state:
-            CUR_LANE.move(self.short_move_dis * -1, self.short_moves_speed, self.short_moves_accel, True)
-            num_tries += 1
-            if num_tries > (CUR_HUB.afc_bowden_length / self.short_move_dis):
-                message = 'HUB NOT CLEARING'
-                self.ERROR.handle_lane_failure(CUR_LANE, message)
-                return False
+            # Confirm the hub is clear after the cut.
+            while CUR_HUB.state:
+                CUR_LANE.move(self.short_move_dis * -1, self.short_moves_speed, self.short_moves_accel, True)
+                num_tries += 1
+                # TODO: Figure out max number of tries
+                if num_tries > (CUR_HUB.afc_bowden_length / self.short_move_dis):
+                    message = 'HUB NOT CLEARING after hub cut\n'
+                    self.ERROR.handle_lane_failure(CUR_LANE, message)
+                    return False
 
         # Finalize unloading and reset lane state.
         CUR_LANE.hub_load = True

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -625,7 +625,7 @@ class afc:
                     tool_attempts += 1
                     CUR_LANE.move(self.short_move_dis, CUR_EXTRUDER.tool_load_speed, self.long_moves_accel)
                     if tool_attempts > 20:
-                        message = ('FAILED TO LOAD {} TO TOOL, CHECK FILAMENT PATH\n||=====||====||==>--||\nTRG   LOAD   HUB   TOOL'.format(CUR_LANE.name.upper()))
+                        message = ('FAILED TO LOAD TO TOOL, CHECK FILAMENT PATH\n||=====||====||==>--||\nTRG   LOAD   HUB   TOOL')
                         self.ERROR.handle_lane_failure(CUR_LANE, message)
                         return False
 
@@ -683,11 +683,11 @@ class afc:
         else:
             # Handle errors if the hub is not clear or the lane is not ready for loading.
             if CUR_HUB.state:
-                message = ('HUB NOT CLEAR WHEN TRYING TO LOAD {}\n||-----||----|x|-----||\nTRG   LOAD   HUB   TOOL'.format(CUR_LANE.name.upper()))
+                message = ('HUB NOT CLEAR WHEN TRYING TO LOAD\n||-----||----|x|-----||\nTRG   LOAD   HUB   TOOL')
                 self.ERROR.handle_lane_failure(CUR_LANE, message)
                 return False
             if not CUR_LANE.load_state:
-                message = ('{} NOT READY, LOAD TRIGGER NOT TRIGGERED\n||==>--||----||-----||\nTRG   LOAD   HUB   TOOL'.format(CUR_LANE.name.upper()))
+                message = ('NOT READY, LOAD TRIGGER NOT TRIGGERED\n||==>--||----||-----||\nTRG   LOAD   HUB   TOOL')
                 self.ERROR.handle_lane_failure(CUR_LANE, message)
                 return False
 

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -961,7 +961,7 @@ class afc:
                 # If a current lane is loaded, unload it first.
                 if self.current is not None:
                     if self.current not in self.stepper:
-                        self.gcode.respond_info(self.current + ' Unknown')
+                        self.gcode.respond_info('{} Unknown'.format(self.current.upper()))
                         return
                     CUR_LANE = self.stepper[self.current]
                     if not self.TOOL_UNLOAD(CUR_LANE):

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -282,7 +282,7 @@ class afc:
         if lane not in self.stepper:
             self.gcode.respond_info('{} Unknown'.format(lane.upper()))
             return
-        CUR_LANE = self.stepper[lane.name]
+        CUR_LANE = self.stepper[lane]
         CUR_LANE.move(distance, self.short_moves_speed, self.short_moves_accel, True)
 
     def save_pos(self):
@@ -364,7 +364,7 @@ class afc:
         if lane not in self.stepper:
             self.gcode.respond_info('{} Unknown'.format(lane.upper()))
             return
-        CUR_LANE = self.stepper[lane.name]
+        CUR_LANE = self.stepper[lane]
         CUR_HUB = self.printer.lookup_object('AFC_hub ' + CUR_LANE.unit)
         CUR_HUB.hub_cut(CUR_LANE)
         self.gcode.respond_info('Hub cut Done!')
@@ -397,7 +397,7 @@ class afc:
         if lane not in self.stepper:
             self.gcode.respond_info('{} Unknown'.format(lane.upper()))
             return
-        CUR_LANE = self.stepper[lane.name]
+        CUR_LANE = self.stepper[lane]
         self.gcode.respond_info('Testing at full speed')
         CUR_LANE.assist(-1)
         self.reactor.pause(self.reactor.monotonic() + 1)
@@ -440,7 +440,7 @@ class afc:
         if lane not in self.stepper:
             self.gcode.respond_info('{} Unknown'.format(lane.upper()))
             return
-        CUR_LANE = self.stepper[lane.name]
+        CUR_LANE = self.stepper[lane]
         CUR_HUB = self.printer.lookup_object('AFC_hub '+ CUR_LANE.unit)
         if CUR_LANE.prep_state == False: return
 
@@ -485,7 +485,7 @@ class afc:
         if lane not in self.stepper:
             self.gcode.respond_info('{} Unknown'.format(lane.upper()))
             return
-        CUR_LANE = self.stepper[lane.name]
+        CUR_LANE = self.stepper[lane]
         CUR_HUB = self.printer.lookup_object('AFC_hub '+ CUR_LANE.unit)
         if CUR_LANE.name != self.current:
             # Setting status as ejecting so if filament is removed and de-activates the prep sensor while
@@ -536,7 +536,7 @@ class afc:
         if self.current is not None:
             self.ERROR.AFC_error("Cannot load {}, {} currently loaded".format(lane.upper(), self.current.upper()), pause=False)
             return
-        CUR_LANE = self.stepper[lane.name]
+        CUR_LANE = self.stepper[lane]
         self.TOOL_LOAD(CUR_LANE)
 
     def TOOL_LOAD(self, CUR_LANE):
@@ -717,7 +717,7 @@ class afc:
         if lane not in self.stepper:
             self.gcode.respond_info('{} Unknown'.format(lane.upper()))
             return
-        CUR_LANE = self.stepper[lane.name]
+        CUR_LANE = self.stepper[lane]
         self.TOOL_UNLOAD(CUR_LANE)
 
         # User manually unloaded spool from toolhead, remove spool from active status
@@ -956,7 +956,7 @@ class afc:
             if lane not in self.stepper:
                 self.gcode.respond_info('{} Unknown'.format(lane.upper()))
                 return
-            CUR_LANE = self.stepper[lane.name]
+            CUR_LANE = self.stepper[lane]
             # Check if the lane has completed the preparation process required for tool changes.
             if CUR_LANE._afc_prep_done:
                 # Log the tool change operation for debugging or informational purposes.
@@ -978,7 +978,7 @@ class afc:
                 if lane not in self.stepper:
                     self.gcode.respond_info('{} Unknown'.format(lane.upper()))
                     return
-                CUR_LANE = self.stepper[lane.name]
+                CUR_LANE = self.stepper[lane]
             # Load the new lane and restore the toolhead position if successful.
             if self.TOOL_LOAD(CUR_LANE) and not self.error_state:
                 self.gcode.respond_info("{} is now loaded in toolhead".format(lane))

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -34,7 +34,7 @@ class afcBoxTurtle:
         if LANE not in self.AFC.stepper:
             self.AFC.gcode.respond_info('{} Unknown'.format(LANE.upper()))
             return
-        CUR_LANE = self.AFC.stepper[LANE] 
+        CUR_LANE = self.AFC.stepper[LANE]
         try: CUR_EXTRUDER = self.printer.lookup_object('AFC_extruder ' + CUR_LANE.extruder_name)
         except:
             error_string = 'Error: No config found for extruder: ' + CUR_LANE.extruder_name + ' in [AFC_stepper ' + CUR_LANE.name + ']. Please make sure [AFC_extruder ' + CUR_LANE.extruder_name + '] config exists in AFC_Hardware.cfg'

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -32,7 +32,7 @@ class afcBoxTurtle:
         msg = ''
         succeeded = True
         if LANE not in self.AFC.stepper:
-            self.AFC.gcode.respond_info(LANE + ' Unknown')
+            self.AFC.gcode.respond_info('{} Unknown'.format(LANE.upper()))
             return
         CUR_LANE = self.AFC.stepper[LANE] 
         try: CUR_EXTRUDER = self.printer.lookup_object('AFC_extruder ' + CUR_LANE.extruder_name)
@@ -184,7 +184,7 @@ class afcBoxTurtle:
 
         def calibrate_lane(LANE):
             if LANE not in self.AFC.stepper:
-                self.AFC.gcode.respond_info(LANE + ' Unknown')
+                self.AFC.gcode.respond_info('{} Unknown'.format(LANE.upper()))
                 return
             CUR_LANE = self.AFC.stepper[LANE.name]
             CUR_HUB = self.printer.lookup_object('AFC_hub {}'.format(CUR_LANE.unit))

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -38,7 +38,7 @@ class afcBoxTurtle:
         try: CUR_EXTRUDER = self.printer.lookup_object('AFC_extruder ' + CUR_LANE.extruder_name)
         except:
             error_string = 'Error: No config found for extruder: ' + CUR_LANE.extruder_name + ' in [AFC_stepper ' + CUR_LANE.name + ']. Please make sure [AFC_extruder ' + CUR_LANE.extruder_name + '] config exists in AFC_Hardware.cfg'
-            self.AFC.AFC_error(error_string, False)
+            self.AFC.ERROR.AFC_error(error_string, False)
             return False
 
         # Run test reverse/forward on each lane

--- a/extras/AFC_NightOwl.py
+++ b/extras/AFC_NightOwl.py
@@ -31,7 +31,7 @@ class afcNightOwl:
         try: CUR_EXTRUDER = self.printer.lookup_object('AFC_extruder ' + CUR_LANE.extruder_name)
         except:
             error_string = 'Error: No config found for extruder: ' + CUR_LANE.extruder_name + ' in [AFC_stepper ' + CUR_LANE.name + ']. Please make sure [AFC_extruder ' + CUR_LANE.extruder_name + '] config exists in AFC_Hardware.cfg'
-            self.AFC.AFC_error(error_string, False)
+            self.AFC.ERROR.AFC_error(error_string, False)
             return False
 
         # Run test reverse/forward on each lane

--- a/extras/AFC_NightOwl.py
+++ b/extras/AFC_NightOwl.py
@@ -27,7 +27,7 @@ class afcNightOwl:
         if LANE not in self.AFC.stepper:
             self.AFC.gcode.respond_info('{} Unknown'.format(LANE.upper()))
             return
-        CUR_LANE = self.AFC.stepper[LANE] 
+        CUR_LANE = self.AFC.stepper[LANE]
         try: CUR_EXTRUDER = self.printer.lookup_object('AFC_extruder ' + CUR_LANE.extruder_name)
         except:
             error_string = 'Error: No config found for extruder: ' + CUR_LANE.extruder_name + ' in [AFC_stepper ' + CUR_LANE.name + ']. Please make sure [AFC_extruder ' + CUR_LANE.extruder_name + '] config exists in AFC_Hardware.cfg'
@@ -52,8 +52,8 @@ class afcNightOwl:
                 msg = '<span class=error--text>CHECK FILAMENT Prep: False - Load: True</span>'
                 succeeded = False
 
-        else: 
-            
+        else:
+
             self.AFC.afc_led(self.AFC.led_ready, CUR_LANE.led_index)
             msg +="<span class=success--text>LOCKED</span>"
             if CUR_LANE.load_state == False:

--- a/extras/AFC_NightOwl.py
+++ b/extras/AFC_NightOwl.py
@@ -25,7 +25,7 @@ class afcNightOwl:
         msg = ''
         succeeded = True
         if LANE not in self.AFC.stepper:
-            self.AFC.gcode.respond_info(LANE + ' Unknown')
+            self.AFC.gcode.respond_info('{} Unknown'.format(LANE.upper()))
             return
         CUR_LANE = self.AFC.stepper[LANE] 
         try: CUR_EXTRUDER = self.printer.lookup_object('AFC_extruder ' + CUR_LANE.extruder_name)

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -136,7 +136,7 @@ class afcError:
         # Disable the stepper for this lane
         CUR_LANE.do_enable(False)
         CUR_LANE.status = 'Error'
-        msg = (CUR_LANE.name.upper() + message)
+        msg = "{} {}".format(CUR_LANE.name.upper(), message)
         self.AFC_error(msg, pause)
         self.AFC.afc_led(self.AFC.led_fault, CUR_LANE.led_index)
 

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -136,7 +136,7 @@ class afcError:
         # Disable the stepper for this lane
         CUR_LANE.do_enable(False)
         CUR_LANE.status = 'Error'
-        msg = (CUR_LANE.name.upper() + ' NOT READY' + message)
+        msg = (CUR_LANE.name.upper() + message)
         self.AFC_error(msg, pause)
         self.AFC.afc_led(self.AFC.led_fault, CUR_LANE.led_index)
 

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -79,7 +79,7 @@ class afcPrep:
                 if LANE.unit not in self.AFC.lanes: self.AFC.lanes[LANE.unit] = {}
                 if LANE.name not in self.AFC.units[LANE.unit]: self.AFC.units[LANE.unit][LANE.name]={}
                 if LANE.name not in self.AFC.lanes[LANE.unit]: self.AFC.lanes[LANE.unit][LANE.name] = {}
-                if 'spool_id' in self.AFC.lanes[LANE.unit][LANE.name]: LANE.spool_id = self.AFC.lanes[LANE.unit][LANE.name]['spool_id'] 
+                if 'spool_id' in self.AFC.lanes[LANE.unit][LANE.name]: LANE.spool_id = self.AFC.lanes[LANE.unit][LANE.name]['spool_id']
 
                 if self.AFC.spoolman_ip !=None and LANE.spool_id != None:
                     self.AFC.SPOOL.set_spoolID(LANE, LANE.spool_id)

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -113,7 +113,7 @@ class afcPrep:
                 try: CUR_HUB = self.printer.lookup_object('AFC_hub '+ UNIT)
                 except:
                     error_string = 'Error: Hub for ' + UNIT + ' not found in AFC_Hardware.cfg. Please add the [AFC_Hub ' + UNIT + '] config section.'
-                    self.AFC.AFC_error(error_string, False)
+                    self.AFC.ERROR.AFC_error(error_string, False)
                     return
                 self.AFC.gcode.respond_info(CUR_HUB.type + ' ' + UNIT +' Prepping lanes')
 

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -6,11 +6,6 @@
 
 import os
 import json
-try:
-    from urllib.request import urlopen
-except:
-    # Python 2.7 support
-    from urllib2 import urlopen
 
 class afcPrep:
     def __init__(self, config):

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -80,15 +80,9 @@ class afcPrep:
                 if LANE.name not in self.AFC.units[LANE.unit]: self.AFC.units[LANE.unit][LANE.name]={}
                 if LANE.name not in self.AFC.lanes[LANE.unit]: self.AFC.lanes[LANE.unit][LANE.name] = {}
                 if 'spool_id' in self.AFC.lanes[LANE.unit][LANE.name]: LANE.spool_id = self.AFC.lanes[LANE.unit][LANE.name]['spool_id'] 
+
                 if self.AFC.spoolman_ip !=None and LANE.spool_id != None:
-                    try:
-                        url = 'http://' + self.AFC.spoolman_ip + ':'+ self.AFC.spoolman_port +"/api/v1/spool/" + self.AFC.lanes[LANE.unit][LANE.name]['spool_id']
-                        result = json.load(urlopen(url))
-                        LANE.material = result['filament']['material']
-                        LANE.color = '#' + result['filament']['color_hex']
-                        if 'remaining_weight' in result: LANE.weight =  result['remaining_weight']
-                    except:
-                        self.AFC.ERROR.AFC_error("Error when trying to get Spoolman data for ID:{}".format(self.AFC.lanes[LANE.unit][LANE.name]['spool_id']), False)
+                    self.AFC.SPOOL.set_spoolID(LANE, LANE.spool_id)
                 else:
                     if 'material' in self.AFC.lanes[LANE.unit][LANE.name]: LANE.material = self.AFC.lanes[LANE.unit][LANE.name]['material']
                     if 'color' in self.AFC.lanes[LANE.unit][LANE.name]: LANE.color = self.AFC.lanes[LANE.unit][LANE.name]['color']

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -56,7 +56,7 @@ class afcSpool:
         lane_switch=self.AFC.tool_cmds[map_cmd]
         self.gcode.respond_info("lane to switch is " + lane_switch)
         if lane not in self.AFC.stepper:
-            self.AFC.gcode.respond_info(lane + ' Unknown')
+            self.AFC.gcode.respond_info('{} Unknown'.format(lane.upper()))
             return
         CUR_LANE = self.AFC.stepper[lane.name]
         for UNIT_SERACH in self.AFC.units.keys():
@@ -98,7 +98,7 @@ class afcSpool:
             return
         color = gcmd.get('COLOR', '#000000')
         if lane not in self.AFC.stepper:
-            self.AFC.gcode.respond_info(lane + ' Unknown')
+            self.AFC.gcode.respond_info('{} Unknown'.format(lane.upper()))
             return
         CUR_LANE = self.AFC.stepper[lane.name]
         CUR_LANE.color = '#' + color
@@ -129,7 +129,7 @@ class afcSpool:
             return
         weight = gcmd.get('WEIGHT', '')
         if lane not in self.AFC.stepper:
-            self.AFC.gcode.respond_info(lane + ' Unknown')
+            self.AFC.gcode.respond_info('{} Unknown'.format(lane.upper()))
             return
         CUR_LANE = self.AFC.stepper[lane.name]
         CUR_LANE.weight = weight
@@ -160,7 +160,7 @@ class afcSpool:
             return
         material = gcmd.get('MATERIAL', '')
         if lane not in self.AFC.stepper:
-            self.AFC.gcode.respond_info(lane + ' Unknown')
+            self.AFC.gcode.respond_info('{} Unknown'.format(lane.upper()))
             return
         CUR_LANE = self.AFC.stepper[lane.name]
         CUR_LANE.material = material
@@ -205,7 +205,7 @@ class afcSpool:
                 return
             SpoolID = gcmd.get('SPOOL_ID', '')
             if lane not in self.AFC.stepper:
-                self.AFC.gcode.respond_info(lane + ' Unknown')
+                self.AFC.gcode.respond_info('{} Unknown'.format(lane.upper()))
                 return
             CUR_LANE = self.AFC.stepper[lane.name]
             self.set_spoolID(CUR_LANE, SpoolID)
@@ -238,7 +238,7 @@ class afcSpool:
     cmd_SET_RUNOUT_help = "change filaments ID"
     def cmd_SET_RUNOUT(self, gcmd):
         """
-        This function handles setting the runout lane (infanet spool) for a specified lane. It retrieves the lane
+        This function handles setting the runout lane (infinite spool) for a specified lane. It retrieves the lane
         specified by the 'LANE' parameter and updates its the lane to use if filament is empty
         based on the information retrieved from the Spoolman API.
 
@@ -260,7 +260,7 @@ class afcSpool:
             return
         runout = gcmd.get('RUNOUT', '')
         if lane not in self.AFC.stepper:
-            self.AFC.gcode.respond_info(lane + ' Unknown')
+            self.AFC.gcode.respond_info('{} Unknown'.format(lane.upper()))
             return
         CUR_LANE = self.AFC.stepper[lane.name]
         CUR_LANE.runout_lane = runout

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -220,8 +220,14 @@ class afcSpool:
                     CUR_LANE.material = result['filament']['material']
                     CUR_LANE.color = '#' + result['filament']['color_hex']
                     if 'remaining_weight' in result: CUR_LANE.weight =  result['remaining_weight']
-                except:
-                    self.AFC.ERROR.AFC_error("Error when trying to get Spoolman data for ID:{}".format(SpoolID), False)
+                    # Check to see if filament is defined as multi color and take the first color for now
+                    # Once support for multicolor is added this needs to be updated
+                    if "multi_color_hexes" in result['filament']:
+                        CUR_LANE.color = '#' + result['filament']['multi_color_hexes'].split(",")[0]
+                    else:
+                        CUR_LANE.color = '#' + result['filament']['color_hex']
+                except Exception as e:
+                    self.AFC.ERROR.AFC_error("Error when trying to get Spoolman data for ID:{}, Error: {}".format(SpoolID, e), False)
             else:
                 CUR_LANE.spool_id = ''
                 CUR_LANE.material = ''

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -239,7 +239,7 @@ class AFCExtruderStepper:
                     self.reactor.pause(self.reactor.monotonic() + 0.1)
                     if x> 40:
                         msg = (' FAILED TO LOAD, CHECK FILAMENT AT TRIGGER\n||==>--||----||------||\nTRG   LOAD   HUB    TOOL')
-                        self.AFC.AFC_error(msg, False)
+                        self.AFC.ERROR.AFC_error(msg, False)
                         self.AFC.afc_led(self.AFC.led_fault, led)
                         self.status=''
                         break

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -85,7 +85,7 @@ class AFCExtruderStepper:
         self.stepper_kinematics = ffi_main.gc(
             ffi_lib.cartesian_stepper_alloc(b'x'), ffi_lib.free)
         self.assist_activate=False
-          
+
         self.hub_dist = config.getfloat('hub_dist',20)
         self.dist_hub = config.getfloat('dist_hub', 60)
         # distance to retract filament from the hub


### PR DESCRIPTION
## Major Changes in this PR
- Found problem where AFC.py was using self.AFC.stepper, changed to self.stepper
- Fixed error where AFC_error was not referenced correctly
- Added more printing errors to help others out .
- Added homing checks to TOOL_LOAD and TOOL_UNLOAD
- In prep using common function for setting spoolman data
- Updated a while loop that should of been indented under a if statement when hub cutting
- Updated changelog dates
- Fixed cut macro to only rip on the last cut like originally intended based of comments in macro, before it was always ripping for every cut
## Notes to Code Reviewers

## How the changes in this PR are tested
- Tested tool loading and unloading sequences
- Manually called macros with wrong names to verify they would error out correctly
## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [ ] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Sent notification to software-design channel requesting review
