### PR TITLE
Miscellaneous updates and updates to documents 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,3 +274,12 @@ file as the code now generates them automatically.
 
 ### Fixes
 - Misc error fixes
+
+## [2024-12-23]
+### Added
+- Added ability to set lower stepper current when printing to help reduce how hot steppers can get.
+  To enable this feature set `global_print_current` in AFC.cfg or `print_current` for each AFC_stepper
+  During testing it was found that 0.6 was optimal, going lower than this may result in buffer not working as intended
+
+- Added check to make sure printer is not printing or homing when trying to load a spool. Doing so before would
+  result in klipper crashing.

--- a/config/AFC.cfg
+++ b/config/AFC.cfg
@@ -10,6 +10,16 @@ short_moves_speed: 50           # mm/s. Default value is 50mm/s.
 short_moves_accel: 300          # mm/s². Default value is 300mm/s².
 short_move_dis: 10              # Move distance for failsafe moves. Default is 10mm.
 
+# global_print_current: 0.6       # Uncomment to set stepper motors to a lower current while printing
+                                # This value can also be set per stepper with print_current: 0.6
+
+#--=================================================================================-
+#------- TRSYNC Values --------------------------------------------------------------
+#--=================================================================================-
+# trsync_update: True             # Uncomment this value to update klippers trsync value
+# trsync_timeout: 0.05            # Uncomment this value if timeout needs to be greater than the default of 0.05
+# trsync_single_timeout: 0.250    # Uncomment this value if single_timeout needs to be greater than the default of 0.250
+
 #--=================================================================================-
 #------- Pause/Resume ---------------------------------------------------------------
 #--=================================================================================-

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -1,0 +1,24 @@
+# Overview of features 
+
+This file goes over the features that can be found in Armored Turtle Automated Filament Changer (AFC) Software
+
+## TurtleNeck Buffer Ram Sensor
+AFC allows the use of using the TurtleNeck Buffers as a ram sensor for detecting when filament is loaded to the toolhead extruder. This can be used inplace of a toolhead filament sensor. To learn more about this feature please see [Buffer Ram Sensor](Buffer_Ram_Sensor.md) document
+
+## Bypass
+You can enable AFC bypass by printing out [bypass](https://github.com/ArmoredTurtle/AFC-Accessories/tree/main/AFC_Bypass) accessory, connecting inline after your buffer and adding a bypass filament sensor to klipper config like below. Once filament is inserted into the bypass side, the switch disables AFC functionality so you can print like normal.
+
+```
+[filament_switch_sensor bypass]
+switch_pin: <replace with MCU pin that switch is connected to>
+pause_on_runout: False
+```
+
+## Lower stepper current when printing
+For longer prints you may want to have the ability to lower BoxTurtles steppers current as they can get hot when engaged for a long period of time.
+
+Enabling lower current during printing can be enabled two ways:
+1. Set `global_print_current` in AFC.cfg file
+2. Set `print_current` for each AFC_stepper, this will override `global_print_current` in AFC.cfg
+
+During testing it was found that 0.6A worked well during printing and kept the steppers warms to the touch. Would not suggest going lower than this or the TurtleNeck buffers may not work as intended.

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -46,58 +46,61 @@ class afc:
         self.absolute_coord = True
 
         # SPOOLMAN
-        self.spoolman_ip = config.get('spoolman_ip', None)
-        self.spoolman_port = config.get('spoolman_port', None)
+        self.spoolman_ip = config.get('spoolman_ip', None)                          # To utilize spoolman enter spoolmans IP address
+        self.spoolman_port = config.get('spoolman_port', None)                      # To utilize spoolman enter spoolmans port
 
         #LED SETTINGS
         self.ind_lights = None
-        self.led_name = config.get('led_name')
-        self.led_fault =config.get('led_fault','1,0,0,0')
-        self.led_ready = config.get('led_ready','1,1,1,1')
-        self.led_not_ready = config.get('led_not_ready','1,1,0,0')
-        self.led_loading = config.get('led_loading','1,0,0,0')
-        self.led_prep_loaded = config.get('led_loading','1,1,0,0')
-        self.led_unloading = config.get('led_unloading','1,1,.5,0')
-        self.led_tool_loaded = config.get('led_tool_loaded','1,1,0,0')
-        self.led_advancing = config.get('led_buffer_advancing','0,0,1,0')
-        self.led_trailing = config.get('led_buffer_trailing','0,1,0,0')
-        self.led_buffer_disabled = config.get('led_buffer_disable', '0,0,0,0.25')
+        self.led_name = config.get('led_name')                                      # Not used removed?
+        self.led_fault =config.get('led_fault','1,0,0,0')                           # LED color to set when faults occur in lane        (R,G,B,W) 0 = off, 1 = full brightness.
+        self.led_ready = config.get('led_ready','1,1,1,1')                          # LED color to set when lane is ready               (R,G,B,W) 0 = off, 1 = full brightness.
+        self.led_not_ready = config.get('led_not_ready','1,1,0,0')                  # LED color to set when lane not ready              (R,G,B,W) 0 = off, 1 = full brightness.
+        self.led_loading = config.get('led_loading','1,0,0,0')                      # LED color to set when lane is loading             (R,G,B,W) 0 = off, 1 = full brightness.
+        self.led_prep_loaded = config.get('led_loading','1,1,0,0')                  # LED color to set when lane is loaded              (R,G,B,W) 0 = off, 1 = full brightness.
+        self.led_unloading = config.get('led_unloading','1,1,.5,0')                 # LED color to set when lane is unloading           (R,G,B,W) 0 = off, 1 = full brightness.
+        self.led_tool_loaded = config.get('led_tool_loaded','1,1,0,0')              # LED color to set when lane is loaded into tool    (R,G,B,W) 0 = off, 1 = full brightness.
+        self.led_advancing = config.get('led_buffer_advancing','0,0,1,0')           # LED color to set when buffer is advancing         (R,G,B,W) 0 = off, 1 = full brightness.
+        self.led_trailing = config.get('led_buffer_trailing','0,1,0,0')             # LED color to set when buffer is trailing          (R,G,B,W) 0 = off, 1 = full brightness.
+        self.led_buffer_disabled = config.get('led_buffer_disable', '0,0,0,0.25')   # LED color to set when buffer is disabled          (R,G,B,W) 0 = off, 1 = full brightness.
 
         # TOOL Cutting Settings
         self.tool = ''
-        self.tool_cut = config.getboolean("tool_cut", False)
-        self.tool_cut_cmd = config.get('tool_cut_cmd', None)
+        self.tool_cut = config.getboolean("tool_cut", False)                        # Set to True to enable toolhead cutting
+        self.tool_cut_cmd = config.get('tool_cut_cmd', None)                        # Macro to use when doing toolhead cutting. Change macro name if you would like to use your own cutting macro
 
         # CHOICES
-        self.park = config.getboolean("park", False)
-        self.park_cmd = config.get('park_cmd', None)
-        self.kick = config.getboolean("kick", False)
-        self.kick_cmd = config.get('kick_cmd', None)
-        self.wipe = config.getboolean("wipe", False)
-        self.wipe_cmd = config.get('wipe_cmd', None)
-        self.poop = config.getboolean("poop", False)
-        self.poop_cmd = config.get('poop_cmd', None)
+        self.park = config.getboolean("park", False)                                # Set to True to enable parking during unload
+        self.park_cmd = config.get('park_cmd', None)                                # Macro to use when parking. Change macro name if you would like to use your own park macro
+        self.kick = config.getboolean("kick", False)                                # Set to True to enable poop kicking after lane loads
+        self.kick_cmd = config.get('kick_cmd', None)                                # Macro to use when kicking. Change macro name if you would like to use your own kick macro
+        self.wipe = config.getboolean("wipe", False)                                # Set to True to enable nozzle wipeing after lane loads
+        self.wipe_cmd = config.get('wipe_cmd', None)                                # Macro to use when nozzle wipeing. Change macro name if you would like to use your own wipe macro
+        self.poop = config.getboolean("poop", False)                                # Set to True to enable pooping(purging color) after lane loads
+        self.poop_cmd = config.get('poop_cmd', None)                                # Macro to use when pooping. Change macro name if you would like to use your own poop/purge macro
 
-        self.form_tip = config.getboolean("form_tip", False)
-        self.form_tip_cmd = config.get('form_tip_cmd', None)
+        self.form_tip = config.getboolean("form_tip", False)                        # Set to True to tip forming when unloading lanes
+        self.form_tip_cmd = config.get('form_tip_cmd', None)                        # Macro to use when tip forming. Change macro name if you would like to use your own tip forming macro
 
         # MOVE SETTINGS
-        self.tool_sensor_after_extruder = config.getfloat("tool_sensor_after_extruder", 0)
-        self.long_moves_speed = config.getfloat("long_moves_speed", 100)
-        self.long_moves_accel = config.getfloat("long_moves_accel", 400)
-        self.short_moves_speed = config.getfloat("short_moves_speed", 25)
-        self.short_moves_accel = config.getfloat("short_moves_accel", 400)
-        self.short_move_dis = config.getfloat("short_move_dis", 10)
-        self.tool_max_unload_attempts = config.getint('tool_max_unload_attempts', 2)
-        self.tool_max_load_checks = config.getint('tool_max_load_checks', 4)
-        self.z_hop =config.getfloat("z_hop", 0)
-        self.xy_resume =config.getboolean("xy_resume", False)
-        self.resume_speed =config.getfloat("resume_speed", 0)
-        self.resume_z_speed = config.getfloat("resume_z_speed", 0)
+        self.tool_sensor_after_extruder = config.getfloat("tool_sensor_after_extruder", 0) # Currently unused
+        self.long_moves_speed = config.getfloat("long_moves_speed", 100)            # Speed in mm/s to move filament when doing long moves
+        self.long_moves_accel = config.getfloat("long_moves_accel", 400)            # Acceleration in mm/s squared when doing long moves
+        self.short_moves_speed = config.getfloat("short_moves_speed", 25)           # Speed in mm/s to move filament when doing short moves
+        self.short_moves_accel = config.getfloat("short_moves_accel", 400)          # Acceleration in mm/s squared when doing short moves
+        self.short_move_dis = config.getfloat("short_move_dis", 10)                 # Move distance in mm for failsafe moves.
+        self.tool_max_unload_attempts = config.getint('tool_max_unload_attempts', 2)# Max number of attempts to unload filament from toolhead when using buffer as ramming sensor
+        self.tool_max_load_checks = config.getint('tool_max_load_checks', 4)        # Max number of attempts to check to make sure filament is loaded into toolhead extruder when using buffer as ramming sensor
+
+        self.z_hop =config.getfloat("z_hop", 0)                                     # Height to move up before and after a tool change completes
+        self.xy_resume =config.getboolean("xy_resume", False)                       # Need description or remove as this is currently an unused variable
+        self.resume_speed =config.getfloat("resume_speed", 0)                       # Speed mm/s of resume move. Set to 0 to use gcode speed
+        self.resume_z_speed = config.getfloat("resume_z_speed", 0)                  # Speed mm/s of resume move in Z. Set to 0 to use gcode speed
+
+        self.global_print_current = config.getfloat("global_print_current", None)   # Global variable to set steppers current to a specified current when printing. Going lower than 0.6 may result in TurtleNeck buffer's not working correctly
 
         self._update_trsync(config)
 
-        self.VarFile = config.get('VarFile')
+        self.VarFile = config.get('VarFile')                                        # Path to the variables file for AFC configuration.
 
         # Get debug and cast to boolean
         #self.debug = True == config.get('debug', 0)
@@ -108,12 +111,12 @@ class afc:
 
     def _update_trsync(self, config):
         # Logic to update trsync values
-        update_trsync = config.getboolean("trsync_update", False)
+        update_trsync = config.getboolean("trsync_update", False)                   # Set to true to enable updating trsync value in klipper mcu. Enabling this and updating the timeouts can help with Timer Too Close(TTC) errors
         if update_trsync:
             try:
                 import mcu
-                trsync_value = config.getfloat("trsync_timeout", 0.05)
-                trsync_single_value = config.getfloat("trsync_single_timeout", 0.5)
+                trsync_value = config.getfloat("trsync_timeout", 0.05)              # Timeout value to update in klipper mcu. Klippers default value is 0.025
+                trsync_single_value = config.getfloat("trsync_single_timeout", 0.5) # Single timeout value to update in klipper mcu. Klippers default value is 0.250
                 self.gcode.respond_info("Applying TRSYNC update")
 
                 # Making sure value exists as kalico(danger klipper) does not have TRSYNC_TIMEOUT value
@@ -295,7 +298,10 @@ class afc:
             self.gcode.respond_info('{} Unknown'.format(lane.upper()))
             return
         CUR_LANE = self.stepper[lane]
+        CUR_LANE.set_load_current() # Making current is set correctly when doing lane moves
+        CUR_LANE.do_enable(True)
         CUR_LANE.move(distance, self.short_moves_speed, self.short_moves_accel, True)
+        CUR_LANE.do_enable(False)
 
     def save_pos(self):
         # Only save previous location on the first toolchange call to keep an error state from overwriting the location
@@ -351,7 +357,7 @@ class afc:
             status = self.get_status(0)
             f.write(json.dumps(status, indent=4))
         with open(self.VarFile+ '.tool', 'w') as f:
-            f.write(json.dumps(self.extruders, indent=4))
+            f.write(json.dumps(status['system']['extruders'], indent=4))
 
     cmd_HUB_CUT_TEST_help = "Test the cutting sequence of the hub cutter, expects LANE=legN"
     def cmd_HUB_CUT_TEST(self, gcmd):
@@ -640,7 +646,7 @@ class afc:
             # Synchronize lane's extruder stepper and finalize tool loading.
             CUR_LANE.status = 'Tooled'
             self.save_vars()
-            CUR_LANE.extruder_stepper.sync_to_extruder(CUR_LANE.extruder_name)
+            CUR_LANE.sync_to_extruder()
 
             # Adjust tool position for loading.
             pos = self.toolhead.get_position()
@@ -652,7 +658,7 @@ class afc:
             # Lane will load until Advance sensor is True
             # After the tool_stn distance the lane will retract off the sensor to confirm load and reset buffer
             if CUR_EXTRUDER.tool_start == "buffer":
-                CUR_LANE.extruder_stepper.sync_to_extruder(None)
+                CUR_LANE.unsync_to_extruder()
                 load_checks = 0
                 while CUR_EXTRUDER.tool_start_state == True:
                     CUR_LANE.move( self.short_move_dis * -1, self.short_moves_speed, self.short_moves_accel )
@@ -664,7 +670,7 @@ class afc:
                         msg += "Tool may not be loaded"
                         self.gcode.respond_info("<span class=warning--text>{}</span>".format(msg))
                         break
-                CUR_LANE.extruder_stepper.sync_to_extruder(CUR_LANE.extruder_name)
+                CUR_LANE.sync_to_extruder()
             # Update tool and lane status.
             CUR_LANE.status = 'Tooled'
             CUR_LANE.tool_loaded = True
@@ -780,7 +786,7 @@ class afc:
 
         if CUR_LANE.extruder_stepper.motion_queue != CUR_LANE.extruder_name:
             # Synchronize the extruder stepper with the lane.
-            CUR_LANE.extruder_stepper.sync_to_extruder(CUR_LANE.extruder_name)
+            CUR_LANE.sync_to_extruder()
 
         # Check and set the extruder temperature if below the minimum.
         wait = True
@@ -812,7 +818,7 @@ class afc:
         num_tries = 0
         if CUR_EXTRUDER.tool_start == "buffer":
             # if ramming is enabled, AFC will retract to collapse buffer before unloading
-            CUR_LANE.extruder_stepper.sync_to_extruder(None)
+            CUR_LANE.unsync_to_extruder()
             while CUR_EXTRUDER.buffer_trailing == False:
                 # attempt to return buffer to trailng pin
                 CUR_LANE.move( self.short_move_dis * -1, self.short_moves_speed, self.short_moves_accel )
@@ -824,7 +830,7 @@ class afc:
                     msg += "Increasing 'tool_max_unload_attempts' may improve loading reliablity"
                     self.gcode.respond_info("<span class=warning--text>{}</span>".format(msg))
                     break
-            CUR_LANE.extruder_stepper.sync_to_extruder(CUR_LANE.extruder_name)
+            CUR_LANE.sync_to_extruder(False)
             pos = self.toolhead.get_position()
             pos[3] -= CUR_EXTRUDER.tool_stn_unload
             self.toolhead.manual_move(pos, CUR_EXTRUDER.tool_unload_speed)
@@ -837,7 +843,7 @@ class afc:
                     message = ('FAILED TO UNLOAD. FILAMENT STUCK IN TOOLHEAD.')
                     self.ERROR.handle_lane_failure(CUR_LANE, message)
                     return False
-                CUR_LANE.extruder_stepper.sync_to_extruder(CUR_LANE.extruder_name)
+                CUR_LANE.sync_to_extruder()
                 pos = self.toolhead.get_position()
                 pos[3] -= CUR_EXTRUDER.tool_stn_unload
                 self.toolhead.manual_move(pos, CUR_EXTRUDER.tool_unload_speed)
@@ -851,7 +857,7 @@ class afc:
             self.toolhead.wait_moves()
 
         # Synchronize and move filament out of the hub.
-        CUR_LANE.extruder_stepper.sync_to_extruder(None)
+        CUR_LANE.unsync_to_extruder()
         CUR_LANE.move(CUR_HUB.afc_bowden_length * -1, self.long_moves_speed, self.long_moves_accel, True)
 
         # Clear toolhead's loaded state for easier error handling later.

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -28,7 +28,7 @@ class afcBoxTurtle:
 
         self.AFC.gcode.register_mux_command('CALIBRATE_AFC', None, None, self.cmd_CALIBRATE_AFC, desc=self.cmd_CALIBRATE_AFC_help)
 
-    def system_Test(self, UNIT, LANE, delay):
+    def system_Test(self, UNIT, LANE, delay, assignTcmd):
         msg = ''
         succeeded = True
         if LANE not in self.AFC.stepper:
@@ -43,7 +43,7 @@ class afcBoxTurtle:
             return False
 
         # Run test reverse/forward on each lane
-        CUR_LANE.extruder_stepper.sync_to_extruder(None)
+        CUR_LANE.unsync_to_extruder(False)
         CUR_LANE.move( 5, self.AFC.short_moves_speed, self.AFC.short_moves_accel, True)
         self.AFC.reactor.pause(self.AFC.reactor.monotonic() + delay)
         CUR_LANE.move( -5, self.AFC.short_moves_speed, self.AFC.short_moves_accel, True)
@@ -73,7 +73,7 @@ class afcBoxTurtle:
                 if CUR_LANE.tool_loaded:
                     if CUR_LANE.extruder_obj.tool_start_state == True or CUR_LANE.extruder_obj.tool_start == "buffer":
                         if self.AFC.extruders[CUR_LANE.extruder_name]['lane_loaded'] == CUR_LANE.name:
-                            CUR_LANE.extruder_stepper.sync_to_extruder(CUR_LANE.extruder_name)
+                            CUR_LANE.sync_to_extruder()
                             msg +="<span class=primary--text> in ToolHead</span>"
                             if CUR_LANE.extruder_obj.tool_start == "buffer":
                                 msg += "<span class=warning--text>\n Ram sensor enabled, confirm tool is loaded</span>"
@@ -93,7 +93,7 @@ class afcBoxTurtle:
                         if not lane_check:
                             return False
 
-        self.AFC.TcmdAssign(CUR_LANE)
+        if assignTcmd: self.AFC.TcmdAssign(CUR_LANE)
         CUR_LANE.do_enable(False)
         self.AFC.gcode.respond_info( '{lane_name} tool cmd: {tcmd:3} {msg}'.format(lane_name=CUR_LANE.name.upper(), tcmd=CUR_LANE.map, msg=msg))
         CUR_LANE.set_afc_prep_done()

--- a/extras/AFC_NightOwl.py
+++ b/extras/AFC_NightOwl.py
@@ -21,7 +21,7 @@ class afcNightOwl:
 
         self.logo_error = '<span class=error--text>Night Owl Not Ready</span>\n'
 
-    def system_Test(self, UNIT, LANE, delay):
+    def system_Test(self, UNIT, LANE, delay, assignTcmd):
         msg = ''
         succeeded = True
         if LANE not in self.AFC.stepper:
@@ -36,7 +36,7 @@ class afcNightOwl:
             return False
 
         # Run test reverse/forward on each lane
-        CUR_LANE.extruder_stepper.sync_to_extruder(None)
+        CUR_LANE.unsync_to_extruder(False)
         CUR_LANE.move( 5, self.AFC.short_moves_speed, self.AFC.short_moves_accel, True)
         self.AFC.reactor.pause(self.AFC.reactor.monotonic() + delay)
         CUR_LANE.move( -5, self.AFC.short_moves_speed, self.AFC.short_moves_accel, True)
@@ -67,7 +67,7 @@ class afcNightOwl:
                 if CUR_LANE.tool_loaded:
                     if CUR_LANE.extruder_obj.tool_start_state == True or CUR_LANE.extruder_obj.tool_start == "buffer":
                         if self.AFC.extruders[CUR_LANE.extruder_name]['lane_loaded'] == CUR_LANE.name:
-                            CUR_LANE.extruder_stepper.sync_to_extruder(CUR_LANE.extruder_name)
+                            CUR_LANE.sync_to_extruder()
                             msg +="<span class=primary--text> in ToolHead</span>"
                             if CUR_LANE.extruder_obj.tool_start == "buffer":
                                 msg += "<span class=warning--text>\n Ram sensor enabled, confirm tool is loaded</span>"
@@ -87,7 +87,7 @@ class afcNightOwl:
                         if not lane_check:
                             return False
 
-        self.AFC.TcmdAssign(CUR_LANE)
+        if assignTcmd: self.AFC.TcmdAssign(CUR_LANE)
         CUR_LANE.do_enable(False)
         self.AFC.gcode.respond_info( '{lane_name} tool cmd: {tcmd:3} {msg}'.format(lane_name=CUR_LANE.name.upper(), tcmd=CUR_LANE.map, msg=msg))
         CUR_LANE.set_afc_prep_done()

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -11,11 +11,13 @@ class afcPrep:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.printer.register_event_handler("klippy:connect", self.handle_connect)
-        self.delay = config.getfloat('delay_time', 0.1, minval=0.0)
-        self.enable = config.getboolean("enable", False)
+        self.delay = config.getfloat('delay_time', 0.1, minval=0.0)                 # Time to delay when moving extruders and spoolers during PREP routine
+        self.enable = config.getboolean("enable", False)                            # Set True to disable PREP checks
 
-        # Flag to set once resume rename as occured for the first time
-        self.rename_occured = False
+        # Flag to set once resume rename as occurred for the first time
+        self.rename_occurred = False
+        # Value gets set to false once prep has been ran for the first time after restarting klipper
+        self.assignTcmd = True
 
     def handle_connect(self):
         """
@@ -33,8 +35,8 @@ class afcPrep:
         """
 
         # Checking to see if rename has already been done, don't want to rename again if prep was already ran
-        if not self.rename_occured:
-            self.rename_occured = True
+        if not self.rename_occurred:
+            self.rename_occurred = True
             # Renaming users Resume macro so that RESUME calls AFC_Resume function instead
             base_resume_name = "RESUME"
             prev_cmd = self.AFC.gcode.register_command(base_resume_name, None)
@@ -128,7 +130,7 @@ class afcPrep:
 
                 LaneCheck = True
                 for LANE in self.AFC.units[UNIT].keys():
-                    if not CUR_HUB.unit.system_Test(UNIT,LANE, self.delay):
+                    if not CUR_HUB.unit.system_Test(UNIT,LANE, self.delay, self.assignTcmd):
                         LaneCheck = False
 
                 if LaneCheck:
@@ -150,6 +152,10 @@ class afcPrep:
         # Defaulting to no active spool, putting at end so endpoint has time to register
         if self.AFC.current is None:
             self.AFC.SPOOL.set_active_spool( None )
+
+        # Setting value to False so the T commands do try to get reassigned when users manually
+        #   run PREP after it has already be ran once upon boot
+        self.assignTcmd = False
 
 def load_config(config):
     return afcPrep(config)

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -54,10 +54,10 @@ class AFCExtruderStepper:
 
         #stored status variables
         self.name = config.get_name().split()[-1]
-        self.extruder_name = config.get('extruder')
+        self.extruder_name = config.get('extruder')                                                 # AFC_extruder name in config file
         self.extruder_obj = None
 
-        self.map = config.get('cmd','NONE')
+        self.map = config.get('cmd','NONE')                                                         # Need description
         self.tool_loaded = False
         self.loaded_to_hub = False
         self.spool_id = None
@@ -66,7 +66,7 @@ class AFCExtruderStepper:
         self.weight = None
         self.runout_lane = 'NONE'
         self.status = 'Not Loaded'
-        unit = config.get('unit', None)
+        unit = config.get('unit', None)                                                             # Unit name(AFC_hub) that this lane belongs to.
         if unit != None:
             self.unit = unit.split(':')[0]
             self.index = int(unit.split(':')[1])
@@ -85,28 +85,26 @@ class AFCExtruderStepper:
             ffi_lib.cartesian_stepper_alloc(b'x'), ffi_lib.free)
         self.assist_activate=False
 
