### PR TITLE
Alot of useful updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-01-11]
+### Added
+- Added clearing spool info and `load_to_hub` when lane retracts too far past Box Turtle extruder, reset once prep goes low
+- Added logic so that buffer/extruder/hubs don't need to be entered per stepper as long as they are defined in their Unit(AFC_BoxTurtle/AFC_NightOwl) section 
+
+For the following please see [Features doc](docs/Features.md) for more information on how to setup
+- Added ability to set and track number of toolchanges when doing multicolor prints
+- Added ability to set extruder temperature based off spoolman values or filament materials type if manually entered
+- Added ability to show sensors as filament sensors in gui's
+- Added ability to use multiple buffers
+- Added automatically loading filament to hub for users that have moved their hubs closer to their toolhead
+
+### Changed
+
+- `http://<ip_address>/printer/objects/query?AFC` has moved to `http://<ip_address>/printer/afc/status`endpoint. If tools have been designed around original endpoint please review results returned as new items have been added
+
+## [2025-01-08]
+### Added
+- If using `tool_end` variable(sensor after extruder gears) `tool_stn` distance will now be based off this sensor
+- When running `CALIBRATE_AFC` command values will be automatically updated and saved to config file
+
+### Fixed
+- Fixed infinite spool logic
+
 ## [2025-01-05]
 
 ### Updated

--- a/README.md
+++ b/README.md
@@ -89,64 +89,6 @@ Finally, review and update the following files as needed for your configuration.
 3. `~/printer_data/config/AFC/AFC_Hardware.cfg`
 4. `~/printer_data/config/AFC/AFC_Turtle_1.cfg`
 
-### Buffer configuration - Manual
-
-If you are using a buffer such as the Turtleneck, Turtleneck v2 or Annex Belay, and you installed the software manually, you may need to make a couple of additional changes.
-
-You should add the following block to your `AFC_Turtle_1.cfg` file based on the type of buffer you are using.
-
-**NOTE** The `pin` value should be set to the pin that the buffer is connected to on your board.
-
-#### Turtleneck
-
-```cfg
-[AFC_buffer TN]
-advance_pin:     # set advance pin
-trailing_pin:    # set trailing pin
-multiplier_high: 1.05   # default 1.05, factor to feed more filament
-multiplier_low:  0.95   # default 0.95, factor to feed less filament
-velocity: 100
-```
-
-Turtleneck v2
-
-```cfg
-[AFC_buffer TN2]
-advance_pin: !turtleneck:ADVANCE
-trailing_pin: !turtleneck:TRAILING
-multiplier_high: 1.05   # default 1.05, factor to feed more filament
-multiplier_low:  0.95   # default 0.95, factor to feed less filament
-led_index: Buffer_Indicator:1
-velocity: 100
-
-[AFC_led Buffer_Indicator]
-pin: turtleneck:RGB
-chain_count: 1
-color_order: GRBW
-initial_RED: 0.0
-initial_GREEN: 0.0
-initial_BLUE: 0.0
-initial_WHITE: 0.0
-```
-
-Annex Belay
-
-```cfg
-[AFC_buffer Belay]
-pin: mcu:BUFFER
-distance: 12
-velocity: 1000
-accel: 1000
-```
-
-Finally, add `Buffer_Name: <TYPE>` to your `AFC.cfg` file. For example, if you are using the Turtleneck v2, you would add the following line:
-
-```cfg
-Buffer_Name: TN2
-```
-
-Additional information about the buffer configuration and operation can be found in the [AFC_buffer.md](./docs/AFC_buffer.md) file.
-
 ## Mandatory Configuration Changes (All)
 
 Prior to operation, the following checks / updates **MUST** be made to your system:
@@ -208,6 +150,78 @@ If using snappy hub cutter update the following values:
 - cut: change to True
 - cut_dist: update to the value that you would like to cut off the end, this may take some tuning to get right
 
+### Buffer configuration - Manual
+
+If you are using a buffer such as the Turtleneck, Turtleneck v2 or Annex Belay, and you installed the software manually, you may need to make a couple of additional changes.
+
+You should add the following block to your `AFC_Turtle_1.cfg` file based on the type of buffer you are using.
+
+**NOTE** The `pin` value should be set to the pin that the buffer is connected to on your board.
+
+#### Turtleneck
+
+```cfg
+[AFC_buffer TN]
+advance_pin:     # set advance pin
+trailing_pin:    # set trailing pin
+multiplier_high: 1.05   # default 1.05, factor to feed more filament
+multiplier_low:  0.95   # default 0.95, factor to feed less filament
+velocity: 100
+```
+
+Turtleneck v2
+
+```cfg
+[AFC_buffer TN2]
+advance_pin: !turtleneck:ADVANCE
+trailing_pin: !turtleneck:TRAILING
+multiplier_high: 1.05   # default 1.05, factor to feed more filament
+multiplier_low:  0.95   # default 0.95, factor to feed less filament
+led_index: Buffer_Indicator:1
+velocity: 100
+
+[AFC_led Buffer_Indicator]
+pin: turtleneck:RGB
+chain_count: 1
+color_order: GRBW
+initial_RED: 0.0
+initial_GREEN: 0.0
+initial_BLUE: 0.0
+initial_WHITE: 0.0
+```
+
+Annex Belay
+
+```cfg
+[AFC_buffer Belay]
+pin: mcu:BUFFER
+distance: 12
+velocity: 1000
+accel: 1000
+```
+
+Finally, add `buffer: <buffer_name>` to either your `AFC_extruder`, `AFC_stepper`, or `AFC_<unit_type>` sections in `AFC_Turtle_(n).cfg` files. For example, if you are using the Turtleneck v2, you would add the following line:
+
+Using this config, buffer will be used for every unit that uses this extruder
+```cfg
+[AFC_extruder extruder]
+buffer: TN2
+```
+
+Using this config, buffer will be used for every lanes that uses this unit
+```cfg
+[AFC_BoxTurtle Turtle_1]
+buffer: TN2
+```
+
+Using this config, buffer will be used for just the lanes the buffers is assigned to, this will override anything set in extruder/unit sections
+```cfg
+[AFC_stepper lane1]
+buffer: TN2
+```
+
+Additional information about the buffer configuration and operation can be found in the [AFC_buffer.md](./docs/AFC_buffer.md) file.
+
 ## Automatic Calibration
 
 The function `CALIBRATE_AFC` can be called in the console to calibrate distances.  
@@ -237,7 +251,7 @@ If using a hub different from the stock set up `hub_clear_move_dis` under AFC un
 
 Debug information about the respooler system can be found by visiting the following URL in your browser:
 
-`{ip address}/printer/objects/query?AFC`
+`{ip address}/printer/afc/status`
 
 ## LEDs not displaying correct color
 

--- a/config/AFC.cfg
+++ b/config/AFC.cfg
@@ -14,6 +14,12 @@ short_move_dis: 10              # Move distance for failsafe moves. Default is 1
 
 # global_print_current: 0.6     # Uncomment to set stepper motors to a lower current while printing
                                 # This value can also be set per stepper with print_current: 0.6
+# enable_sensors_in_gui: True    # Uncomment to show all sensor switches as filament sensors in mainsail/fluidd gui
+                                 # this can also be set at individual levels in your config file
+default_material_temps: PLA:210, ABS:235, ASA:235 # Default temperature to set extruder when loading/unloading lanes.
+                                                  # Material needs to be either manually set or uses material from spoolman if extruder temp is not
+                                                  # set in spoolman. Follow current format to add more
+load_to_hub: True             # Fast loads filament to hub when inserted, set to False to disable. This is a global setting and can be overridden at AFC_stepper
 
 #--=================================================================================-
 #------- TRSYNC Values --------------------------------------------------------------

