### PR TITLE
Fix hub cutting so grip on filament is not lost; add assisted retracts to hub cutting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -301,3 +301,17 @@ file as the code now generates them automatically.
   Allows to update tip forming configuration at runtime.
 
   See command_reference doc for more info
+
+## [2025-01-10]
+
+### Changed
+- Due to a too long retraction, hub cuts had the risk of ejecting filament from the extruder,
+  requiring manual intervention. The hub cut sequence was changed to avoid this situation.
+
+  **NOTE**: due to the new way hub cuts are performed, the configuration has to be updated!
+        The value `cut_dist` in `[AFC_Hub]` has to be reduced by about 150. Please recalibrate
+        this before the next print.
+
+### Added
+- [AFC_Hub] has a new config option: `assisted_retract`. If set to true, retracts are assisted so
+  that filament can't get loose on the spool.

--- a/extras/AFC_hub.py
+++ b/extras/AFC_hub.py
@@ -29,6 +29,7 @@ class afc_hub:
 
         self.move_dis = config.getfloat("move_dis", 50)
         self.hub_clear_move_dis = config.getfloat("hub_clear_move_dis", 50)
+        self.assisted_retract = config.getboolean("assisted_retract", False) # if True, retracts are assisted to prevent loose windings on the spool
         self.afc_bowden_length = config.getfloat("afc_bowden_length", 900)
         self.config_bowden_length = self.afc_bowden_length                          # Used by SET_BOWDEN_LENGTH macro
         buttons = self.printer.load_object(config, "buttons")
@@ -63,7 +64,7 @@ class afc_hub:
         # To have an accurate reference position for `hub_cut_dist`, move back and forth in smaller steps
         # to find the point where the hub just triggers.
         while self.state:
-            CUR_LANE.move(-10, self.AFC.short_moves_speed, self.AFC.short_moves_accel)
+            CUR_LANE.move(-10, self.AFC.short_moves_speed, self.AFC.short_moves_accel, self.assisted_retract)
         while not self.state:
             CUR_LANE.move(2, self.AFC.short_moves_speed, self.AFC.short_moves_accel)
 
@@ -88,7 +89,7 @@ class afc_hub:
         self.gcode.run_script_from_command(servo_string.format(angle=self.cut_servo_pass_angle))
 
         # Retract lane by `hub_cut_clear`.
-        CUR_LANE.move(-self.cut_clear, self.AFC.short_moves_speed, self.AFC.short_moves_accel)
+        CUR_LANE.move(-self.cut_clear, self.AFC.short_moves_speed, self.AFC.short_moves_accel, self.assisted_retract)
 
 def load_config_prefix(config):
     return afc_hub(config)

--- a/templates/AFC_Hardware-AFC.cfg
+++ b/templates/AFC_Hardware-AFC.cfg
@@ -140,6 +140,7 @@ tool_load_speed: 25             # Load speed in mm/s. Default is 25mm/s.
 Type: Box_Turtle
 afc_bowden_length: 940         # Length of the Bowden tube from the hub to the toolhead sensor in mm.
 move_dis: 50                   # Distance to move the filament within the hub in mm.
+assisted_retract: False        # If True, retracts are assisted to prevent loose windows on the spool
 cut: False                     # Hub has Cutter
 #--=================================================================================--
 #------- Hub Cut ---------------------------------------------------------------------

--- a/templates/AFC_Hardware-AFC.cfg
+++ b/templates/AFC_Hardware-AFC.cfg
@@ -145,7 +145,7 @@ cut: False                     # Hub has Cutter
 #------- Hub Cut ---------------------------------------------------------------------
 #--=================================================================================--
 cut_cmd: AFC                   # CMD to use
-cut_dist: 200                  # How much filament to cut off (in mm).
+cut_dist: 50                  # How much filament to cut off (in mm).
 cut_clear: 120                 # How far the filament should retract back from the hub (in mm).
 cut_servo_name: cut            # Servos name in configuration to use
 cut_min_length: 300.0

--- a/templates/AFC_Hardware-MMB.cfg
+++ b/templates/AFC_Hardware-MMB.cfg
@@ -120,7 +120,7 @@ cut: False                      # Hub has Cutter
 #------- Hub Cut ---------------------------------------------------------------------
 #--=================================================================================--
 cut_cmd: AFC                    # CMD to use
-cut_dist: 200                   # How much filament to cut off (in mm).
+cut_dist: 50                   # How much filament to cut off (in mm).
 cut_clear: 120                  # How far the filament should retract back from the hub (in mm).
 cut_servo_name: cut             # Servos name in configuration to use
 cut_min_length: 300.0

--- a/templates/AFC_Hardware-MMB.cfg
+++ b/templates/AFC_Hardware-MMB.cfg
@@ -115,6 +115,7 @@ tool_load_speed: 25             # Load speed in mm/s. Default is 25mm/s.
 Type: Box_Turtle
 afc_bowden_length: 940          # Length of the Bowden tube from the hub to the toolhead sensor in mm.
 move_dis: 50                    # Distance to move the filament within the hub in mm.
+assisted_retract: False        # If True, retracts are assisted to prevent loose windows on the spool
 cut: False                      # Hub has Cutter
 #--=================================================================================--
 #------- Hub Cut ---------------------------------------------------------------------


### PR DESCRIPTION
## Major Changes in this PR

The long retract (4*move_dis) in the hub cut sequence moves the filament to the entry of the extruder. This has a large risk of losing grip on the filament (happend in roughly 30 % of attempts for me).
Using the hub as reference point instead of extruder entry fixes that completely.

However, this requires users to update their configuration! Please consider announcing this in the appropriate Discord channel, so noone is surprised.

I also added assisted retracts as an option during hub cuts, so the filament stays tight on the spol

## Notes to Code Reviewers

## How the changes in this PR are tested
I performed my serial number print with this modification. Worked perfectly, which before I again and again had to intervene when grip was lost.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Sent notification to software-design channel requesting review