-        self.hub_dist = config.getfloat('hub_dist',20)
-        self.dist_hub = config.getfloat('dist_hub', 60)
-        # distance to retract filament from the hub
-        self.park_dist = config.getfloat('park_dist', 10)
-        self.led_index = config.get('led_index', None)
+        self.dist_hub = config.getfloat('dist_hub', 60)                                             # Bowden distance between Boxturtle extruder and hub
+        self.park_dist = config.getfloat('park_dist', 10)                                           # Currently unused
+        self.led_index = config.get('led_index', None)                                              # LED index of lane in chain of lane LEDs
         # lane triggers
         buttons = self.printer.load_object(config, "buttons")
-        self.prep = config.get('prep', None)
+        self.prep = config.get('prep', None)                                                        # MCU pin for prep trigger
         if self.prep is not None:
             self.prep_state = False
             buttons.register_buttons([self.prep], self.prep_callback)
-        self.load = config.get('load', None)
+        self.load = config.get('load', None)                                                        # MCU pin load trigger
         if self.load is not None:
             self.load_state = False
             buttons.register_buttons([self.load], self.load_callback)
         # Respoolers
-        self.afc_motor_rwd = config.get('afc_motor_rwd', None)
-        self.afc_motor_fwd = config.get('afc_motor_fwd', None)
-        self.afc_motor_enb = config.get('afc_motor_enb', None)
-        self.afc_motor_fwd_pulse = config.getfloat('afc_motor_fwd_pulse', None)
-        self.afc_motor_fwd_gear_ratio = config.get('afc_motor_fwd_gear_ratio', None)
-        self.afc_motor_fwd_drive_diam = config.getfloat('afc_motor_fwd_drive_diam', None)
+        self.afc_motor_rwd = config.get('afc_motor_rwd', None)                                      # Reverse pin on MCU for spoolers
+        self.afc_motor_fwd = config.get('afc_motor_fwd', None)                                      # Forwards pin on MCU for spoolers
+        self.afc_motor_enb = config.get('afc_motor_enb', None)                                      # Enable pin on MCU for spoolers
+        self.afc_motor_fwd_pulse = config.getfloat('afc_motor_fwd_pulse', None)                     # Need description
+        self.afc_motor_fwd_gear_ratio = config.get('afc_motor_fwd_gear_ratio', None)                # Need description
+        self.afc_motor_fwd_drive_diam = config.getfloat('afc_motor_fwd_drive_diam', None)           # Need description
         if self.afc_motor_rwd is not None:
             self.afc_motor_rwd = AFC_assist.AFCassistMotor(config, 'rwd')
         if self.afc_motor_fwd is not None:
