### PR TITLE
Fixing issues with changing hub_loaded to loaded_to_hub in saved variables file

### DIFF
--- a/docs/command_reference.md
+++ b/docs/command_reference.md
@@ -79,15 +79,6 @@ current lane and loading the new lane.
 Usage: ``CHANGE_TOOL LANE=<lane>``  
 Example: ``CHANGE_TOOL LANE=leg1``  
 
-### CALIBRATE_AFC
-_Description_: This function performs the calibration of the hub and Bowden length for one or more lanes within an AFC
-(Automated Filament Changer) system. The function uses precise movements to adjust the positions of the
-steppers, check the state of the hubs and tools, and calculate distances for calibration based on the
-user-provided input. If no specific lane is provided, the function defaults to notifying the user that no lane has been selected. The function also includes
-the option to calibrate the Bowden length for a particular lane, if specified.  
-Usage: ``CALIBRATE_AFC LANES=<lane> DISTANCE=<distance> TOLERANCE=<tolerance> BOWDEN=<lane>``  
-Example: `CALIBRATE_AFC LANES=all Bowden=leg1`  
-
 ### SET_MULTIPLIER
 _Description_: This function handles the adjustment of the buffer multipliers for the turtleneck buffer.
 It retrieves the multiplier type ('HIGH' or 'LOW') and the factor to be applied. The function
@@ -119,19 +110,40 @@ specified by the 'LANE' parameter and sets its color to the value provided by th
 Usage: ``SET_COLOR LANE=<lane> COLOR=<color>``  
 Example: ``SET_COLOR LANE=leg1 COLOR=FF0000``  
 
-### SET_SPOOLID
+### SET_WEIGHT
+_Description_: This function handles changing the material of a specified lane. It retrieves the lane
+specified by the 'LANE' parameter and sets its material to the value provided by the 'MATERIAL' parameter.  
+Usage: `SET_WEIGHT LANE=<lane> WEIGHT=<weight>`  
+Example: `SET_WEIGHT LANE=leg1 WEIGHT=850`  
+
+### SET_MATERIAL
+_Description_: This function handles changing the material of a specified lane. It retrieves the lane
+specified by the 'LANE' parameter and sets its material to the value provided by the 'MATERIAL' parameter.  
+Usage: `SET_MATERIAL LANE=<lane> MATERIAL=<material>`  
+Example: `SET_MATERIAL LANE=leg1 MATERIAL=ABS`  
+
+### SET_SPOOL_ID
 _Description_: This function handles setting the spool ID for a specified lane. It retrieves the lane
 specified by the 'LANE' parameter and updates its spool ID, material, color, and weight
 based on the information retrieved from the Spoolman API.  
-Usage: ``SET_SPOOLID LANE=<lane> SPOOL_ID=<spool_id>``  
-Example: ``SET_SPOOLID LANE=leg1 SPOOL_ID=12345``  
+Usage: ``SET_SPOOL_ID LANE=<lane> SPOOL_ID=<spool_id>``  
+Example: ``SET_SPOOL_IDD LANE=leg1 SPOOL_ID=12345``  
 
 ### SET_RUNOUT
-_Description_: This function handles setting the runout lane (infanet spool) for a specified lane. It retrieves the lane
+_Description_: This function handles setting the runout lane (infinite spool) for a specified lane. It retrieves the lane
 specified by the 'LANE' parameter and updates its the lane to use if filament is empty
 based on the information retrieved from the Spoolman API.  
 Usage: ``SET_RUNOUT LANE=<lane> RUNOUT=<lane>``  
 Example: ``SET_RUNOUT LANE=lane1 RUNOUT=lane4``  
+
+### CALIBRATE_AFC
+_Description_: This function performs the calibration of the hub and Bowden length for one or more lanes within an AFC
+(Automated Filament Changer) system. The function uses precise movements to adjust the positions of the
+steppers, check the state of the hubs and tools, and calculate distances for calibration based on the
+user-provided input. If no specific lane is provided, the function defaults to notifying the user that no lane has been selected. The function also includes
+the option to calibrate the Bowden length for a particular lane, if specified.  
+Usage: ``CALIBRATE_AFC LANES=<lane> DISTANCE=<distance> TOLERANCE=<tolerance> BOWDEN=<lane>``  
+Example: `CALIBRATE_AFC LANE=leg1`  
 
 ## AFC Macros
 
@@ -151,11 +163,3 @@ _Description_: Move the specified lane the specified amount
 _Description_: Resume the print after an error
 ### BT_PREP
 _Description_: Run the AFC PREP sequence
-### T0
-_Description_: Change to tool 0
-### T1
-_Description_: Change to tool 1
-### T2
-_Description_: Change to tool 2
-### T3
-_Description_: Change to tool 3

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -145,9 +145,10 @@ class afc:
         self.gcode.register_command('HUB_CUT_TEST', self.cmd_HUB_CUT_TEST, desc=self.cmd_HUB_CUT_TEST_help)
         self.gcode.register_mux_command('SET_BOWDEN_LENGTH', 'AFC', None, self.cmd_SET_BOWDEN_LENGTH, desc=self.cmd_SET_BOWDEN_LENGTH_help)
         self.gcode.register_command('AFC_STATUS', self.cmd_AFC_STATUS, desc=self.cmd_AFC_STATUS_help)
