### PR TITLE
Misc Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-01-17]
+### Added
+- Added ability to break up long bowden moves into shorter moves with `max_move_dis` variable to help with users that are facing timer too close issues when doing long moves. This variable can be set in `AFC.cfg` as a global setting or in the stepper/config sections.
+
+### Changed
+- Function `isPrinting` is determined by `print_stats` instead of `idle_timeout`
+- Check extruder temp function only sets temperature if hotend can't extrude(temp below min value) and if printer is not printing, so that hotend temperature is not changed while printing
+
 ## [2025-01-12]
 ### Added
 

--- a/docs/CONFIGURATION_OPTIONS.md
+++ b/docs/CONFIGURATION_OPTIONS.md
@@ -30,6 +30,7 @@
 - `short_moves_speed` (default: `25`): Speed in mm/s to move filament when doing short moves
 - `short_moves_accel` (default: `400`): Acceleration in mm/s squared when doing short moves
 - `short_move_dis` (default: `10`): Move distance in mm for failsafe moves.
+- `max_move_dis` (default: `999999`): Maximum distance to move filament. AFC breaks filament moves over this number into multiple moves. Useful to lower this number if running into timer too close errors when doing long filament moves.
 - `tool_max_unload_attempts` (default: `2`): Max number of attempts to unload filament from toolhead when using buffer as ramming sensor
 - `tool_max_load_checks` (default: `4`): Max number of attempts to check to make sure filament is loaded into toolhead extruder when using buffer as ramming sensor
 - `z_hop` (default: `0`): Height to move up before and after a tool change completes
@@ -49,6 +50,9 @@
 
 ## AFC_extruder
 - `enable_sensors_in_gui` (default: `False`): Set to True toolhead sensors switches as filament sensors in mainsail/fluidd gui, overrides value set in AFC.cfg
+
+## AFC_hub
+- `assisted_retract` (default: `False`): if True, retracts are assisted to prevent loose windings on the spool
 
 ## AFC_prep
 - `delay_time` (default: `0.1, minval=0.0`): Time to delay when moving extruders and spoolers during PREP routine
@@ -72,6 +76,7 @@
 - `short_moves_speed` (default: `None`): Speed in mm/s to move filament when doing short moves. Setting value here overrides values set in AFC.cfg file
 - `short_moves_accel` (default: `None`): Acceleration in mm/s squared when doing short moves. Setting value here overrides values set in AFC.cfg file
 - `short_move_dis` (default: `None`): Move distance in mm for failsafe moves. Setting value here overrides values set in AFC.cfg file
+- `max_move_dis` (default: `999999`): Maximum distance to move filament. AFC breaks filament moves over this number into multiple moves. Useful to lower this number if running into timer too close errors when doing long filament moves. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
 - `dist_hub` (default: `60`): Bowden distance between Box Turtle extruder and hub
 - `park_dist` (default: `10`): Currently unused
 - `load_to_hub` (default: `True`): Fast loads filament to hub when inserted, set to False to disable. Setting here overrides global setting in AFC.cfg
@@ -112,6 +117,7 @@
 - `short_moves_speed` (default: `25`): Speed in mm/s to move filament when doing short moves. Setting value here overrides values set in AFC.cfg file
 - `short_moves_accel` (default: `400`): Acceleration in mm/s squared when doing short moves. Setting value here overrides values set in AFC.cfg file
 - `short_move_dis` (default: `400`): Move distance in mm for failsafe moves. Setting value here overrides values set in AFC.cfg file
+- `max_move_dis` (default: `999999`): Maximum distance to move filament. AFC breaks filament moves over this number into multiple moves. Useful to lower this number if running into timer too close errors when doing long filament moves. Setting value here overrides values set in AFC.cfg file
 
 ## AFC_NightOwl
 - `hub` (default: `None`): Hub name(AFC_hub) that belongs to this unit, can be overridden in AFC_stepper section