@@ -114,15 +112,18 @@ class AFCExtruderStepper:
         if self.afc_motor_enb is not None:
             self.afc_motor_enb = AFC_assist.AFCassistMotor(config, 'enb')
 
-        self.filament_diameter = config.getfloat("filament_diameter", 1.75)
-        self.filament_density = config.getfloat("filament_density", 1.24)
-        self.inner_diameter = config.getfloat("spool_inner_diameter", 100)  # Inner diameter in mm
-        self.outer_diameter = config.getfloat("spool_outer_diameter", 200)  # Outer diameter in mm
-        self.empty_spool_weight = config.getfloat("empty_spool_weight", 190)  # Empty spool weight in g
-        self.remaining_weight = config.getfloat("spool_weight", 1000)  # Remaining spool weight in g
-        self.max_motor_rpm = config.getfloat("assist_max_motor_rpm", 500)  # Max motor RPM
-        self.rwd_speed_multi = config.getfloat("rwd_speed_multiplier", 0.5) # Multiplier to apply to rpm
-        self.fwd_speed_multi = config.getfloat("fwd_speed_multiplier", 0.5) # Multiplier to apply to rpm
+        self.tmc_print_current = config.getfloat("print_current", self.AFC.global_print_current)    # Current to use while printing, set to a lower current to reduce stepper heat when printing. Defaults to global_print_current, if not specified current is not changed.
+        self._get_tmc_values( config )
+
+        self.filament_diameter = config.getfloat("filament_diameter", 1.75)                         # Diameter of filament being used
+        self.filament_density = config.getfloat("filament_density", 1.24)                           # Density of filament being used
+        self.inner_diameter = config.getfloat("spool_inner_diameter", 100)                          # Inner diameter in mm
+        self.outer_diameter = config.getfloat("spool_outer_diameter", 200)                          # Outer diameter in mm
+        self.empty_spool_weight = config.getfloat("empty_spool_weight", 190)                        # Empty spool weight in g
+        self.remaining_weight = config.getfloat("spool_weight", 1000)                               # Remaining spool weight in g
+        self.max_motor_rpm = config.getfloat("assist_max_motor_rpm", 500)                           # Max motor RPM
+        self.rwd_speed_multi = config.getfloat("rwd_speed_multiplier", 0.5)                         # Multiplier to apply to rpm
+        self.fwd_speed_multi = config.getfloat("fwd_speed_multiplier", 0.5)                         # Multiplier to apply to rpm
         self.diameter_range = self.outer_diameter - self.inner_diameter  # Range for effective diameter
 
         # Set hub loading speed depending on distance between extruder and hub
