### PR TITLE
Updating ConfigRewrite function to not modify other sections

### DIFF
--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -136,7 +136,6 @@ class afcBoxTurtle(afcUnit):
             CUR_LANE.do_enable(False)
         else:
             self.AFC.gcode.respond_info('CALIBRATE_AFC is not currently supported without tool start sensor')
-        self.AFC.gcode.respond_info(cal_msg)
         self.AFC.save_vars()
 
     # Helper functions for movement and calibration


### PR DESCRIPTION
## Major Changes in this PR
Fixes bug where others sections were getting updated with updating configuration values when running CALIBRATE_AFC macro
## Notes to Code Reviewers

## How the changes in this PR are tested
Results from test, manually verified that other sections were not updated that were not supposed to be updated
```
// Starting AFC distance Calibrations
// Turtle_1
// Calibrating leg1
// leg1 dist_hub: New: 485.0 Old: 485.0
// Saved dist_hub:485.0 in AFC_stepper leg1 section to configuration file
// leg2 not loaded, load before calibration
// Calibrating leg3
// leg3 dist_hub: New: 675.0 Old: 60
// Key dist_hub not found in section AFC_stepper leg3, cannot update
// Calibrating leg4
// leg4 dist_hub: New: 745.0 Old: 745.0
// Saved dist_hub:745.0 in AFC_stepper leg4 section to configuration file

// Starting AFC distance Calibrations
// Calibrating Bowden Length with leg1
// afc_bowden_length: New: 990.0 Old: 990.031
// Saved afc_bowden_length:990.0 in AFC_hub Turtle_1 section to configuration file
```
## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
