### PR TITLE
AFC-27: Fix for tip forming when toolchange_temp is not zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -284,5 +284,8 @@ file as the code now generates them automatically.
 - **New Command: `TEST_AFC_TIP_FORMING`**
     Gives ability to test AFC tip forming without doing a tool change
 
+- **New Command: `RESET_AFC_MAPPING`**
+    Resets all tool lane mapping to the order that is setup in configuration
+
 ### Fixed
 - Fixed error in tip forming when `toolchange_temp` value is not zero

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -271,3 +271,18 @@ file as the code now generates them automatically.
 ### Updated
 - Updated Cut.cfg macro to have the ability to up stepper current when doing filament cutting, 
   see layer shift troubleshooting section on what values need to be set
+
+## [2024-12-22]
+
+### Added
+- **New Command: `SET_BUFFER_VELOCITY`**
+    Allows users to tweak buffer velocity setting while printing. This setting is not
+    saved in configuration.
+
+    See command_reference doc for more info
+
+- **New Command: `TEST_AFC_TIP_FORMING`**
+    Gives ability to test AFC tip forming without doing a tool change
+
+### Fixed
+- Fixed error in tip forming when `toolchange_temp` value is not zero

--- a/docs/command_reference.md
+++ b/docs/command_reference.md
@@ -16,6 +16,11 @@ runs the resume script, and restores the toolhead position to the last saved pos
 Usage: ``AFC_RESUME``  
 Example: ``AFC_RESUME``  
 
+### TEST_AFC_TIP_FORMING
+_Description_: Gives ability to test AFC tip forming without doing a tool change  
+Usage: `TEST_AFC_TIP_FORMING LANE=<lane>`  
+Example: `TEST_AFC_TIP_FORMING LANE=leg1`  
+
 ### AFC_STATUS
 _Description_: This function generates a status message for each unit and lane, indicating the preparation,
 loading, hub, and tool states. The status message is formatted with HTML tags for display.  

--- a/docs/command_reference.md
+++ b/docs/command_reference.md
@@ -106,7 +106,7 @@ Example: `QUERY_BUFFER BUFFER=TN2`
 
 ### SET_BUFFER_VELOCITY
 _Description_: Allows users to tweak buffer velocity setting while printing. This setting is not
-saved in configuration. Please update your configuration file once you find a velocity that 
+saved in configuration. Please update your configuration file once you find a velocity that
 works for your setup.  
 Usage: `SET_BUFFER_VELOCITY BUFFER=<buffer_name> VELOCITY=<value>`  
 Example: `SET_BUFFER_VELOCITY BUFFER=TN2 VELOCITY=100`  
@@ -148,13 +148,18 @@ based on the information retrieved from the Spoolman API.
 Usage: ``SET_RUNOUT LANE=<lane> RUNOUT=<lane>``  
 Example: ``SET_RUNOUT LANE=lane1 RUNOUT=lane4``  
 
+### RESET_AFC_MAPPING
+_Description_: This commands resets all tool lane mapping to the order that is setup in configuration.  
+Usage: `RESET_AFC_MAPPING LANE=<lane>`  
+Example: `RESET_AFC_MAPPING LANE=leg1`  
+
 ### CALIBRATE_AFC
 _Description_: This function performs the calibration of the hub and Bowden length for one or more lanes within an AFC
 (Automated Filament Changer) system. The function uses precise movements to adjust the positions of the
 steppers, check the state of the hubs and tools, and calculate distances for calibration based on the
 user-provided input. If no specific lane is provided, the function defaults to notifying the user that no lane has been selected. The function also includes
 the option to calibrate the Bowden length for a particular lane, if specified.  
-Usage: ``CALIBRATE_AFC LANES=<lane> DISTANCE=<distance> TOLERANCE=<tolerance> BOWDEN=<lane>``  
+Usage: ``CALIBRATE_AFC LANE=<lane> DISTANCE=<distance> TOLERANCE=<tolerance> BOWDEN=<lane>``  
 Example: `CALIBRATE_AFC LANE=leg1`  
 
 ## AFC Macros