-    
+
     def print_version(self):
-        import subprocess, os
+        import subprocess
+        import os
         afc_dir  = os.path.dirname(os.path.realpath(__file__))
         git_hash = subprocess.check_output(['git', '-C', '{}'.format(afc_dir), 'rev-parse', '--short', 'HEAD']).decode('ascii').strip()
         git_commit_num = subprocess.check_output(['git', '-C', '{}'.format(afc_dir), 'rev-list', 'HEAD', '--count']).decode('ascii').strip()

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -682,7 +682,7 @@ class afc:
                 self.gcode.run_script_from_command(self.wipe_cmd)
 
             # Update lane and extruder state for tracking.
-            self.extruders[CUR_LANE.extruder_name]['lane_loaded'] = CUR_LANE.name
+            CUR_EXTRUDER.lane_loaded = CUR_LANE.name
             self.SPOOL.set_active_spool(CUR_LANE.spool_id)
             self.afc_led(self.led_tool_loaded, CUR_LANE.led_index)
             self.save_vars()
@@ -855,7 +855,7 @@ class afc:
 
         # Clear toolhead's loaded state for easier error handling later.
         CUR_LANE.tool_loaded = False
-        self.extruders[CUR_LANE.extruder_name]['lane_loaded'] = ''
+        CUR_EXTRUDER.lane_loaded = ''
         CUR_LANE.status = None
         self.current = None
 
@@ -996,7 +996,7 @@ class afc:
     def get_filament_status(self, LANE):
         if LANE.prep_state:
             if LANE.load_state:
-                if self.extruders[LANE.extruder_name]['lane_loaded'] == LANE.name:
+                if LANE.extruder_obj is not None and LANE.extruder_obj.lane_loaded == LANE.name:
                     return 'In Tool:' + self.HexConvert(self.led_tool_loaded)
                 return "Ready:" + self.HexConvert(self.led_ready)
             return 'Prep:' + self.HexConvert(self.led_prep_loaded)
@@ -1029,7 +1029,6 @@ class afc:
                 screen_mac = 'None'
             str[UNIT]={}
             for NAME in self.units[UNIT].keys():
-                if NAME == "system": continue
                 CUR_LANE=self.stepper[NAME]
                 str[UNIT][NAME]={}
                 str[UNIT][NAME]['LANE'] = CUR_LANE.index
@@ -1064,9 +1063,9 @@ class afc:
         for EXTRUDE in self.extruders.keys():
             str["system"]["extruders"][EXTRUDE]={}
             CUR_EXTRUDER = self.printer.lookup_object('AFC_extruder ' + EXTRUDE)
-            str["system"]["extruders"][EXTRUDE]['lane_loaded'] = self.extruders[CUR_EXTRUDER.name]['lane_loaded']
+            str["system"]["extruders"][EXTRUDE]['lane_loaded'] = CUR_EXTRUDER.lane_loaded
             if CUR_EXTRUDER.tool_start == "buffer":
-                if self.extruders[CUR_EXTRUDER.name]['lane_loaded'] == '':
+                if CUR_EXTRUDER.lane_loaded == '':
                     str ["system"]["extruders"][EXTRUDE]['tool_start_sensor'] = False
                 else:
                     str["system"]["extruders"][EXTRUDE]['tool_start_sensor'] = True

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -8,6 +8,8 @@
 import json
 from configparser import Error as error
 
+AFC_VERSION="1.0.0"
+
 class afc:
     def __init__(self, config):
         self.printer = config.get_printer()
@@ -101,6 +103,9 @@ class afc:
         #self.debug = True == config.get('debug', 0)
         self.debug = False
 
+        # Printing here will not display in console but it will go to klippy.log
+        self.print_version()
+
     def _update_trsync(self, config):
         # Logic to update trsync values
         update_trsync = config.getboolean("trsync_update", False)
@@ -140,6 +145,13 @@ class afc:
         self.gcode.register_command('HUB_CUT_TEST', self.cmd_HUB_CUT_TEST, desc=self.cmd_HUB_CUT_TEST_help)
         self.gcode.register_mux_command('SET_BOWDEN_LENGTH', 'AFC', None, self.cmd_SET_BOWDEN_LENGTH, desc=self.cmd_SET_BOWDEN_LENGTH_help)
         self.gcode.register_command('AFC_STATUS', self.cmd_AFC_STATUS, desc=self.cmd_AFC_STATUS_help)
+    
+    def print_version(self):
+        import subprocess, os
+        afc_dir  = os.path.dirname(os.path.realpath(__file__))
+        git_hash = subprocess.check_output(['git', '-C', '{}'.format(afc_dir), 'rev-parse', '--short', 'HEAD']).decode('ascii').strip()
+        git_commit_num = subprocess.check_output(['git', '-C', '{}'.format(afc_dir), 'rev-list', 'HEAD', '--count']).decode('ascii').strip()
+        self.gcode.respond_info("AFC Version: v{}-{}-{}".format(AFC_VERSION, git_commit_num, git_hash))
 
     cmd_AFC_STATUS_help = "Return current status of AFC"
     def cmd_AFC_STATUS(self, gcmd):

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -35,7 +35,7 @@ class afcBoxTurtle:
             self.AFC.gcode.respond_info('{} Unknown'.format(LANE.upper()))
             return
         CUR_LANE = self.AFC.stepper[LANE]