--- a/docs/command_reference.md
+++ b/docs/command_reference.md
@@ -6,7 +6,6 @@ The following commands are built-in the AFC-Klipper-Add-On and are available thr
 the Klipper console.
 
 NOTE: LANE/HUB/BUFFER etc. names are case sensitive and should exactly match the names defined in config files
-
 ### SET_AFC_TOOLCHANGES
 _Description_: This macro can be used to set total number of toolchanges from slicer. AFC will keep track of tool changes and print out
 current tool change number when a T(n) command is called from gcode  
@@ -92,30 +91,30 @@ Example: ``AFC_RESUME``
 
 ### TEST_AFC_TIP_FORMING
 _Description_: Gives ability to test AFC tip forming without doing a tool change  
-Usage: `TEST_AFC_TIP_FORMING LANE=<lane>`  
-Example: `TEST_AFC_TIP_FORMING LANE=leg1`  
+Usage: `TEST_AFC_TIP_FORMING`  
+Example: `TEST_AFC_TIP_FORMING`  
 
 ### GET_TIP_FORMING
 _Description_: Shows the tip forming configuration  
 Usage: `GET_TIP_FORMING`  
-Example: `GET_TIP_FORMING LANE=leg1`  
+Example: `GET_TIP_FORMING`  
 
 ### SET_TIP_FORMING
 _Description_: Sets the tip forming configuration  
 Usage: `SET_TIP_FORMING PARAMETER=VALUE ...`  
-Example: `SET_TIP_FORMING ramming_volume=20 toolchange_temp=220`
+Example: `SET_TIP_FORMING ramming_volume=20 toolchange_temp=220`  
 
 ### AFC_CALIBRATION
-_Description_: Open a prompt to start AFC calibration by selecting a unit to calibrate. Creates buttons for each unit and 
+_Description_: Open a prompt to start AFC calibration by selecting a unit to calibrate. Creates buttons for each unit and
 allows the option to calibrate all lanes across all units.  
 Usage: ``AFC_CALIBRATION``  
-Example: `AFC_CALIBRATION`  
+Example: ``AFC_CALIBRATION``  
 
 ### ALL_CALIBRATION
-_Description_: Open a prompt to confirm calibration of all lanes in all units. Provides 'Yes' to confirm and 'Back' to 
+_Description_: Open a prompt to confirm calibration of all lanes in all units. Provides 'Yes' to confirm and 'Back' to
 return to the previous menu.  
 Usage: ``ALL_CALIBRATION``  
-Example: `ALL_CALIBRATION`
+Example: ``ALL_CALIBRATION``  
 
 ### CALIBRATE_AFC
 _Description_: This function performs the calibration of the hub and Bowden length for one or more lanes within an AFC
@@ -125,25 +124,6 @@ user-provided input. If no specific lane is provided, the function defaults to n
 the option to calibrate the Bowden length for a particular lane, if specified.  
 Usage: ``CALIBRATE_AFC LANE=<lane> DISTANCE=<distance> TOLERANCE=<tolerance> BOWDEN=<lane>``  
 Example: `CALIBRATE_AFC LANE=leg1`  
-
-### UNIT_CALIBRATION
-_Description_: Open a prompt to calibrate either the distance between the extruder and the hub or the Bowden length
-for the selected unit. Provides buttons for lane calibration, Bowden length calibration, and a back option.  
-Usage: ``UNIT_CALIBRATION UNIT=<unit>``  
-Example: `UNIT_CALIBRATION UNIT=Turtle_1`  
-
-### UNIT_LANE_CALIBRATION
-_Description_: Open a prompt to calibrate the extruder-to-hub distance for each lane in the selected unit. Creates buttons
-for each lane, grouped in sets of two, and allows calibration for all lanes or individual lanes.  
-Usage: ``UNIT_LANE_CALIBRATION UNIT=<unit>``  
-Example: `UNIT_LANE_CALIBRATION UNIT=Turtle_1`  
-
-### UNIT_BOW_CALIBRATION
-_Description_: Open a prompt to calibrate the Bowden length for a specific lane in the selected unit. Provides buttons
-for each lane, with a note to only calibrate one lane per unit.  
-Usage: ``UNIT_CALIBRATION UNIT=<unit>``  
-Example: `UNIT_BOW_CALIBRATION UNIT=Turtle_1`  
-
 
 ### SET_BOWDEN_LENGTH
 _Description_: This function adjusts the length of the Bowden tube between the hub and the toolhead.