@@ -134,6 +135,17 @@ class AFCExtruderStepper:
 
         # Get and save base rotation dist
         self.base_rotation_dist = self.extruder_stepper.stepper.get_rotation_distance()[0]
+
+    def _get_tmc_values(self, config):
+        """
+        Searches for TMC driver that corresponds to stepper to get run current that is specified in config
+        """
+        try:
+            self.tmc_driver = next(config.getsection(s) for s in config.fileconfig.sections() if 'tmc' in s and config.get_name() in s)
+        except:
+            raise self.gcode.error("Count not find TMC for stepper {}".format(self.name))
+
+        self.tmc_load_current = self.tmc_driver.getfloat('run_current')
 
     def assist(self, value, is_resend=False):
         if self.afc_motor_rwd is None:
@@ -231,6 +243,11 @@ class AFCExtruderStepper:
             led = self.led_index
             if self.prep_state == True:
                 x = 0
+                # Check to see if the printer is printing or moving as trying to load while printer is doing something will crash klipper
+                if self.AFC.is_printing():
+                    self.AFC.ERROR.AFC_error("Cannot load spools while printer is actively moving or homing", False)
+                    return
+
                 while self.load_state == False and self.prep_state == True:
                     x += 1
                     self.do_enable(True)
@@ -286,6 +303,45 @@ class AFCExtruderStepper:
             toolhead.dwell(self.next_cmd_time - print_time)
         else:
             self.next_cmd_time = print_time