-        try: 
+        try:
             CUR_LANE.extruder_obj = self.printer.lookup_object('AFC_extruder ' + CUR_LANE.extruder_name)
         except:
             error_string = 'Error: No config found for extruder: ' + CUR_LANE.extruder_name + ' in [AFC_stepper ' + CUR_LANE.name + ']. Please make sure [AFC_extruder ' + CUR_LANE.extruder_name + '] config exists in AFC_Hardware.cfg'

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -53,7 +53,6 @@ class afcBoxTurtle:
                 msg += 'EMPTY READY FOR SPOOL'
             else:
                 self.AFC.afc_led(self.AFC.led_fault, CUR_LANE.led_index)
-                CUR_LANE.status = None
                 msg +="<span class=error--text> NOT READY</span>"
                 CUR_LANE.do_enable(False)
                 msg = '<span class=error--text>CHECK FILAMENT Prep: False - Load: True</span>'
@@ -79,6 +78,7 @@ class afcBoxTurtle:
                                 msg += "<span class=warning--text>\n Ram sensor enabled, confirm tool is loaded</span>"
                             self.AFC.SPOOL.set_active_spool(CUR_LANE.spool_id)
                             self.AFC.afc_led(self.AFC.led_tool_loaded, CUR_LANE.led_index)
+                            CUR_LANE.status = 'Tooled'
                             if len(self.AFC.extruders) == 1:
                                 self.AFC.current = CUR_LANE.name
                                 CUR_EXTRUDER.enable_buffer()
