### PR TITLE
Buffer Query update, and small clean up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-02-03]
+
+### Changed
+- Added expanded and compressed to buffer query for easier troubleshooting
+
+### Fixed
+- Corrected readme to point to the correct files
+- Added check for key on bowden length calibration to not crash klipper if the wrong value is provided
+
 ## [2025-01-28]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -110,15 +110,20 @@ info_tags:
 
 Prior to operation, the following checks / updates **MUST** be made to your system:
 
-1.  Update the following values in the `~/printer_data/config/AFC/AFC.cfg` file:
+1.  Update the following values in the `~/printer_data/config/AFC/AFC_Hardware-{board}.cfg` file:  
+    *default name with AFC-lite will be AFC_Hardware-AFC.cfg*
 
     - tool_stn: This value is the length from your toolhead sensor to nozzle
     - tool_stn_unload: This value is the amount to unload from extruder when doing a filament change.
+
+2.  Update the following in the `~/printer_data/config/AFC/AFC_Turtle_{n}.cfg` file:  
+    *for systems with a single unit, the file will show as `AFC_Turtle_1.cfg` addtional units with be 2, 3 etc.*
+
     - afc_bowden_length: This value is the length from your hub to your toolhead sensor
 
-2.  Verify that `pin_tool_start` is set to the correct pin for your toolhead sensor. If you are using an existing filament sensor as your toolhead sensor make sure you comment out the filament sensor section in your `printer.cfg` file.
+3.  Verify that `pin_tool_start` is set to the correct pin for your toolhead sensor. If you are using an existing filament sensor as your toolhead sensor make sure you comment out any filament sensor sections in your `printer.cfg` file.
 
-3.  If you are using any of the built-in macros, the variables in the `~/printer_data/config/AFC/AFC_Macro_Vars.cfg` file
+4.  If you are using any of the built-in macros, the variables in the `~/printer_data/config/AFC/AFC_Macro_Vars.cfg` file
     must also be modified to match your configuration for your system.
 
         Required variables to verify and update if necessary for the following default macros
@@ -143,7 +148,7 @@ Prior to operation, the following checks / updates **MUST** be made to your syst
           - cooling_tube_position
           - cooling_tube_length
 
-4.  If you would like to use your own macro instead of the provided macros, make sure to update the command with your custom macro in `~/printer_data/config/AFC/AFC.cfg`  
+5.  If you would like to use your own macro instead of the provided macros, make sure to update the command with your custom macro in `~/printer_data/config/AFC/AFC.cfg`  
      ex. If using custom park macro, change `park_cmd` from `AFC_PARK` to your macro name
 
 **Failure to update these values can result in damage to your system**

--- a/extras/AFC_buffer.py
+++ b/extras/AFC_buffer.py
@@ -316,7 +316,12 @@ class AFCtrigger:
             - Both the buffer state and, if applicable, the stepper motor's rotation
             distance are sent back as G-code responses.
         """
+        state_mapping = {
+            TRAILING_STATE_NAME: ' (Compressed)',
+            ADVANCE_STATE_NAME: ' (Expanded)',
+            }
         state_info = self.buffer_status()
+        state_info += state_mapping.get(state_info, '')
         if self.turtleneck:
             if self.enable:
                 LANE = self.AFC.lanes[self.AFC.current]

--- a/extras/AFC_buffer.py
+++ b/extras/AFC_buffer.py
@@ -152,7 +152,6 @@ class AFCtrigger:
             self.AFC.FUNCTION.afc_led(self.led_buffer_disabled, self.led_index)
         if self.turtleneck:
             self.reset_multiplier()
-        self.last_state = False
 
     # Turtleneck commands
     def set_multiplier(self, multiplier):

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -156,6 +156,10 @@ class afcFunction:
             self.AFC.ERROR.AFC_error("{} not a valid unit".format(unit), pause=False)
             return
 
+        if afc_bl not in self.AFC.lanes:
+            self.AFC.ERROR.AFC_error("{} not a valid lane".format(afc_bl), pause=False)
+            return
+
         # Determine if a specific lane is provided
         if lanes is not None:
             self.AFC.gcode.respond_info('Starting AFC distance Calibrations')


### PR DESCRIPTION
## Major Changes in this PR
- Changed buffer query to show expanded or compressed as well as they systems state.
- Removed last_state getting set to false when buffer is disabled.
- added key check in calibration for bowden length

## Notes to Code Reviewers

## How the changes in this PR are tested
- Query buffer and see updated message
- enter wrong value for BOWDEN in calibration, will error but not crash klipper

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