+
+    def sync_to_extruder(self, update_current=True):
+        """
+        Helper function to sync lane to extruder and set print current if specified.
+
+        :param update_current: Sets current to specified print current when True
+        """
+        self.extruder_stepper.sync_to_extruder(self.extruder_name)
+        if update_current: self.set_print_current()
+
+    def unsync_to_extruder(self, update_current=True):
+        """
+        Helper function to un-sync lane to extruder and set load current if specified.
+
+        :param update_current: Sets current to specified load current when True
+        """
+        self.extruder_stepper.sync_to_extruder(None)
+        if update_current: self.set_load_current()
+
+    def _set_current(self, current):
+        """
+        Helper function to update TMC current.
+
+        :param current: Sets TMC current to specified value
+        """
+        if self.tmc_print_current is not None:
+            self.gcode.run_script_from_command("SET_TMC_CURRENT STEPPER='{}' CURRENT={}".format(self.name, current))
+
+    def set_load_current(self):
+        """
+        Helper function to update TMC current to use run current value
+        """
+        self._set_current( self.tmc_load_current )
+
+    def set_print_current(self):
+        """
+        Helper function to update TMC current to use print current value
+        """
+        self._set_current( self.tmc_print_current )
 
     def update_rotation_distance(self, multiplier):
         self.extruder_stepper.stepper.set_rotation_distance( self.base_rotation_dist / multiplier )


