### PR TITLE
Implement GET_TIP_FORMING and SET_TIP_FORMING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,3 +289,15 @@ file as the code now generates them automatically.
 
 ### Fixed
 - Fixed error in tip forming when `toolchange_temp` value is not zero
+
+## [2024-12-29]
+
+### Added
+- **New Command: `GET_TIP_FORMING`**
+  Shows the current tip forming configuration. Mostly interesting together with
+  SET_TIP_FORMING.
+
+- **New Command: `SET_TIP_FORMING`**
+  Allows to update tip forming configuration at runtime.
+
+  See command_reference doc for more info

--- a/docs/command_reference.md
+++ b/docs/command_reference.md
@@ -5,6 +5,42 @@
 The following commands are built-in the AFC-Klipper-Add-On and are available through 
 the Klipper console.
 
+### SET_MULTIPLIER
+_Description_: This function handles the adjustment of the buffer multipliers for the turtleneck buffer.
+It retrieves the multiplier type ('HIGH' or 'LOW') and the factor to be applied. The function
+ensures that the factor is valid and updates the corresponding multiplier.  
+Usage: `SET_BUFFER_MULTIPLIER MULTIPLIER=<HIGH/LOW> FACTOR=<factor>`  
+Example: `SET_BUFFER_MULTIPLIER MULTIPLIER=HIGH FACTOR=1.2`  
+
+### SET_ROTATION_FACTOR
+_Description_: Adjusts the rotation distance of the current AFC stepper motor by applying a
+specified factor. If no factor is provided, it defaults to 1.0, which resets
+the rotation distance to the base value.  
+Usage: `SET_ROTATION_FACTOR FACTOR=<factor>`  
+Example: `SET_ROTATION_FACTOR FACTOR=1.2`  
+
+### QUERY_BUFFER
+_Description_: Reports the current state of the buffer sensor and, if applicable, the rotation
+distance of the current AFC stepper motor.  
+Usage: `QUERY_BUFFER BUFFER=<buffer_name>`  
+Example: `QUERY_BUFFER BUFFER=TN2`  
+
+### SET_BUFFER_VELOCITY
+_Description_: Allows users to tweak buffer velocity setting while printing. This setting is not
+saved in configuration. Please update your configuration file once you find a velocity that
+works for your setup.  
+Usage: `SET_BUFFER_VELOCITY BUFFER=<buffer_name> VELOCITY=<value>`  
+Example: `SET_BUFFER_VELOCITY BUFFER=TN2 VELOCITY=100`  
+
+### CALIBRATE_AFC
+_Description_: This function performs the calibration of the hub and Bowden length for one or more lanes within an AFC
+(Automated Filament Changer) system. The function uses precise movements to adjust the positions of the
+steppers, check the state of the hubs and tools, and calculate distances for calibration based on the
+user-provided input. If no specific lane is provided, the function defaults to notifying the user that no lane has been selected. The function also includes
+the option to calibrate the Bowden length for a particular lane, if specified.  
+Usage: ``CALIBRATE_AFC LANE=<lane> DISTANCE=<distance> TOLERANCE=<tolerance> BOWDEN=<lane>``  
+Example: `CALIBRATE_AFC LANE=leg1`  
+
 ### RESET_FAILURE
 _Description_: This function clears the error state of the AFC system by setting the error state to False.  
 Usage: ``RESET_FAILURE``  
@@ -15,11 +51,6 @@ _Description_: This function clears the error state of the AFC system, sets the 
 runs the resume script, and restores the toolhead position to the last saved position.  
 Usage: ``AFC_RESUME``  
 Example: ``AFC_RESUME``  
-
-### TEST_AFC_TIP_FORMING
-_Description_: Gives ability to test AFC tip forming without doing a tool change  
-Usage: `TEST_AFC_TIP_FORMING LANE=<lane>`  
-Example: `TEST_AFC_TIP_FORMING LANE=leg1`  
 
 ### AFC_STATUS
 _Description_: This function generates a status message for each unit and lane, indicating the preparation,
@@ -84,32 +115,20 @@ current lane and loading the new lane.
 Usage: ``CHANGE_TOOL LANE=<lane>``  
 Example: ``CHANGE_TOOL LANE=leg1``  
 
-### SET_MULTIPLIER
-_Description_: This function handles the adjustment of the buffer multipliers for the turtleneck buffer.
-It retrieves the multiplier type ('HIGH' or 'LOW') and the factor to be applied. The function
-ensures that the factor is valid and updates the corresponding multiplier.  
-Usage: `SET_BUFFER_MULTIPLIER MULTIPLIER=<HIGH/LOW> FACTOR=<factor>`  
-Example: `SET_BUFFER_MULTIPLIER MULTIPLIER=HIGH FACTOR=1.2`  
+### TEST_AFC_TIP_FORMING
+_Description_: Gives ability to test AFC tip forming without doing a tool change  
+Usage: `TEST_AFC_TIP_FORMING`  
+Example: `TEST_AFC_TIP_FORMING LANE=leg1`  
 