--- a/docs/AFC_buffer.md
+++ b/docs/AFC_buffer.md
@@ -114,6 +114,25 @@ velocity: 1000
 accel: 1000
 ```
 
+## Off-Nominal Buffer Configurations
+Buffers can also be set per Unit/Stepper. If multiple lanes use the same buffer for one Unit then the buffer can just be added to Unit config (`AFC_BoxTurtle`, `AFC_NightOwl`, etc). If a buffer is inputted into the `AFC_Stepper` config then this will override whatever is set at the Unit level.
+
+### Example
+
+Setting buffer for a single unit
+```
+[AFC_BoxTurtle Turtle_1]
+buffer: TN
+```
+Overriding buffer at stepper
+```
+[AFC_Stepper lane1]
+unit: Turtle_1:1
+buffer: TN2
+<rest of config>
+```
+
+
 ## AFC buffer commands
 
 ### QUERY BUFFER
@@ -133,13 +152,13 @@ _for TurtleNeck Style Buffers_
 This command allows the adjustment of rotation distance of the current AFC stepper motor by applying a factor. Factors greater than 1 will increase the rate filament is fed to the primary extruder, factors less than 1 but greater than 0 will decrease the rate filament to the primary extruder.
 
 Example Usage:
-`SET_ROTATION_FACTOR FACTOR=1.1`
+`SET_ROTATION_FACTOR BUFFER=TN FACTOR=1.1`
 
 ### SET_BUFFER_MULTIPLIER
 _for TurtleNeck Style Buffers_
 
 `SET_BUFFER_MULTIPLIER` used to live adjust the high and low multipliers for the buffer
-- To change `multiplier_high`: `SET_BUFFER_MULTIPLIER MULTIPLIER=HIGH FACTOR=1.2`
-- To change `multiplier_low`: `SET_BUFFER_MULTIPLIER MULTIPLIER=HIGH FACTOR=0.8`
+- To change `multiplier_high`: `SET_BUFFER_MULTIPLIER BUFFER=TN MULTIPLIER=HIGH FACTOR=1.2`
+- To change `multiplier_low`: `SET_BUFFER_MULTIPLIER BUFFER=TN MULTIPLIER=HIGH FACTOR=0.8`
     
 __Buffer config section must be updated for values to be saved__

--- a/docs/Buffer_Ram_Sensor.md
+++ b/docs/Buffer_Ram_Sensor.md
@@ -34,6 +34,28 @@ __advance_pin and trailing_pin must be defined__
 - __advance_pin__: Pin for the advance sensor.
 - __trailing_pin__: Pin for the trailing sensor.
 
+Under `[AFC_extruder <extruder_name>]`, `[AFC_<unit_name> <name>]` or `[AFC_stepper lane(n)]` buffer name must be defined. This allows having a buffer per extruder, unit or lane. Defining buffer in `AFC_stepper` config overrides buffer variable being set in other places, and defining buffer in `AFC_<unit_name>` overrides buffer being set in `AFC_extruder`. 
+
+Examples
+```
+[AFC_extruder <extruder_name>]
+buffer: TN
+pin_tool_start: buffer
+<reset_of_config>
+```
+
+```
+[AFC_BoxTurtle <unit_name>]
+buffer: TN
+<reset_of_config>
+```
+
+```
+[AFC_Stepper <stepper_name>]
+buffer: TN
+<reset_of_config>
+```
+
 ### Optional Configuration
 
 Under `[AFC_extruder extruder]` section:

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -22,3 +22,37 @@ Enabling lower current during printing can be enabled two ways:
 2. Set `print_current` for each AFC_stepper, this will override `global_print_current` in AFC.cfg
 
 During testing it was found that 0.6A worked well during printing and kept the steppers warms to the touch. Would not suggest going lower than this or the TurtleNeck buffers may not work as intended.
+
+
+## Enabling switches to show up in mainsail/fluidd guis
+AFC has the ability to add sensors as filament switches so they show up in mainsail/fluidd web gui. This can either be enabled globally by adding/uncommenting `enable_sensors_in_gui: True` in AFC.cfg file or enabled/disabled in individual sections in your config file. Enabling this globally us usefull for debugging purposes, but setting in individual sections will override the global setting
+
+AFC_buffer, AFC_extruder, AFC_hub, and AFC_stepper sections in your AFC_hardware.cfg or AFC_Turtle(n).cfg have the ability to enable sensor by adding `enable_sensors_in_gui: True`. There is an extra config value for AFC_stepper to allow you to either show both sensors or just prep/load sensors by using `sensor_to_show: prep` or `sensor_to_show: load`, leaving out sensor_to_show will show both sensors.
+
+## Tool change count
+AFC has the ability to keep track of number of tool changes when doing multicolor prints. The macro can be used to set total number of toolchanges from slicer. AFC will keep track of tool changes and print out
+current tool change number when a T(n) command is called from gcode.
+
+This call can be added to the slicer by adding the following lines to Change filament G-code section in your slicer.
+You may already have `T[next_extruder]`, just make sure the toolchange call is after your T(n) call
+```cfg
+T[next_extruder]
+{ if toolchange_count == 1 }SET_AFC_TOOLCHANGES TOOLCHANGES=[total_toolchanges]{endif }
+```
+
+The following can also be added to your `PRINT_END` section in your slicer to set number of toolchanges back to zero
+`SET_AFC_TOOLCHANGES TOOLCHANGES=0`
+
+## Setting extruder temp
+AFC has the ability to automatically set extruder temperature based off filament material type loaded or spoolman extruder temperature if its set.
+
+If not using spoolman make sure the material is set for your lanes and the temperature values will be pulled from `default_material_temps` variable in `AFC.cfg` file. This list can also be updated/added to, just make sure new entries have a comma inbetween and follow current format when adding new variable.
+
+If spoolman extruder temperature or material type is not defined AFC default's to `min_extrude_temp` variable defined in `[extruder]` section in `printer.cfg`
+
+```cfg
+default_material_temps: PLA:210, ABS:235, ASA:235 # Default temperature to set extruder when loading/unloading lanes.
+```
+
+## Loading filament to hub
+For users that have a hub not located in their Box Turtle, AFC has the ability to load filament to their hub once its inserted. This is turned on by default and this will happen even if your hub is located in your Box Turtle. This can be disabled by setting `load_to_hub: False` in your `AFC.cfg` file. Also individual lanes can be turn on/off by setting `load_to_hub: True/False` under `[AFC_stepper <lane_name>]` section in your config.

--- a/docs/command_reference.md
+++ b/docs/command_reference.md
@@ -5,51 +5,12 @@
 The following commands are built-in the AFC-Klipper-Add-On and are available through 
 the Klipper console.
 
-### RESET_FAILURE
-_Description_: This function clears the error state of the AFC system by setting the error state to False.  
-Usage: ``RESET_FAILURE``  
-Example: ``RESET_FAILURE``  
-
-### AFC_RESUME
-_Description_: This function clears the error state of the AFC system, sets the in_toolchange flag to False,
-runs the resume script, and restores the toolhead position to the last saved position.  
-Usage: ``AFC_RESUME``  
-Example: ``AFC_RESUME``  
-
-### TEST_AFC_TIP_FORMING
-_Description_: Gives ability to test AFC tip forming without doing a tool change  
-Usage: `TEST_AFC_TIP_FORMING LANE=<lane>`  
-Example: `TEST_AFC_TIP_FORMING LANE=leg1`  
-
-### AFC_STATUS
-_Description_: This function generates a status message for each unit and lane, indicating the preparation,
-loading, hub, and tool states. The status message is formatted with HTML tags for display.  
-Usage: ``AFC_STATUS``  
-Example: ``AFC_STATUS``  
-
-### SET_BOWDEN_LENGTH
-_Description_: This function adjusts the length of the Bowden tube between the hub and the toolhead.
-It retrieves the hub specified by the 'HUB' parameter and the length adjustment specified
-by the 'LENGTH' parameter. If the hub is not specified and a lane is currently loaded,
-it uses the hub of the current lane.  
-Usage: ``SET_BOWDEN_LENGTH HUB=<hub> LENGTH=<length>``  
-Example: ``SET_BOWDEN_LENGTH HUB=Turtle_1 LENGTH=100``  
-
-### HUB_CUT_TEST
-_Description_: This function tests the cutting sequence of the hub cutter for a specified lane.
-It retrieves the lane specified by the 'LANE' parameter, performs the hub cut,
-and responds with the status of the operation.  
-Usage: ``HUB_CUT_TEST LANE=<lane>``  
-Example: ``HUB_CUT_TEST LANE=leg1``  
-
-### TEST
-_Description_: This function tests the assist motors of a specified lane at various speeds.
-It performs the following steps:
-1. Retrieves the lane specified by the 'LANE' parameter.
-2. Tests the assist motor at full speed, 50%, 30%, and 10% speeds.
-3. Reports the status of each test step.  
-Usage: ``TEST LANE=<lane>``  
-Example: ``TEST LANE=leg1``  
+NOTE: LANE/HUB/BUFFER etc. names are case sensitive and should exactly match the names defined in config files
+### SET_AFC_TOOLCHANGES
+_Description_: This macro can be used to set total number of toolchanges from slicer. AFC will keep track of tool changes and print out
+current tool change number when a T(n) command is called from gcode  
+Usage: ``SET_AFC_TOOLCHANGES TOOLCHANGES=<number>``  
+Example: ``SET_AFC_TOOLCHANGES TOOLCHANGES=100``  
 
 ### HUB_LOAD
 _Description_: This function handles the loading of a specified lane into the hub. It performs
@@ -84,25 +45,31 @@ current lane and loading the new lane.
 Usage: ``CHANGE_TOOL LANE=<lane>``  
 Example: ``CHANGE_TOOL LANE=leg1``  
 
+### AFC_STATUS
+_Description_: This function generates a status message for each unit and lane, indicating the preparation,
+loading, hub, and tool states. The status message is formatted with HTML tags for display.  
+Usage: ``AFC_STATUS``  
+Example: ``AFC_STATUS``  
+
 ### SET_MULTIPLIER
 _Description_: This function handles the adjustment of the buffer multipliers for the turtleneck buffer.
 It retrieves the multiplier type ('HIGH' or 'LOW') and the factor to be applied. The function
 ensures that the factor is valid and updates the corresponding multiplier.  
-Usage: `SET_BUFFER_MULTIPLIER MULTIPLIER=<HIGH/LOW> FACTOR=<factor>`  
-Example: `SET_BUFFER_MULTIPLIER MULTIPLIER=HIGH FACTOR=1.2`  
+Usage: `SET_BUFFER_MULTIPLIER BUFFER=<buffer_name> MULTIPLIER=<HIGH/LOW> FACTOR=<factor>`  
+Example: `SET_BUFFER_MULTIPLIER BUFFER=TN MULTIPLIER=HIGH FACTOR=1.2`  
 
 ### SET_ROTATION_FACTOR
 _Description_: Adjusts the rotation distance of the current AFC stepper motor by applying a
 specified factor. If no factor is provided, it defaults to 1.0, which resets
 the rotation distance to the base value.  
-Usage: `SET_ROTATION_FACTOR FACTOR=<factor>`  
-Example: `SET_ROTATION_FACTOR FACTOR=1.2`  
+Usage: `SET_ROTATION_FACTOR BUFFER=<buffer_name> FACTOR=<factor>`  
+Example: `SET_ROTATION_FACTOR BUFFER=TN FACTOR=1.2`  
 
 ### QUERY_BUFFER
 _Description_: Reports the current state of the buffer sensor and, if applicable, the rotation
 distance of the current AFC stepper motor.  
 Usage: `QUERY_BUFFER BUFFER=<buffer_name>`  
-Example: `QUERY_BUFFER BUFFER=TN2`  
+Example: `QUERY_BUFFER BUFFER=TN`  
 
 ### SET_BUFFER_VELOCITY
 _Description_: Allows users to tweak buffer velocity setting while printing. This setting is not
@@ -110,6 +77,55 @@ saved in configuration. Please update your configuration file once you find a ve
 works for your setup.  
 Usage: `SET_BUFFER_VELOCITY BUFFER=<buffer_name> VELOCITY=<value>`  
 Example: `SET_BUFFER_VELOCITY BUFFER=TN2 VELOCITY=100`  
+
+### RESET_FAILURE
+_Description_: This function clears the error state of the AFC system by setting the error state to False.  
+Usage: ``RESET_FAILURE``  
+Example: ``RESET_FAILURE``  
+
+### AFC_RESUME
+_Description_: This function clears the error state of the AFC system, sets the in_toolchange flag to False,
+runs the resume script, and restores the toolhead position to the last saved position.  
+Usage: ``AFC_RESUME``  
+Example: ``AFC_RESUME``  
+
+### TEST_AFC_TIP_FORMING
+_Description_: Gives ability to test AFC tip forming without doing a tool change  
+Usage: `TEST_AFC_TIP_FORMING LANE=<lane>`  
+Example: `TEST_AFC_TIP_FORMING LANE=leg1`  
+
+### CALIBRATE_AFC
+_Description_: This function performs the calibration of the hub and Bowden length for one or more lanes within an AFC
+(Automated Filament Changer) system. The function uses precise movements to adjust the positions of the
+steppers, check the state of the hubs and tools, and calculate distances for calibration based on the
+user-provided input. If no specific lane is provided, the function defaults to notifying the user that no lane has been selected. The function also includes
+the option to calibrate the Bowden length for a particular lane, if specified.  
+Usage: ``CALIBRATE_AFC LANE=<lane> DISTANCE=<distance> TOLERANCE=<tolerance> BOWDEN=<lane>``  
+Example: `CALIBRATE_AFC LANE=leg1`  
+
+### SET_BOWDEN_LENGTH
+_Description_: This function adjusts the length of the Bowden tube between the hub and the toolhead.
+It retrieves the hub specified by the 'HUB' parameter and the length adjustment specified
+by the 'LENGTH' parameter. If the hub is not specified and a lane is currently loaded,
+it uses the hub of the current lane.  
+Usage: ``SET_BOWDEN_LENGTH HUB=<hub> LENGTH=<length>``  
+Example: ``SET_BOWDEN_LENGTH HUB=Turtle_1 LENGTH=100``  
+
+### HUB_CUT_TEST
+_Description_: This function tests the cutting sequence of the hub cutter for a specified lane.
+It retrieves the lane specified by the 'LANE' parameter, performs the hub cut,
+and responds with the status of the operation.  
+Usage: ``HUB_CUT_TEST LANE=<lane>``  
+Example: ``HUB_CUT_TEST LANE=leg1``  
+
+### TEST
+_Description_: This function tests the assist motors of a specified lane at various speeds.
+It performs the following steps:
+1. Retrieves the lane specified by the 'LANE' parameter.
+2. Tests the assist motor at full speed, 50%, 30%, and 10% speeds.
+3. Reports the status of each test step.  
+Usage: ``TEST LANE=<lane>``  
+Example: ``TEST LANE=leg1``  
 
 ### SET_MAP
 _Description_: This function handles changing the GCODE tool change command for a Lane.  
@@ -139,7 +155,7 @@ _Description_: This function handles setting the spool ID for a specified lane. 
 specified by the 'LANE' parameter and updates its spool ID, material, color, and weight
 based on the information retrieved from the Spoolman API.  
 Usage: ``SET_SPOOL_ID LANE=<lane> SPOOL_ID=<spool_id>``  
-Example: ``SET_SPOOL_IDD LANE=leg1 SPOOL_ID=12345``  
+Example: ``SET_SPOOL_ID LANE=leg1 SPOOL_ID=12345``  
 
 ### SET_RUNOUT
 _Description_: This function handles setting the runout lane (infinite spool) for a specified lane. It retrieves the lane
@@ -152,15 +168,6 @@ Example: ``SET_RUNOUT LANE=lane1 RUNOUT=lane4``
 _Description_: This commands resets all tool lane mapping to the order that is setup in configuration.  
 Usage: `RESET_AFC_MAPPING LANE=<lane>`  
 Example: `RESET_AFC_MAPPING LANE=leg1`  
-
-### CALIBRATE_AFC
-_Description_: This function performs the calibration of the hub and Bowden length for one or more lanes within an AFC
-(Automated Filament Changer) system. The function uses precise movements to adjust the positions of the
-steppers, check the state of the hubs and tools, and calculate distances for calibration based on the
-user-provided input. If no specific lane is provided, the function defaults to notifying the user that no lane has been selected. The function also includes
-the option to calibrate the Bowden length for a particular lane, if specified.  
-Usage: ``CALIBRATE_AFC LANE=<lane> DISTANCE=<distance> TOLERANCE=<tolerance> BOWDEN=<lane>``  
-Example: `CALIBRATE_AFC LANE=leg1`  
 
 ## AFC Macros
 

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -1,66 +1,27 @@
+# Armored Turtle Automated Filament Changer
+#
+# Copyright (C) 2024 Armored Turtle
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
 
-class afcBoxTurtle:
+from configparser import Error as error
+try:
+    from extras.AFC_unit import afcUnit
+except:
+    raise error("Error trying to import AFC_unit, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper")
+
+class afcBoxTurtle(afcUnit):
     def __init__(self, config):
-        self.printer = config.get_printer()
-        self.printer.register_event_handler("klippy:connect", self.handle_connect)
-        self.printer.register_event_handler("klippy:ready", self._handle_ready)
-                
-        self.name = config.get_name().split()[-1]
+        super().__init__(config)
         self.type = config.get('type', 'Box_Turtle')
-        self.screen_mac = config.get('screen_mac', None)
-        self.hub = config.get('hub', None)
-        self.buffer = config.get('buffer', None)
-        self.buffer_obj = None
-        
-        self.led_name =config.get('led_name', None)
-        self.led_fault =config.get('led_fault', None)
-        self.led_ready = config.get('led_ready', None)
-        self.led_not_ready = config.get('led_not_ready', None)
-        self.led_loading = config.get('led_loading', None)
-        self.led_prep_loaded = config.get('led_loading', None)
-        self.led_unloading = config.get('led_unloading', None)
-        self.led_tool_loaded = config.get('led_tool_loaded', None)
 
-        self.long_moves_speed = config.getfloat("long_moves_speed",  None)            # Speed in mm/s to move filament when doing long moves
-        self.long_moves_accel = config.getfloat("long_moves_accel",  None)            # Acceleration in mm/s squared when doing long moves
-        self.short_moves_speed = config.getfloat("short_moves_speed",  None)           # Speed in mm/s to move filament when doing short moves
-        self.short_moves_accel = config.getfloat("short_moves_accel",  None)          # Acceleration in mm/s squared when doing short moves
-        self.short_move_dis = config.getfloat("short_move_dis",  None)                 # Move distance in mm for failsafe moves.
-    
     def handle_connect(self):
         """
         Handle the connection event.
         This function is called when the printer connects. It looks up AFC info
         and assigns it to the instance variable `self.AFC`.
         """
-        self.AFC = self.printer.lookup_object('AFC')
-
-    def _handle_ready(self):
-        
-        self.lanes = []
-        if self.hub == None: self.hub = self.AFC.hub
-        if self.buffer == None: self.buffer = self.AFC.buffer
-
-        self.AFC.units[self.name] = self
-        self.hub_obj = self.AFC.hubs[self.hub]
-        
-        if self.buffer is not None: self.buffer_obj = self.AFC.buffers[self.buffer]
-
-        if self.led_name is None: self.led_name = self.AFC.led_name
-        if self.led_fault is None: self.led_fault = self.AFC.led_fault
-        if self.led_ready is None: self.led_ready = self.AFC.led_ready
-        if self.led_not_ready is None: self.led_not_ready = self.AFC.led_not_ready
-        if self.led_loading is None: self.led_loading = self.AFC.led_loading
-        if self.led_prep_loaded is None: self.led_prep_loaded = self.AFC.led_prep_loaded
-        if self.led_unloading is None: self.led_unloading = self.AFC.led_unloading
-        if self.led_tool_loaded is None: self.led_tool_loaded = self.AFC.led_tool_loaded
-
-        if self.long_moves_speed is None: self.long_moves_speed = self.AFC.long_moves_speed        # Speed in mm/s to move filament when doing long moves
-        if self.long_moves_accel is None: self.long_moves_accel = self.AFC.long_moves_accel           # Acceleration in mm/s squared when doing long moves
-        if self.short_moves_speed is None: self.short_moves_speed = self.AFC.short_moves_speed          # Speed in mm/s to move filament when doing short moves
-        if self.short_moves_accel is None: self.short_moves_accel = self.AFC.short_moves_accel        # Acceleration in mm/s squared when doing short moves
-        if self.short_move_dis is None: self.short_move_dis = self.AFC.short_move_dis                # Move distance in mm for failsafe moves.
-
+        super().handle_connect()
 
         firstLeg = '<span class=warning--text>|</span><span class=error--text>_</span>'
         secondLeg = firstLeg + '<span class=warning--text>|</span>'
@@ -79,18 +40,19 @@ class afcBoxTurtle:
         self.logo_error+='! \_________/ |___|</span>\n'
         self.logo_error+= '  ' + self.name + '\n'
 
-    def system_Test(self, LANE, delay, assignTcmd):
+    def system_Test(self, CUR_LANE, delay, assignTcmd, enable_movement):
         msg = ''
         succeeded = True
-        if LANE not in self.AFC.lanes:
-            self.AFC.gcode.respond_info('{} Unknown'.format(LANE.upper()))
-            return
-        CUR_LANE = self.AFC.lanes[LANE]
+
         # Run test reverse/forward on each lane
         CUR_LANE.unsync_to_extruder(False)
-        CUR_LANE.move( 5, self.AFC.short_moves_speed, self.AFC.short_moves_accel, True)
-        self.AFC.reactor.pause(self.AFC.reactor.monotonic() + delay)
-        CUR_LANE.move( -5, self.AFC.short_moves_speed, self.AFC.short_moves_accel, True)
+        if enable_movement:
+            CUR_LANE.move( 5, self.AFC.short_moves_speed, self.AFC.short_moves_accel, True)
+            self.AFC.reactor.pause(self.AFC.reactor.monotonic() + delay)
+            CUR_LANE.move( -5, self.AFC.short_moves_speed, self.AFC.short_moves_accel, True)
+        else:
+            self.AFC.reactor.pause(self.AFC.reactor.monotonic() + delay)
+
         if CUR_LANE.prep_state == False:
             if CUR_LANE.load_state == False:
                 self.AFC.FUNCTION.afc_led(CUR_LANE.led_not_ready, CUR_LANE.led_index)
@@ -101,6 +63,7 @@ class afcBoxTurtle:
                 CUR_LANE.do_enable(False)
                 msg = '<span class=error--text>CHECK FILAMENT Prep: False - Load: True</span>'
                 succeeded = False
+
         else:
             self.AFC.FUNCTION.afc_led(CUR_LANE.led_ready, CUR_LANE.led_index)
             msg +="<span class=success--text>LOCKED</span>"
@@ -111,8 +74,9 @@ class afcBoxTurtle:
             else:
                 CUR_LANE.status = 'Loaded'
                 msg +="<span class=success--text> AND LOADED</span>"
+
                 if CUR_LANE.tool_loaded:
-                    if CUR_LANE.extruder_obj.tool_start_state == True or CUR_LANE.extruder_obj.tool_start == "buffer":
+                    if CUR_LANE.get_toolhead_sensor_state() == True or CUR_LANE.extruder_obj.tool_start == "buffer":
                         if CUR_LANE.extruder_obj.lane_loaded == CUR_LANE.name:
                             self.AFC.current = CUR_LANE.name
                             CUR_LANE.sync_to_extruder()
@@ -122,10 +86,9 @@ class afcBoxTurtle:
                             self.AFC.SPOOL.set_active_spool(CUR_LANE.spool_id)
                             self.AFC.FUNCTION.afc_led(CUR_LANE.led_tool_loaded, CUR_LANE.led_index)
                             CUR_LANE.status = 'Tooled'
-                            CUR_LANE.extruder_obj.enable_buffer()
-                            CUR_LANE.extruder_obj.lane_loaded = CUR_LANE.name
+                            CUR_LANE.enable_buffer()
                         else:
-                            if CUR_LANE.extruder_obj.tool_start_state == True:
+                            if CUR_LANE.get_toolhead_sensor_state() == True:
                                 msg +="<span class=error--text> error in ToolHead. \nLane identified as loaded in AFC.vars.unit file\n but not identified as loaded in AFC.var.tool file</span>"
                                 succeeded = False
                     else:
@@ -135,46 +98,48 @@ class afcBoxTurtle:
 
         if assignTcmd: self.AFC.FUNCTION.TcmdAssign(CUR_LANE)
         CUR_LANE.do_enable(False)
-        self.AFC.gcode.respond_info( '{lane_name} tool cmd: {tcmd:3} {msg}'.format(lane_name=CUR_LANE.name.upper(), tcmd=CUR_LANE.map, msg=msg))
+        self.AFC.gcode.respond_info( '{lane_name} tool cmd: {tcmd:3} {msg}'.format(lane_name=CUR_LANE.name, tcmd=CUR_LANE.map, msg=msg))
         CUR_LANE.set_afc_prep_done()
-        return succeeded
-    
-    def get_status(self, eventtime=None):
-        self.response = {}
-        self.response['lanes'] = self.lanes
 
-        return self.response
-    
+        return succeeded
+
     def calibrate_bowden(self, CUR_LANE, dis, tol):
         CUR_EXTRUDER = CUR_LANE.extruder_obj
         CUR_HUB = CUR_LANE.hub_obj
-        self.AFC.gcode.respond_info('Calibrating Bowden Length with {}'.format(CUR_LANE.name.upper()))
+        self.AFC.gcode.respond_info('Calibrating Bowden Length with {}'.format(CUR_LANE.name))
         self.move_until_state(CUR_LANE, lambda: CUR_HUB.state, CUR_HUB.move_dis, tol, CUR_LANE.short_move_dis)
         bow_pos = 0
         if CUR_EXTRUDER.tool_start:
-            while not CUR_EXTRUDER.tool_start_state:
+            # Clear until toolhead sensor is clear
+            while not CUR_LANE.get_toolhead_sensor_state():
                 CUR_LANE.move(dis, self.short_moves_speed, self.short_moves_accel)
                 bow_pos += dis
                 self.AFC.reactor.pause(self.AFC.reactor.monotonic() + 0.1)
-            bow_pos = self.calc_position(CUR_LANE, lambda: CUR_EXTRUDER.tool_start_state, bow_pos, CUR_LANE.short_move_dis, tol)
+
+            bow_pos = self.calc_position(CUR_LANE, lambda: CUR_LANE.get_toolhead_sensor_state(), bow_pos, CUR_LANE.short_move_dis, tol)
             CUR_LANE.move(bow_pos * -1, CUR_LANE.long_moves_speed, CUR_LANE.long_moves_accel, True)
+
+            self.calibrate_hub( CUR_LANE, tol)
+
             if CUR_HUB.state:
                 CUR_LANE.move(CUR_HUB.move_dis * -1, CUR_LANE.short_moves_speed, CUR_LANE.short_moves_accel, True)
+
+            bowden_dist = 0
             if CUR_EXTRUDER.tool_start == 'buffer':
-                cal_msg = '\n afc_bowden_length: {}'.format(bow_pos - (CUR_LANE.short_move_dis * 2))
-                CUR_LANE.hub_obj.afc_bowden_length = bow_pos - (CUR_LANE.short_move_dis * 2)
-                self.AFC.FUNCTION.ConfigRewrite(CUR_HUB.fullname, "afc_bowden_length", bow_pos - (CUR_LANE.short_move_dis * 2), cal_msg)
+                bowden_dist = bow_pos - (CUR_LANE.short_move_dis * 2)
             else:
-                cal_msg = '\n afc_bowden_length: {}'.format(bow_pos - CUR_LANE.short_move_dis)
-                CUR_LANE.hub_obj.afc_bowden_length = bow_pos - CUR_LANE.short_move_dis
-                self.AFC.FUNCTION.ConfigRewrite(CUR_HUB.fullname, "afc_bowden_length", bow_pos - CUR_LANE.short_move_dis, cal_msg)
+                bowden_dist = bow_pos - CUR_LANE.short_move_dis
+
+            cal_msg = '\n afc_bowden_length: New: {} Old: {}'.format(bowden_dist, CUR_LANE.hub_obj.afc_bowden_length)
+            CUR_LANE.hub_obj.afc_bowden_length = bowden_dist
+            self.AFC.FUNCTION.ConfigRewrite(CUR_HUB.fullname, "afc_bowden_length", bowden_dist, cal_msg)
             CUR_LANE.do_enable(False)
         else:
             self.AFC.gcode.respond_info('CALIBRATE_AFC is not currently supported without tool start sensor')
         self.AFC.gcode.respond_info(cal_msg)
         self.AFC.save_vars()
 
-        # Helper functions for movement and calibration
+    # Helper functions for movement and calibration
     def calibrate_hub(self, CUR_LANE, tol):
         hub_pos = 0
         hub_pos = self.move_until_state(CUR_LANE, lambda: CUR_LANE.hub_obj.state, CUR_LANE.hub_obj.move_dis, tol, CUR_LANE.short_move_dis, hub_pos)
@@ -211,21 +176,23 @@ class afcBoxTurtle:
             self.AFC.gcode.respond_info('Hub is not clear, check before calibration')
             return False, ""
         if not CUR_LANE.load_state:
-            self.AFC.gcode.respond_info('{} not loaded, load before calibration'.format(CUR_LANE.name.upper()))
+            self.AFC.gcode.respond_info('{} not loaded, load before calibration'.format(CUR_LANE.name))
             return True, ""
 
-        self.AFC.gcode.respond_info('Calibrating {}'.format(CUR_LANE.name.upper()))
+        self.AFC.gcode.respond_info('Calibrating {}'.format(CUR_LANE.name))
         # reset to extruder
         self.calc_position(CUR_LANE, lambda: CUR_LANE.load_state, 0, CUR_LANE.short_move_dis, tol)
         hub_pos = self.calibrate_hub(CUR_LANE, tol)
         if CUR_HUB.state:
             CUR_LANE.move(CUR_HUB.move_dis * -1, CUR_LANE.short_moves_speed, CUR_LANE.short_moves_accel, True)
-        CUR_LANE.hub_load = True
+
+        cal_dist = hub_pos - CUR_HUB.hub_clear_move_dis
+        cal_msg = "\n{} dist_hub: New: {} Old: {}".format(CUR_LANE.name, cal_dist, CUR_LANE.dist_hub)
+        CUR_LANE.loaded_to_hub  = True
         CUR_LANE.do_enable(False)
-        CUR_LANE.dist_hub = hub_pos - CUR_HUB.hub_clear_move_dis
-        cal_msg = "\n{} dist_hub: {}".format(CUR_LANE.name.upper(), (hub_pos - CUR_HUB.hub_clear_move_dis))
-        self.AFC.FUNCTION.ConfigRewrite(CUR_LANE.fullname, "dist_hub", hub_pos - CUR_HUB.hub_clear_move_dis, cal_msg)
+        CUR_LANE.dist_hub = cal_dist
+        self.AFC.FUNCTION.ConfigRewrite(CUR_LANE.fullname, "dist_hub", cal_dist, cal_msg)
         return True, cal_msg
-        
+
 def load_config_prefix(config):
     return afcBoxTurtle(config)

--- a/extras/AFC_NightOwl.py
+++ b/extras/AFC_NightOwl.py
@@ -1,39 +1,26 @@
-class afcNightOwl:
-    def __init__(self, config):
-        self.printer = config.get_printer()
-        self.AFC = self.printer.lookup_object('AFC')
-        self.printer.register_event_handler("klippy:connect", self.handle_connect)
-        self.name = config.get_name().split()[-1]
-        self.type='Box_Turtle'
-        self.screen_mac = config.get('screen_mac', None)
-        self.lanes=[]
-        self.AFC.units[self.name]=config.get_name().split()[0]
- 
-        self.led_name =config.get('led_name',self.AFC.led_name)
-        self.led_fault =config.get('led_fault',self.AFC.led_fault)
-        self.led_ready = config.get('led_ready',self.AFC.led_ready)
-        self.led_not_ready = config.get('led_not_ready',self.AFC.led_not_ready)
-        self.led_loading = config.get('led_loading',self.AFC.led_loading)
-        self.led_prep_loaded = config.get('led_loading',self.AFC.led_prep_loaded)
-        self.led_unloading = config.get('led_unloading',self.AFC.led_unloading)
-        self.led_tool_loaded = config.get('led_tool_loaded',self.AFC.led_tool_loaded)
+# Armored Turtle Automated Filament Changer
+#
+# Copyright (C) 2024 Armored Turtle
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+from configparser import Error as error
+try:
+    from extras.AFC_BoxTurtle import afcBoxTurtle
+except:
+    raise error("Error trying to import AFC_BoxTurtle, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper")
 
-    def get_status(self, eventtime=None):
-        self.response = {}
-        self.response['name'] = self.name
-        self.response['type'] = self.type
-        self.response['screen'] = self.screen_mac
-        self.response['lanes'] = self.lanes
-        
-        return self.response
-    
+class afcNightOwl(afcBoxTurtle):
+    def __init__(self, config):
+        super().__init__(config)
+        self.type = config.get('type', 'Night_Owl')
+
     def handle_connect(self):
         """
         Handle the connection event.
         This function is called when the printer connects. It looks up AFC info
         and assigns it to the instance variable `self.AFC`.
         """
-        self.AFC = self.printer.lookup_object('AFC')
+        super().handle_connect()
 
         self.logo = '<span class=success--text>Night Owl Ready</span>'
         self.logo ='<span class=success--text>R  ,     ,\n'
@@ -45,73 +32,5 @@ class afcNightOwl:
 
         self.logo_error = '<span class=error--text>Night Owl Not Ready</span>\n'
 
-    def _handle_ready(self):
-        if self.hub == None:
-            self.hub = self.AFC.hub
-        if self.buffer == None:
-            self.buffer = self.AFC.buffer
-        self.hub_obj = self.AFC.hubs[self.hub]
-        self.buffer_obj = self.AFC.buffers[self.buffer]
-
-    def system_Test(self, LANE, delay, assignTcmd):
-        msg = ''
-        succeeded = True
-        if LANE not in self.AFC.lanes:
-            self.AFC.gcode.respond_info('{} Unknown'.format(LANE.upper()))
-            return
-        CUR_LANE = self.AFC.lanes[LANE]
-        # Run test reverse/forward on each lane
-        CUR_LANE.unsync_to_extruder(False)
-        CUR_LANE.move( 5, self.AFC.short_moves_speed, self.AFC.short_moves_accel, True)
-        self.AFC.reactor.pause(self.AFC.reactor.monotonic() + delay)
-        CUR_LANE.move( -5, self.AFC.short_moves_speed, self.AFC.short_moves_accel, True)
-        if CUR_LANE.prep_state == False:
-            if CUR_LANE.load_state == False:
-                self.AFC.afc_led(CUR_LANE.led_not_ready, CUR_LANE.led_index)
-                msg += 'EMPTY READY FOR SPOOL'
-            else:
-                self.AFC.afc_led(CUR_LANE.led_fault, CUR_LANE.led_index)
-                msg +="<span class=error--text> NOT READY</span>"
-                CUR_LANE.do_enable(False)
-                msg = '<span class=error--text>CHECK FILAMENT Prep: False - Load: True</span>'
-                succeeded = False
-        else:
-            self.AFC.afc_led(CUR_LANE.led_ready, CUR_LANE.led_index)
-            msg +="<span class=success--text>LOCKED</span>"
-            if CUR_LANE.load_state == False:
-                msg +="<span class=error--text> NOT LOADED</span>"
-                self.AFC.afc_led(CUR_LANE.led_not_ready, CUR_LANE.led_index)
-                succeeded = False
-            else:
-                CUR_LANE.status = 'Loaded'
-                msg +="<span class=success--text> AND LOADED</span>"
-                if CUR_LANE.tool_loaded:
-                    if CUR_LANE.extruder_obj.tool_start_state == True or CUR_LANE.extruder_obj.tool_start == "buffer":
-                        if CUR_LANE.extruder_obj.lane_loaded == CUR_LANE.name:
-                            self.AFC.current = CUR_LANE.name
-                            CUR_LANE.sync_to_extruder()
-                            msg +="<span class=primary--text> in ToolHead</span>"
-                            if CUR_LANE.extruder_obj.tool_start == "buffer":
-                                msg += "<span class=warning--text>\n Ram sensor enabled, confirm tool is loaded</span>"
-                            self.AFC.SPOOL.set_active_spool(CUR_LANE.spool_id)
-                            self.AFC.afc_led(CUR_LANE.led_tool_loaded, CUR_LANE.led_index)
-                            CUR_LANE.status = 'Tooled'
-                            CUR_LANE.extruder_obj.enable_buffer()
-                            CUR_LANE.extruder_obj.lane_loaded = CUR_LANE.name
-                        else:
-                            if CUR_LANE.extruder_obj.tool_start_state == True:
-                                msg +="<span class=error--text> error in ToolHead. \nLane identified as loaded in AFC.vars.unit file\n but not identified as loaded in AFC.var.tool file</span>"
-                                succeeded = False
-                    else:
-                        lane_check=self.AFC.ERROR.fix('toolhead',CUR_LANE)  #send to error handling
-                        if not lane_check:
-                            return False
-
-        if assignTcmd: self.AFC.TcmdAssign(CUR_LANE)
-        CUR_LANE.do_enable(False)
-        self.AFC.gcode.respond_info( '{lane_name} tool cmd: {tcmd:3} {msg}'.format(lane_name=CUR_LANE.name.upper(), tcmd=CUR_LANE.map, msg=msg))
-        CUR_LANE.set_afc_prep_done()
-        return succeeded
-    
 def load_config_prefix(config):
-    return afcBoxTurtle(config)
+    return afcNightOwl(config)

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -3,13 +3,18 @@
 # Copyright (C) 2024 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from configparser import Error as error
+try:
+    from extras.AFC_utils import add_filament_switch
+except:
+    raise error("Error trying to import AFC_utils, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper")
 
 class AFCextruder:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.printer.register_event_handler("klippy:connect", self.handle_connect)
-        self.printer.register_event_handler("klippy:ready", self._handle_ready)
         buttons = self.printer.load_object(config, "buttons")
+        self.AFC = self.printer.lookup_object('AFC')
 
         self.name = config.get_name().split(' ')[-1]
         self.tool_stn = config.getfloat("tool_stn", 72)
@@ -20,114 +25,62 @@ class AFCextruder:
         self.tool_start = config.get('pin_tool_start', None)
         self.tool_end = config.get('pin_tool_end', None)
         self.lane_loaded = None
+        self.lanes = {}
         self.buffer_name = config.get('buffer', None)
-        self.buffer = None
 
-        ppins = self.printer.lookup_object('pins')
         self.gcode = self.printer.lookup_object('gcode')
-  
-        # RAMMING
-        # Use buffer sensors for loading and unloading filament
-        if self.tool_start == "buffer":
-            self.r_enabled = False
-            b = config.getsection("AFC_buffer {}".format(self.buffer_name))
-            ap = b.get('advance_pin', None)
-            tp = b.get('trailing_pin', None)
-            if ap is not None and tp is not None:
-                self.r_enabled = True
-                self.advance_pin = ap
-                self.trailing_pin = tp
-                pins = ap.strip("!^"), tp.strip("!^")
-                for pin_desc in pins:
-                    ppins.allow_multi_use_pin(pin_desc)
+        self.enable_sensors_in_gui = config.getboolean("enable_sensors_in_gui", self.AFC.enable_sensors_in_gui) # Set to True toolhead sensors switches as filament sensors in mainsail/fluidd gui, overrides value set in AFC.cfg
+
+        self.tool_start_state = False
+        if self.tool_start is not None:
+            if self.tool_start == "buffer":
+                self.gcode.respond_info("Setting up as buffer")
             else:
-                self.gcode.respond_info("advance_pin and trailing_pin must be defined to enable ram sensor")
-            if self.r_enabled == True:
                 self.tool_start_state = False
-                self.buffer_trailing = False
-                buttons.register_buttons([self.advance_pin], self.tool_start_callback)
-                buttons.register_buttons([self.trailing_pin], self.buffer_trailing_callback)
-        else:
-            self.tool_start_state = False
-            buttons.register_buttons([self.tool_start], self.tool_start_callback)
+                buttons.register_buttons([self.tool_start], self.tool_start_callback)
+                if self.enable_sensors_in_gui:
+                    self.tool_start_filament_switch_name = "filament_switch_sensor {}".format("tool_start")
+                    self.fila_tool_start = add_filament_switch(self.tool_start_filament_switch_name, self.tool_start, self.printer )
+
+        self.tool_end_state = False
         if self.tool_end is not None:
-            self.tool_end_state = False
             buttons.register_buttons([self.tool_end], self.tool_end_callback)
-
-    def _handle_ready(self):
-       self.AFC.tools[self.name] = self
-
+            if self.enable_sensors_in_gui:
+                self.tool_end_state_filament_switch_name = "filament_switch_sensor {}".format("tool_end")
+                self.fila_avd = add_filament_switch(self.tool_end_state_filament_switch_name, self.tool_end, self.printer )
     def handle_connect(self):
         """
         Handle the connection event.
         This function is called when the printer connects. It looks up AFC info
         and assigns it to the instance variable `self.AFC`.
         """
-        self.AFC = self.printer.lookup_object('AFC')
         self.reactor = self.AFC.reactor
-
-        self.get_buffer()
-
-    def get_buffer(self):
-      """
-      Retrieve the buffer object associated with the current buffer name.
-      If `buffer_name` is set, this method assigns the buffer object to `self.buffer`
-      by looking it up using the printer's AFC buffer system.
-      """
-      if self.buffer_name is not None:
-          self.buffer = self.printer.lookup_object('AFC_buffer ' + self.buffer_name)
+        self.AFC.tools[self.name] = self
 
     def tool_start_callback(self, eventtime, state):
         self.tool_start_state = state
+
     def buffer_trailing_callback(self, eventtime, state):
         self.buffer_trailing = state
+
     def tool_end_callback(self, eventtime, state):
         self.tool_end_state = state
-
-    def enable_buffer(self):
-      """
-      Enable the buffer if `buffer_name` is set.
-      Retrieves the buffer object and calls its `enable_buffer()` method to activate it.
-      """
-      if self.buffer_name is not None:
-         self.buffer.enable_buffer()
-
-    def disable_buffer(self):
-       """
-       Disable the buffer if `buffer_name` is set.
-       Calls the buffer's `disable_buffer()` method to deactivate it.
-       """
-       if self.buffer_name is not None:
-          self.buffer.disable_buffer()
-
-    def buffer_status(self):
-       """
-       Retrieve the current status of the buffer.
-       If `buffer_name` is set, returns the buffer's status using `buffer_status()`.
-       Otherwise, returns None.
-       """
-       if self.buffer_name is not None:
-          return self.buffer.buffer_status()
-
-       else: return None
 
     def get_status(self, eventtime=None):
         self.response = {}
         self.response['tool_stn'] = self.tool_stn
         self.response['tool_stn_unload'] = self.tool_stn_unload
         self.response['tool_sensor_after_extruder'] = self.tool_sensor_after_extruder
-        self.response['tool_unload_speed'] = self.tool_unload_speed 
+        self.response['tool_unload_speed'] = self.tool_unload_speed
         self.response['tool_load_speed'] = self.tool_load_speed
         self.response['buffer'] = self.buffer_name
         self.response['lane_loaded'] = self.lane_loaded
         self.response['tool_start'] = self.tool_start
         self.response['tool_start_status'] = bool(self.tool_start_state)
         self.response['tool_end'] = self.tool_end
-        if self.tool_end is not None:
-            self.response['tool_end_status'] = bool(self.tool_end_state)
-        else:
-            self.response['tool_end_status'] =False
+        self.response['tool_end_status'] = bool(self.tool_end_state)
+        self.response['lanes'] = [lane.name for lane in self.lanes.values()]
         return self.response
-    
+
 def load_config_prefix(config):
     return AFCextruder(config)

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -8,6 +8,11 @@ import math
 import chelper
 from kinematics import extruder
 from . import AFC_assist
+from configfile import error
+try:
+    from extras.AFC_utils import add_filament_switch
+except:
+    raise error("Error trying to import AFC_utils, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper")
 
 #LED
 BACKGROUND_PRIORITY_CLOCK = 0x7fffffff00000000
@@ -47,50 +52,66 @@ def calc_move_time(dist, speed, accel):
 class AFCExtruderStepper:
     def __init__(self, config):
         self.printer = config.get_printer()
-        self.printer.register_event_handler("klippy:connect", self.handle_connect)
         self.printer.register_event_handler("klippy:ready", self._handle_ready)
         self.AFC = self.printer.lookup_object('AFC')
         self.gcode = self.printer.lookup_object('gcode')
         self.reactor = self.printer.get_reactor()
         self.extruder_stepper = extruder.ExtruderStepper(config)
 
+        self.unit_obj       = None
+        self.hub_obj        = None
+        self.buffer_obj     = None
+        self.extruder_obj   = None
+
         #stored status variables
-        self.name = config.get_name().split()[-1]
-        self.fullname = config.get_name()
-        self.extruder_name = config.get('extruder')
-        self.extruder_obj = None
-        self.map = config.get('cmd','NONE')
-        self.tool_loaded = False
-        self.loaded_to_hub = False
-        self.spool_id = None
-        self.material = None
-        self.color = None
-        self.weight = None
-        self.runout_lane = 'NONE'
-        self.status = None
-        unit = config.get('unit')                                                             # Unit name(AFC_hub) that this lane belongs to.
-        self.unit = unit.split(':')[0]
-        self.index = int(unit.split(':')[1])
+        self.fullname           = config.get_name()
+        self.name               = self.fullname.split()[-1]
+        self.tool_loaded        = False
+        self.loaded_to_hub      = False
+        self.spool_id           = None
+        self.material           = None
+        self.color              = None
+        self.weight             = None
+        self.material           = None
+        self.extruder_temp      = None
+        self.runout_lane        = 'NONE'
+        self.status             = None
+        self.multi_hubs_found   = False
+        unit                    = config.get('unit')                                    # Unit name(AFC_BoxTurtle/NightOwl/etc) that belongs to this stepper.
+        # Overrides buffers set at the unit level
+        self.hub 				= config.get('hub',None)                                # Hub name(AFC_hub) that belongs to this stepper, overrides hub that is set in unit(AFC_BoxTurtle/NightOwl/etc) section.
+        # Overrides buffers set at the unit and extruder level
+        self.buffer_name        = config.get("buffer", None)                            # Buffer name(AFC_buffer) that belongs to this stepper, overrides buffer that is set in extrider(AFC_extruder) or unit(AFC_BoxTurtle/NightOwl/etc) sections.
+        self.unit               = unit.split(':')[0]
+        self.index              = int(unit.split(':')[1])
 
-        self.led_index = config.get('led_index', None)                                              # LED index of lane in chain of lane LEDs
-        self.led_name =config.get('led_name',None)
-        self.led_fault =config.get('led_fault',None)
-        self.led_ready = config.get('led_ready',None)
-        self.led_not_ready = config.get('led_not_ready',None)
-        self.led_loading = config.get('led_loading',None)
-        self.led_prep_loaded = config.get('led_loading',None)
-        self.led_unloading = config.get('led_unloading',None)
-        self.led_tool_loaded = config.get('led_tool_loaded',None)
+        self.extruder_name      = config.get('extruder', None)                          # Extruder name(AFC_extruder) that belongs to this stepper, overrides extruer that is set in unit(AFC_BoxTurtle/NightOwl/etc) section.
+        self.map                = config.get('cmd','NONE')
+        self.led_index 			= config.get('led_index', None)                         # LED index of lane in chain of lane LEDs
+        self.led_name 			= config.get('led_name',None)
+        self.led_fault 			= config.get('led_fault',None)                          # LED color to set when faults occur in lane        (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
+        self.led_ready 			= config.get('led_ready',None)                          # LED color to set when lane is ready               (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
+        self.led_not_ready 		= config.get('led_not_ready',None)                      # LED color to set when lane not ready              (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
+        self.led_loading 		= config.get('led_loading',None)                        # LED color to set when lane is loading             (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
+        self.led_prep_loaded 	= config.get('led_loading',None)                        # LED color to set when lane is loaded              (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
+        self.led_unloading 		= config.get('led_unloading',None)                      # LED color to set when lane is unloading           (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
+        self.led_tool_loaded 	= config.get('led_tool_loaded',None)                    # LED color to set when lane is loaded into tool    (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
 
-        self.long_moves_speed = config.getfloat("long_moves_speed", None)            # Speed in mm/s to move filament when doing long moves
-        self.long_moves_accel = config.getfloat("long_moves_accel", None)            # Acceleration in mm/s squared when doing long moves
-        self.short_moves_speed = config.getfloat("short_moves_speed", None)           # Speed in mm/s to move filament when doing short moves
-        self.short_moves_accel = config.getfloat("short_moves_accel", None)          # Acceleration in mm/s squared when doing short moves
-        self.short_move_dis = config.getfloat("short_move_dis", None)                 # Move distance in mm for failsafe moves.
+        self.long_moves_speed 	= config.getfloat("long_moves_speed", None)            # Speed in mm/s to move filament when doing long moves. Setting value here overrides values set in AFC.cfg file
+        self.long_moves_accel 	= config.getfloat("long_moves_accel", None)            # Acceleration in mm/s squared when doing long moves. Setting value here overrides values set in AFC.cfg file
+        self.short_moves_speed 	= config.getfloat("short_moves_speed", None)           # Speed in mm/s to move filament when doing short moves. Setting value here overrides values set in AFC.cfg file
+        self.short_moves_accel	= config.getfloat("short_moves_accel", None)           # Acceleration in mm/s squared when doing short moves. Setting value here overrides values set in AFC.cfg file
+        self.short_move_dis 	= config.getfloat("short_move_dis", None)              # Move distance in mm for failsafe moves. Setting value here overrides values set in AFC.cfg file
 
-        self.hub = config.get('hub',None)
-        self.buffer = config.get('buffer',None)
-        
+        self.dist_hub           = config.getfloat('dist_hub', 60)                      # Bowden distance between Boxturtle extruder and hub
+        self.park_dist          = config.getfloat('park_dist', 10)                     # Currently unused
+
+        self.load_to_hub        = config.getboolean("load_to_hub", self.AFC.load_to_hub) # Fast loads filament to hub when inserted, set to False to disable. Setting here overrides global setting in AFC.cfg
+        self.enable_sensors_in_gui = config.getboolean("enable_sensors_in_gui", self.AFC.enable_sensors_in_gui) # Set to True to show prep and load sensors switches as filament sensors in mainsail/fluidd gui, overrides value set in AFC.cfg
+        self.sensor_to_show     = config.get("sensor_to_show", None)                   # Set to prep to only show prep sensor, set to load to only show load sensor. Do not add if you want both prep and load sensors to show in web gui
+
+        self.printer.register_event_handler("AFC_unit_{}:connect".format(self.unit),self.handle_unit_connect)
+
         self.motion_queue = None
         self.next_cmd_time = 0.
         ffi_main, ffi_lib = chelper.get_ffi()
@@ -101,9 +122,6 @@ class AFCExtruderStepper:
             ffi_lib.cartesian_stepper_alloc(b'x'), ffi_lib.free)
         self.assist_activate=False
 
-        self.dist_hub = config.getfloat('dist_hub', 60)                                             # Bowden distance between Boxturtle extruder and hub
-        self.park_dist = config.getfloat('park_dist', 10)                                           # Currently unused
-        
         # lane triggers
         buttons = self.printer.load_object(config, "buttons")
         self.prep = config.get('prep', None)                                                        # MCU pin for prep trigger
@@ -152,21 +170,100 @@ class AFCExtruderStepper:
         # Get and save base rotation dist
         self.base_rotation_dist = self.extruder_stepper.stepper.get_rotation_distance()[0]
 
-    def handle_connect(self):
-        """
-        Handle the connection event.
-        This function is called when the printer connects. It looks up AFC info
-        and assigns it to the instance variable `self.AFC`.
-        """
-        self.AFC.lanes[self.name] = self
+        if self.enable_sensors_in_gui:
+            if self.sensor_to_show is None or self.sensor_to_show == 'prep':
+                self.prep_filament_switch_name = "filament_switch_sensor {}_prep".format(self.name)
+                self.fila_prep = add_filament_switch(self.prep_filament_switch_name, self.prep, self.printer )
+
+            if self.sensor_to_show is None or self.sensor_to_show == 'load':
+                self.load_filament_switch_name = "filament_switch_sensor {}_load".format(self.name)
+                self.fila_load = add_filament_switch(self.load_filament_switch_name, self.load, self.printer )
+        self.connect_done = False
 
     def _handle_ready(self):
-        self.unit_obj=self.AFC.units[self.unit]
-        self.extruder_obj = self.AFC.tools[self.extruder_name] 
-        if self.hub is None: self.hub = self.unit_obj.hub_obj.name
-        if self.buffer is None and self.unit_obj.buffer_obj is not None: self.buffer = self.unit_obj.buffer_obj.name
-       
-        self.hub_obj = self.AFC.hubs[self.hub]
+        """
+        Handles klippy:ready callback and verifies that steppers have units defined in their config
+        """
+        if self.unit_obj is None:
+            raise error("Unit {unit} is not defined in your configuration file. Please defined unit ex. [AFC_BoxTurtle {unit}]".format(unit=self.unit))
+
+    def handle_unit_connect(self, unit_obj):
+        """
+        Callback from <unit_name>:connect to verify units/hub/buffer/extruder object. Errors out if user specified names and they do not exist in their configuration
+        """
+        # Saving reference to unit
+        self.unit_obj = unit_obj
+        self.buffer_obj = self.unit_obj.buffer_obj
+
+        # Registering lane name in unit
+        self.unit_obj.lanes[self.name] = self
+        self.AFC.lanes[self.name] = self
+
+        self.hub_obj = self.unit_obj.hub_obj
+        # TODO: once supported add check if users is not using a hub
+        if self.hub is not None:
+            try:
+                self.hub_obj = self.printer.lookup_object("AFC_hub {}".format(self.hub))
+            except:
+                error_string = 'Error: No config found for hub: {hub} in [AFC_stepper {stepper}]. Please make sure [AFC_hub {hub}] section exists in your config'.format(
+                hub=self.hub, stepper=self.name )
+                raise error(error_string)
+        elif self.hub_obj is None:
+            # Check to make sure at least 1 hub exists in config, if not error out with message
+            if len(self.AFC.hubs) == 0:
+                error_string = "Error: AFC_hub not found in configuration please make sure there is a [AFC_hub <hub_name>] defined in your configuration"
+                raise error(error_string)
+            # Setting hub to first hub in AFC hubs dictionary
+            if len(self.AFC.hubs) > 0:
+                self.hub_obj = next(iter(self.AFC.hubs.values()))
+            # Set flag to warn during prep that multiple hubs were found
+            if len(self.AFC.hubs) > 1:
+                self.multi_hubs_found = True
+
+        # Assigning hub name just in case stepper is using hub defined in units config
+        self.hub = self.hub_obj.name
+        self.hub_obj.lanes[self.name] = self
+
+        self.extruder_obj = self.unit_obj.extruder_obj
+        if self.extruder_name is not None:
+            try:
+                self.extruder_obj = self.printer.lookup_object('AFC_extruder {}'.format(self.extruder_name))
+            except:
+                error_string = 'Error: No config found for extruder: {extruder} in [AFC_stepper {stepper}]. Please make sure [AFC_extruder {extruder}] section exists in your config'.format(
+                    extruder=self.extruder_name, stepper=self.name )
+                raise error(error_string)
+        elif self.extruder_obj is None:
+            error_string = "Error: Extruder has not been configured for stepper {name}, please add extruder variable to either [AFC_stepper {name}] or [AFC_{unit_type} {unit_name}] in your config file".format(
+                        name=self.name, unit_type=self.unit_obj.type.replace("_", ""), unit_name=self.unit_obj.name)
+            raise error(error_string)
+
+        # Assigning extruder name just in case stepper is using extruder defined in units config
+        self.extruder_name = self.extruder_obj.name
+        self.extruder_obj.lanes[self.name] = self
+
+        # Use buffer defined in stepper and override buffers that maybe set at the UNIT or extruder levels
+        self.buffer_obj = self.unit_obj.buffer_obj
+        if self.buffer_name is not None:
+            try:
+                self.buffer_obj = self.printer.lookup_object("AFC_buffer {}".format(self.buffer_name))
+            except:
+                error_string = 'Error: No config found for buffer: {buffer} in [AFC_stepper {stepper}]. Please make sure [AFC_buffer {buffer}] section exists in your config'.format(
+                    buffer=self.buffer_name, stepper=self.name )
+                raise error(error_string)
+
+        # Checking if buffer was defined in extruder if not defined in unit/stepper
+        elif self.buffer_obj is None and self.extruder_obj.tool_start == "buffer":
+            if self.extruder_obj.buffer_name is not None:
+                self.buffer_obj = self.printer.lookup_object("AFC_buffer {}".format(self.extruder_obj.buffer_name))
+            else:
+                error_string = 'Error: Buffer was defined as tool_start in [AFC_extruder {extruder}] config, but buffer variable has not been configured. Please add buffer variable to either [AFC_extruder {extruder}], [AFC_stepper {name}] or [AFC_{unit_type} {unit_name}] section in your config file'.format(
+                    extruder=self.extruder_obj.name, name=self.name, unit_type=self.unit_obj.type.replace("_", ""), unit_name=self.unit_obj.name )
+                raise error(error_string)
+        # Valid to not have a buffer defined, check to make sure object exists before adding lane to buffer
+        if self.buffer_obj is not None:
+            self.buffer_obj.lanes[self.name] = self
+            # Assigning buffer name just in case stepper is using buffer defined in units/extruder config
+            self.buffer_name = self.buffer_obj.name
 
         if self.led_name is None: self.led_name = self.unit_obj.led_name
         if self.led_fault is None: self.led_fault = self.unit_obj.led_fault
@@ -177,11 +274,16 @@ class AFCExtruderStepper:
         if self.led_unloading is None: self.led_unloading = self.unit_obj.led_unloading
         if self.led_tool_loaded is None: self.led_tool_loaded = self.unit_obj.led_tool_loaded
 
-        if self.long_moves_speed is None: self.long_moves_speed = self.unit_obj.long_moves_speed        # Speed in mm/s to move filament when doing long moves
-        if self.long_moves_accel is None: self.long_moves_accel = self.unit_obj.long_moves_accel           # Acceleration in mm/s squared when doing long moves
-        if self.short_moves_speed is None: self.short_moves_speed = self.unit_obj.short_moves_speed          # Speed in mm/s to move filament when doing short moves
-        if self.short_moves_accel is None: self.short_moves_accel = self.unit_obj.short_moves_accel        # Acceleration in mm/s squared when doing short moves
-        if self.short_move_dis is None: self.short_move_dis = self.unit_obj.short_move_dis                # Move distance in mm for failsafe moves.
+        if self.long_moves_speed is None: self.long_moves_speed = self.unit_obj.long_moves_speed
+        if self.long_moves_accel is None: self.long_moves_accel = self.unit_obj.long_moves_accel
+        if self.short_moves_speed is None: self.short_moves_speed = self.unit_obj.short_moves_speed
+        if self.short_moves_accel is None: self.short_moves_accel = self.unit_obj.short_moves_accel
+        if self.short_move_dis is None: self.short_move_dis = self.unit_obj.short_move_dis
+
+        # Send out event so that macros and be registered properly with valid lane names
+        self.printer.send_event("afc_stepper:register_macros", self)
+
+        self.connect_done = True
 
     def _get_tmc_values(self, config):
         """
@@ -287,8 +389,10 @@ class AFCExtruderStepper:
         self.prep_state = state
         # Checking to make sure printer is ready and making sure PREP has been called before trying to load anything
         if self.printer.state_message == 'Printer is ready' and True == self._afc_prep_done and self.status != 'Tool Unloading':
-            if self.prep_state == True:
+            # Only try to load when load state trigger is false
+            if self.prep_state == True and self.load_state == False:
                 x = 0
+                # Check to see if the printer is printing or moving as trying to load while printer is doing something will crash klipper
                 if self.AFC.FUNCTION.is_printing():
                     self.AFC.ERROR.AFC_error("Cannot load spools while printer is actively moving or homing", False)
                     return
@@ -304,11 +408,17 @@ class AFCExtruderStepper:
                         self.status=''
                         break
                 self.status=''
+
+                # Checking if loaded to hub(it should not be since filament was just inserted), if false load to hub. Does a fast load if hub distance is over 200mm
+                if self.load_to_hub and not self.loaded_to_hub and self.load_state and self.prep_state:
+                    self.move(self.dist_hub, self.dist_hub_move_speed, self.dist_hub_move_accel, self.dist_hub > 200)
+                    self.loaded_to_hub = True
+
                 self.do_enable(False)
                 if self.load_state == True and self.prep_state == True:
                     self.status = 'Loaded'
                     self.AFC.FUNCTION.afc_led(self.AFC.led_ready, self.led_index)
-           
+
             elif self.prep_state == False and self.name == self.AFC.current and self.AFC.FUNCTION.is_printing() and self.load_state and self.status != 'ejecting':
                 # Checking to make sure runout_lane is set and does not equal 'NONE'
                 if  self.runout_lane != 'NONE':
@@ -317,11 +427,18 @@ class AFCExtruderStepper:
                     self.AFC.gcode.respond_info("Infinite Spool triggered for {}".format(self.name))
                     empty_LANE = self.AFC.lanes[self.AFC.current]
                     change_LANE = self.AFC.lanes[self.runout_lane]
+                    # Pause printer
                     self.gcode.run_script_from_command('PAUSE')
+					# Change Tool
                     self.AFC.CHANGE_TOOL(change_LANE)
-                    self.gcode.run_script_from_command('SET_MAP LANE=' + change_LANE.name + ' MAP=' + empty_LANE.map)
-                    self.gcode.run_script_from_command('LANE_UNLOAD LANE=' + empty_LANE.name)
+                    # Change Mapping
+                    self.gcode.run_script_from_command('SET_MAP LANE={} MAP={}'.format(change_LANE.name, empty_LANE.map))
+                    # Eject lane from BT
+                    self.gcode.run_script_from_command('LANE_UNLOAD LANE={}'.format(empty_LANE.name))
+                    # Resume
                     self.gcode.run_script_from_command('RESUME')
+                    # Set LED to not ready
+                    self.AFC.FUNCTION.afc_led(self.led_not_ready, self.led_index)
                 else:
                     # Pause print
                     self.status = None
@@ -330,7 +447,10 @@ class AFCExtruderStepper:
                     self.AFC.ERROR.pause_print()
             else:
                 self.status = None
+                self.loaded_to_hub = False
+                self.AFC.SPOOL._clear_values(self)
                 self.AFC.FUNCTION.afc_led(self.AFC.led_not_ready, self.led_index)
+            self.AFC.save_vars()
 
     def do_enable(self, enable):
         self.sync_print_time()
@@ -450,29 +570,96 @@ class AFCExtruderStepper:
         if self.remaining_weight < self.empty_spool_weight:
             self.remaining_weight = self.empty_spool_weight  # Ensure weight doesn't drop below empty spool weight
 
+    def set_loaded(self):
+        """
+        Helper function for setting multiple variables when lane is loaded
+        """
+        self.tool_loaded = True
+        self.AFC.current = self.extruder_obj.lane_loaded = self.name
+        self.AFC.current_loading = None
+        self.status = 'Tooled'
+        self.AFC.SPOOL.set_active_spool(self.spool_id)
+
+    def set_unloaded(self):
+        """
+        Helper function for setting multiple variables when lane is unloaded
+        """
+        self.tool_loaded = False
+        self.extruder_obj.lane_loaded = ""
+        self.status = None
+        self.AFC.current = None
+        self.AFC.current_loading = None
+
+    def enable_buffer(self):
+        """
+        Enable the buffer if `buffer_name` is set.
+        Retrieves the buffer object and calls its `enable_buffer()` method to activate it.
+        """
+        if self.buffer_obj is not None:
+            self.buffer_obj.enable_buffer()
+
+    def disable_buffer(self):
+        """
+        Disable the buffer if `buffer_name` is set.
+        Calls the buffer's `disable_buffer()` method to deactivate it.
+        """
+        if self.buffer_obj is not None:
+            self.buffer_obj.disable_buffer()
+
+    def buffer_status(self):
+        """
+        Retrieve the current status of the buffer.
+        If `buffer_name` is set, returns the buffer's status using `buffer_status()`.
+        Otherwise, returns None.
+        """
+        if self.buffer_obj is not None:
+            return self.buffer_obj.buffer_status()
+
+        else: return None
+
+    def get_toolhead_sensor_state(self):
+        """
+        Helper function that returns current state of toolhead sensor or buffer if user has extruder setup for ramming
+
+        returns Status of toolhead sensor or the current buffer advance state
+        """
+        if self.extruder_obj.tool_start == "buffer":
+            return self.buffer_obj.advance_state
+        else:
+            return self.extruder_obj.tool_start_state
+    def get_trailing(self):
+        """
+        Helper function to get trailing status, returns none if buffer is not defined
+        """
+        if self.buffer_obj is not None:
+            return self.buffer_obj.trailing_state
+        else: return None
+
     def get_status(self, eventtime=None):
-        self.response = {}
-        self.response['name'] = self.name
-        self.response['unit'] = self.unit
-        self.response['hub'] = self.hub
-        self.response['buffer'] = self.buffer
-        self.response['lane'] = self.index
-        self.response['map'] = self.map
-        self.response['load'] = bool(self.load_state)
-        self.response["prep"] =bool(self.prep_state)
-        self.response["tool_loaded"] = self.tool_loaded
-        self.response["loaded_to_hub"] = self.loaded_to_hub
-        self.response["material"]=self.material
-        self.response["spool_id"]=self.spool_id
-        self.response["color"]=self.color
-        self.response["weight"]=self.weight
-        self.response["runout_lane"]=self.runout_lane
-        if self.led_name is not None:
-            filiment_stat=self.AFC.FUNCTION.get_filament_status(self).split(':')
-            self.response['filament_status'] = filiment_stat[0]
-            self.response['filament_status_led'] = filiment_stat[1]
-        self.response['status'] = self.status
-        return self.response
-    
+        response = {}
+        if not self.connect_done: return response
+        response['name'] = self.name
+        response['unit'] = self.unit
+        response['hub'] = self.hub
+        response['extruder'] = self.extruder_name
+        response['buffer'] = self.buffer_name
+        response['buffer_status'] = self.buffer_status()
+        response['lane'] = self.index
+        response['map'] = self.map
+        response['load'] = bool(self.load_state)
+        response["prep"] =bool(self.prep_state)
+        response["tool_loaded"] = self.tool_loaded
+        response["loaded_to_hub"] = self.loaded_to_hub
+        response["material"]=self.material
+        response["spool_id"]=self.spool_id
+        response["color"]=self.color
+        response["weight"]=self.weight
+        response["runout_lane"]=self.runout_lane
+        filiment_stat=self.AFC.FUNCTION.get_filament_status(self).split(':')
+        response['filament_status'] = filiment_stat[0]
+        response['filament_status_led'] = filiment_stat[1]
+        response['status'] = self.status
+        return response
+
 def load_config_prefix(config):
     return AFCExtruderStepper(config)

--- a/extras/AFC_utils.py
+++ b/extras/AFC_utils.py
@@ -1,0 +1,33 @@
+# Armored Turtle Automated Filament Changer
+#
+# Copyright (C) 2024 Armored Turtle
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+# File is used to hold common functions that can be called from anywhere and don't belong to a class
+
+def add_filament_switch( switch_name, switch_pin, printer ):
+    """
+    Helper function to register pins as filament switch sensor so it will show up in web guis
+
+    :param switch_name: Name of switch to register, should be in the following format: `filament_switch_sensor <name>`
+    :param switch_pin: Pin to add to config for switch
+    :param printer: printer object
+
+    :return returns filament_switch_sensor object
+    """
+    import configparser
+    import configfile
+    ppins = printer.lookup_object('pins')
+    ppins.allow_multi_use_pin(switch_pin.strip("!^"))
+    filament_switch_config = configparser.RawConfigParser()
+    filament_switch_config.add_section( switch_name )
+    filament_switch_config.set( switch_name, 'switch_pin', switch_pin)
+
+    cfg_wrap = configfile.ConfigWrapper( printer, filament_switch_config, {}, switch_name)
+
+    fila = printer.load_object(cfg_wrap, switch_name)
+    fila.runout_helper.sensor_enabled = False
+    fila.runout_helper.runout_pause = False
+
+    return fila

--- a/templates/AFC_Turtle_1.cfg
+++ b/templates/AFC_Turtle_1.cfg
@@ -3,6 +3,9 @@ canbus_uuid: <can UID>
 
 [AFC_BoxTurtle Turtle_1]
 type: 'Box Turtle'
+hub: Turtle_1
+extruder: extruder
+# buffer: <buffer_name> Uncomment and add buffer name if using a buffer
 
 [temperature_sensor Turtle_1]
 sensor_type: temperature_mcu
@@ -10,8 +13,6 @@ sensor_mcu: Turtle_1
 
 [AFC_stepper lane1]
 unit: Turtle_1:1
-hub: Turtle_1
-extruder: extruder
 step_pin: Turtle_1:M1_STEP
 dir_pin: !Turtle_1:M1_DIR
 enable_pin: !Turtle_1:M1_EN
@@ -40,7 +41,6 @@ sense_resistor: 0.110
 
 [AFC_stepper lane2]
 unit: Turtle_1:2
-extruder: extruder
 step_pin: Turtle_1:M2_STEP
 dir_pin: !Turtle_1:M2_DIR
 enable_pin: !Turtle_1:M2_EN
@@ -66,7 +66,6 @@ sense_resistor: 0.110
 
 [AFC_stepper lane3]
 unit: Turtle_1:3
-extruder: extruder
 step_pin: Turtle_1:M3_STEP
 dir_pin: !Turtle_1:M3_DIR
 enable_pin: !Turtle_1:M3_EN
@@ -90,7 +89,6 @@ sense_resistor: 0.110
 
 [AFC_stepper lane4]
 unit: Turtle_1:4
-extruder: extruder
 step_pin: Turtle_1:M4_STEP
 dir_pin: !Turtle_1:M4_DIR
 enable_pin: !Turtle_1:M4_EN

--- a/utilities/generate_docs.py
+++ b/utilities/generate_docs.py
@@ -72,6 +72,7 @@ def format_markdown(cmd_functions):
         "\n",
         "The following commands are built-in the AFC-Klipper-Add-On and are available through \n",
         "the Klipper console.\n",
+        "\nNOTE: LANE/HUB/BUFFER etc. names are case sensitive and should exactly match the names defined in config files",
         "\n"
     ]
     for name, docstring in cmd_functions:


### PR DESCRIPTION
## Major Changes in this PR
- Added clearing spool info and `load_to_hub` when lane retracts too far past Box Turtle extruder, reset once prep goes low
- Added logic so that buffer/extruder/hubs don't need to be entered per stepper as long as they are defined in their Unit(AFC_BoxTurtle/AFC_NightOwl) section
- Added ability to set and track number of toolchanges when doing multicolor prints
- Added ability to set extruder temperature based off spoolman values or filament materials type if manually entered
- Added ability to show sensors as filament sensors in gui's
- Added ability to use multiple buffers
- Added automatically loading filament to hub for users that have moved their hubs closer to their toolhead
- Moved results from `http://<ip_address>/printer/objects/query?AFC` endpoint to `http://<ip_address>/printer/afc/status`endpoint.
- Added raising errors when AFC import fail
- Using inheritance for Units, base unit is AFC_unit.py
- Adds fixes for Issue #183 

## Notes to Code Reviewers

## How the changes in this PR are tested
Manually tested every macro and function

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