@@ -208,8 +188,26 @@ Example: ``SET_RUNOUT LANE=lane1 RUNOUT=lane4``
 
 ### RESET_AFC_MAPPING
 _Description_: This commands resets all tool lane mapping to the order that is setup in configuration.  
-Usage: `RESET_AFC_MAPPING LANE=<lane>`  
-Example: `RESET_AFC_MAPPING LANE=leg1`  
+Usage: `RESET_AFC_MAPPING`  
+Example: `RESET_AFC_MAPPING`  
+
+### UNIT_CALIBRATION
+_Description_: Open a prompt to calibrate either the distance between the extruder and the hub or the Bowden length
+for the selected unit. Provides buttons for lane calibration, Bowden length calibration, and a back option.  
+Usage: ``UNIT_CALIBRATION UNIT=<unit>``  
+Example: ``UNIT_CALIBRATION UNIT=Turtle_1``  
+
+### UNIT_LANE_CALIBRATION
+_Description_: Open a prompt to calibrate the extruder-to-hub distance for each lane in the selected unit. Creates buttons
+for each lane, grouped in sets of two, and allows calibration for all lanes or individual lanes.  
+Usage: ``UNIT_LANE_CALIBRATION UNIT=<unit>``  
+Example: ``UNIT_LANE_CALIBRATION UNIT=Turtle_1``  
+
+### UNIT_BOW_CALIBRATION
+_Description_: Open a prompt to calibrate the Bowden length for a specific lane in the selected unit. Provides buttons
+for each lane, with a note to only calibrate one lane per unit.  
+Usage: ``UNIT_CALIBRATION UNIT=<unit>``  
+Example: ``UNIT_CALIBRATION UNIT=Turtle_1``  
 
 ## AFC Macros
 

--- a/extras/AFC_form_tip.py
+++ b/extras/AFC_form_tip.py
@@ -44,6 +44,8 @@ class afc_tip_form:
         Gives ability to test AFC tip forming without doing a tool change
 
         Usage: TEST_AFC_TIP_FORMING
+
+        Example: TEST_AFC_TIP_FORMING
         '''
         self.tip_form()
 
@@ -54,6 +56,7 @@ class afc_tip_form:
         Shows the tip forming configuration
 
         Usage: GET_TIP_FORMING
+        Example: GET_TIP_FORMING
         '''
         status_msg = "Tip Forming Configuration:\n"
         status_msg += "ramming_volume:        {}\n".format(self.ramming_volume)

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -5,7 +5,11 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
 import os
-from extras.AFC_respond import AFCprompt
+from configfile import error
+try:
+    from extras.AFC_respond import AFCprompt
+except:
+    raise error("Error trying to import AFC_respond, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper")
 
 def load_config(config):
     return afcFunction(config)
@@ -56,8 +60,7 @@ class afcFunction:
         allows the option to calibrate all lanes across all units.
 
         Usage:`AFC_CALIBRATION`
-        Examples:
-            - `AFC_CALIBRATION`
+        Example: `AFC_CALIBRATION`
         Args:
             None
 
@@ -88,8 +91,7 @@ class afcFunction:
         return to the previous menu.
 
         Usage:`ALL_CALIBRATION`
-        Examples:
-            - `ALL_CALIBRATION`
+        Example: `ALL_CALIBRATION`
         Args:
             None
 
@@ -144,6 +146,14 @@ class afcFunction:
             return
 
         cal_msg = ''
+        # Check to make sure lane and unit is valid
+        if lanes is not None and lanes != 'all' and lanes not in self.AFC.lanes:
+            self.AFC.ERROR.AFC_error("{} not a valid lane".format(lanes), pause=False)
+            return
+
+        if unit is not None and unit not in self.AFC.units:
+            self.AFC.ERROR.AFC_error("{} not a valid unit".format(unit), pause=False)
+            return
 
         # Determine if a specific lane is provided
         if lanes is not None:
