### PR TITLE
Remove vars.tool file if it exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-02-13]
+
+### Changed
+- The `install-afc.sh` install script will now remove the `AFC.var.tool` file if detected as it is no longer needed.
+
 ## [2025-02-04]
 
 ### Changed
@@ -66,7 +71,7 @@ but the configuration did not display this value. For future installations, this
 - Added `docs/CONFIGURATION_OPTIONS.md` file that describes the different config parameters, still a work in progress
 
 ### Changed
-- AFC-Klipper-Add-On now pulls spoolman ip/port from moonracker.conf file, please remove `spoolman_ip` and `spoolman_port` from `AFC/AFC.cfg` file
+- AFC-Klipper-Add-On now pulls spoolman ip/port from moonraker.conf file, please remove `spoolman_ip` and `spoolman_port` from `AFC/AFC.cfg` file
 
 
 ## [2025-01-11]

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -89,7 +89,7 @@ class afcBoxTurtle(afcUnit):
                             CUR_LANE.enable_buffer()
                         else:
                             if CUR_LANE.get_toolhead_sensor_state() == True:
-                                msg +="<span class=error--text> error in ToolHead. \nLane identified as loaded in AFC.vars.unit file\n but not identified as loaded in AFC.var.tool file</span>"
+                                msg +="<span class=error--text> error in ToolHead. \nLane identified as loaded \n but not identified as loaded in extruder</span>"
                                 succeeded = False
                     else:
                         lane_check=self.AFC.ERROR.fix('toolhead',CUR_LANE)  #send to error handling

--- a/include/menus/main_menu.sh
+++ b/include/menus/main_menu.sh
@@ -42,11 +42,11 @@ completed you will not be able to use this assisted process for any future updat
     fi
     printf "\e[48;5;143m \e[49m \e[48;5;29m    \e[49m        \e[48;5;29m     \e[49m        \e[48;5;29m    \e[49m \e[48;5;143m \e[m  \n"
     printf "\e[48;5;143m \e[49m \e[48;5;29m    \e[49m        \e[48;5;29m     \e[49m        \e[48;5;29m    \e[49m \e[48;5;143m \e[m  \n"
-    printf "\e[48;5;143m \e[49m \e[48;5;29m    \e[49m        \e[48;5;29m     \e[49m        \e[48;5;29m    \e[49m \e[48;5;143m \e[m  1. Printer Config Directory : %s \n" $printer_config_dir
-    printf "\e[48;5;143m \e[49m \e[48;5;29m    \e[49m        \e[48;5;29m     \e[49m        \e[48;5;29m    \e[49m \e[48;5;143m \e[m  2. Klipper Directory        : %s \n" $klipper_dir
-    printf "\e[38;5;143;48;5;143m▄▄\e[38;5;143;49m▄\e[38;5;143;48;5;29m▄\e[49;38;5;29m▀\e[38;5;29;48;5;29m▄\e[49m        \e[48;5;29m     \e[49m        \e[38;5;29;48;5;29m▄\e[49;38;5;29m▀\e[38;5;143;48;5;29m▄\e[38;5;143;49m▄\e[38;5;143;48;5;143m▄▄\e[m  3. Moonraker Config File    : %s \n" $moonraker_config_file
-    printf "\e[49m  \e[49;38;5;143m▀▀\e[38;5;143;48;5;143m▄▄\e[38;5;143;49m▄▄\e[49m      \e[48;5;29m     \e[49m      \e[38;5;143;49m▄▄\e[38;5;143;48;5;143m▄▄\e[49;38;5;143m▀▀\e[49m  \e[m  4. Klipper Service Name     : %s \n" $klipper_service
-    printf "\e[49m      \e[49;38;5;143m▀\e[38;5;143;48;5;143m▄▄\e[38;5;143;49m▄▄\e[49m   \e[48;5;29m     \e[49m   \e[38;5;143;49m▄▄\e[38;5;143;48;5;143m▄▄\e[49;38;5;143m▀\e[49m      \e[m  5. Branch                   : %s \n" $branch
+    printf "\e[48;5;143m \e[49m \e[48;5;29m    \e[49m        \e[48;5;29m     \e[49m        \e[48;5;29m    \e[49m \e[48;5;143m \e[m  1. Printer Config Directory  : %s \n" $printer_config_dir
+    printf "\e[48;5;143m \e[49m \e[48;5;29m    \e[49m        \e[48;5;29m     \e[49m        \e[48;5;29m    \e[49m \e[48;5;143m \e[m  2. Klipper Directory         : %s \n" $klipper_dir
+    printf "\e[38;5;143;48;5;143m▄▄\e[38;5;143;49m▄\e[38;5;143;48;5;29m▄\e[49;38;5;29m▀\e[38;5;29;48;5;29m▄\e[49m        \e[48;5;29m     \e[49m        \e[38;5;29;48;5;29m▄\e[49;38;5;29m▀\e[38;5;143;48;5;29m▄\e[38;5;143;49m▄\e[38;5;143;48;5;143m▄▄\e[m  3. Moonraker Config File     : %s \n" $moonraker_config_file
+    printf "\e[49m  \e[49;38;5;143m▀▀\e[38;5;143;48;5;143m▄▄\e[38;5;143;49m▄▄\e[49m      \e[48;5;29m     \e[49m      \e[38;5;143;49m▄▄\e[38;5;143;48;5;143m▄▄\e[49;38;5;143m▀▀\e[49m  \e[m  4. Klipper Service Name      : %s \n" $klipper_service
+    printf "\e[49m      \e[49;38;5;143m▀\e[38;5;143;48;5;143m▄▄\e[38;5;143;49m▄▄\e[49m   \e[48;5;29m     \e[49m   \e[38;5;143;49m▄▄\e[38;5;143;48;5;143m▄▄\e[49;38;5;143m▀\e[49m      \e[m  5. AFC-Klipper-Add-On Branch : %s \n" $branch
     printf "\e[49m         \e[49;38;5;143m▀▀\e[38;5;143;48;5;143m▄▄\e[38;5;143;49m▄▄\e[49;38;5;29m▀\e[38;5;29;48;5;29m▄\e[49;38;5;29m▀\e[38;5;143;49m▄▄\e[38;5;143;48;5;143m▄▄\e[49;38;5;143m▀▀\e[49m         \e[m\n"
     printf "\e[49m             \e[49;38;5;143m▀▀\e[38;5;143;48;5;143m▄\e[38;5;143;49m▄\e[38;5;143;48;5;143m▄\e[49;38;5;143m▀▀\e[49m             \e[m  (Select a number to change the default value)\n"
     echo ""