--- a/docs/command_reference.md
+++ b/docs/command_reference.md
@@ -79,15 +79,6 @@ current lane and loading the new lane.
 Usage: ``CHANGE_TOOL LANE=<lane>``  
 Example: ``CHANGE_TOOL LANE=leg1``  
 
-### CALIBRATE_AFC
-_Description_: This function performs the calibration of the hub and Bowden length for one or more lanes within an AFC
-(Automated Filament Changer) system. The function uses precise movements to adjust the positions of the
-steppers, check the state of the hubs and tools, and calculate distances for calibration based on the
-user-provided input. If no specific lane is provided, the function defaults to notifying the user that no lane has been selected. The function also includes
-the option to calibrate the Bowden length for a particular lane, if specified.  
-Usage: ``CALIBRATE_AFC LANES=<lane> DISTANCE=<distance> TOLERANCE=<tolerance> BOWDEN=<lane>``  
-Example: `CALIBRATE_AFC LANES=all Bowden=leg1`  
-
 ### SET_MULTIPLIER
 _Description_: This function handles the adjustment of the buffer multipliers for the turtleneck buffer.
 It retrieves the multiplier type ('HIGH' or 'LOW') and the factor to be applied. The function
@@ -108,6 +99,13 @@ distance of the current AFC stepper motor.
 Usage: `QUERY_BUFFER BUFFER=<buffer_name>`  
 Example: `QUERY_BUFFER BUFFER=TN2`  
 
+### SET_BUFFER_VELOCITY
+_Description_: Allows users to tweak buffer velocity setting while printing. This setting is not
+saved in configuration. Please update your configuration file once you find a velocity that 
+works for your setup.  
+Usage: `SET_BUFFER_VELOCITY BUFFER=<buffer_name> VELOCITY=<value>`  
+Example: `SET_BUFFER_VELOCITY BUFFER=TN2 VELOCITY=100`  
+
 ### SET_MAP
 _Description_: This function handles changing the GCODE tool change command for a Lane.  
 Usage: ``SET_MAP LANE=<lane> MAP=<cmd>``  
@@ -118,6 +116,18 @@ _Description_: This function handles changing the color of a specified lane. It 
 specified by the 'LANE' parameter and sets its color to the value provided by the 'COLOR' parameter.  
 Usage: ``SET_COLOR LANE=<lane> COLOR=<color>``  
 Example: ``SET_COLOR LANE=leg1 COLOR=FF0000``  
+
+### SET_WEIGHT
+_Description_: This function handles changing the material of a specified lane. It retrieves the lane
+specified by the 'LANE' parameter and sets its material to the value provided by the 'MATERIAL' parameter.  
+Usage: `SET_WEIGHT LANE=<lane> WEIGHT=<weight>`  
+Example: `SET_WEIGHT LANE=leg1 WEIGHT=850`  
+
+### SET_MATERIAL
+_Description_: This function handles changing the material of a specified lane. It retrieves the lane
+specified by the 'LANE' parameter and sets its material to the value provided by the 'MATERIAL' parameter.  
+Usage: `SET_MATERIAL LANE=<lane> MATERIAL=<material>`  
+Example: `SET_MATERIAL LANE=leg1 MATERIAL=ABS`  
 
 ### SET_SPOOLID
 _Description_: This function handles setting the spool ID for a specified lane. It retrieves the lane
@@ -132,6 +142,15 @@ specified by the 'LANE' parameter and updates its the lane to use if filament is
 based on the information retrieved from the Spoolman API.  
 Usage: ``SET_RUNOUT LANE=<lane> RUNOUT=<lane>``  
 Example: ``SET_RUNOUT LANE=lane1 RUNOUT=lane4``  
