### PR TITLE
Fixing issues based on feedback from users testing DEV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-02-19]
+
+### Added
+- Clearing error_state when print starts, before this could be set before printing and would cause AFC to not save/restore position
+- Added 1 second time debounce to prep callback
+- Added abs function when determining speed for LANE_MOVE macro
+
+### Changed
+- Updated error print out messages when loading/unloading
+- The way error messages printed out so they are grouped together
+
+### Fixed
+- Issue where getting spoolman data would error out when server variable in moonraker ended in a slash
+- Issue where prep would no longer activate extruder motors when user rapidely triggered prep sensor
+
 ## [2025-02-16]
 
 ### Added

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -51,7 +51,7 @@ class afcBoxTurtle(afcUnit):
             self.AFC.reactor.pause(self.AFC.reactor.monotonic() + delay)
             CUR_LANE.move( -5, self.AFC.short_moves_speed, self.AFC.short_moves_accel, True)
         else:
-            self.AFC.reactor.pause(self.AFC.reactor.monotonic() + delay)
+            self.AFC.reactor.pause(self.AFC.reactor.monotonic() + 0.7)
 
         if CUR_LANE.prep_state == False:
             if CUR_LANE.load_state == False:

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -89,7 +89,7 @@ class afcError:
         self.AFC.gcode.respond_info ('PAUSING')
         self.AFC.gcode.run_script_from_command('PAUSE')
 
-    def set_error_state(self, state):
+    def set_error_state(self, state=False):
         # Only save position on first error state call
         if state == True and self.AFC.error_state == False:
             self.AFC.save_pos()
@@ -101,8 +101,7 @@ class afcError:
         # Print to logger since respond_raw does not write to logger
         logging.warning(msg)
         # Handle AFC errors
-        for line in msg.split("\n"):
-            self.AFC.gcode.respond_raw( "!! {}".format(line) )
+        self.AFC.gcode.respond_raw( "!! {}".format(msg) )
         if pause: self.pause_print()
 
 

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -7,9 +7,11 @@
 import json
 try:
     from urllib.request import urlopen
+    import urllib.parse as urlparse
 except:
     # Python 2.7 support
     from urllib2 import urlopen
+    import urlparse
 
 class afcSpool:
     def __init__(self, config):
@@ -248,7 +250,7 @@ class afcSpool:
         if self.AFC.spoolman !=None:
             if SpoolID !='':
                 try:
-                    url =  "{}{}".format(self.AFC.spoolman + '/api/v1/spool/', SpoolID)
+                    url =  urlparse.urljoin(self.AFC.spoolman, '/api/v1/spool/{}'.format(SpoolID))
                     result = json.load(urlopen(url))
                     CUR_LANE.spool_id = SpoolID
 

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -184,6 +184,7 @@ class AFCExtruderStepper:
                 self.fila_load = add_filament_switch(self.load_filament_switch_name, self.load, self.printer )
         self.connect_done = False
         self.prep_active = False
