### PR TITLE
New feature: assisted unload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-02-13]
+
+### Added
+- Assisted unload  
+  When enabled, the retracts out of the toolhead before the long, fast move back throught the bowden tube is assisted.
+  This helps with full spools where even a retract of a few centimeters can cause a loop to fall off the spool.
+
 ## [2025-02-04]
 
 ### Changed

--- a/config/AFC.cfg
+++ b/config/AFC.cfg
@@ -22,6 +22,8 @@ default_material_temps: PLA:210, ABS:235, ASA:235 # Default temperature to set e
 load_to_hub: True               # Fast loads filament to hub when inserted, set to False to disable. This is a global setting and can be overridden at AFC_stepper
 # moonraker_port: 7125            # Port to connect to when interacting with moonraker. Used when there are multiple moonraker/klipper instances on a single host
 
+assisted_unload: True           # If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool. This is a global setting and can be overridden at the unit and stepper level.
+
 #--=================================================================================-
 #------- TRSYNC Values --------------------------------------------------------------
 #--=================================================================================-

--- a/docs/CONFIGURATION_OPTIONS.md
+++ b/docs/CONFIGURATION_OPTIONS.md
@@ -44,6 +44,7 @@
 - `trsync_update` (default: `False`): Set to true to enable updating trsync value in klipper mcu. Enabling this and updating the timeouts can help with Timer Too Close(TTC) errors
 - `trsync_timeout` (default: `0.05`): Timeout value to update in klipper mcu. Klippers default value is 0.025
 - `trsync_single_timeout` (default: `0.5`): Single timeout value to update in klipper mcu. Klippers default value is 0.250
+- `assisted_unload` (default: `False`): If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool
 
 ## AFC_buffer
 - `enable_sensors_in_gui` (default: `False`): Set to True toolhead sensors switches as filament sensors in mainsail/fluidd gui, overrides value set in AFC.cfg
@@ -99,6 +100,7 @@
 - `assist_max_motor_rpm` (default: `500`): Max motor RPM
 - `rwd_speed_multiplier` (default: `0.5`): Multiplier to apply to rpm
 - `fwd_speed_multiplier` (default: `0.5`): Multiplier to apply to rpm
+- `assisted_unload` (default: `None`): If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
 
 ## AFC_BoxTurtle
 - `hub` (default: `None`): Hub name(AFC_hub) that belongs to this unit, can be overridden in AFC_stepper section
@@ -117,6 +119,7 @@
 - `short_moves_accel` (default: `400`): Acceleration in mm/s squared when doing short moves. Setting value here overrides values set in AFC.cfg file
 - `short_move_dis` (default: `400`): Move distance in mm for failsafe moves. Setting value here overrides values set in AFC.cfg file
 - `max_move_dis` (default: `999999`): Maximum distance to move filament. AFC breaks filament moves over this number into multiple moves. Useful to lower this number if running into timer too close errors when doing long filament moves. Setting value here overrides values set in AFC.cfg file
+- `assisted_unload` (default: `False`): If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool. Setting value here overrides values set in AFC.cfg file
 
 ## AFC_NightOwl
 - `hub` (default: `None`): Hub name(AFC_hub) that belongs to this unit, can be overridden in AFC_stepper section
@@ -134,3 +137,4 @@
 - `short_moves_speed` (default: `25`): Speed in mm/s to move filament when doing short moves. Setting value here overrides values set in AFC.cfg file
 - `short_moves_accel` (default: `400`): Acceleration in mm/s squared when doing short moves. Setting value here overrides values set in AFC.cfg file
 - `short_move_dis` (default: `400`): Move distance in mm for failsafe moves. Setting value here overrides values set in AFC.cfg file
+- `assisted_unload` (default: `False`): If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool. Setting value here overrides values set in AFC.cfg file

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -44,6 +44,8 @@ class afcUnit:
         self.short_move_dis     = config.getfloat("short_move_dis",  self.AFC.short_move_dis)       # Move distance in mm for failsafe moves. Setting value here overrides values set in AFC.cfg file
         self.max_move_dis       = config.getfloat("max_move_dis", self.AFC.max_move_dis)            # Maximum distance to move filament. AFC breaks filament moves over this number into multiple moves. Useful to lower this number if running into timer too close errors when doing long filament moves. Setting value here overrides values set in AFC.cfg file
 
+        self.assisted_unload    = config.getboolean("assisted_unload", self.AFC.assisted_unload) # If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool. Setting value here overrides values set in AFC.cfg file
+
     def handle_connect(self):
         """
         Handles klippy:connect event, and does error checking to make sure users have hub/extruder/buffers sections if these variables are defined at the unit level


### PR DESCRIPTION
## Major Changes in this PR

New feature: assisted unload

When enabled, the retracts out of the toolhead before the long, fast move back throught the bowden tube is assisted. This helps with full spools where even a retract of a few centimeters can cause a loop to fall off the spool.

**TBD**: do we want to enable this by default? I don't really see a reason why not. In the worst case it neither helps nor harms, in the best case users don't have to find out that they need this themselves.

## Notes to Code Reviewers

## How the changes in this PR are tested
By setting the flag on AFC, unit and extruder level and checking if on unload the spool is turned by the respoolers.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Sent notification to software-design channel requesting review
