### PR TITLE
Add Nightowl as Installation type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-## [2025-01-25]
+## [2025-01-26]
 ### Added
 - Added installation type for NightOwl, currently only ERB2.0 board is supported
+- Moved MCU include from AFC.cfg to AFC_Turtle_1 or Nightowl respectively
 
 ## [2025-01-26]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-## [2025-01-26]
+## [2025-02-05]
 ### Added
 - Added installation type for NightOwl, currently only ERB2.0 board is supported
 - Moved MCU include from AFC.cfg to AFC_Turtle_1 or Nightowl respectively

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-01-25]
+### Added
+- Added installation type for NightOwl, currently only ERB2.0 board is supported
+
 ## [2025-01-17]
 ### Added
 - Added ability to break up long bowden moves into shorter moves with `max_move_dis` variable to help with users that are facing timer too close issues when doing long moves. This variable can be set in `AFC.cfg` as a global setting or in the stepper/config sections.

--- a/config/AFC.cfg
+++ b/config/AFC.cfg
@@ -1,5 +1,3 @@
-[include mcu/AFC_Lite.cfg]
-
 [AFC]
 VarFile: ../printer_data/config/AFC/AFC.var   # Path to the variables file for AFC configuration.
 

--- a/config/mcu/ERB_2.0.cfg
+++ b/config/mcu/ERB_2.0.cfg
@@ -1,0 +1,26 @@
+[board_pins NightOwl]
+#fysetc erb2.0
+mcu: NightOwl # Assuming using an external / extra mcu dedicated to MMU
+aliases:
+    LANE1_UART=gpio17,
+    LANE1_STEP=gpio16,
+    LANE1_DIR=gpio15,
+    LANE1_EN=gpio14,
+    LANE1_DIAG=gpio19,
+    LANE1_ENDSTOP=gpio24,
+    LANE2_UART=gpio11,
+    LANE2_STEP=gpio10,
+    LANE2_DIR=gpio9,
+    LANE2_EN=gpio8,
+    LANE2_DIAG=gpio13,
+    MMU_SERVO=gpio23,
+    MMU_ENCODER=gpio22,
+    MMU_GATE_SENSOR=,
+    MMU_NEOPIXEL=gpio21,
+    LANE1_TRIG=gpio3,
+    LANE2_TRIG=gpio5,
+    LANE1_EXT=gpio4,
+    LANE2_EXT=gpio6,
+    NT_HUB=gpio12,
+    TN_ADV=gpio2,
+    TN_TRL=gpio18

--- a/include/install_functions.sh
+++ b/include/install_functions.sh
@@ -55,9 +55,11 @@ copy_unit_files() {
   if [ "$installation_type" == "BoxTurtle" ]; then
     cp "${afc_path}/templates/AFC_Hardware-AFC.cfg" "${afc_config_dir}/AFC_Hardware.cfg"
     cp "${afc_path}/templates/AFC_Turtle_1.cfg" "${afc_config_dir}/AFC_Turtle_1.cfg"
+  # If we are installing a Nightowl, then copy these files over.
   elif [ "$installation_type" == "NightOwl" ]; then
     cp "${afc_path}/templates/AFC_Hardware-NightOwl.cfg" "${afc_config_dir}/AFC_Hardware.cfg"
     cp "${afc_path}/templates/AFC_NightOwl_1.cfg" "${afc_config_dir}/AFC_NightOwl_1.cfg"
+    cp "${afc_path}/config/mcu/ERB2.0.cfg" "${afc_config_dir}/mcu/ERB2.0.cfg"
   fi
 }
 