### PR DESCRIPTION
## Major Changes in this PR
- AFC-28 Added ability to change stepper current when printing
- AFC-25 Added a boolean flag to PREP so that TCMD assignment does not happens twice in a single restart
- AFC-29 Added a check during prep load to make sure print is not printing,homing or moving as this would normally crash klipper
- Added comments to configuration variables to help aid in auto documentation of config variables
- Added features document to put features of AFC. Added bypass, print current and ram sensor to this document.
## Notes to Code Reviewers

## How the changes in this PR are tested
Testing results from trying to load printer when homing/moving
![image](https://github.com/user-attachments/assets/0f55fa7d-8de4-4c1b-989b-047e53dc713a)

Testing for setting different current
```
Tool load:
    // Tool Change - None -> leg1
    // Loading leg1
    // Run Current: 0.61A Hold Current: 0.61A Home Current: 0.80A          # First sync to extruder for people using a toolhead sensor
    // Run Current: 0.80A Hold Current: 0.80A Home Current: 0.80A          # Unsync to extruder for ramming
    // Run Current: 0.61A Hold Current: 0.61A Home Current: 0.80A          # Sync back to extruder once ramming is done
    // New rotation distance after applying factor: 5.222222222222222
    // TURTLENECK buffer enabled
    // leg1 is now loaded in toolhead

PREP - Current is set to print current to lane that is loaded into toolhead
    // Run Current: 0.61A Hold Current: 0.61A Home Current: 0.80A
    // LEG1 tool cmd: T0  LOCKED AND LOADED in ToolHead

Tool unload
    // Unloading leg1
    // AFC_Cut: Cut Filament
    // AFC_Park: Park Toolhead z_safe: 14.0
    // Run Current: 0.80A Hold Current: 0.80A Home Current: 0.80A       # Unsyncing from extruder for buffer retract
    // Run Current: 0.80A Hold Current: 0.80A Home Current: 0.80A       # Unsyncing from extruder for long retract
```

Prep being called again after prep being automatically ran does not output error

![image](https://github.com/user-attachments/assets/a9ad31e7-5dc2-4a0e-bad7-a438aad2843d)

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