-### SET_ROTATION_FACTOR
-_Description_: Adjusts the rotation distance of the current AFC stepper motor by applying a
-specified factor. If no factor is provided, it defaults to 1.0, which resets
-the rotation distance to the base value.  
-Usage: `SET_ROTATION_FACTOR FACTOR=<factor>`  
-Example: `SET_ROTATION_FACTOR FACTOR=1.2`  
+### GET_TIP_FORMING
+_Description_: Shows the tip forming configuration  
+Usage: `GET_TIP_FORMING`  
+Example: `GET_TIP_FORMING LANE=leg1`  
 
-### QUERY_BUFFER
-_Description_: Reports the current state of the buffer sensor and, if applicable, the rotation
-distance of the current AFC stepper motor.  
-Usage: `QUERY_BUFFER BUFFER=<buffer_name>`  
-Example: `QUERY_BUFFER BUFFER=TN2`  
-
-### SET_BUFFER_VELOCITY
-_Description_: Allows users to tweak buffer velocity setting while printing. This setting is not
-saved in configuration. Please update your configuration file once you find a velocity that
-works for your setup.  
-Usage: `SET_BUFFER_VELOCITY BUFFER=<buffer_name> VELOCITY=<value>`  
-Example: `SET_BUFFER_VELOCITY BUFFER=TN2 VELOCITY=100`  
+### SET_TIP_FORMING
+_Description_: Sets the tip forming configuration  
+Usage: `SET_TIP_FORMING PARAMETER=VALUE ...`  
+Example: `SET_TIP_FORMING ramming_volume=20 toolchange_temp=220`  
 
 ### SET_MAP
 _Description_: This function handles changing the GCODE tool change command for a Lane.  
@@ -150,17 +169,8 @@ Example: ``SET_RUNOUT LANE=lane1 RUNOUT=lane4``
 
 ### RESET_AFC_MAPPING
 _Description_: This commands resets all tool lane mapping to the order that is setup in configuration.  
-Usage: `RESET_AFC_MAPPING LANE=<lane>`  
+Usage: `RESET_AFC_MAPPING`  
 Example: `RESET_AFC_MAPPING LANE=leg1`  
-
-### CALIBRATE_AFC
-_Description_: This function performs the calibration of the hub and Bowden length for one or more lanes within an AFC
-(Automated Filament Changer) system. The function uses precise movements to adjust the positions of the
-steppers, check the state of the hubs and tools, and calculate distances for calibration based on the
-user-provided input. If no specific lane is provided, the function defaults to notifying the user that no lane has been selected. The function also includes
-the option to calibrate the Bowden length for a particular lane, if specified.  
-Usage: ``CALIBRATE_AFC LANE=<lane> DISTANCE=<distance> TOLERANCE=<tolerance> BOWDEN=<lane>``  
-Example: `CALIBRATE_AFC LANE=leg1`  
 
 ## AFC Macros
 

--- a/extras/AFC_form_tip.py
+++ b/extras/AFC_form_tip.py
@@ -28,6 +28,8 @@ class afc_tip_form:
         self.melt_zone_pause  = config.getfloat("melt_zone_pause", 4)
         self.cooling_zone_pause  = config.getfloat("cooling_zone_pause", 4)
         self.gcode.register_command("TEST_AFC_TIP_FORMING", self.cmd_TEST_AFC_TIP_FORMING, desc=self.cmd_TEST_AFC_TIP_FORMING_help)
+        self.gcode.register_command("GET_TIP_FORMING", self.cmd_GET_TIP_FORMING, desc=self.cmd_GET_TIP_FORMING_help)
+        self.gcode.register_command("SET_TIP_FORMING", self.cmd_SET_TIP_FORMING, desc=self.cmd_SET_TIP_FORMING_help)
 
 
     def afc_extrude(self, distance, speed):
@@ -41,9 +43,69 @@ class afc_tip_form:
         '''
         Gives ability to test AFC tip forming without doing a tool change
 
-        USAGE: TEST_AFC_TIP_FORMING
+        Usage: TEST_AFC_TIP_FORMING
         '''
         self.tip_form()