@@ -93,20 +95,17 @@ install_afc() {
   elif [ "$toolhead_sensor" == "Ramming" ]; then
     update_switch_pin "${afc_config_dir}/AFC_Hardware.cfg" "buffer"
   fi
-  if [ "$buffer_type" == "TurtleNeck" && "$installation_type" == "BoxTurtle" ]; then
-    query_tn_pins "TN"
-    append_buffer_config "TurtleNeck" "$tn_advance_pin" "$tn_trailing_pin"
-    add_buffer_to_extruder "${afc_config_dir}/AFC_Turtle_1.cfg" "Turtle_1"
-  elif [ "$buffer_type" == "TurtleNeckV2" && "$installation_type" == "BoxTurtle" ]; then
-    append_buffer_config "TurtleNeckV2"
-    add_buffer_to_extruder "${afc_config_dir}/AFC_Turtle_1.cfg" "Turtle_1"
-  elif [ "$buffer_type" == "TurtleNeckV2" && "$installation_type" == "NightOwl" ]; then
-    append_buffer_config "TurtleNeckV2"
-    add_buffer_to_extruder "${afc_config_dir}/AFC_NightOwl_1.cfg" "NightOwl_1"
-  elif [ "$buffer_type" == "TurtleNeck" && "$installation_type" == "NightOwl" ]; then
-    query_tn_pins "TN"
-    append_buffer_config "TurtleNeck" "$tn_advance_pin" "$tn_trailing_pin"
-    add_buffer_to_extruder "${afc_config_dir}/AFC_NightOwl_1.cfg" "NightOwl_1"
+  # When using Boxturtle as Installation Type then insert selected buffer configuration
+  # Nightowl uses Turtleneck as default for now
+  if [ "$installation_type" == "BoxTurtle" ]; then
+    if [ "$buffer_type" == "TurtleNeck" ]; then
+      query_tn_pins "TN"
+      append_buffer_config "TurtleNeck" "$tn_advance_pin" "$tn_trailing_pin"
+      add_buffer_to_extruder "${afc_config_dir}/AFC_Turtle_1.cfg" "Turtle_1"
+    elif [ "$buffer_type" == "TurtleNeckV2" ]; then
+      append_buffer_config "TurtleNeckV2"
+      add_buffer_to_extruder "${afc_config_dir}/AFC_Turtle_1.cfg" "Turtle_1"
+    fi
   fi
   check_and_append_prep "${afc_config_dir}/AFC.cfg"
   replace_varfile_path "${afc_config_dir}/AFC.cfg"

--- a/include/install_functions.sh
+++ b/include/install_functions.sh
@@ -55,6 +55,9 @@ copy_unit_files() {
   if [ "$installation_type" == "BoxTurtle" ]; then
     cp "${afc_path}/templates/AFC_Hardware-AFC.cfg" "${afc_config_dir}/AFC_Hardware.cfg"
     cp "${afc_path}/templates/AFC_Turtle_1.cfg" "${afc_config_dir}/AFC_Turtle_1.cfg"
+  elif [ "$installation_type" == "NightOwl" ]; then
+    cp "${afc_path}/templates/AFC_Hardware-NightOwl.cfg" "${afc_config_dir}/AFC_Hardware.cfg"
+    cp "${afc_path}/templates/AFC_NightOwl_1.cfg" "${afc_config_dir}/AFC_NightOwl_1.cfg"
   fi
 }
 
@@ -90,13 +93,20 @@ install_afc() {
   elif [ "$toolhead_sensor" == "Ramming" ]; then
     update_switch_pin "${afc_config_dir}/AFC_Hardware.cfg" "buffer"
   fi
-  if [ "$buffer_type" == "TurtleNeck" ]; then
+  if [ "$buffer_type" == "TurtleNeck" && "$installation_type" == "BoxTurtle" ]; then
     query_tn_pins "TN"
     append_buffer_config "TurtleNeck" "$tn_advance_pin" "$tn_trailing_pin"
     add_buffer_to_extruder "${afc_config_dir}/AFC_Turtle_1.cfg" "Turtle_1"
-  elif [ "$buffer_type" == "TurtleNeckV2" ]; then
+  elif [ "$buffer_type" == "TurtleNeckV2" && "$installation_type" == "BoxTurtle" ]; then
     append_buffer_config "TurtleNeckV2"
     add_buffer_to_extruder "${afc_config_dir}/AFC_Turtle_1.cfg" "Turtle_1"
+  elif [ "$buffer_type" == "TurtleNeckV2" && "$installation_type" == "NightOwl" ]; then
+    append_buffer_config "TurtleNeckV2"
+    add_buffer_to_extruder "${afc_config_dir}/AFC_NightOwl_1.cfg" "NightOwl_1"
+  elif [ "$buffer_type" == "TurtleNeck" && "$installation_type" == "NightOwl" ]; then
+    query_tn_pins "TN"
+    append_buffer_config "TurtleNeck" "$tn_advance_pin" "$tn_trailing_pin"
+    add_buffer_to_extruder "${afc_config_dir}/AFC_NightOwl_1.cfg" "NightOwl_1"
   fi
   check_and_append_prep "${afc_config_dir}/AFC.cfg"
   replace_varfile_path "${afc_config_dir}/AFC.cfg"
@@ -107,9 +117,18 @@ install_afc() {
 - AFC Configuration updated with selected options at ${afc_file}
 
 - AFC-Klipper-Add-On python extensions installed to ${klipper_dir}/klippy/extras/
+  """
+if [ "$installation_type" == "BoxTurtle" ]; then
+  message+="""
 
 - Ensure you enter either your CAN bus or serial information in the ${afc_config_dir}/AFC_Turtle_1.cfg file
-"""
+  """
+elif [ "$installation_type" == "NightOwl" ]; then
+  message+="""
+
+- Ensure you enter either your CAN bus or serial information in the ${afc_config_dir}/AFC_NightOwl_1.cfg file
+  """
+fi
 if [ "$buffer_type" == "TurtleNeckV2" ]; then
   message+="""
 - Ensure you add the correct serial information to the ${afc_config_dir}/mcu/TurtleNeckv2.cfg file

--- a/include/install_functions.sh
+++ b/include/install_functions.sh
@@ -59,7 +59,6 @@ copy_unit_files() {
   elif [ "$installation_type" == "NightOwl" ]; then
     cp "${afc_path}/templates/AFC_Hardware-NightOwl.cfg" "${afc_config_dir}/AFC_Hardware.cfg"
     cp "${afc_path}/templates/AFC_NightOwl_1.cfg" "${afc_config_dir}/AFC_NightOwl_1.cfg"
-    cp "${afc_path}/config/mcu/ERB2.0.cfg" "${afc_config_dir}/mcu/ERB2.0.cfg"
   fi
 }
 

--- a/include/menus/install_menu.sh
+++ b/include/menus/install_menu.sh
@@ -70,7 +70,13 @@ install_menu() {
 
     case $choice in
       T)
-        message="Currently only BoxTurtle is supported, more coming soon!"
+        installation_type=$(
+          case "$installation_type" in
+            "BoxTurtle") echo "NightOwl" ;;
+            "NightOwl") echo "BoxTurtle" ;;
+          esac
+        )
+        message="Installation Type: $installation_type"
         export message ;;
       1)
         afc_includes=$([ "$afc_includes" == "True" ] && echo "False" || echo "True")

--- a/templates/AFC_Hardware-NightOwl.cfg
+++ b/templates/AFC_Hardware-NightOwl.cfg
@@ -1,0 +1,24 @@
+[force_move]
+enable_force_move: True
+
+[AFC_extruder extruder]
+pin_tool_start: enter_tool_start_pin
+#pin_tool_end: ^!nhk:gpio12
+tool_stn: 113.52                # Distance from the toolhead sensor to the tip of the nozzle in mm.
+tool_stn_unload: 100            # Unload distance for the toolhead in mm.
+tool_sensor_after_extruder: 0   # Distance in mm.
+tool_unload_speed: 25           # Unload speed in mm/s. Default is 25mm/s.
+tool_load_speed: 25             # Load speed in mm/s. Default is 25mm/s.
+buffer: TN
+
+#[filament_switch_sensor bypass]
+#switch_pin: turtleneck:PB5
+#pause_on_runout: False
+
+
+[AFC_buffer TN]
+advance_pin: ^NightOwl:TN_ADV    # set advance pin
+trailing_pin: ^NightOwl:TN_TRL  # set trailing pin
+multiplier_high: 1.05   # default 1.05, factor to feed more filament
+multiplier_low:  0.95   # default 0.95, factor to feed less filament
+velocity: 100

--- a/templates/AFC_Hardware-NightOwl.cfg
+++ b/templates/AFC_Hardware-NightOwl.cfg
@@ -9,10 +9,9 @@ tool_stn_unload: 100            # Unload distance for the toolhead in mm.
 tool_sensor_after_extruder: 0   # Distance in mm.
 tool_unload_speed: 25           # Unload speed in mm/s. Default is 25mm/s.
 tool_load_speed: 25             # Load speed in mm/s. Default is 25mm/s.
-buffer: TN
 
 #[filament_switch_sensor bypass]
-#switch_pin: turtleneck:PB5
+#switch_pin: ^Nightowl:PB5
 #pause_on_runout: False
 
 
@@ -21,4 +20,4 @@ advance_pin: ^NightOwl:TN_ADV    # set advance pin
 trailing_pin: ^NightOwl:TN_TRL  # set trailing pin
 multiplier_high: 1.05   # default 1.05, factor to feed more filament
 multiplier_low:  0.95   # default 0.95, factor to feed less filament
-velocity: 100
+velocity: 0

--- a/templates/AFC_NightOwl_1.cfg
+++ b/templates/AFC_NightOwl_1.cfg
@@ -1,0 +1,119 @@
+[board_pins NightOwl]
+#fysetc erb2.0
+mcu: NightOwl # Assuming using an external / extra mcu dedicated to MMU
+aliases:
+    LANE1_UART=gpio17,
+    LANE1_STEP=gpio16,
+    LANE1_DIR=gpio15,
+    LANE1_EN=gpio14,
+    LANE1_DIAG=gpio19,
+    LANE1_ENDSTOP=gpio24,
+    LANE2_UART=gpio11,
+    LANE2_STEP=gpio10,
+    LANE2_DIR=gpio9,
+    LANE2_EN=gpio8,
+    LANE2_DIAG=gpio13,
+    MMU_SERVO=gpio23,
+    MMU_ENCODER=gpio22,
+    MMU_GATE_SENSOR=,
+    MMU_NEOPIXEL=gpio21,
+    LANE1_TRIG=gpio3,
+    LANE2_TRIG=gpio5,
+    LANE1_EXT=gpio4,
+    LANE2_EXT=gpio6,
+    NT_HUB=gpio12,
+    TN_ADV=gpio2,
+    TN_TRL=gpio18
+
+[mcu NightOwl]
+#comment one out and add serial or uuid of the board nightowl uses
+#serial:
+#canbus_uuid:
+
+[temperature_sensor NightOwl-ERB]
+sensor_type: temperature_mcu
+sensor_mcu: NightOwl
+
+[AFC_NightOwl NightOwl]
+type: 'NightOwl'
+hub: NightOwl_Hub
+extruder: extruder
+
+[AFC_stepper lane1]
+unit: NightOwl:1
+extruder: extruder
+step_pin: NightOwl:LANE1_STEP
+dir_pin: NightOwl:LANE1_DIR
+enable_pin: !NightOwl:LANE1_EN
+microsteps: 16
+rotation_distance: 4.65
+dist_hub: 45.0
+park_dist: 10
+load: ^NightOwl:LANE1_TRIG
+prep: ^NightOwl:LANE1_EXT
+cmd: T0
+
+[tmc2209 AFC_stepper lane1]
+uart_pin: NightOwl:LANE1_UART
+uart_address: 0
+run_current: 0.8
+sense_resistor: 0.110
+
+[AFC_stepper lane2]
+unit: NightOwl:2
+extruder: extruder
+step_pin: NightOwl:LANE2_STEP
+dir_pin: !NightOwl:LANE2_DIR
+enable_pin: !NightOwl:LANE2_EN
+microsteps: 16
+rotation_distance: 4.65
+dist_hub: 45.0
+park_dist: 10
+load: ^NightOwl:LANE2_TRIG
+prep: ^NightOwl:LANE2_EXT
+cmd: T1
+
+[tmc2209 AFC_stepper lane2]
+uart_pin: NightOwl:LANE2_UART
+uart_address: 0
+run_current: 0.8
+sense_resistor: 0.110
+
+[AFC_hub NightOwl_Hub]
+afc_bowden_length: 1690.032
+move_dis: 50                # Distance to move the filament within the hub in mm.
+cut: False # Hub has Cutter
+#--=================================================================================--#
+######### Hub Cut #####################################################################
+#--=================================================================================--#
+cut_cmd: AFC #CMD to use
+cut_dist: 200               # How much filament to cut off (in mm).
+cut_clear: 120              # How far the filament should retract back from the hub (in mm).
+cut_min_length: 300.0
+cut_servo_pass_angle: 10    # Servo angle to align the Bowden tube with the hole for loading the toolhead.
+cut_servo_clip_angle: 180   # Servo angle for cutting the filament.
+cut_servo_prep_angle: 80    # Servo angle to prepare the filament for cutting (aligning the exit hole).
+switch_pin: ^NightOwl:NT_HUB
+
+#[AFC_screen Turtle_1]
+#mac_address: None
+
+#[AFC_led AFC_Indicator]
+#pin: Turtle_1:RGB1
+#chain_count: 4
+#color_order: GRBW
+
+#[neopixel Extra2]
+#pin: Turtle_1:RGB2
+#chain_count: 6
+#color_order: GRB
+
+#[neopixel Extra3]
+#pin: Turtle_1:RGB3
+#chain_count: 6
+#color_order: GRB
+
+#[neopixel Extra4]
+#pin: Turtle_1:RGB4
+#chain_count: 4
+#color_order: GRB

--- a/templates/AFC_NightOwl_1.cfg
+++ b/templates/AFC_NightOwl_1.cfg
@@ -1,29 +1,4 @@
-[board_pins NightOwl]
-#fysetc erb2.0
-mcu: NightOwl # Assuming using an external / extra mcu dedicated to MMU
-aliases:
-    LANE1_UART=gpio17,
-    LANE1_STEP=gpio16,
-    LANE1_DIR=gpio15,
-    LANE1_EN=gpio14,
-    LANE1_DIAG=gpio19,
-    LANE1_ENDSTOP=gpio24,
-    LANE2_UART=gpio11,
-    LANE2_STEP=gpio10,
-    LANE2_DIR=gpio9,
-    LANE2_EN=gpio8,
-    LANE2_DIAG=gpio13,
-    MMU_SERVO=gpio23,
-    MMU_ENCODER=gpio22,
-    MMU_GATE_SENSOR=,
-    MMU_NEOPIXEL=gpio21,
-    LANE1_TRIG=gpio3,
-    LANE2_TRIG=gpio5,
-    LANE1_EXT=gpio4,
-    LANE2_EXT=gpio6,
-    NT_HUB=gpio12,
-    TN_ADV=gpio2,
-    TN_TRL=gpio18
+[include mcu/ERB_2.0.cfg]
 
 [mcu NightOwl]
 #comment one out and add serial or uuid of the board nightowl uses

--- a/templates/AFC_NightOwl_1.cfg
+++ b/templates/AFC_NightOwl_1.cfg
@@ -1,7 +1,9 @@
+# When using different hardware use config below as template
+# Adapt pins in config file 
 [include mcu/ERB_2.0.cfg]
 
 [mcu NightOwl]
-#comment one out and add serial or uuid of the board nightowl uses
+#comment one out and add serial or uuid of the board nightowl
 #serial:
 #canbus_uuid:
 
@@ -13,6 +15,7 @@ sensor_mcu: NightOwl
 type: 'NightOwl'
 hub: NightOwl_Hub
 extruder: extruder
+buffer: TN                  #Turtleneck as standard Buffer
 
 [AFC_stepper lane1]
 unit: NightOwl:1
@@ -26,7 +29,6 @@ dist_hub: 45.0
 park_dist: 10
 load: ^NightOwl:LANE1_TRIG
 prep: ^NightOwl:LANE1_EXT
-cmd: T0
 
 [tmc2209 AFC_stepper lane1]
 uart_pin: NightOwl:LANE1_UART
@@ -46,7 +48,6 @@ dist_hub: 45.0
 park_dist: 10
 load: ^NightOwl:LANE2_TRIG
 prep: ^NightOwl:LANE2_EXT
-cmd: T1
 
 [tmc2209 AFC_stepper lane2]
 uart_pin: NightOwl:LANE2_UART
@@ -57,11 +58,11 @@ sense_resistor: 0.110
 [AFC_hub NightOwl_Hub]
 afc_bowden_length: 1690.032
 move_dis: 50                # Distance to move the filament within the hub in mm.
-cut: False # Hub has Cutter
+cut: False                  # Hub has Cutter
 #--=================================================================================--#
 ######### Hub Cut #####################################################################
 #--=================================================================================--#
-cut_cmd: AFC #CMD to use
+cut_cmd: AFC                #CMD to use
 cut_dist: 200               # How much filament to cut off (in mm).
 cut_clear: 120              # How far the filament should retract back from the hub (in mm).
 cut_min_length: 300.0
@@ -69,26 +70,3 @@ cut_servo_pass_angle: 10    # Servo angle to align the Bowden tube with the hole
 cut_servo_clip_angle: 180   # Servo angle for cutting the filament.
 cut_servo_prep_angle: 80    # Servo angle to prepare the filament for cutting (aligning the exit hole).
 switch_pin: ^NightOwl:NT_HUB
-
-#[AFC_screen Turtle_1]
-#mac_address: None
-
-#[AFC_led AFC_Indicator]
-#pin: Turtle_1:RGB1
-#chain_count: 4
-#color_order: GRBW
-
-#[neopixel Extra2]
-#pin: Turtle_1:RGB2
-#chain_count: 6
-#color_order: GRB
-
-#[neopixel Extra3]
-#pin: Turtle_1:RGB3
-#chain_count: 6
-#color_order: GRB
-
-#[neopixel Extra4]
-#pin: Turtle_1:RGB4
-#chain_count: 4
-#color_order: GRB

--- a/templates/AFC_NightOwl_1.cfg
+++ b/templates/AFC_NightOwl_1.cfg
@@ -57,7 +57,7 @@ sense_resistor: 0.110
 
 [AFC_hub NightOwl_Hub]
 afc_bowden_length: 1690.032
-move_dis: 50                # Distance to move the filament within the hub in mm.
+move_dis: 25                # Distance to move the filament within the hub in mm.
 cut: False                  # Hub has Cutter
 #--=================================================================================--#
 ######### Hub Cut #####################################################################

--- a/templates/AFC_Turtle_1.cfg
+++ b/templates/AFC_Turtle_1.cfg
@@ -1,3 +1,5 @@
+[include mcu/AFC_Lite.cfg]
+
 [mcu Turtle_1]
 canbus_uuid: <replace with your can UUID>
 #serial: <replace with your /dev/serial/by-id/...> and comment out canbus_uuid above


### PR DESCRIPTION
## Major Changes in this PR
- Installation Type can be changed between BoxTurtle and Nightowl
- Relocation of the mcu config include from AFC.cfg to AFC_Hardware.cfg for ease of us when using different hardware.

## Notes to Code Reviewers
Please be gentle :)
If there's a better way to realize the additional Installation type i'm ready to learn.
I can imagine that the buffer (TN, TN2, or no) if query could get complicated when more installation types are supported.

The Nightowl AFC config is coming from @thunderkeys made for Schlonky's printer.

## How the changes in this PR are tested
Tested install for Nightowl and seems to work fine. 
Boxturtle install hasn't been tested, because lack of hardware


## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x ] I have performed a self-review of my code
- [x ] CHANGELOG.md is updated (if end-user facing)
- [ ] Sent notification to software-design channel requesting review