+
+### CALIBRATE_AFC
+_Description_: This function performs the calibration of the hub and Bowden length for one or more lanes within an AFC
+(Automated Filament Changer) system. The function uses precise movements to adjust the positions of the
+steppers, check the state of the hubs and tools, and calculate distances for calibration based on the
+user-provided input. If no specific lane is provided, the function defaults to notifying the user that no lane has been selected. The function also includes
+the option to calibrate the Bowden length for a particular lane, if specified.  
+Usage: ``CALIBRATE_AFC LANES=<lane> DISTANCE=<distance> TOLERANCE=<tolerance> BOWDEN=<lane>``  
+Example: `CALIBRATE_AFC LANE=leg1`  
 
 ## AFC Macros
 
@@ -151,11 +170,3 @@ _Description_: Move the specified lane the specified amount
 _Description_: Resume the print after an error
 ### BT_PREP
 _Description_: Run the AFC PREP sequence
-### T0
-_Description_: Change to tool 0
-### T1
-_Description_: Change to tool 1
-### T2
-_Description_: Change to tool 2
-### T3
-_Description_: Change to tool 3

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -105,9 +105,9 @@ class afcBoxTurtle:
         user-provided input. If no specific lane is provided, the function defaults to notifying the user that no lane has been selected. The function also includes
         the option to calibrate the Bowden length for a particular lane, if specified.
 
-        Usage:`CALIBRATE_AFC LANES=<lane> DISTANCE=<distance> TOLERANCE=<tolerance> BOWDEN=<lane>`
+        Usage:`CALIBRATE_AFC LANE=<lane> DISTANCE=<distance> TOLERANCE=<tolerance> BOWDEN=<lane>`
         Examples:
-            - `CALIBRATE_AFC LANES=all Bowden=leg1 DISTANCE=30 TOLERANCE=3`
+            - `CALIBRATE_AFC LANE=all Bowden=leg1 DISTANCE=30 TOLERANCE=3`
             - `CALIBRATE_AFC BOWDEN=leg1` (Calibrates the Bowden length for 'leg1')
 
         Args:
@@ -125,7 +125,7 @@ class afcBoxTurtle:
         tol = gcmd.get_float('TOLERANCE', 5)
         afc_bl = gcmd.get('BOWDEN', None)
         short_dis = self.AFC.short_move_dis
-        lanes = gcmd.get('LANES', None)
+        lanes = gcmd.get('LANE', None)
 
         if self.AFC.current is not None:
             self.AFC.gcode.respond_info('Tool must be unloaded to calibrate Bowden length')

--- a/extras/AFC_buffer.py
+++ b/extras/AFC_buffer.py
@@ -69,6 +69,7 @@ class AFCtrigger:
 
         self.printer.register_event_handler("klippy:ready", self._handle_ready)
         self.gcode.register_mux_command("QUERY_BUFFER", "BUFFER", self.name, self.cmd_QUERY_BUFFER, desc=self.cmd_QUERY_BUFFER_help)
+        self.gcode.register_mux_command("SET_BUFFER_VELOCITY", "BUFFER", self.name, self.cmd_SET_BUFFER_VELOCITY, desc=self.cmd_SET_BUFFER_VELOCITY_help)
 
         # Belay Buffer
         if self.belay:
@@ -302,6 +303,26 @@ class AFCtrigger:
                 state_info += ("\n{} Rotation distance: {}".format(LANE.name.upper(), rotation_dist))
 
         self.gcode.respond_info("{} : {}".format(self.name, state_info))
+    
+    cmd_SET_BUFFER_VELOCITY_help = "Set buffer velocity realtime for forward assist"
+    def cmd_SET_BUFFER_VELOCITY(self, gcmd):
+        """
+        Allows users to tweak buffer velocity setting while printing. This setting is not
+        saved in configuration. Please update your configuration file once you find a velocity that 
+        works for your setup.
+
+        Usage: SET_BUFFER_VELOCITY BUFFER=<buffer_name> VELOCITY=<value>
+        Example: SET_BUFFER_VELOCITY BUFFER=TN2 VELOCITY=100
+
+        Behavior:
+            - Updates the value that the espooler use for forward assist during printing.
+            - Setting value to zero disables forward assist during printing.
+            - Velocity is not saved to configuration file, needs to be manually updated.
+        """
+        old_velocity = self.velocity
+        self.velocity = gcmd.get_float('VELOCITY', 0.0)
+        self.gcode.respond_info("VELOCITY for {} was updated from {} to {}".format(self.name, old_velocity, self.velocity))
+        
 
 def load_config_prefix(config):
     return AFCtrigger(config)

