### PR TITLE
Fixing issues from users testing DEV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-02-21]
+
+### Added
+- Checking to make sure lane was not None in cmd_CHANGE_TOOL
+- Pauses in TOOL_LOAD/TOOL_UNLOAD/CHANGE_TOOL for early returns if printer is currently in a print
+
+### Fixed
+- Error in cmd_CHANGE_TOOL where change logic was being triggered if change was in a comment on the same line
+- Turned runout pause message into error message which also pauses printer
+- Error where infinite spool would crash klipper when calling change tool
+
 ## [2025-02-20]
 
 ### Added

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -4,6 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
+import logging
 from extras.AFC import State
 
 def load_config(config):
@@ -90,6 +91,7 @@ class afcError:
         self.AFC.gcode.run_script_from_command('PAUSE')
 
     def set_error_state(self, state=False):
+        logging.warning("AFC debug: setting error state {}".format(state))
         # Only save position on first error state call
         if state == True and self.AFC.error_state == False:
             self.AFC.save_pos()
@@ -97,7 +99,6 @@ class afcError:
         self.AFC.current_state = State.ERROR if state else State.IDLE
 
     def AFC_error(self, msg, pause=True):
-        import logging
         # Print to logger since respond_raw does not write to logger
         logging.warning(msg)
         # Handle AFC errors

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -536,9 +536,11 @@ class AFCExtruderStepper:
                     else:
                         # Pause print
                         self.status = None
+                        msg = "Runout triggered for lane {} and runout lane is not setup to switch to another lane".format(self.name)
+                        msg += "\nPlease manually load next spool into toolhead and then hit resume to continue"
                         self.AFC.FUNCTION.afc_led(self.AFC.led_not_ready, self.led_index)
-                        self.AFC.gcode.respond_info("Runout triggered for lane {} and runout lane is not setup to switch to another lane".format(self.name))
-                        self.AFC.ERROR.pause_print()
+                        self.AFC.ERROR.AFC_error(msg)
+
                 elif self.prep_state == True and self.load_state == True and not self.AFC.FUNCTION.is_printing():
                     message = 'Cannot load {} load sensor is triggered.'.format(self.name)
                     message += '\n    Make sure filament is not stuck in load sensor or check to make sure load sensor is not stuck triggered.'


### PR DESCRIPTION
## Major Changes in this PR
- Fixed error in cmd_CHANGE_TOOL where change logic was being triggered if change was in a comment on the same line
- Added checking to make sure lane was not none in cmd_CHANGE_TOOL
- Added pauses in some places if printer is currently in a print
- Changed print in runout pause to display as error so it pauses correctly and saves position
- Fixed issue with infinite spool where calling CHANGE_TOOL would error out

## Notes to Code Reviewers

## How the changes in this PR are tested
Manually tested pause on runout and infinite spool rollover

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