+
+
+    cmd_GET_TIP_FORMING_help = "Shows the tip forming configuration"
+    def cmd_GET_TIP_FORMING(self, gcmd):
+        '''
+        Shows the tip forming configuration
+
+        Usage: GET_TIP_FORMING
+        '''
+        status_msg = "Tip Forming Configuration:\n"
+        status_msg += "ramming_volume:        {}\n".format(self.ramming_volume)
+        status_msg += "toolchange_temp:       {}\n".format(self.toolchange_temp)
+        status_msg += "unloading_speed_start: {}\n".format(self.unloading_speed_start)
+        status_msg += "unloading_speed:       {}\n".format(self.unloading_speed)
+        status_msg += "cooling_tube_position: {}\n".format(self.cooling_tube_position)
+        status_msg += "cooling_tube_length:   {}\n".format(self.cooling_tube_length)
+        status_msg += "initial_cooling_speed: {}\n".format(self.initial_cooling_speed)
+        status_msg += "final_cooling_speed:   {}\n".format(self.final_cooling_speed)
+        status_msg += "cooling_moves:         {}\n".format(self.cooling_moves)
+        status_msg += "use_skinnydip:         {}\n".format(self.use_skinnydip)
+        status_msg += "skinnydip_distance:    {}\n".format(self.skinnydip_distance)
+        status_msg += "dip_insertion_speed:   {}\n".format(self.dip_insertion_speed)
+        status_msg += "dip_extraction_speed:  {}\n".format(self.dip_extraction_speed)
+        status_msg += "melt_zone_pause:       {}\n".format(self.melt_zone_pause)
+        status_msg += "cooling_zone_pause:    {}\n".format(self.cooling_zone_pause)
+
+        self.gcode.respond_raw(status_msg)
+
+
+    cmd_SET_TIP_FORMING_help = "Sets tip forming configuration"
+    def cmd_SET_TIP_FORMING(self, gcmd):
+        '''
+        Sets the tip forming configuration
+
+        Unspecified ones are left unchanged. True boolean values (use_skinnydip) are specified as "true"
+        (case insensitive); every other values is considered as "false".
+
+        Note: this will not update the configuration file. To make settings permanent, update the configuration file
+        manually.
+
+        Usage: SET_TIP_FORMING PARAMETER=VALUE ...
+        Example: SET_TIP_FORMING ramming_volume=20 toolchange_temp=220
+        '''
+
+        self.ramming_volume = gcmd.get_float("RAMMING_VOLUME", self.ramming_volume)
+        self.toolchange_temp = gcmd.get_float("TOOLCHANGE_TEMP", self.toolchange_temp)
+        self.unloading_speed_start = gcmd.get_float("UNLOADING_SPEED_START", self.unloading_speed_start)
+        self.unloading_speed = gcmd.get_float("UNLOADING_SPEED", self.unloading_speed)
+        self.cooling_tube_position = gcmd.get_float("COOLING_TUBE_POSITION", self.cooling_tube_position)
+        self.cooling_tube_length = gcmd.get_float("COOLING_TUBE_LENGTH", self.cooling_tube_length)
+        self.initial_cooling_speed = gcmd.get_float("INITIAL_COOLING_SPEED", self.initial_cooling_speed)
+        self.final_cooling_speed = gcmd.get_float("FINAL_COOLING_SPEED", self.final_cooling_speed)
+        self.cooling_moves = gcmd.get_int("COOLING_MOVES", self.cooling_moves)
+        self.use_skinnydip = gcmd.get("USE_SKINNYDIP", str(self.use_skinnydip)).lower() == "true"
+        self.skinnydip_distance = gcmd.get_float("SKINNYDIP_DISTANCE", self.skinnydip_distance)
+        self.dip_insertion_speed = gcmd.get_float("DIP_INSERTION_SPEED", self.dip_insertion_speed)
+        self.dip_extraction_speed = gcmd.get_float("DIP_EXTRACTION_SPEED", self.dip_extraction_speed)
+        self.melt_zone_pause = gcmd.get_float("MELT_ZONE_PAUSE", self.melt_zone_pause)
+        self.cooling_zone_pause = gcmd.get_float("COOLING_ZONE_PAUSE", self.cooling_zone_pause)
+
 
     def tip_form(self):
         step = 1

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -255,7 +255,7 @@ class afcSpool:
 
         Useful to put in your PRINT_END macro to reset mapping
 
-        USAGE: RESET_AFC_MAPPING
+        Usage: RESET_AFC_MAPPING
         """
         t_index = 0
         for key, unit in self.AFC.lanes.items():


### PR DESCRIPTION
These commands allow to view and update the tip forming configuration at runtime.

## Major Changes in this PR
Implement GET_TIP_FORMING and SET_TIP_FORMING, so that the tip forming configuration can be viewed and updated at runtime.

## Notes to Code Reviewers

## How the changes in this PR are tested
Manually

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [X] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Sent notification to software-design channel requesting review