@@ -143,8 +143,8 @@ class afcBoxTurtle:
 
             Returns: The lane name if found, otherwise None
             """
-            for UNIT in self.AFC.lanes.keys():
-                if lane_name in self.AFC.lanes[UNIT]:
+            for UNIT in self.AFC.unit.keys():
+                if lane_name in self.AFC.unit[UNIT]:
                     return lane_name
 
             # If the lane was not found
@@ -201,7 +201,7 @@ class afcBoxTurtle:
             hub_pos = calibrate_hub(CUR_LANE, CUR_HUB)
             if CUR_HUB.state:
                 CUR_LANE.move(CUR_HUB.move_dis * -1, self.AFC.short_moves_speed, self.AFC.short_moves_accel, True)
-            CUR_LANE.hub_load = True
+            CUR_LANE.loaded_to_hub = True
             CUR_LANE.do_enable(False)
             cal_msg = "\n{} dist_hub: {}".format(CUR_LANE.name.upper(), (hub_pos - CUR_HUB.hub_clear_move_dis))
             return True, cal_msg

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -35,7 +35,8 @@ class afcBoxTurtle:
             self.AFC.gcode.respond_info('{} Unknown'.format(LANE.upper()))
             return
         CUR_LANE = self.AFC.stepper[LANE]
-        try: CUR_EXTRUDER = self.printer.lookup_object('AFC_extruder ' + CUR_LANE.extruder_name)
+        try: 
+            CUR_LANE.extruder_obj = self.printer.lookup_object('AFC_extruder ' + CUR_LANE.extruder_name)
         except:
             error_string = 'Error: No config found for extruder: ' + CUR_LANE.extruder_name + ' in [AFC_stepper ' + CUR_LANE.name + ']. Please make sure [AFC_extruder ' + CUR_LANE.extruder_name + '] config exists in AFC_Hardware.cfg'
             self.AFC.ERROR.AFC_error(error_string, False)
@@ -70,20 +71,21 @@ class afcBoxTurtle:
                 msg +="<span class=success--text> AND LOADED</span>"
 
                 if CUR_LANE.tool_loaded:
-                    if CUR_EXTRUDER.tool_start_state == True or CUR_EXTRUDER.tool_start == "buffer":
+                    if CUR_LANE.extruder_obj.tool_start_state == True or CUR_LANE.extruder_obj.tool_start == "buffer":
                         if self.AFC.extruders[CUR_LANE.extruder_name]['lane_loaded'] == CUR_LANE.name:
                             CUR_LANE.extruder_stepper.sync_to_extruder(CUR_LANE.extruder_name)
                             msg +="<span class=primary--text> in ToolHead</span>"
-                            if CUR_EXTRUDER.tool_start == "buffer":
+                            if CUR_LANE.extruder_obj.tool_start == "buffer":
                                 msg += "<span class=warning--text>\n Ram sensor enabled, confirm tool is loaded</span>"
                             self.AFC.SPOOL.set_active_spool(CUR_LANE.spool_id)
                             self.AFC.afc_led(self.AFC.led_tool_loaded, CUR_LANE.led_index)
                             CUR_LANE.status = 'Tooled'
                             if len(self.AFC.extruders) == 1:
                                 self.AFC.current = CUR_LANE.name
-                                CUR_EXTRUDER.enable_buffer()
+                                CUR_LANE.extruder_obj.enable_buffer()
+                                CUR_LANE.extruder_obj.lane_loaded = CUR_LANE.name
                         else:
-                            if CUR_EXTRUDER.tool_start_state == True:
+                            if CUR_LANE.extruder_obj.tool_start_state == True:
                                 msg +="<span class=error--text> error in ToolHead. \nLane identified as loaded in AFC.vars.unit file\n but not identified as loaded in AFC.var.tool file</span>"
                                 succeeded = False
                     else:

--- a/extras/AFC_NightOwl.py
+++ b/extras/AFC_NightOwl.py
@@ -28,7 +28,7 @@ class afcNightOwl:
             self.AFC.gcode.respond_info('{} Unknown'.format(LANE.upper()))
             return
         CUR_LANE = self.AFC.stepper[LANE]
-        try: 
+        try:
             CUR_LANE.extruder_obj = self.printer.lookup_object('AFC_extruder ' + CUR_LANE.extruder_name)
         except:
             error_string = 'Error: No config found for extruder: ' + CUR_LANE.extruder_name + ' in [AFC_stepper ' + CUR_LANE.name + ']. Please make sure [AFC_extruder ' + CUR_LANE.extruder_name + '] config exists in AFC_Hardware.cfg'

--- a/extras/AFC_NightOwl.py
+++ b/extras/AFC_NightOwl.py
@@ -28,7 +28,8 @@ class afcNightOwl:
             self.AFC.gcode.respond_info('{} Unknown'.format(LANE.upper()))
             return
         CUR_LANE = self.AFC.stepper[LANE]
-        try: CUR_EXTRUDER = self.printer.lookup_object('AFC_extruder ' + CUR_LANE.extruder_name)
+        try: 
+            CUR_LANE.extruder_obj = self.printer.lookup_object('AFC_extruder ' + CUR_LANE.extruder_name)
         except:
             error_string = 'Error: No config found for extruder: ' + CUR_LANE.extruder_name + ' in [AFC_stepper ' + CUR_LANE.name + ']. Please make sure [AFC_extruder ' + CUR_LANE.extruder_name + '] config exists in AFC_Hardware.cfg'
             self.AFC.ERROR.AFC_error(error_string, False)
@@ -64,20 +65,21 @@ class afcNightOwl:
                 msg +="<span class=success--text> AND LOADED</span>"
 
                 if CUR_LANE.tool_loaded:
-                    if CUR_EXTRUDER.tool_start_state == True or CUR_EXTRUDER.tool_start == "buffer":
+                    if CUR_LANE.extruder_obj.tool_start_state == True or CUR_LANE.extruder_obj.tool_start == "buffer":
                         if self.AFC.extruders[CUR_LANE.extruder_name]['lane_loaded'] == CUR_LANE.name:
                             CUR_LANE.extruder_stepper.sync_to_extruder(CUR_LANE.extruder_name)
                             msg +="<span class=primary--text> in ToolHead</span>"
-                            if CUR_EXTRUDER.tool_start == "buffer":
+                            if CUR_LANE.extruder_obj.tool_start == "buffer":
                                 msg += "<span class=warning--text>\n Ram sensor enabled, confirm tool is loaded</span>"
                             self.AFC.SPOOL.set_active_spool(CUR_LANE.spool_id)
                             self.AFC.afc_led(self.AFC.led_tool_loaded, CUR_LANE.led_index)
                             CUR_LANE.status = 'Tooled'
                             if len(self.AFC.extruders) == 1:
                                 self.AFC.current = CUR_LANE.name
-                                CUR_EXTRUDER.enable_buffer()
+                                CUR_LANE.extruder_obj.enable_buffer()
+                                CUR_LANE.extruder_obj.lane_loaded = CUR_LANE.name
                         else:
-                            if CUR_EXTRUDER.tool_start_state == True:
+                            if CUR_LANE.extruder_obj.tool_start_state == True:
                                 msg +="<span class=error--text> error in ToolHead. \nLane identified as loaded in AFC.vars.unit file\n but not identified as loaded in AFC.var.tool file</span>"
                                 succeeded = False
                     else:

--- a/extras/AFC_NightOwl.py
+++ b/extras/AFC_NightOwl.py
@@ -46,7 +46,6 @@ class afcNightOwl:
                 msg += 'EMPTY READY FOR SPOOL'
             else:
                 self.AFC.afc_led(self.AFC.led_fault, CUR_LANE.led_index)
-                CUR_LANE.status = None
                 msg +="<span class=error--text> NOT READY</span>"
                 CUR_LANE.do_enable(False)
                 msg = '<span class=error--text>CHECK FILAMENT Prep: False - Load: True</span>'
@@ -73,6 +72,7 @@ class afcNightOwl:
                                 msg += "<span class=warning--text>\n Ram sensor enabled, confirm tool is loaded</span>"
                             self.AFC.SPOOL.set_active_spool(CUR_LANE.spool_id)
                             self.AFC.afc_led(self.AFC.led_tool_loaded, CUR_LANE.led_index)
+                            CUR_LANE.status = 'Tooled'
                             if len(self.AFC.extruders) == 1:
                                 self.AFC.current = CUR_LANE.name
                                 CUR_EXTRUDER.enable_buffer()

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -52,7 +52,7 @@ class afcError:
                     CUR_LANE.move(-5, self.AFC.short_moves_speed, self.AFC.short_moves_accel, True)
                 while CUR_LANE.load_state == False:  # reload lane extruder
                     CUR_LANE.move(5, self.AFC.short_moves_speed, self.AFC.short_moves_accel, True)
-                
+
                 CUR_LANE.tool_load = False
                 CUR_LANE.loaded_to_hub = False
                 CUR_LANE.extruder_obj.lane_loaded = ''

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -55,7 +55,7 @@ class afcError:
                 
                 CUR_LANE.tool_load = False
                 CUR_LANE.loaded_to_hub = False
-                self.AFC.extruders[CUR_LANE.extruder_name]['lane_loaded']= ''
+                CUR_LANE.extruder_obj.lane_loaded = ''
                 self.AFC.save_vars()
                 self.pause = False
                 return True

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -52,7 +52,9 @@ class afcError:
                     CUR_LANE.move(-5, self.AFC.short_moves_speed, self.AFC.short_moves_accel, True)
                 while CUR_LANE.load_state == False:  # reload lane extruder
                     CUR_LANE.move(5, self.AFC.short_moves_speed, self.AFC.short_moves_accel, True)
-                self.AFC.lanes[CUR_LANE.unit][CUR_LANE.name]['tool_loaded'] = False
+                
+                CUR_LANE.tool_load = False
+                CUR_LANE.loaded_to_hub = False
                 self.AFC.extruders[CUR_LANE.extruder_name]['lane_loaded']= ''
                 self.AFC.save_vars()
                 self.pause = False

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -26,6 +26,8 @@ class AFCextruder:
       self.tool_start = config.get('pin_tool_start', None)
       self.tool_end = config.get('pin_tool_end', None)
 
+      self.lane_loaded = ''
+
       # RAMMING
       # Use buffer sensors for loading and unloading filament
       if self.tool_start == "buffer":

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -51,7 +51,7 @@ class afcPrep:
             self.AFC.reactor.pause(self.AFC.reactor.monotonic() + 1)
 
         self._rename_resume()
-
+        self.AFC.print_version()
         extruders={}
         units={}
         ## load Unit variables

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -59,10 +59,10 @@ class afcPrep:
             units=json.load(open(self.AFC.VarFile + '.unit'))
         ## load Toolhead variables
         if os.path.exists(self.AFC.VarFile + '.tool') and os.stat(self.AFC.VarFile + '.tool').st_size > 0:
-            extruders=json.load(open(self.AFC.VarFile + '.tool'))           
+            extruders=json.load(open(self.AFC.VarFile + '.tool'))
 
         self.AFC.tool_cmds={}
-        
+
         for PO in self.printer.objects:
             if 'AFC_stepper' in PO and 'tmc' not in PO:
                 LANE=self.printer.lookup_object(PO)
@@ -73,18 +73,18 @@ class afcPrep:
                 else: self.AFC.extruders[LANE.extruder_name] = extruders[LANE.extruder_name]
 
                 # If units section exists in vars file add currently stored data to AFC.units array
-                if LANE.unit not in self.AFC.units: 
+                if LANE.unit not in self.AFC.units:
                     # Only adding unit to array if it does not already exist
                     if LANE.unit not in units: self.AFC.units[LANE.unit] = {}
                     else:
                         self.AFC.units[LANE.unit] = units[LANE.unit]
                         # Removing system as this causes problems with AFC.get_status function
                         self.AFC.units[LANE.unit].pop("system", None)
-                
+
                 # If lane section exists in vars file add currently stored data to AFC.units array
                 if LANE.name not in self.AFC.units[LANE.unit]: self.AFC.units[LANE.unit][LANE.name]={}
                 else: self.AFC.units[LANE.unit][LANE.name] = units[LANE.unit][LANE.name]
-                
+
                 if 'spool_id' in self.AFC.units[LANE.unit][LANE.name]: LANE.spool_id = self.AFC.units[LANE.unit][LANE.name]['spool_id']
 
                 if self.AFC.spoolman_ip !=None and LANE.spool_id != None:

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -68,15 +68,20 @@ class afcPrep:
                 LANE=self.printer.lookup_object(PO)
                 self.AFC.stepper[LANE.name]=LANE
 
+                # If extruder section exists in vars file add currently stored data to AFC.extruders array
                 if LANE.extruder_name not in extruders: self.AFC.extruders[LANE.extruder_name]={}
                 else: self.AFC.extruders[LANE.extruder_name] = extruders[LANE.extruder_name]
-                
+
+                # If units section exists in vars file add currently stored data to AFC.units array
                 if LANE.unit not in self.AFC.units: 
+                    # Only adding unit to array if it does not already exist
                     if LANE.unit not in units: self.AFC.units[LANE.unit] = {}
                     else:
                         self.AFC.units[LANE.unit] = units[LANE.unit]
+                        # Removing system as this causes problems with AFC.get_status function
                         self.AFC.units[LANE.unit].pop("system", None)
                 
+                # If lane section exists in vars file add currently stored data to AFC.units array
                 if LANE.name not in self.AFC.units[LANE.unit]: self.AFC.units[LANE.unit][LANE.name]={}
                 else: self.AFC.units[LANE.unit][LANE.name] = units[LANE.unit][LANE.name]
                 

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -70,10 +70,10 @@ class afcPrep:
 
                 if LANE.extruder_name not in extruders: self.AFC.extruders[LANE.extruder_name]={}
                 else: self.AFC.extruders[LANE.extruder_name] = extruders[LANE.extruder_name]
-
-                if LANE.unit not in units: self.AFC.units[LANE.unit] = {}
-                else:
-                    if LANE.unit not in self.AFC.units:
+                
+                if LANE.unit not in self.AFC.units: 
+                    if LANE.unit not in units: self.AFC.units[LANE.unit] = {}
+                    else:
                         self.AFC.units[LANE.unit] = units[LANE.unit]
                         self.AFC.units[LANE.unit].pop("system", None)
                 

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -52,45 +52,55 @@ class afcPrep:
 
         self._rename_resume()
 
+        extruders={}
+        units={}
         ## load Unit variables
         if os.path.exists(self.AFC.VarFile + '.unit') and os.stat(self.AFC.VarFile + '.unit').st_size > 0:
-            self.AFC.lanes=json.load(open(self.AFC.VarFile + '.unit'))
+            units=json.load(open(self.AFC.VarFile + '.unit'))
         ## load Toolhead variables
         if os.path.exists(self.AFC.VarFile + '.tool') and os.stat(self.AFC.VarFile + '.tool').st_size > 0:
-            self.AFC.extruders=json.load(open(self.AFC.VarFile + '.tool'))
-        else:
-            self.AFC.extruders={}
-
-        temp=[]
+            extruders=json.load(open(self.AFC.VarFile + '.tool'))           
 
         self.AFC.tool_cmds={}
+        
         for PO in self.printer.objects:
             if 'AFC_stepper' in PO and 'tmc' not in PO:
                 LANE=self.printer.lookup_object(PO)
                 self.AFC.stepper[LANE.name]=LANE
-                temp.append(LANE.name)
-                if LANE.extruder_name not in self.AFC.extruders: self.AFC.extruders[LANE.extruder_name]={}
-                if LANE.unit not in self.AFC.units: self.AFC.units[LANE.unit] = {}
-                if LANE.unit not in self.AFC.lanes: self.AFC.lanes[LANE.unit] = {}
+
+                if LANE.extruder_name not in extruders: self.AFC.extruders[LANE.extruder_name]={}
+                else: self.AFC.extruders[LANE.extruder_name] = extruders[LANE.extruder_name]
+
+                if LANE.unit not in units: self.AFC.units[LANE.unit] = {}
+                else:
+                    if LANE.unit not in self.AFC.units:
+                        self.AFC.units[LANE.unit] = units[LANE.unit]
+                        self.AFC.units[LANE.unit].pop("system", None)
+                
                 if LANE.name not in self.AFC.units[LANE.unit]: self.AFC.units[LANE.unit][LANE.name]={}
-                if 'spool_id' in self.AFC.lanes[LANE.unit][LANE.name]: LANE.spool_id = self.AFC.lanes[LANE.unit][LANE.name]['spool_id']
+                else: self.AFC.units[LANE.unit][LANE.name] = units[LANE.unit][LANE.name]
+                
+                if 'spool_id' in self.AFC.units[LANE.unit][LANE.name]: LANE.spool_id = self.AFC.units[LANE.unit][LANE.name]['spool_id']
 
                 if self.AFC.spoolman_ip !=None and LANE.spool_id != None:
-                    self.AFC.SPOOL.set_spoolID(LANE, LANE.spool_id)
+                    self.AFC.SPOOL.set_spoolID(LANE, LANE.spool_id, save_vars=False)
                 else:
-                    if 'material' in self.AFC.lanes[LANE.unit][LANE.name]: LANE.material = self.AFC.lanes[LANE.unit][LANE.name]['material']
-                    if 'color' in self.AFC.lanes[LANE.unit][LANE.name]: LANE.color = self.AFC.lanes[LANE.unit][LANE.name]['color']
-                    if 'weight' in self.AFC.lanes[LANE.unit][LANE.name]: LANE.weight=self.AFC.lanes[LANE.unit][LANE.name]['weight']
+                    if 'material' in self.AFC.units[LANE.unit][LANE.name]: LANE.material = self.AFC.units[LANE.unit][LANE.name]['material']
+                    if 'color' in self.AFC.units[LANE.unit][LANE.name]: LANE.color = self.AFC.units[LANE.unit][LANE.name]['color']
+                    if 'weight' in self.AFC.units[LANE.unit][LANE.name]: LANE.weight=self.AFC.units[LANE.unit][LANE.name]['weight']
 
-                if 'runout_lane' in self.AFC.lanes[LANE.unit][LANE.name]: LANE.runout_lane = self.AFC.lanes[LANE.unit][LANE.name]['runout_lane']
+                if 'runout_lane' in self.AFC.units[LANE.unit][LANE.name]: LANE.runout_lane = self.AFC.units[LANE.unit][LANE.name]['runout_lane']
                 if LANE.runout_lane == '': LANE.runout_lane='NONE'
-                if 'map' in self.AFC.lanes[LANE.unit][LANE.name]: LANE.map = self.AFC.lanes[LANE.unit][LANE.name]['map']
+                if 'map' in self.AFC.units[LANE.unit][LANE.name]: LANE.map = self.AFC.units[LANE.unit][LANE.name]['map']
                 if LANE.map != 'NONE':
                    self.AFC.tool_cmds[LANE.map] = LANE.name
-                if 'hub_loaded' in self.AFC.lanes[LANE.unit][LANE.name]: LANE.hub_loaded = self.AFC.lanes[LANE.unit][LANE.name]['hub_loaded']
-                if 'tool_loaded' in self.AFC.lanes[LANE.unit][LANE.name]: LANE.tool_loaded = self.AFC.lanes[LANE.unit][LANE.name]['tool_loaded']
-                if 'status' in self.AFC.lanes[LANE.unit][LANE.name]: LANE.status = self.AFC.lanes[LANE.unit][LANE.name]['status']
-        self.AFC.lanes={}
+                # Check first for hub_loaded as this was the old name in software with version <= 1030
+                if 'hub_loaded' in self.AFC.units[LANE.unit][LANE.name]: LANE.loaded_to_hub = self.AFC.units[LANE.unit][LANE.name]['hub_loaded']
+                # Check for loaded_to_hub as this is how its being saved version > 1030
+                if 'loaded_to_hub' in self.AFC.units[LANE.unit][LANE.name]: LANE.loaded_to_hub = self.AFC.units[LANE.unit][LANE.name]['loaded_to_hub']
+                if 'tool_loaded' in self.AFC.units[LANE.unit][LANE.name]: LANE.tool_loaded = self.AFC.units[LANE.unit][LANE.name]['tool_loaded']
+                if 'status' in self.AFC.units[LANE.unit][LANE.name]: LANE.status = self.AFC.units[LANE.unit][LANE.name]['status']
+
         self.AFC.save_vars()
         if self.enable == False:
             self.AFC.gcode.respond_info('Prep Checks Disabled')

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -58,7 +58,7 @@ class afcSpool:
         if lane not in self.AFC.stepper:
             self.AFC.gcode.respond_info('{} Unknown'.format(lane.upper()))
             return
-        CUR_LANE = self.AFC.stepper[lane.name]
+        CUR_LANE = self.AFC.stepper[lane]
         for UNIT_SERACH in self.AFC.units.keys():
             self.gcode.respond_info("looking for "+lane+" in " + UNIT_SERACH)
             if lane in self.AFC.units[UNIT_SERACH]:
@@ -100,7 +100,7 @@ class afcSpool:
         if lane not in self.AFC.stepper:
             self.AFC.gcode.respond_info('{} Unknown'.format(lane.upper()))
             return
-        CUR_LANE = self.AFC.stepper[lane.name]
+        CUR_LANE = self.AFC.stepper[lane]
         CUR_LANE.color = '#' + color
         self.AFC.save_vars()
 
@@ -131,7 +131,7 @@ class afcSpool:
         if lane not in self.AFC.stepper:
             self.AFC.gcode.respond_info('{} Unknown'.format(lane.upper()))
             return
-        CUR_LANE = self.AFC.stepper[lane.name]
+        CUR_LANE = self.AFC.stepper[lane]
         CUR_LANE.weight = weight
         self.AFC.save_vars()
 
@@ -162,7 +162,7 @@ class afcSpool:
         if lane not in self.AFC.stepper:
             self.AFC.gcode.respond_info('{} Unknown'.format(lane.upper()))
             return
-        CUR_LANE = self.AFC.stepper[lane.name]
+        CUR_LANE = self.AFC.stepper[lane]
         CUR_LANE.material = material
         self.AFC.save_vars()
     def set_active_spool(self, ID):
@@ -207,10 +207,10 @@ class afcSpool:
             if lane not in self.AFC.stepper:
                 self.AFC.gcode.respond_info('{} Unknown'.format(lane.upper()))
                 return
-            CUR_LANE = self.AFC.stepper[lane.name]
+            CUR_LANE = self.AFC.stepper[lane]
             self.set_spoolID(CUR_LANE, SpoolID)
 
-    def set_spoolID(self, CUR_LANE, SpoolID):
+    def set_spoolID(self, CUR_LANE, SpoolID, save_vars=True):
         if self.AFC.spoolman_ip !=None:
             if SpoolID !='':
                 try:
@@ -233,7 +233,7 @@ class afcSpool:
                 CUR_LANE.material = ''
                 CUR_LANE.color = ''
                 CUR_LANE.weight = ''
-            self.AFC.save_vars()
+            if save_vars: self.AFC.save_vars()
 
     cmd_SET_RUNOUT_help = "change filaments ID"
     def cmd_SET_RUNOUT(self, gcmd):
@@ -262,7 +262,7 @@ class afcSpool:
         if lane not in self.AFC.stepper:
             self.AFC.gcode.respond_info('{} Unknown'.format(lane.upper()))
             return
-        CUR_LANE = self.AFC.stepper[lane.name]
+        CUR_LANE = self.AFC.stepper[lane]
         CUR_LANE.runout_lane = runout
         self.AFC.save_vars()
         self.gcode.respond_info("This is a feature WIP. Not functioning yet")

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -24,7 +24,7 @@ class afcSpool:
         self.gcode.register_mux_command('SET_COLOR',None,None, self.cmd_SET_COLOR, desc=self.cmd_SET_COLOR_help)
         self.gcode.register_mux_command('SET_WEIGHT',None,None, self.cmd_SET_WEIGHT, desc=self.cmd_SET_WEIGHT_help)
         self.gcode.register_mux_command('SET_MATERIAL',None,None, self.cmd_SET_MATERIAL, desc=self.cmd_SET_MATERIAL_help)
-        self.gcode.register_mux_command('SET_SPOOL_ID',None,None, self.cmd_SET_SPOOLID, desc=self.cmd_SET_SPOOLID_help)
+        self.gcode.register_mux_command('SET_SPOOL_ID',None,None, self.cmd_SET_SPOOL_ID, desc=self.cmd_SET_SPOOL_ID_help)
         self.gcode.register_mux_command('SET_RUNOUT',None,None, self.cmd_SET_RUNOUT, desc=self.cmd_SET_RUNOUT_help)
         self.gcode.register_mux_command('SET_MAP',None,None, self.cmd_SET_MAP, desc=self.cmd_SET_MAP_help)
 
@@ -68,7 +68,7 @@ class afcSpool:
 
         for UNIT_SERACH in self.AFC.units.keys():
             if lane_switch in self.AFC.units[UNIT_SERACH]:
-                SW_LANE = self.AFC.stepper(lane_switch)
+                SW_LANE = self.AFC.stepper[lane_switch]
                 self.AFC.tool_cmds[map_switch]=lane_switch
                 SW_LANE.map = map_switch
                 SW_LANE.map=map_switch
@@ -179,15 +179,15 @@ class afcSpool:
             except self.printer.command_error as e:
                 self.gcode._respond_error("Error trying to set active spool \n{}".format(e))
 
-    cmd_SET_SPOOLID_help = "change filaments ID"
-    def cmd_SET_SPOOLID(self, gcmd):
+    cmd_SET_SPOOL_ID_help = "change filaments ID"
+    def cmd_SET_SPOOL_ID(self, gcmd):
         """
         This function handles setting the spool ID for a specified lane. It retrieves the lane
         specified by the 'LANE' parameter and updates its spool ID, material, color, and weight
         based on the information retrieved from the Spoolman API.
 