@@ -245,11 +255,9 @@ class afcFunction:
 
     def is_printing(self):
         eventtime = self.AFC.reactor.monotonic()
-        idle_timeout = self.printer.lookup_object("idle_timeout")
-        if idle_timeout.get_status(eventtime)["state"] == "Printing":
-            return True
-        else:
-            False
+        # idle_timeout = self.printer.lookup_object("idle_timeout")
+        print_stats = self.printer.lookup_object("print_stats")
+        return print_stats.get_status(eventtime)["state"] == "printing"
 
     def is_paused(self):
         eventtime = self.AFC.reactor.monotonic()

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -311,6 +311,8 @@ class afcSpool:
         Useful to put in your PRINT_END macro to reset mapping
 
         Usage: RESET_AFC_MAPPING
+
+        Example: RESET_AFC_MAPPING
         """
         t_index = 0
         for key, unit in self.AFC.units.items():

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -42,6 +42,7 @@ class afcUnit:
         self.short_moves_speed  = config.getfloat("short_moves_speed",  self.AFC.short_moves_speed) # Speed in mm/s to move filament when doing short moves. Setting value here overrides values set in AFC.cfg file
         self.short_moves_accel  = config.getfloat("short_moves_accel",  self.AFC.short_moves_accel) # Acceleration in mm/s squared when doing short moves. Setting value here overrides values set in AFC.cfg file
         self.short_move_dis     = config.getfloat("short_move_dis",  self.AFC.short_move_dis)       # Move distance in mm for failsafe moves. Setting value here overrides values set in AFC.cfg file
+        self.max_move_dis       = config.getfloat("max_move_dis", self.AFC.max_move_dis)            # Maximum distance to move filament. AFC breaks filament moves over this number into multiple moves. Useful to lower this number if running into timer too close errors when doing long filament moves. Setting value here overrides values set in AFC.cfg file
 
     def handle_connect(self):
         """
@@ -106,8 +107,7 @@ class afcUnit:
         for the selected unit. Provides buttons for lane calibration, Bowden length calibration, and a back option.
 
         Usage:`UNIT_CALIBRATION UNIT=<unit>`
-        Examples:
-            - `UNIT_CALIBRATION UNIT=Turtle_1`
+        Example: `UNIT_CALIBRATION UNIT=Turtle_1`
         Args:
             None
 
@@ -133,8 +133,7 @@ class afcUnit:
         for each lane, grouped in sets of two, and allows calibration for all lanes or individual lanes.
 
         Usage:`UNIT_LANE_CALIBRATION UNIT=<unit>`
-        Examples:
-            - `UNIT_LANE_CALIBRATION UNIT=Turtle_1`
+        Example: `UNIT_LANE_CALIBRATION UNIT=Turtle_1`
 
         Args:
             UNIT: Specifies the unit to be used in calibration
@@ -175,8 +174,7 @@ class afcUnit:
         for each lane, with a note to only calibrate one lane per unit.
 
         Usage:`UNIT_CALIBRATION UNIT=<unit>`
-        Examples:
-            - `UNIT_CALIBRATION UNIT=Turtle_1`
+        Example: `UNIT_CALIBRATION UNIT=Turtle_1`
 
         Args:
             UNIT: Specifies the unit to be used in calibration


### PR DESCRIPTION
## Major Changes in this PR
- Added ability to break up long bowden moves into shorter moves with max_move_dis variable, defaults to 99999
- Function isPrinting is determined by print_stats instead of idle_timeout
- Check extruder temp function only sets temperature if hotend can't extrude(temp below min value) and if printer is not printing
- Added checks to CALIBRATE_AFC to make sure lanes/units passed in are valid

## Notes to Code Reviewers

## How the changes in this PR are tested
Tested load/unload, AFC_CALIBRATE, and printed at higher temp to make sure a lane change didn't put temp back to 245

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