+        self.last_prep_time = 0
 
     def _handle_ready(self):
         """
@@ -457,86 +458,97 @@ class AFCExtruderStepper:
     def prep_callback(self, eventtime, state):
         self.prep_state = state
 
+        delta_time = eventtime - self.last_prep_time
+        self.last_prep_time = eventtime
+
         if self.prep_active:
             return
 
         self.prep_active = True
 
         # Checking to make sure printer is ready and making sure PREP has been called before trying to load anything
-        if self.printer.state_message == 'Printer is ready' and True == self._afc_prep_done and self.status != 'Tool Unloading':
-            # Only try to load when load state trigger is false
-            if self.prep_state == True and self.load_state == False:
-                x = 0
-                # Check to see if the printer is printing or moving, as trying to load while printer is doing something will crash klipper
-                if self.AFC.FUNCTION.is_printing(check_movement=True):
-                    self.AFC.ERROR.AFC_error("Cannot load spools while printer is actively moving or homing", False)
-                    return
-                while self.load_state == False and self.prep_state == True and self.load != None:
-                    x += 1
-                    self.do_enable(True)
-                    self.move(10,500,400)
-                    self.reactor.pause(self.reactor.monotonic() + 0.1)
-                    if x> 40:
-                        msg = (' FAILED TO LOAD, CHECK FILAMENT AT TRIGGER\n||==>--||----||------||\nTRG   LOAD   HUB    TOOL')
-                        self.AFC.ERROR.AFC_error(msg, False)
-                        self.AFC.FUNCTION.afc_led(self.AFC.led_fault, self.led_index)
-                        self.status=''
+        for i in range(1):
+        # Hacky way for do{}while(0) loop, DO NOT return from this for loop, use break instead so that self.prep_state variable gets sets correctly
+        #  before exiting function
+            if self.printer.state_message == 'Printer is ready' and True == self._afc_prep_done and self.status != 'Tool Unloading':
+                # Only try to load when load state trigger is false
+                if self.prep_state == True and self.load_state == False:
+                    x = 0
+                    # Checking to make sure last time prep switch was activated was less than 1 second, returning to keep is printing message from spamming
+                    # the console since it takes klipper some time to transition to idle when idle_resume=printing
+                    if delta_time < 1.0:
                         break
-                self.status=''
 
-                # Verify that load state is still true as this would still trigger if prep sensor was triggered and then filament was removed
-                #   This is only really a issue when using direct and still using load sensor
-                if self.hub == 'direct' and self.prep_state:
-                    self.AFC.TOOL_LOAD(self)
-                    self.prep_active = False
-                    return
+                    # Check to see if the printer is printing or moving, as trying to load while printer is doing something will crash klipper
+                    if self.AFC.FUNCTION.is_printing(check_movement=True):
+                        self.AFC.ERROR.AFC_error("Cannot load spools while printer is actively moving or homing", False)
+                        break
 
-                # Checking if loaded to hub(it should not be since filament was just inserted), if false load to hub. Does a fast load if hub distance is over 200mm
-                if self.load_to_hub and not self.loaded_to_hub and self.load_state and self.prep_state:
-                    self.move(self.dist_hub, self.dist_hub_move_speed, self.dist_hub_move_accel, self.dist_hub > 200)
-                    self.loaded_to_hub = True
+                    while self.load_state == False and self.prep_state == True and self.load != None:
+                        x += 1
+                        self.do_enable(True)
+                        self.move(10,500,400)
+                        self.reactor.pause(self.reactor.monotonic() + 0.1)
+                        if x> 40:
+                            msg = (' FAILED TO LOAD, CHECK FILAMENT AT TRIGGER\n||==>--||----||------||\nTRG   LOAD   HUB    TOOL')
+                            self.AFC.ERROR.AFC_error(msg, False)
+                            self.AFC.FUNCTION.afc_led(self.AFC.led_fault, self.led_index)
+                            self.status=''
+                            break
+                    self.status=''
 
-                self.do_enable(False)
-                if self.load_state == True and self.prep_state == True:
-                    self.status = 'Loaded'
-                    self.AFC.FUNCTION.afc_led(self.AFC.led_ready, self.led_index)
+                    # Verify that load state is still true as this would still trigger if prep sensor was triggered and then filament was removed
+                    #   This is only really a issue when using direct and still using load sensor
+                    if self.hub == 'direct' and self.prep_state:
+                        self.AFC.TOOL_LOAD(self)
+                        break
 
-            elif self.prep_state == False and self.name == self.AFC.current and self.AFC.FUNCTION.is_printing() and self.load_state and self.status != 'ejecting':
-                # Checking to make sure runout_lane is set and does not equal 'NONE'
-                if  self.runout_lane != 'NONE':
-                    self.status = None
-                    self.AFC.FUNCTION.afc_led(self.AFC.led_not_ready, self.led_index)
-                    self.AFC.gcode.respond_info("Infinite Spool triggered for {}".format(self.name))
-                    empty_LANE = self.AFC.lanes[self.AFC.current]
-                    change_LANE = self.AFC.lanes[self.runout_lane]
-                    # Pause printer
-                    self.gcode.run_script_from_command('PAUSE')
-					# Change Tool
-                    self.AFC.CHANGE_TOOL(change_LANE)
-                    # Change Mapping
-                    self.gcode.run_script_from_command('SET_MAP LANE={} MAP={}'.format(change_LANE.name, empty_LANE.map))
-                    # Eject lane from BT
-                    self.gcode.run_script_from_command('LANE_UNLOAD LANE={}'.format(empty_LANE.name))
-                    # Resume
-                    self.gcode.run_script_from_command('RESUME')
-                    # Set LED to not ready
-                    self.AFC.FUNCTION.afc_led(self.led_not_ready, self.led_index)
+                    # Checking if loaded to hub(it should not be since filament was just inserted), if false load to hub. Does a fast load if hub distance is over 200mm
+                    if self.load_to_hub and not self.loaded_to_hub and self.load_state and self.prep_state:
+                        self.move(self.dist_hub, self.dist_hub_move_speed, self.dist_hub_move_accel, self.dist_hub > 200)
+                        self.loaded_to_hub = True
+
+                    self.do_enable(False)
+                    if self.load_state == True and self.prep_state == True:
+                        self.status = 'Loaded'
+                        self.AFC.FUNCTION.afc_led(self.AFC.led_ready, self.led_index)
+
+                elif self.prep_state == False and self.name == self.AFC.current and self.AFC.FUNCTION.is_printing() and self.load_state and self.status != 'ejecting':
+                    # Checking to make sure runout_lane is set and does not equal 'NONE'
+                    if  self.runout_lane != 'NONE':
+                        self.status = None
+                        self.AFC.FUNCTION.afc_led(self.AFC.led_not_ready, self.led_index)
+                        self.AFC.gcode.respond_info("Infinite Spool triggered for {}".format(self.name))
+                        empty_LANE = self.AFC.lanes[self.AFC.current]
+                        change_LANE = self.AFC.lanes[self.runout_lane]
+                        # Pause printer
+                        self.gcode.run_script_from_command('PAUSE')
+                        # Change Tool
+                        self.AFC.CHANGE_TOOL(change_LANE)
+                        # Change Mapping
+                        self.gcode.run_script_from_command('SET_MAP LANE={} MAP={}'.format(change_LANE.name, empty_LANE.map))
+                        # Eject lane from BT
+                        self.gcode.run_script_from_command('LANE_UNLOAD LANE={}'.format(empty_LANE.name))
+                        # Resume
+                        self.gcode.run_script_from_command('RESUME')
+                        # Set LED to not ready
+                        self.AFC.FUNCTION.afc_led(self.led_not_ready, self.led_index)
+                    else:
+                        # Pause print
+                        self.status = None
+                        self.AFC.FUNCTION.afc_led(self.AFC.led_not_ready, self.led_index)
+                        self.AFC.gcode.respond_info("Runout triggered for lane {} and runout lane is not setup to switch to another lane".format(self.name))
+                        self.AFC.ERROR.pause_print()
+                elif self.prep_state == True and self.load_state == True and not self.AFC.FUNCTION.is_printing():
+                    message = 'Cannot load {} load sensor is triggered.'.format(self.name)
+                    message += '\n    Make sure filament is not stuck in load sensor or check to make sure load sensor is not stuck triggered.'
+                    message += '\n    Once cleared try loading again'
+                    self.AFC.ERROR.AFC_error(message, pause=False)
                 else:
-                    # Pause print
                     self.status = None
+                    self.loaded_to_hub = False
+                    self.AFC.SPOOL._clear_values(self)
                     self.AFC.FUNCTION.afc_led(self.AFC.led_not_ready, self.led_index)
-                    self.AFC.gcode.respond_info("Runout triggered for lane {} and runout lane is not setup to switch to another lane".format(self.name))
-                    self.AFC.ERROR.pause_print()
-            elif self.prep_state == True and self.load_state == True and not self.AFC.FUNCTION.is_printing():
-                message = 'Cannot load {} load sensor is triggered.'.format(self.name)
-                message += '\n    Make sure filament is not stuck in load sensor or check to make sure load sensor is not stuck triggered.'
-                message += '\n    Once cleared try loading again'
-                self.AFC.ERROR.AFC_error(message, pause=False)
-            else:
-                self.status = None
-                self.loaded_to_hub = False
-                self.AFC.SPOOL._clear_values(self)
-                self.AFC.FUNCTION.afc_led(self.AFC.led_not_ready, self.led_index)
 
         self.prep_active = False
         self.AFC.save_vars()


### PR DESCRIPTION
## Major Changes in this PR
- Clearing error_state when print starts, before this could be set before printing and would cause AFC to not save/restore position
- Added abs function when determining speed for LANE_MOVE macro
- Updated error print out messages when loading/unloading
- Changed the way error messages printed out so they are grouped together
- Fixed issue where getting spoolman data would error out when server variable in moonraker ended in a slash
- Added 1 second time debounce to prep callback and fixed issue where prep would no longer activate extruder motors when user rapidely triggered prep sensor

## Notes to Code Reviewers

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