-        Usage: `SET_SPOOLID LANE=<lane> SPOOL_ID=<spool_id>`
-        Example: `SET_SPOOLID LANE=leg1 SPOOL_ID=12345`
+        Usage: `SET_SPOOL_ID LANE=<lane> SPOOL_ID=<spool_id>`
+        Example: `SET_SPOOL_IDD LANE=leg1 SPOOL_ID=12345`
 
         Args:
             gcmd: The G-code command object containing the parameters for the command.

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -64,7 +64,7 @@ class AFCExtruderStepper:
         self.color = None
         self.weight = None
         self.runout_lane = 'NONE'
-        self.status = None
+        self.status = 'Not Loaded'
         unit = config.get('unit', None)
         if unit != None:
             self.unit = unit.split(':')[0]
@@ -75,8 +75,6 @@ class AFCExtruderStepper:
         self.hub= ''
 
         self.motion_queue = None
-        self.status = None
-        self.hub_load = False
         self.next_cmd_time = 0.
         ffi_main, ffi_lib = chelper.get_ffi()
         self.trapq = ffi_main.gc(ffi_lib.trapq_alloc(), ffi_lib.trapq_free)

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -55,6 +55,7 @@ class AFCExtruderStepper:
         #stored status variables
         self.name = config.get_name().split()[-1]
         self.extruder_name = config.get('extruder')
