### PR TITLE
Add update notification and moonraker changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-02-20]
+
+### Added
+
+- Users are now able to specify a non default moonraker address when using the `install-afc.sh` script. This value defaults to `http://localhost` but
+can be adjusted for cases such as a remote moonraker installation, https, etc. This value can be set during the installation process by using the `-a <address>` flag.
+
 ## [2025-02-19]
 
 ### Added

--- a/include/check_commands.sh
+++ b/include/check_commands.sh
@@ -141,7 +141,7 @@ query_printer_status() {
   local response
   local state
 
-  response=$(curl -s http://localhost/printer/objects/query?idle_timeout)
+  response=$(curl -s "$moonraker_address"/printer/objects/query?idle_timeout)
   state=$(echo "$response" | jq -r '.result.status.idle_timeout.state')
 
   if [ "$state" == "Ready" ]; then

--- a/include/constants.sh
+++ b/include/constants.sh
@@ -16,6 +16,7 @@ moonraker_config_file="$printer_config_dir/moonraker.conf"
 
 # Service related constants
 klipper_service="klipper"
+moonraker_address="http://localhost"
 
 # Git related constants
 gitrepo="https://github.com/ArmoredTurtle/AFC-Klipper-Add-On.git"

--- a/include/menus/main_menu.sh
+++ b/include/menus/main_menu.sh
@@ -47,7 +47,7 @@ completed you will not be able to use this assisted process for any future updat
     printf "\e[38;5;143;48;5;143m▄▄\e[38;5;143;49m▄\e[38;5;143;48;5;29m▄\e[49;38;5;29m▀\e[38;5;29;48;5;29m▄\e[49m        \e[48;5;29m     \e[49m        \e[38;5;29;48;5;29m▄\e[49;38;5;29m▀\e[38;5;143;48;5;29m▄\e[38;5;143;49m▄\e[38;5;143;48;5;143m▄▄\e[m  3. Moonraker Config File    : %s \n" $moonraker_config_file
     printf "\e[49m  \e[49;38;5;143m▀▀\e[38;5;143;48;5;143m▄▄\e[38;5;143;49m▄▄\e[49m      \e[48;5;29m     \e[49m      \e[38;5;143;49m▄▄\e[38;5;143;48;5;143m▄▄\e[49;38;5;143m▀▀\e[49m  \e[m  4. Klipper Service Name     : %s \n" $klipper_service
     printf "\e[49m      \e[49;38;5;143m▀\e[38;5;143;48;5;143m▄▄\e[38;5;143;49m▄▄\e[49m   \e[48;5;29m     \e[49m   \e[38;5;143;49m▄▄\e[38;5;143;48;5;143m▄▄\e[49;38;5;143m▀\e[49m      \e[m  5. Branch                   : %s \n" $branch
-    printf "\e[49m         \e[49;38;5;143m▀▀\e[38;5;143;48;5;143m▄▄\e[38;5;143;49m▄▄\e[49;38;5;29m▀\e[38;5;29;48;5;29m▄\e[49;38;5;29m▀\e[38;5;143;49m▄▄\e[38;5;143;48;5;143m▄▄\e[49;38;5;143m▀▀\e[49m         \e[m\n"
+    printf "\e[49m         \e[49;38;5;143m▀▀\e[38;5;143;48;5;143m▄▄\e[38;5;143;49m▄▄\e[49;38;5;29m▀\e[38;5;29;48;5;29m▄\e[49;38;5;29m▀\e[38;5;143;49m▄▄\e[38;5;143;48;5;143m▄▄\e[49;38;5;143m▀▀\e[49m \e[m          6. Moonraker Address        : %s    \n" $moonraker_address
     printf "\e[49m             \e[49;38;5;143m▀▀\e[38;5;143;48;5;143m▄\e[38;5;143;49m▄\e[38;5;143;48;5;143m▄\e[49;38;5;143m▀▀\e[49m             \e[m  (Select a number to change the default value)\n"
     echo ""
     printf "${MENU_GREEN}▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄ \n"
@@ -85,6 +85,8 @@ completed you will not be able to use this assisted process for any future updat
         export message="To change the klipper service name, please re-run this script with a '-s <name>' option." ;;
       5)
         export message="To change the branch, please re-run this script with a '-b <branch>' option." ;;
+      6)
+        export message="To change the moonraker address, please re-run this script with a '-a <address>' option." ;;
       I)
         if [ "$force_update" == "True" ] && [ "$prior_installation" == "True" ]; then
           backup_afc_config