--- a/include/utils.sh
+++ b/include/utils.sh
@@ -162,8 +162,8 @@ remove_afc_version() {
 }
 
 remove_vars_tool_file() {
-  if [ -f "${afc_config_dir}/AFC.var.tool" ]; then
-    rm "${afc_config_dir}/AFC.var.tool"
+  if [ -f "${afc_config_dir}/*.tool" ]; then
+    rm "${afc_config_dir}/*.tool"
   fi
 }
 

--- a/include/utils.sh
+++ b/include/utils.sh
@@ -127,8 +127,9 @@ restart_klipper() {
 exit_afc_install() {
   if [ "$files_updated_or_installed" == "True" ]; then
     update_afc_version "$current_install_version"
-  restart_klipper
+    restart_klipper
   fi
+  remove_vars_tool_file
   exit 0
 }
 
@@ -158,6 +159,12 @@ update_afc_version() {
 
 remove_afc_version() {
   curl -s -XDELETE "localhost/server/database/item?namespace=afc-install&key=version" > /dev/null
+}
+
+remove_vars_tool_file() {
+  if [ -f "${afc_config_dir}/AFC.vars.tool" ]; then
+    rm "${afc_config_dir}/AFC.vars.tool"
+  fi
 }
 
 stop_service() {

--- a/include/utils.sh
+++ b/include/utils.sh
@@ -162,8 +162,8 @@ remove_afc_version() {
 }
 
 remove_vars_tool_file() {
-  if [ -f "${afc_config_dir}/AFC.vars.tool" ]; then
-    rm "${afc_config_dir}/AFC.vars.tool"
+  if [ -f "${afc_config_dir}/AFC.var.tool" ]; then
+    rm "${afc_config_dir}/AFC.var.tool"
   fi
 }
 


### PR DESCRIPTION
## Major Changes in this PR
This pull request includes updates to the `main_menu.sh` and `utils.sh` scripts to improve functionality and maintainability. The most important changes include an update to the branch display name in the main menu and the addition of a function to remove a specific configuration file.

Updates to main menu:

* [`include/menus/main_menu.sh`](diffhunk://#diff-b37d5a03e34abdb7894ed50f0ec833afe8856faf271fb195b23f93168e185c71L49-R49): Updated the branch display name from "Branch" to "AFC-Klipper-Add-On Branch" to provide clearer context.

Enhancements to utility functions:

* [`include/utils.sh`](diffhunk://#diff-9e64712e624ee22bf3a68f5ecd584c7f805f610eb1fb10ce184a3d3beb0b8352R132): Added a call to `remove_vars_tool_file` in the `exit_afc_install` function to ensure cleanup of the `AFC.var.tool` file upon exit.
* [`include/utils.sh`](diffhunk://#diff-9e64712e624ee22bf3a68f5ecd584c7f805f610eb1fb10ce184a3d3beb0b8352R164-R169): Introduced the `remove_vars_tool_file` function to delete the `AFC.var.tool` file if it exists, enhancing the cleanup process.
## Notes to Code Reviewers

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