+        self.extruder_obj = None
 
         self.map = config.get('cmd','NONE')
         self.tool_loaded = False

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -253,8 +253,8 @@ class AFCExtruderStepper:
                     self.status = None
                     self.AFC.afc_led(self.AFC.led_not_ready, led)
                     self.AFC.gcode.respond_info("Infinite Spool triggered for {}".format(self.name))
-                    empty_LANE = self.AFC.stepper(self.AFC.current)
-                    change_LANE = self.AFC.stepper(self.runout_lane)
+                    empty_LANE = self.AFC.stepper[self.AFC.current]
+                    change_LANE = self.AFC.stepper[self.runout_lane]
                     self.gcode.run_script_from_command(change_LANE.map)
                     self.gcode.run_script_from_command('SET_MAP LANE=' + change_LANE.name + ' MAP=' + empty_LANE.map)
                     self.gcode.run_script_from_command('LANE_UNLOAD LANE=' + empty_LANE.name)


### PR DESCRIPTION
## Major Changes in this PR
- Fixing issue where hub_loaded is not loaded_to_hub in vars file, added a backwards combability check so users can upgrade without problem
- Added an extruder object to lane so that extruder does not have to be looked up all the time
- Fixed some more places where lane.name was being used as a key
- Fixed error when trying to map lanes
- Updated SET_SPOOLID to SET_SPOOL_ID so the documentation would match the actual macro name
## Notes to Code Reviewers

## How the changes in this PR are tested
- Went through tool load and unload, tested mapping lanes.
- Deleted vars files to make sure they were recreated correctly
- Copied over old format of vars file to make sure configuration stayed the same between the old and new format
## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