--- a/include/menus/update_menu.sh
+++ b/include/menus/update_menu.sh
@@ -6,14 +6,13 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
 update_menu() {
-  local message
   local choice
   while true; do
     clear
     printf "%b▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄ \n" "$MENU_GREEN"
     printf "█%b                                    AFC Script Help      %b                            █\n" "$RESET" "$MENU_GREEN"
     printf "%b▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀%b \n" "$MENU_GREEN" "$RESET"
-    printf "%b\n" "$message"
+    printf "%b\n" "$update_message"
     printf "%b▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄ \n" "$MENU_GREEN"
     printf "█%b            Please review the following options to update your system%b                █\n" "$RESET" "$MENU_GREEN"
     printf "█%b        Use the provided option selection to cycle through available choices%b         █\n" "$RESET" "$MENU_GREEN"

--- a/include/update_functions.sh
+++ b/include/update_functions.sh
@@ -8,9 +8,9 @@
 update_afc() {
   link_extensions
   remove_t_macros
-  message="""
+  update_message="""
 AFC Klipper Add-On updated successfully.
 """
-  export message
+  export update_message
   files_updated_or_installed="True"
 }

--- a/include/utils.sh
+++ b/include/utils.sh
@@ -17,6 +17,7 @@ function show_help() {
   echo "Usage: install-afc.sh [options]"
   echo ""
   echo "Options:"
+  echo "  -a <moonraker address>      Specify the address of the Moonraker server (default: http://localhost)"
   echo "  -k <path>                   Specify the path to the Klipper directory"
   echo "  -m <moonraker config path>  Specify the path to the Moonraker config file (default: ~/printer_data/config/moonraker.conf)"
   echo "  -s <klipper service name>   Specify the name of the Klipper service (default: klipper)"
@@ -25,7 +26,7 @@ function show_help() {
   echo "  -h                          Display this help message"
   echo ""
   echo "Example:"
-  echo " $0 [-k <klipper_path>] [-s <klipper_service_name>] [-m <moonraker_config_path>] [-p <printer_config_dir>] [-b <branch>] [-h] "
+  echo " $0 [-a <moonraker address>] [-k <klipper_path>] [-s <klipper_service_name>] [-m <moonraker_config_path>] [-p <printer_config_dir>] [-b <branch>] [-h] "
 }
 
 function copy_config() {
@@ -142,7 +143,7 @@ function auto_update() {
 
 check_version_and_set_force_update() {
   local current_version
-  current_version=$(curl -s "localhost/server/database/item?namespace=afc-install&key=version" | jq -r .result.value)
+  current_version=$(curl -s "$moonraker_address/server/database/item?namespace=afc-install&key=version" | jq -r .result.value)
   if [[ -z "$current_version" || "$current_version" == "null" || "$current_version" < "$min_version" ]]; then
     force_update=True
   else
@@ -153,11 +154,11 @@ check_version_and_set_force_update() {
 update_afc_version() {
   local version_update
   version_update=$1
-  curl -s -XPOST "localhost/server/database/item?namespace=afc-install&key=version&value=$version_update" > /dev/null
+  curl -s -XPOST "$moonraker_address/server/database/item?namespace=afc-install&key=version&value=$version_update" > /dev/null
 }
 
 remove_afc_version() {
-  curl -s -XDELETE "localhost/server/database/item?namespace=afc-install&key=version" > /dev/null
+  curl -s -XDELETE "$moonraker_address/server/database/item?namespace=afc-install&key=version" > /dev/null
 }
 
 stop_service() {

--- a/install-afc.sh
+++ b/install-afc.sh
@@ -28,8 +28,9 @@ source include/utils.sh
 
 ###################### Main script logic below ######################
 
-while getopts "k:s:m:b:p:u:th" arg; do
+while getopts "a:k:s:m:b:p:u:th" arg; do
   case ${arg} in
+  a) moonraker_address=${OPTARG} ;;
   k) klipper_dir=${OPTARG} ;;
   m) moonraker_config_file=${OPTARG} ;;
   s) klipper_service=${OPTARG} ;;


### PR DESCRIPTION
## Major Changes in this PR

This pull request introduces the ability for users to specify a non-default Moonraker address when using the `install-afc.sh` script. This change includes updates to various scripts and configuration files to support the new feature. The most important changes are as follows:

### New Feature: Custom Moonraker Address

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R14): Documented the new feature allowing users to specify a non-default Moonraker address using the `-a <address>` flag during the installation process.
* [`include/constants.sh`](diffhunk://#diff-136fe1bcdb8818f9c4dbd399c55de34fc1c3426774f0135576365b3152460627R19): Added a new constant `moonraker_address` with the default value `http://localhost`.
* [`include/utils.sh`](diffhunk://#diff-9e64712e624ee22bf3a68f5ecd584c7f805f610eb1fb10ce184a3d3beb0b8352R20): Updated the `show_help` function to include the new `-a <moonraker address>` option in the usage instructions. [[1]](diffhunk://#diff-9e64712e624ee22bf3a68f5ecd584c7f805f610eb1fb10ce184a3d3beb0b8352R20) [[2]](diffhunk://#diff-9e64712e624ee22bf3a68f5ecd584c7f805f610eb1fb10ce184a3d3beb0b8352L28-R29)
* [`install-afc.sh`](diffhunk://#diff-808409cb3827534e4d3012fedbf1671577db5a220159b4b5d7b253bff3d890caL31-R33): Modified the script to handle the new `-a` option for specifying the Moonraker address.

### Script Updates

* [`include/check_commands.sh`](diffhunk://#diff-91f04686173d0b0c6fe7b66c8e14e887f57ce6a144b68023c53d291a81e6fcc0L144-R144): Updated the `query_printer_status` function to use the `moonraker_address` variable instead of a hardcoded address.
* [`include/menus/main_menu.sh`](diffhunk://#diff-b37d5a03e34abdb7894ed50f0ec833afe8856faf271fb195b23f93168e185c71L50-R50): Added a new menu item to display and change the Moonraker address. [[1]](diffhunk://#diff-b37d5a03e34abdb7894ed50f0ec833afe8856faf271fb195b23f93168e185c71L50-R50) [[2]](diffhunk://#diff-b37d5a03e34abdb7894ed50f0ec833afe8856faf271fb195b23f93168e185c71R88-R89)
* [`include/menus/update_menu.sh`](diffhunk://#diff-7fbbebe0014257d46a3a05fa92e978567af4516e7701450c4bcf67a8998dc16aL9-R15): Replaced the `message` variable with `update_message` for consistency.
* [`include/update_functions.sh`](diffhunk://#diff-e640ec65703f5a9486beb53f428b150d6d1f3b3f7956b24766b783061f5d5ddeL11-R14): Updated the `update_afc` function to use `update_message` instead of `message`.
* [`include/utils.sh`](diffhunk://#diff-9e64712e624ee22bf3a68f5ecd584c7f805f610eb1fb10ce184a3d3beb0b8352L145-R146): Updated various functions to use the `moonraker_address` variable instead of hardcoded addresses. [[1]](diffhunk://#diff-9e64712e624ee22bf3a68f5ecd584c7f805f610eb1fb10ce184a3d3beb0b8352L145-R146) [[2]](diffhunk://#diff-9e64712e624ee22bf3a68f5ecd584c7f805f610eb1fb10ce184a3d3beb0b8352L156-R161)

## Notes to Code Reviewers

## How the changes in this PR are tested

Local testing
## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
