### PR TITLE
Fixes bug with UNLOAD_FILAMENT macro override when bypass is being used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-01-23]
+## Fixed
+- Fixed not being able to unload filament with UNLOAD_FILAMENT macro when using bypass
+
 ## [2025-01-17]
 ### Added
 - Added ability to break up long bowden moves into shorter moves with `max_move_dis` variable to help with users that are facing timer too close issues when doing long moves. This variable can be set in `AFC.cfg` as a global setting or in the stepper/config sections.

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -729,6 +729,9 @@ class afc:
         Returns:
             None
         """
+        # Check if the bypass filament sensor detects filament; if so unload filament and abort the tool load.
+        if self._check_bypass(unload=True): return False
+
         lane = gcmd.get('LANE', self.current)
         if lane == None:
             return


### PR DESCRIPTION
## Major Changes in this PR
Added bypass check to cmd_TOOL_UNLOAD function, fixes not being able to unload with UNLOAD_FILAMENT macro if bypass is being used
## Notes to Code Reviewers

## How the changes in this PR are tested
Tested from a virtual klipperscreen

![image](https://github.com/user-attachments/assets/375f40ab-7aa3-4b45-85c5-9dcd92364944)

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