--- a/extras/AFC_buffer.py
+++ b/extras/AFC_buffer.py
@@ -303,12 +303,12 @@ class AFCtrigger:
                 state_info += ("\n{} Rotation distance: {}".format(LANE.name.upper(), rotation_dist))
 
         self.gcode.respond_info("{} : {}".format(self.name, state_info))
-    
+
     cmd_SET_BUFFER_VELOCITY_help = "Set buffer velocity realtime for forward assist"
     def cmd_SET_BUFFER_VELOCITY(self, gcmd):
         """
         Allows users to tweak buffer velocity setting while printing. This setting is not
-        saved in configuration. Please update your configuration file once you find a velocity that 
+        saved in configuration. Please update your configuration file once you find a velocity that
         works for your setup.
 
         Usage: SET_BUFFER_VELOCITY BUFFER=<buffer_name> VELOCITY=<value>
@@ -322,7 +322,7 @@ class AFCtrigger:
         old_velocity = self.velocity
         self.velocity = gcmd.get_float('VELOCITY', 0.0)
         self.gcode.respond_info("VELOCITY for {} was updated from {} to {}".format(self.name, old_velocity, self.velocity))
-        
+
 
 def load_config_prefix(config):
     return AFCtrigger(config)

--- a/extras/AFC_form_tip.py
+++ b/extras/AFC_form_tip.py
@@ -27,6 +27,7 @@ class afc_tip_form:
         self.dip_extraction_speed  = config.getfloat("dip_extraction_speed", 4)
         self.melt_zone_pause  = config.getfloat("melt_zone_pause", 4)
         self.cooling_zone_pause  = config.getfloat("cooling_zone_pause", 4)
+        self.gcode.register_command("TEST_AFC_TIP_FORMING", self.cmd_TEST_AFC_TIP_FORMING, desc=self.cmd_TEST_AFC_TIP_FORMING_help)
 
 
     def afc_extrude(self, distance, speed):
@@ -35,10 +36,20 @@ class afc_tip_form:
         self.AFC.toolhead.manual_move(pos, speed)
         self.AFC.toolhead.wait_moves()
 
+    cmd_TEST_AFC_TIP_FORMING_help = "Gives ability to test AFC tip forming without doing a tool change"
+    def cmd_TEST_AFC_TIP_FORMING(self, gcmd):
+        '''
+        Gives ability to test AFC tip forming without doing a tool change
 
+        USAGE: TEST_AFC_TIP_FORMING
+        '''
+        self.tip_form()
 
     def tip_form(self):
         step = 1
+        extruder = self.AFC.toolhead.get_extruder()
+        pheaters = self.printer.lookup_object('heaters')
+        current_temp = extruder.get_heater().target_temp     # Saving current temp so it can be set back when done if toolchange_temp is not zero
         if self.ramming_volume > 0:
             self.gcode.respond_info('AFC-TIP-FORM: Step ' + str(step) + ': Ramming')
             ratio = self.ramming_volume / 23
@@ -69,8 +80,8 @@ class afc_tip_form:
                 wait = False
             else:
                 wait =  True
-            extruder = self.AFC.toolhead.get_extruder()
-            pheaters = self.printer.lookup_object('heaters')
+
+            self.gcode.respond_info("AFC-TIP-FORM: Waiting for temperature to get to {}".format(self.toolchange_temp))
             pheaters.set_temperature(extruder.get_heater(), self.toolchange_temp, wait)
         step +=1
         self.gcode.respond_info('AFC-TIP-FORM: Step ' + str(step) + ': Cooling Moves')
@@ -86,6 +97,12 @@ class afc_tip_form:
             self.reactor.pause(self.reactor.monotonic() + self.melt_zone_pause)
             self.afc_extrude(self.skinnydip_distance * -1, self.dip_extraction_speed * 60)
             self.reactor.pause(self.reactor.monotonic() + self.cooling_zone_pause)
+
+        if extruder.get_heater().target_temp != current_temp:
+            self.gcode.respond_info('AFC-TIP-FORM: Setting temperature back to {}'.format(current_temp))
+            pheaters.set_temperature(extruder.get_heater(), current_temp)
+
+        self.gcode.respond_info('AFC-TIP-FORM: Done')
 
 def load_config(config):
     return afc_tip_form(config)

--- a/extras/AFC_form_tip.py
+++ b/extras/AFC_form_tip.py
@@ -69,7 +69,7 @@ class afc_tip_form:
                 wait = False
             else:
                 wait =  True
-            extruder = self.toolhead.get_extruder()
+            extruder = self.AFC.toolhead.get_extruder()
             pheaters = self.printer.lookup_object('heaters')
             pheaters.set_temperature(extruder.get_heater(), self.toolchange_temp, wait)
         step +=1

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -27,6 +27,7 @@ class afcSpool:
         self.gcode.register_mux_command('SET_SPOOL_ID',None,None, self.cmd_SET_SPOOLID, desc=self.cmd_SET_SPOOLID_help)
         self.gcode.register_mux_command('SET_RUNOUT',None,None, self.cmd_SET_RUNOUT, desc=self.cmd_SET_RUNOUT_help)
         self.gcode.register_mux_command('SET_MAP',None,None, self.cmd_SET_MAP, desc=self.cmd_SET_MAP_help)
+        self.gcode.register_command("RESET_AFC_MAPPING", self.cmd_RESET_AFC_MAPPING, desc=self.cmd_RESET_AFC_MAPPING_help)
 
         self.URL = 'http://{}:{}/api/v1/spool/'.format(self.AFC.spoolman_ip, self.AFC.spoolman_port)
 
@@ -246,6 +247,27 @@ class afcSpool:
         self.AFC.lanes[CUR_LANE.unit][CUR_LANE.name]['runout_lane'] = runout
         self.AFC.save_vars()
         self.gcode.respond_info("This is a feature WIP. Not functioning yet")
+    
+    cmd_RESET_AFC_MAPPING_help = "Resets all lane mapping in AFC"
+    def cmd_RESET_AFC_MAPPING(self, gcmd):
+        """
+        This commands resets all tool lane mapping to the order that is setup in configuration.
+
+        Useful to put in your PRINT_END macro to reset mapping
+
+        USAGE: RESET_AFC_MAPPING
+        """
+        t_index = 0
+        for key, unit in self.AFC.lanes.items():
+            for lane in unit:
+                map_cmd = "T{}".format(t_index)
+                self.AFC.tool_cmds[map_cmd] = lane
+                self.AFC.lanes[key][lane]['map']=map_cmd
+                self.printer.lookup_object('AFC_stepper ' + lane).map = map_cmd
+                t_index += 1
+
+        self.AFC.save_vars()
+        self.AFC.gcode.respond_info("Tool mappings reset")
 
 def load_config(config):
     return afcSpool(config)


### PR DESCRIPTION
## Major Changes in this PR
- Fixed issue with klipper error out when toolchange_temp is not zero
- Added two new macros, TEST_AFC_TIP_FORMING, SET_BUFFER_VELOCITY, RESET_AFC_MAPPING
## Notes to Code Reviewers

## How the changes in this PR are tested
Tested tip forming with new macro command
Tested SET_BUFFER_VELOCITY command
Tested RESET_AFC_MAPPING to make sure it reset and save to vars correctly
## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
