### PR TITLE
Multiple updates, including adding new logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-02-28]
+
+### Added
+- Logging of delta time and total time for how long toolchanges take
+- Logging for AFC now logs to AFC.log file
+- Ability to turn off/on AFC leds with `TURN_OFF_AFC_LED`/`TURN_ON_AFC_LED`
+- `default_material_type` variable to assign to spool when loaded into lane
+- `pause_when_bypass_active` variable to pause print if bypass is active, defaults to false
+- `unload_on_runout variable` to unload lane when runout happens and another lane is not setup to change to, default to false
+- Updated calibration to use buffer as tool_pin_start if only tool_pin_end is defined and buffer is also defined
+- Ability to change tool_stn/tool_stn_unload/tool_sensor_after_extruder without restarting
+
+### Fixed
+- Issue where filament was not unloading correctly when only tool_pin_end is defined
+- Issue where prep logic would try to unload forever if only tool_pin_end was defined
+
 ## [2025-02-25]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Prior to operation, the following checks / updates **MUST** be made to your syst
 1.  Update the following values in the `~/printer_data/config/AFC/AFC_Hardware-{board}.cfg` file:  
     *default name with AFC-lite will be AFC_Hardware-AFC.cfg*
 
-    - tool_stn: This value is the length from your toolhead sensor to nozzle
+    - tool_stn: This value is the length from your toolhead sensor to nozzle, if `tool_end` is defined then distance is from this sensor
     - tool_stn_unload: This value is the amount to unload from extruder when doing a filament change.
 
 2.  Update the following in the `~/printer_data/config/AFC/AFC_Turtle_{n}.cfg` file:  

--- a/config/AFC.cfg
+++ b/config/AFC.cfg
@@ -14,15 +14,20 @@ short_move_dis: 10              # Move distance for failsafe moves. Default is 1
 
 #global_print_current: 0.6       # Uncomment to set stepper motors to a lower current while printing
                                 # This value can also be set per stepper with print_current: 0.6
-#enable_sensors_in_gui: True     # Uncomment to show all sensor switches as filament sensors in mainsail/fluidd gui
+enable_sensors_in_gui: True     # Uncomment to show all sensor switches as filament sensors in mainsail/fluidd gui
                                 # this can also be set at individual levels in your config file
 default_material_temps: default: 235, PLA:210, ABS:235, ASA:235 # Default temperature to set extruder when loading/unloading lanes.
                                                   # Material needs to be either manually set or uses material from spoolman if extruder temp is not
                                                   # set in spoolman. Follow current format to add more
+#default_material_type: PLA      # Default material type to assign to a spool once loaded into a lane
+
 load_to_hub: True               # Fast loads filament to hub when inserted, set to False to disable. This is a global setting and can be overridden at AFC_stepper
-# moonraker_port: 7125            # Port to connect to when interacting with moonraker. Used when there are multiple moonraker/klipper instances on a single host
+#moonraker_port: 7125            # Port to connect to when interacting with moonraker. Used when there are multiple moonraker/klipper instances on a single host
 
 assisted_unload: True           # If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool. This is a global setting and can be overridden at the unit and stepper level.
+#pause_when_bypass_active: True  # When True AFC pauses print when change tool is called and bypass is loaded
+#unload_on_runout: True          # When True AFC will unload lane and then pause when runout is triggered and spool to swap to is not set(infinite spool)
+#debug: True                     # Setting to True turns on more debugging to show on console
 
 #--=================================================================================-
 #------- TRSYNC Values --------------------------------------------------------------

--- a/docs/command_reference.md
+++ b/docs/command_reference.md
@@ -9,24 +9,28 @@ NOTE: LANE/HUB/BUFFER etc. names are case sensitive and should exactly match the
 ### AFC_CALIBRATION
 _Description_: Open a prompt to start AFC calibration by selecting a unit to calibrate. Creates buttons for each unit and
 allows the option to calibrate all lanes across all units.  
+  
 Usage: ``AFC_CALIBRATION``  
 Example: ``AFC_CALIBRATION``  
 
 ### AFC_RESUME
 _Description_: This function clears the error state of the AFC system, sets the in_toolchange flag to False,
 runs the resume script, and restores the toolhead position to the last saved position.  
+  
 Usage: ``AFC_RESUME``  
 Example: ``AFC_RESUME``  
 
 ### AFC_STATUS
 _Description_: This function generates a status message for each unit and lane, indicating the preparation,
 loading, hub, and tool states. The status message is formatted with HTML tags for display.  
+  
 Usage: ``AFC_STATUS``  
 Example: ``AFC_STATUS``  
 
 ### ALL_CALIBRATION
 _Description_: Open a prompt to confirm calibration of all lanes in all units. Provides 'Yes' to confirm and 'Back' to
 return to the previous menu.  
+  
 Usage: ``ALL_CALIBRATION``  
 Example: ``ALL_CALIBRATION``  
 
@@ -36,18 +40,22 @@ _Description_: This function performs the calibration of the hub and Bowden leng
 steppers, check the state of the hubs and tools, and calculate distances for calibration based on the
 user-provided input. If no specific lane is provided, the function defaults to notifying the user that no lane has been selected. The function also includes
 the option to calibrate the Bowden length for a particular lane, if specified.  
+  
 Usage: ``CALIBRATE_AFC LANE=<lane> DISTANCE=<distance> TOLERANCE=<tolerance> BOWDEN=<lane>``  
 Example: `CALIBRATE_AFC LANE=lane1`  
 
 ### CHANGE_TOOL
 _Description_: This function handles the tool change process. It retrieves the lane specified by the 'LANE' parameter,
 checks the filament sensor, saves the current position, and performs the tool change by unloading the
-current lane and loading the new lane.  
+current lane and loading the new lane.
+Optionally setting PURGE_LENGTH parameter to pass a value into poop macro.  
+  
 Usage: ``CHANGE_TOOL LANE=<lane> PURGE_LENGTH=<purge_length>(optional value)``  
 Example: ``CHANGE_TOOL LANE=lane1 PURGE_LENGTH=100``  
 
 ### GET_TIP_FORMING
 _Description_: Shows the tip forming configuration  
+  
 Usage: `GET_TIP_FORMING`  
 Example: `GET_TIP_FORMING`  
 
@@ -55,40 +63,61 @@ Example: `GET_TIP_FORMING`
 _Description_: This function tests the cutting sequence of the hub cutter for a specified lane.
 It retrieves the lane specified by the 'LANE' parameter, performs the hub cut,
 and responds with the status of the operation.  
+  
 Usage: ``HUB_CUT_TEST LANE=<lane>``  
 Example: ``HUB_CUT_TEST LANE=lane1``  
 
 ### HUB_LOAD
 _Description_: This function handles the loading of a specified lane into the hub. It performs
 several checks and movements to ensure the lane is properly loaded.  
+  
 Usage: ``HUB_LOAD LANE=<lane>``  
 Example: ``HUB_LOAD LANE=lane1``  
 
 ### LANE_UNLOAD
 _Description_: This function handles the unloading of a specified lane from the extruder. It performs
 several checks and movements to ensure the lane is properly unloaded.  
+  
 Usage: ``LANE_UNLOAD LANE=<lane>``  
 Example: ``LANE_UNLOAD LANE=lane1``  
 
 ### QUERY_BUFFER
 _Description_: Reports the current state of the buffer sensor and, if applicable, the rotation
 distance of the current AFC stepper motor.  
+  
 Usage: `QUERY_BUFFER BUFFER=<buffer_name>`  
 Example: `QUERY_BUFFER BUFFER=TN`  
 
 ### RESET_AFC_MAPPING
-_Description_: This commands resets all tool lane mapping to the order that is setup in configuration.  
+_Description_: This commands resets all tool lane mapping to the order that is setup in configuration. Useful to put in your PRINT_END macro to reset mapping  
+  
 Usage: `RESET_AFC_MAPPING`  
 Example: `RESET_AFC_MAPPING`  
 
 ### RESET_FAILURE
 _Description_: This function clears the error state of the AFC system by setting the error state to False.  
+  
 Usage: ``RESET_FAILURE``  
 Example: ``RESET_FAILURE``  
 
+### SAVE_EXTRUDER_VALUES
+_Description_: Macro call to write tool_stn, tool_stn_unload and tool_sensor_after_extruder variables to config file for specified extruder.  
+  
+Usage: ``SAVE_EXTRUDER_VALUES EXTRUDER=<extruder>``  
+Example: ``SAVE_EXTRUDER_VALUES EXTRUDER=extruder``  
+
 ### SET_AFC_TOOLCHANGES
 _Description_: This macro can be used to set total number of toolchanges from slicer. AFC will keep track of tool changes and print out
-current tool change number when a T(n) command is called from gcode  
+current tool change number when a T(n) command is called from gcode.  
+The following call can be added to the slicer by adding the following lines to Change filament G-code section in your slicer.
+You may already have `T[next_extruder]`, just make sure the toolchange call is after your T(n) call
+```
+T[next_extruder]
+{ if toolchange_count == 1 }SET_AFC_TOOLCHANGES TOOLCHANGES=[total_toolchanges]{endif }
+```
+The following can also be added to your `PRINT_END` section in your slicer to set number of toolchanges back to zero
+`SET_AFC_TOOLCHANGES TOOLCHANGES=0`  
+  
 Usage: ``SET_AFC_TOOLCHANGES TOOLCHANGES=<number>``  
 Example: ``SET_AFC_TOOLCHANGES TOOLCHANGES=100``  
 
@@ -97,6 +126,7 @@ _Description_: This function adjusts the length of the Bowden tube between the h
 It retrieves the hub specified by the 'HUB' parameter and the length adjustment specified
 by the 'LENGTH' parameter. If the hub is not specified and a lane is currently loaded,
 it uses the hub of the current lane.  
+  
 Usage: ``SET_BOWDEN_LENGTH HUB=<hub> LENGTH=<length>``  
 Example: ``SET_BOWDEN_LENGTH HUB=Turtle_1 LENGTH=100``  
 
@@ -104,30 +134,36 @@ Example: ``SET_BOWDEN_LENGTH HUB=Turtle_1 LENGTH=100``
 _Description_: Allows users to tweak buffer velocity setting while printing. This setting is not
 saved in configuration. Please update your configuration file once you find a velocity that
 works for your setup.  
+  
 Usage: `SET_BUFFER_VELOCITY BUFFER=<buffer_name> VELOCITY=<value>`  
 Example: `SET_BUFFER_VELOCITY BUFFER=TN2 VELOCITY=100`  
 
 ### SET_COLOR
 _Description_: This function handles changing the color of a specified lane. It retrieves the lane
 specified by the 'LANE' parameter and sets its color to the value provided by the 'COLOR' parameter.  
+  
 Usage: ``SET_COLOR LANE=<lane> COLOR=<color>``  
 Example: ``SET_COLOR LANE=lane1 COLOR=FF0000``  
 
 ### SET_LANE_LOADED
 _Description_: This macro handles manually setting a lane loaded into the toolhead. This is useful when manually loading lanes
-during prints after AFC detects an error when loading/unloading and pauses. If there is a lane already loaded this macro 
+during prints after AFC detects an error when loading/unloading and pauses. If there is a lane already loaded this macro
 will also desync that lane extruder from the toolhead extruder and set its values and led appropriately.  
+Retrieves the lane specified by the 'LANE' parameter and set the appropriate values in AFC to continue using the lane.  
+  
 Usage: ``SET_LANE_LOADED LANE=<lane>``  
 Example: ``SET_LANE_LOADED LANE=lane1``  
 
 ### SET_MAP
 _Description_: This function handles changing the GCODE tool change command for a Lane.  
+  
 Usage: ``SET_MAP LANE=<lane> MAP=<cmd>``  
 Example: ``SET_MAP LANE=lane1 MAP=T1``  
 
 ### SET_MATERIAL
 _Description_: This function handles changing the material of a specified lane. It retrieves the lane
 specified by the 'LANE' parameter and sets its material to the value provided by the 'MATERIAL' parameter.  
+  
 Usage: `SET_MATERIAL LANE=<lane> MATERIAL=<material>`  
 Example: `SET_MATERIAL LANE=lane1 MATERIAL=ABS`  
 
@@ -135,6 +171,7 @@ Example: `SET_MATERIAL LANE=lane1 MATERIAL=ABS`
 _Description_: This function handles the adjustment of the buffer multipliers for the turtleneck buffer.
 It retrieves the multiplier type ('HIGH' or 'LOW') and the factor to be applied. The function
 ensures that the factor is valid and updates the corresponding multiplier.  
+  
 Usage: `SET_BUFFER_MULTIPLIER BUFFER=<buffer_name> MULTIPLIER=<HIGH/LOW> FACTOR=<factor>`  
 Example: `SET_BUFFER_MULTIPLIER BUFFER=TN MULTIPLIER=HIGH FACTOR=1.2`  
 
@@ -142,12 +179,14 @@ Example: `SET_BUFFER_MULTIPLIER BUFFER=TN MULTIPLIER=HIGH FACTOR=1.2`
 _Description_: Adjusts the rotation distance of the current AFC stepper motor by applying a
 specified factor. If no factor is provided, it defaults to 1.0, which resets
 the rotation distance to the base value.  
+  
 Usage: `SET_ROTATION_FACTOR BUFFER=<buffer_name> FACTOR=<factor>`  
 Example: `SET_ROTATION_FACTOR BUFFER=TN FACTOR=1.2`  
 
 ### SET_RUNOUT
 _Description_: This function handles setting the runout lane (infinite spool) for a specified lane. It retrieves the lane
 specified by the 'LANE' parameter and updates its the lane to use if filament runs out by untriggering prep sensor  
+  
 Usage: ``SET_RUNOUT LANE=<lane> RUNOUT=<lane>``  
 Example: ``SET_RUNOUT LANE=lane1 RUNOUT=lane4``  
 
@@ -155,17 +194,24 @@ Example: ``SET_RUNOUT LANE=lane1 RUNOUT=lane4``
 _Description_: This function handles setting the spool ID for a specified lane. It retrieves the lane
 specified by the 'LANE' parameter and updates its spool ID, material, color, and weight
 based on the information retrieved from the Spoolman API.  
+  
 Usage: ``SET_SPOOL_ID LANE=<lane> SPOOL_ID=<spool_id>``  
 Example: ``SET_SPOOL_ID LANE=lane1 SPOOL_ID=12345``  
 
 ### SET_TIP_FORMING
-_Description_: Sets the tip forming configuration  
+_Description_: Sets the tip forming configuration
+Unspecified ones are left unchanged. True boolean values (use_skinnydip) are specified as "true"
+(case insensitive); every other values is considered as "false".
+Note: this will not update the configuration file. To make settings permanent, update the configuration file
+manually.  
+  
 Usage: `SET_TIP_FORMING PARAMETER=VALUE ...`  
 Example: `SET_TIP_FORMING ramming_volume=20 toolchange_temp=220`  
 
 ### SET_WEIGHT
 _Description_: This function handles changing the material of a specified lane. It retrieves the lane
 specified by the 'LANE' parameter and sets its material to the value provided by the 'MATERIAL' parameter.  
+  
 Usage: `SET_WEIGHT LANE=<lane> WEIGHT=<weight>`  
 Example: `SET_WEIGHT LANE=lane1 WEIGHT=850`  
 
@@ -175,11 +221,13 @@ It performs the following steps:
 1. Retrieves the lane specified by the 'LANE' parameter.
 2. Tests the assist motor at full speed, 50%, 30%, and 10% speeds.
 3. Reports the status of each test step.  
+  
 Usage: ``TEST LANE=<lane>``  
 Example: ``TEST LANE=lane1``  
 
 ### TEST_AFC_TIP_FORMING
 _Description_: Gives ability to test AFC tip forming without doing a tool change  
+  
 Usage: `TEST_AFC_TIP_FORMING`  
 Example: `TEST_AFC_TIP_FORMING`  
 
@@ -187,6 +235,8 @@ Example: `TEST_AFC_TIP_FORMING`
 _Description_: This function handles the loading of a specified lane into the tool. It retrieves
 the lane specified by the 'LANE' parameter and calls the TOOL_LOAD method to perform
 the loading process.  
+Optionally setting PURGE_LENGTH parameter to pass a value into poop macro.  
+  
 Usage: ``TOOL_LOAD LANE=<lane> PURGE_LENGTH=<purge_length>(optional value)``  
 Example: ``TOOL_LOAD LANE=lane1 PURGE_LENGTH=80``  
 
@@ -194,32 +244,65 @@ Example: ``TOOL_LOAD LANE=lane1 PURGE_LENGTH=80``
 _Description_: This function handles the unloading of a specified lane from the tool head. It retrieves
 the lane specified by the 'LANE' parameter or uses the currently loaded lane if no parameter
 is provided, and calls the TOOL_UNLOAD method to perform the unloading process.  
+  
 Usage: ``TOOL_UNLOAD LANE=<lane>``  
 Example: ``TOOL_UNLOAD LANE=lane1``  
+
+### TURN_OFF_AFC_LED
+_Description_: This macro handles turning off all LEDs for AFC_led configurations. Color for LEDs are saved if colors are changed while they are turned off.  
+  
+Usage: ``TURN_OFF_AFC_LED``  
+Example: ``TURN_OFF_AFC_LED``  
+
+### TURN_ON_AFC_LED
+_Description_: This macro handles turning on all LEDs for AFC_led configurations. LEDs are restored to last previous state.  
+  
+Usage: ``TURN_ON_AFC_LED``  
+Example: ``TURN_ON_AFC_LED``  
 
 ### UNIT_BOW_CALIBRATION
 _Description_: Open a prompt to calibrate the Bowden length for a specific lane in the selected unit. Provides buttons
 for each lane, with a note to only calibrate one lane per unit.  
+  
 Usage: ``UNIT_CALIBRATION UNIT=<unit>``  
 Example: ``UNIT_CALIBRATION UNIT=Turtle_1``  
 
 ### UNIT_CALIBRATION
 _Description_: Open a prompt to calibrate either the distance between the extruder and the hub or the Bowden length
 for the selected unit. Provides buttons for lane calibration, Bowden length calibration, and a back option.  
+  
 Usage: ``UNIT_CALIBRATION UNIT=<unit>``  
 Example: ``UNIT_CALIBRATION UNIT=Turtle_1``  
 
 ### UNIT_LANE_CALIBRATION
 _Description_: Open a prompt to calibrate the extruder-to-hub distance for each lane in the selected unit. Creates buttons
 for each lane, grouped in sets of two, and allows calibration for all lanes or individual lanes.  
+  
 Usage: ``UNIT_LANE_CALIBRATION UNIT=<unit>``  
 Example: ``UNIT_LANE_CALIBRATION UNIT=Turtle_1``  
 
 ### UNSET_LANE_LOADED
 _Description_: Unsets current lane from AFC loaded status. Mainly this would be used if AFC thinks that there is a lane loaded into the toolhead
-but nothing is actually loaded.  
+but nothing is actually loaded. Retrieves the lane specified by the 'LANE' parameter and set the appropriate values in AFC to continue using the lane.  
+  
 Usage: ``UNSET_LANE_LOADED``  
 Example: ``UNSET_LANE_LOADED``  
+
+### UPDATE_TOOLHEAD_SENSORS
+_Description_: Macro call to adjust `tool_stn`\`tool_stn_unload`\`tool_sensor_after_extruder` lengths for specified extruder without having to update config file and restart klipper.  
+  
+tool_stn length is the length from the sensor before extruder gears (tool_start) to nozzle. If sensor after extruder gears(tool_end)
+is set then the value if from tool_end sensor.  
+  
+tool_stn_unload length is the length to unload so that filament is not in extruder gears anymore.  
+  
+tool_sensor_after_extruder length is mainly used for those that have a filament sensor after extruder gears, target this
+length to retract filament enough so that it's not in the extruder gears anymore.  
+  
+Please pause print if you need to adjust this value while printing  
+  
+Usage: ``UPDATE_TOOLHEAD_SENSORS EXTRUDER=<extruder> TOOL_STN=<length> TOOL_STN_UNLOAD=<length> TOOL_AFTER_EXTRUDER=<length>``  
+Example: ``UPDATE_TOOLHEAD_SENSORS EXTRUDER=extruder TOOL_STN=100``  
 
 ## AFC Macros
 

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -4,14 +4,25 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
-import logging
 import json
 import re
+from configfile import error
+
 try:
     from urllib.request import urlopen
 except:
     # Python 2.7 support
     from urllib2 import urlopen
+
+try:
+    from extras.AFC_logger import AFC_logger
+except:
+    raise error("Error trying to import AFC_logger, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper")
+
+try:
+    from extras.AFC_functions import afcDeltaTime
+except:
+    raise error("Error trying to import afcDeltaTime, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper")
 
 AFC_VERSION="1.0.0"
 
@@ -35,6 +46,7 @@ class afc:
         self.reactor = self.printer.get_reactor()
         self.webhooks = self.printer.lookup_object('webhooks')
         self.printer.register_event_handler("klippy:connect",self.handle_connect)
+        self.logger  = AFC_logger(self.printer)
 
         self.SPOOL      = self.printer.load_object(config,'AFC_spool')
         self.ERROR      = self.printer.load_object(config,'AFC_error')
@@ -66,6 +78,7 @@ class afc:
         self.hubs       = {}
         self.buffers    = {}
         self.tool_cmds  = {}
+        self.led_obj    = {}
         self.monitoring = False
         self.number_of_toolchanges  = 0
         self.current_toolchange     = 0
@@ -84,80 +97,85 @@ class afc:
         self.absolute_coord = True
 
         # Config get section
-        self.moonraker_port = config.get("moonraker_port", None)                    # Port to connect to when interacting with moonraker. Used when there are multiple moonraker/klipper instances on a single host
-        self.unit_order_list = config.get('unit_order_list','')
-        self.VarFile = config.get('VarFile','../printer_data/config/AFC/') 			# Path to the variables file for AFC configuration.
-        self.cfgloc = self._remove_after_last(self.VarFile,"/")
-        self.default_material_temps = config.getlists("default_material_temps", None) # Default temperature to set extruder when loading/unloading lanes. Material needs to be either manually set or uses material from spoolman if extruder temp is not set in spoolman.
-        self.default_material_temps = list(self.default_material_temps)
+        self.moonraker_port         = config.get("moonraker_port", None)             # Port to connect to when interacting with moonraker. Used when there are multiple moonraker/klipper instances on a single host
+        self.unit_order_list        = config.get('unit_order_list','')
+        self.VarFile                = config.get('VarFile','../printer_data/config/AFC/')# Path to the variables file for AFC configuration.
+        self.cfgloc                 = self._remove_after_last(self.VarFile,"/")
+        self.default_material_temps = config.getlists("default_material_temps", None)# Default temperature to set extruder when loading/unloading lanes. Material needs to be either manually set or uses material from spoolman if extruder temp is not set in spoolman.
+        self.default_material_temps = list(self.default_material_temps) if self.default_material_temps is not None else None
+        self.default_material_type  = config.get("default_material_type", None)     # Default material type to assign to a spool once loaded into a lane
 
         #LED SETTINGS
         self.ind_lights = None
         # led_name is not used, either use or needs to be removed
-        self.led_name = config.get('led_name',None)
-        self.led_fault =config.get('led_fault','1,0,0,0')                           # LED color to set when faults occur in lane        (R,G,B,W) 0 = off, 1 = full brightness.
-        self.led_ready = config.get('led_ready','1,1,1,1')                          # LED color to set when lane is ready               (R,G,B,W) 0 = off, 1 = full brightness.
-        self.led_not_ready = config.get('led_not_ready','1,1,0,0')                  # LED color to set when lane not ready              (R,G,B,W) 0 = off, 1 = full brightness.
-        self.led_loading = config.get('led_loading','1,0,0,0')                      # LED color to set when lane is loading             (R,G,B,W) 0 = off, 1 = full brightness.
-        self.led_prep_loaded = config.get('led_loading','1,1,0,0')                  # LED color to set when lane is loaded              (R,G,B,W) 0 = off, 1 = full brightness.
-        self.led_unloading = config.get('led_unloading','1,1,.5,0')                 # LED color to set when lane is unloading           (R,G,B,W) 0 = off, 1 = full brightness.
-        self.led_tool_loaded = config.get('led_tool_loaded','1,1,0,0')              # LED color to set when lane is loaded into tool    (R,G,B,W) 0 = off, 1 = full brightness.
-        self.led_advancing = config.get('led_buffer_advancing','0,0,1,0')           # LED color to set when buffer is advancing         (R,G,B,W) 0 = off, 1 = full brightness.
-        self.led_trailing = config.get('led_buffer_trailing','0,1,0,0')             # LED color to set when buffer is trailing          (R,G,B,W) 0 = off, 1 = full brightness.
-        self.led_buffer_disabled = config.get('led_buffer_disable', '0,0,0,0.25')   # LED color to set when buffer is disabled          (R,G,B,W) 0 = off, 1 = full brightness.
+        self.led_name               = config.get('led_name',None)
+        self.led_fault              = config.get('led_fault','1,0,0,0')             # LED color to set when faults occur in lane        (R,G,B,W) 0 = off, 1 = full brightness.
+        self.led_ready              = config.get('led_ready','1,1,1,1')             # LED color to set when lane is ready               (R,G,B,W) 0 = off, 1 = full brightness.
+        self.led_not_ready          = config.get('led_not_ready','1,1,0,0')         # LED color to set when lane not ready              (R,G,B,W) 0 = off, 1 = full brightness.
+        self.led_loading            = config.get('led_loading','1,0,0,0')           # LED color to set when lane is loading             (R,G,B,W) 0 = off, 1 = full brightness.
+        self.led_prep_loaded        = config.get('led_loading','1,1,0,0')           # LED color to set when lane is loaded              (R,G,B,W) 0 = off, 1 = full brightness.
+        self.led_unloading          = config.get('led_unloading','1,1,.5,0')        # LED color to set when lane is unloading           (R,G,B,W) 0 = off, 1 = full brightness.
+        self.led_tool_loaded        = config.get('led_tool_loaded','1,1,0,0')       # LED color to set when lane is loaded into tool    (R,G,B,W) 0 = off, 1 = full brightness.
+        self.led_advancing          = config.get('led_buffer_advancing','0,0,1,0')  # LED color to set when buffer is advancing         (R,G,B,W) 0 = off, 1 = full brightness.
+        self.led_trailing           = config.get('led_buffer_trailing','0,1,0,0')   # LED color to set when buffer is trailing          (R,G,B,W) 0 = off, 1 = full brightness.
+        self.led_buffer_disabled    = config.get('led_buffer_disable', '0,0,0,0.25')# LED color to set when buffer is disabled          (R,G,B,W) 0 = off, 1 = full brightness.
 
         # TOOL Cutting Settings
-        self.tool = ''
-        self.tool_cut = config.getboolean("tool_cut", False)                        # Set to True to enable toolhead cutting
-        self.tool_cut_cmd = config.get('tool_cut_cmd', None)                        # Macro to use when doing toolhead cutting. Change macro name if you would like to use your own cutting macro
+        self.tool                   = ''
+        self.tool_cut               = config.getboolean("tool_cut", False)          # Set to True to enable toolhead cutting
+        self.tool_cut_cmd           = config.get('tool_cut_cmd', None)              # Macro to use when doing toolhead cutting. Change macro name if you would like to use your own cutting macro
 
         # CHOICES
-        self.park = config.getboolean("park", False)                                # Set to True to enable parking during unload
-        self.park_cmd = config.get('park_cmd', None)                                # Macro to use when parking. Change macro name if you would like to use your own park macro
-        self.kick = config.getboolean("kick", False)                                # Set to True to enable poop kicking after lane loads
-        self.kick_cmd = config.get('kick_cmd', None)                                # Macro to use when kicking. Change macro name if you would like to use your own kick macro
-        self.wipe = config.getboolean("wipe", False)                                # Set to True to enable nozzle wiping after lane loads
-        self.wipe_cmd = config.get('wipe_cmd', None)                                # Macro to use when nozzle wiping. Change macro name if you would like to use your own wipe macro
-        self.poop = config.getboolean("poop", False)                                # Set to True to enable pooping(purging color) after lane loads
-        self.poop_cmd = config.get('poop_cmd', None)                                # Macro to use when pooping. Change macro name if you would like to use your own poop/purge macro
+        self.park                   = config.getboolean("park", False)              # Set to True to enable parking during unload
+        self.park_cmd               = config.get('park_cmd', None)                  # Macro to use when parking. Change macro name if you would like to use your own park macro
+        self.kick                   = config.getboolean("kick", False)              # Set to True to enable poop kicking after lane loads
+        self.kick_cmd               = config.get('kick_cmd', None)                  # Macro to use when kicking. Change macro name if you would like to use your own kick macro
+        self.wipe                   = config.getboolean("wipe", False)              # Set to True to enable nozzle wiping after lane loads
+        self.wipe_cmd               = config.get('wipe_cmd', None)                  # Macro to use when nozzle wiping. Change macro name if you would like to use your own wipe macro
+        self.poop                   = config.getboolean("poop", False)              # Set to True to enable pooping(purging color) after lane loads
+        self.poop_cmd               = config.get('poop_cmd', None)                  # Macro to use when pooping. Change macro name if you would like to use your own poop/purge macro
 
-        self.form_tip = config.getboolean("form_tip", False)                        # Set to True to tip forming when unloading lanes
-        self.form_tip_cmd = config.get('form_tip_cmd', None)                        # Macro to use when tip forming. Change macro name if you would like to use your own tip forming macro
+        self.form_tip               = config.getboolean("form_tip", False)          # Set to True to tip forming when unloading lanes
+        self.form_tip_cmd           = config.get('form_tip_cmd', None)              # Macro to use when tip forming. Change macro name if you would like to use your own tip forming macro
 
         # MOVE SETTINGS
-        self.long_moves_speed   = config.getfloat("long_moves_speed", 100)          # Speed in mm/s to move filament when doing long moves
-        self.long_moves_accel   = config.getfloat("long_moves_accel", 400)          # Acceleration in mm/s squared when doing long moves
-        self.short_moves_speed  = config.getfloat("short_moves_speed", 25)          # Speed in mm/s to move filament when doing short moves
-        self.short_moves_accel  = config.getfloat("short_moves_accel", 400)         # Acceleration in mm/s squared when doing short moves
-        self.short_move_dis     = config.getfloat("short_move_dis", 10)             # Move distance in mm for failsafe moves.
-        self.max_move_dis       = config.getfloat("max_move_dis", 999999)           # Maximum distance to move filament. AFC breaks filament moves over this number into multiple moves. Useful to lower this number if running into timer too close errors when doing long filament moves.
+        self.long_moves_speed       = config.getfloat("long_moves_speed", 100)      # Speed in mm/s to move filament when doing long moves
+        self.long_moves_accel       = config.getfloat("long_moves_accel", 400)      # Acceleration in mm/s squared when doing long moves
+        self.short_moves_speed      = config.getfloat("short_moves_speed", 25)      # Speed in mm/s to move filament when doing short moves
+        self.short_moves_accel      = config.getfloat("short_moves_accel", 400)     # Acceleration in mm/s squared when doing short moves
+        self.short_move_dis         = config.getfloat("short_move_dis", 10)         # Move distance in mm for failsafe moves.
+        self.max_move_dis           = config.getfloat("max_move_dis", 999999)       # Maximum distance to move filament. AFC breaks filament moves over this number into multiple moves. Useful to lower this number if running into timer too close errors when doing long filament moves.
         self.n20_break_delay_time   = config.getfloat("n20_break_delay_time", 0.200)# Time to wait between breaking n20 motors(nSleep/FWD/RWD all 1) and then releasing the break to allow coasting.
 
-        self.tool_max_unload_attempts = config.getint('tool_max_unload_attempts', 2)# Max number of attempts to unload filament from toolhead when using buffer as ramming sensor
-        self.tool_max_load_checks = config.getint('tool_max_load_checks', 4)        # Max number of attempts to check to make sure filament is loaded into toolhead extruder when using buffer as ramming sensor
+        self.tool_max_unload_attempts= config.getint('tool_max_unload_attempts', 2) # Max number of attempts to unload filament from toolhead when using buffer as ramming sensor
+        self.tool_max_load_checks   = config.getint('tool_max_load_checks', 4)      # Max number of attempts to check to make sure filament is loaded into toolhead extruder when using buffer as ramming sensor
 
-        self.z_hop = config.getfloat("z_hop", 0)                                     # Height to move up before and after a tool change completes
-        self.xy_resume = config.getboolean("xy_resume", False)                       # Need description or remove as this is currently an unused variable
-        self.resume_speed = config.getfloat("resume_speed", 0)                       # Speed mm/s of resume move. Set to 0 to use gcode speed
-        self.resume_z_speed = config.getfloat("resume_z_speed", 0)                  # Speed mm/s of resume move in Z. Set to 0 to use gcode speed
+        self.z_hop                  = config.getfloat("z_hop", 0)                   # Height to move up before and after a tool change completes
+        self.xy_resume              = config.getboolean("xy_resume", False)         # Need description or remove as this is currently an unused variable
+        self.resume_speed           = config.getfloat("resume_speed", 0)            # Speed mm/s of resume move. Set to 0 to use gcode speed
+        self.resume_z_speed         = config.getfloat("resume_z_speed", 0)          # Speed mm/s of resume move in Z. Set to 0 to use gcode speed
 
-        self.global_print_current = config.getfloat("global_print_current", None)   # Global variable to set steppers current to a specified current when printing. Going lower than 0.6 may result in TurtleNeck buffer's not working correctly
+        self.global_print_current   = config.getfloat("global_print_current", None) # Global variable to set steppers current to a specified current when printing. Going lower than 0.6 may result in TurtleNeck buffer's not working correctly
 
-        self.enable_sensors_in_gui = config.getboolean("enable_sensors_in_gui", False) # Set to True to show all sensor switches as filament sensors in mainsail/fluidd gui
-        self.load_to_hub = config.getboolean("load_to_hub", True)            # Fast loads filament to hub when inserted, set to False to disable. This is a global setting and can be overridden at AFC_stepper
-        self.assisted_unload = config.getboolean("assisted_unload", False)   # If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool
+        self.enable_sensors_in_gui  = config.getboolean("enable_sensors_in_gui", False) # Set to True to show all sensor switches as filament sensors in mainsail/fluidd gui
+        self.load_to_hub            = config.getboolean("load_to_hub", True)        # Fast loads filament to hub when inserted, set to False to disable. This is a global setting and can be overridden at AFC_stepper
+        self.assisted_unload        = config.getboolean("assisted_unload", True)    # If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool
+        self.bypass_pause           = config.getboolean("pause_when_bypass_active", False) # When true AFC pauses print when change tool is called and bypass is loaded
+        self.unload_on_runout       = config.getboolean("unload_on_runout", False)  # When True AFC will unload lane and then pause when runout is triggered and spool to swap to is not set(infinite spool)
 
+        self.debug                  = config.getboolean('debug', False)             # Setting to True turns on more debugging to show on console
+        # Get debug and cast to boolean
+        self.logger.set_debug( self.debug )
         self._update_trsync(config)
 
-        # Get debug and cast to boolean
-        #self.debug = True == config.get('debug', 0)
-        self.debug = False
 
         # Printing here will not display in console but it will go to klippy.log
         self.print_version()
 
         self.BASE_UNLOAD_FILAMENT    = 'UNLOAD_FILAMENT'
         self.RENAMED_UNLOAD_FILAMENT = '_AFC_RENAMED_{}_'.format(self.BASE_UNLOAD_FILAMENT)
+
+        self.afcDeltaTime = afcDeltaTime(self)
 
     def _remove_after_last(self, string, char):
         last_index = string.rfind(char)
@@ -174,16 +192,16 @@ class afc:
                 import mcu
                 trsync_value = config.getfloat("trsync_timeout", 0.05)              # Timeout value to update in klipper mcu. Klippers default value is 0.025
                 trsync_single_value = config.getfloat("trsync_single_timeout", 0.5) # Single timeout value to update in klipper mcu. Klippers default value is 0.250
-                self.gcode.respond_info("Applying TRSYNC update")
+                self.logger.info("Applying TRSYNC update")
 
                 # Making sure value exists as kalico(danger klipper) does not have TRSYNC_TIMEOUT value
                 if( hasattr(mcu, "TRSYNC_TIMEOUT")): mcu.TRSYNC_TIMEOUT = max(mcu.TRSYNC_TIMEOUT, trsync_value)
-                else : self.gcode.respond_info("TRSYNC_TIMEOUT does not exist in mcu file, not updating")
+                else : self.logger.info("TRSYNC_TIMEOUT does not exist in mcu file, not updating")
 
                 if( hasattr(mcu, "TRSYNC_SINGLE_MCU_TIMEOUT")): mcu.TRSYNC_SINGLE_MCU_TIMEOUT = max(mcu.TRSYNC_SINGLE_MCU_TIMEOUT, trsync_single_value)
-                else : self.gcode.respond_info("TRSYNC_SINGLE_MCU_TIMEOUT does not exist in mcu file, not updating")
+                else : self.logger.info("TRSYNC_SINGLE_MCU_TIMEOUT does not exist in mcu file, not updating")
             except Exception as e:
-                self.gcode.respond_info("Unable to update TRSYNC_TIMEOUT: {}".format(e))
+                self.logger.info("Unable to update TRSYNC_TIMEOUT: {}".format(e))
 
     def register_lane_macros(self, lane_obj):
         """
@@ -220,9 +238,11 @@ class afc:
         self.gcode.register_command('AFC_STATUS',           self.cmd_AFC_STATUS,            desc=self.cmd_AFC_STATUS_help)
         self.gcode.register_command('SET_AFC_TOOLCHANGES',  self.cmd_SET_AFC_TOOLCHANGES,   desc=self.cmd_SET_AFC_TOOLCHANGES_help)
         self.gcode.register_command('UNSET_LANE_LOADED',    self.cmd_UNSET_LANE_LOADED,     desc=self.cmd_UNSET_LANE_LOADED_help)
+        self.gcode.register_command('TURN_OFF_AFC_LED',     self.cmd_TURN_OFF_AFC_LED,      desc=self.cmd_TURN_OFF_AFC_LED_help)
+        self.gcode.register_command('TURN_ON_AFC_LED',      self.cmd_TURN_ON_AFC_LED,       desc=self.cmd_TURN_ON_AFC_LED_help)
         self.current_state = State.IDLE
 
-    def print_version(self):
+    def print_version(self, console_only=False):
         """
         Calculated AFC git version and displays to console and log
         """
@@ -231,7 +251,9 @@ class afc:
         afc_dir  = os.path.dirname(os.path.realpath(__file__))
         git_hash = subprocess.check_output(['git', '-C', '{}'.format(afc_dir), 'rev-parse', '--short', 'HEAD']).decode('ascii').strip()
         git_commit_num = subprocess.check_output(['git', '-C', '{}'.format(afc_dir), 'rev-list', 'HEAD', '--count']).decode('ascii').strip()
-        self.gcode.respond_info("AFC Version: v{}-{}-{}".format(AFC_VERSION, git_commit_num, git_hash))
+        string  = "AFC Version: v{}-{}-{}".format(AFC_VERSION, git_commit_num, git_hash)
+
+        self.logger.info(string, console_only)
 
     def _get_default_material_temps(self, CUR_LANE):
         """
@@ -275,6 +297,7 @@ class afc:
         extruder = self.toolhead.get_extruder()
         self.heater = extruder.get_heater()
         pheaters = self.printer.lookup_object('heaters')
+        wait = False
 
         # If extruder can extruder and printing return and do not update temperature, don't want to modify extruder temperature during prints
         if self.heater.can_extrude and self.FUNCTION.is_printing():
@@ -285,8 +308,25 @@ class afc:
         if self.heater.target_temp <= (target_temp-5) or (self.heater.target_temp >= (target_temp+5) and not using_min_value):
             wait = False if self.heater.target_temp >= (target_temp+5) else True
 
-            self.gcode.respond_info('Setting extruder temperature to {} {}'.format(target_temp, "and waiting for extruder to reach temperature" if wait else ""))
+            self.logger.info('Setting extruder temperature to {} {}'.format(target_temp, "and waiting for extruder to reach temperature" if wait else ""))
             pheaters.set_temperature(extruder.get_heater(), target_temp, wait=wait)
+
+        return wait
+
+    def _get_bypass_state(self):
+        """
+        Helper function to return if filament is present in bypass sensor
+
+        :return Returns current state of bypass sensor. If bypass sensor does not exist, always returns False
+        """
+        bypass_state = False
+        try:
+            bypass = self.printer.lookup_object('filament_switch_sensor bypass').runout_helper
+            bypass_state = bypass.filament_present
+        except:
+            pass
+
+        return bypass_state
 
     def _check_bypass(self, unload=False):
         """
@@ -296,17 +336,15 @@ class afc:
         :return        Returns true if filament is present in sensor
         """
         try:
-            bypass = self.printer.lookup_object('filament_switch_sensor bypass').runout_helper
-            if bypass.filament_present:
+            if self._get_bypass_state():
                 if unload:
-                    self.gcode.respond_info("Bypass detected, calling manual unload filament routine")
+                    self.logger.info("Bypass detected, calling manual unload filament routine")
                     self.gcode.run_script_from_command(self.RENAMED_UNLOAD_FILAMENT)
-                    self.gcode.respond_info("Filament unloaded")
+                    self.logger.info("Filament unloaded")
                 else:
                     msg = "Filament loaded in bypass, not doing tool load"
-                    # If printing report as error so position is saved and then print is paused
-                    self.ERROR.AFC_error(msg, pause=self.FUNCTION.in_print())
-
+                    # If printing report as error, only pause if in a print and bypass_pause variable is True
+                    self.ERROR.AFC_error(msg, pause= ( self.FUNCTION.in_print() and self.bypass_pause ) )
                 return True
         except:
             pass
@@ -316,9 +354,7 @@ class afc:
     def cmd_UNSET_LANE_LOADED(self, gcmd):
         """
         Unsets current lane from AFC loaded status. Mainly this would be used if AFC thinks that there is a lane loaded into the toolhead
-        but nothing is actually loaded.
-
-        It retrieves the lane specified by the 'LANE' parameter and set the appropiate values in AFC to continue using the lane.
+        but nothing is actually loaded. Retrieves the lane specified by the 'LANE' parameter and set the appropriate values in AFC to continue using the lane.
 
         Usage: `UNSET_LANE_LOADED`
         Example: `UNSET_LANE_LOADED`
@@ -335,15 +371,13 @@ class afc:
     def cmd_SET_AFC_TOOLCHANGES(self, gcmd):
         """
         This macro can be used to set total number of toolchanges from slicer. AFC will keep track of tool changes and print out
-        current tool change number when a T(n) command is called from gcode
-
-        This call can be added to the slicer by adding the following lines to Change filament G-code section in your slicer.
+        current tool change number when a T(n) command is called from gcode.  <nl>
+        The following call can be added to the slicer by adding the following lines to Change filament G-code section in your slicer.
         You may already have `T[next_extruder]`, just make sure the toolchange call is after your T(n) call
         ```
         T[next_extruder]
         { if toolchange_count == 1 }SET_AFC_TOOLCHANGES TOOLCHANGES=[total_toolchanges]{endif }
         ```
-
         The following can also be added to your `PRINT_END` section in your slicer to set number of toolchanges back to zero
         `SET_AFC_TOOLCHANGES TOOLCHANGES=0`
 
@@ -359,14 +393,13 @@ class afc:
         self.number_of_toolchanges  = gcmd.get_int("TOOLCHANGES")
         self.current_toolchange     = 0 # Reset back to one
         if self.number_of_toolchanges > 0:
-            self.gcode.respond_info("Total number of toolchanges set to {}".format(self.number_of_toolchanges))
+            self.logger.info("Total number of toolchanges set to {}".format(self.number_of_toolchanges))
 
     cmd_LANE_MOVE_help = "Lane Manual Movements"
     def cmd_LANE_MOVE(self, gcmd):
         """
         This function handles the manual movement of a specified lane. It retrieves the lane
-        specified by the 'LANE' parameter and moves it by the distance specified by the 'DISTANCE' parameter.
-
+        specified by the 'LANE' parameter and moves it by the distance specified by the 'DISTANCE' parameter.  <nl>
         Distance's lower than 200 moves extruder at short_move_speed/accel, values above 200 move extruder at long_move_speed/accel
 
         Usage: `LANE_MOVE LANE=<lane> DISTANCE=<distance>`
@@ -389,7 +422,7 @@ class afc:
         lane = gcmd.get('LANE', None)
         distance = gcmd.get_float('DISTANCE', 0)
         if lane not in self.lanes:
-            self.gcode.respond_info('{} Unknown'.format(lane))
+            self.logger.info('{} Unknown'.format(lane))
             return
         CUR_LANE = self.lanes[lane]
         self.current_state = State.MOVING_LANE
@@ -415,25 +448,27 @@ class afc:
                 self.homing_position        = self.gcode_move.homing_position
                 self.speed                  = self.gcode_move.speed
                 self.absolute_coord         = self.gcode_move.absolute_coord
-                logging.warning("AFC debug : Saving position {}".format(self.last_toolhead_position))
-                logging.warning("  Base position: {}".format(self.base_position))
-                logging.warning("  last_gcode_position: {}".format(self.last_gcode_position))
-                logging.warning("  homing_position: {}".format(self.homing_position))
-                logging.warning("  speed: {}".format(self.speed))
-                logging.warning("  absolute_coord: {}".format(self.absolute_coord))
-
+                msg = "Saving position {}".format(self.last_toolhead_position)
+                msg += " Base position: {}".format(self.base_position)
+                msg += " last_gcode_position: {}".format(self.last_gcode_position)
+                msg += " homing_position: {}".format(self.homing_position)
+                msg += " speed: {}".format(self.speed)
+                msg += " absolute_coord: {}\n".format(self.absolute_coord)
+                self.logger.debug(msg)
 
     def restore_pos(self):
         """
         restore_pos function restores the previous saved position, speed and coord type. The resume uses
         the z_hop value to lift, move to previous x,y coords, then lower to saved z position.
         """
-        logging.warning("AFC debug : Restoring Postion {}".format(self.last_toolhead_position))
-        logging.warning("  Base position: {}".format(self.base_position))
-        logging.warning("  last_gcode_position: {}".format(self.last_gcode_position))
-        logging.warning("  homing_position: {}".format(self.homing_position))
-        logging.warning("  speed: {}".format(self.speed))
-        logging.warning("  absolute_coord: {}".format(self.absolute_coord))
+        msg = "Restoring Postion {}".format(self.last_toolhead_position)
+        msg += " Base position: {}".format(self.base_position)
+        msg += " last_gcode_position: {}".format(self.last_gcode_position)
+        msg += " homing_position: {}".format(self.homing_position)
+        msg += " speed: {}".format(self.speed)
+        msg += " absolute_coord: {}\n".format(self.absolute_coord)
+        self.logger.debug(msg)
+
         self.current_state = State.RESTORING_POS
         newpos = self.toolhead.get_position()
         newpos[2] = self.last_gcode_position[2] + self.z_hop
@@ -522,7 +557,7 @@ class afc:
 
         lane = gcmd.get('LANE', None)
         if lane not in self.lanes:
-            self.gcode.respond_info('{} Unknown'.format(lane))
+            self.logger.info('{} Unknown'.format(lane))
             return
         CUR_LANE = self.lanes[lane]
         CUR_HUB = CUR_LANE.hub_obj
@@ -566,7 +601,7 @@ class afc:
 
         lane = gcmd.get('LANE', None)
         if lane not in self.lanes:
-            self.gcode.respond_info('{} Unknown'.format(lane))
+            self.logger.info('{} Unknown'.format(lane))
             return
         CUR_LANE = self.lanes[lane]
         CUR_HUB = CUR_LANE.hub_obj
@@ -592,14 +627,14 @@ class afc:
 
             # Removing spool from vars since it was ejected
             self.SPOOL.set_spoolID( CUR_LANE, "")
-            self.gcode.respond_info("LANE {} eject done".format(CUR_LANE.name))
+            self.logger.info("LANE {} eject done".format(CUR_LANE.name))
             self.FUNCTION.afc_led(CUR_LANE.led_not_ready, CUR_LANE.led_index)
 
         elif CUR_LANE.name == self.current:
-            self.gcode.respond_info("LANE {} is loaded in toolhead, can't unload.".format(CUR_LANE.name))
+            self.logger.info("LANE {} is loaded in toolhead, can't unload.".format(CUR_LANE.name))
 
         elif CUR_LANE.hub == 'direct':
-            self.gcode.respond_info("LANE {} is a direct lane must be tool unloaded.".format(CUR_LANE.name))
+            self.logger.info("LANE {} is a direct lane must be tool unloaded.".format(CUR_LANE.name))
 
         self.current_state = State.IDLE
 
@@ -608,8 +643,7 @@ class afc:
         """
         This function handles the loading of a specified lane into the tool. It retrieves
         the lane specified by the 'LANE' parameter and calls the TOOL_LOAD method to perform
-        the loading process.
-
+        the loading process.  <nl>
         Optionally setting PURGE_LENGTH parameter to pass a value into poop macro.
 
         Usage: `TOOL_LOAD LANE=<lane> PURGE_LENGTH=<purge_length>(optional value)`
@@ -625,9 +659,10 @@ class afc:
         Returns:
             None
         """
+        self.afcDeltaTime.set_start_time()
         lane = gcmd.get('LANE', None)
         if lane not in self.lanes:
-            self.gcode.respond_info('{} Unknown'.format(lane))
+            self.logger.info('{} Unknown'.format(lane))
             return
 
         if self.current is not None:
@@ -660,7 +695,7 @@ class afc:
         # Check if the bypass filament sensor is triggered; abort loading if filament is already present.
         if self._check_bypass(): return False
 
-        self.gcode.respond_info("Loading {}".format(CUR_LANE.name))
+        self.logger.info("Loading {}".format(CUR_LANE.name))
 
         # Lookup extruder and hub objects associated with the lane.
         CUR_HUB = CUR_LANE.hub_obj
@@ -677,7 +712,8 @@ class afc:
         # Check if the lane is in a state ready to load and hub is clear.
         if (CUR_LANE.load_state and not CUR_HUB.state) or CUR_LANE.hub == 'direct':
 
-            self._check_extruder_temp(CUR_LANE)
+            if self._check_extruder_temp(CUR_LANE):
+                self.afcDeltaTime.log_with_time("Done heating toolhead")
 
             # Enable the lane for filament movement.
             CUR_LANE.do_enable(True)
@@ -685,6 +721,7 @@ class afc:
             # Move filament to the hub if it's not already loaded there.
             if not CUR_LANE.loaded_to_hub or CUR_LANE.hub == 'direct':
                 CUR_LANE.move(CUR_LANE.dist_hub, CUR_LANE.dist_hub_move_speed, CUR_LANE.dist_hub_move_accel, CUR_LANE.dist_hub > 200)
+                self.afcDeltaTime.log_with_time("Loaded to hub")
 
             CUR_LANE.loaded_to_hub = True
             hub_attempts = 0
@@ -704,6 +741,8 @@ class afc:
                     self.ERROR.handle_lane_failure(CUR_LANE, message)
                     return False
 
+            self.afcDeltaTime.log_with_time("Filament loaded to hub")
+
             # Move filament towards the toolhead.
             if CUR_LANE.hub != 'direct':
                 CUR_LANE.move(CUR_HUB.afc_bowden_length, CUR_LANE.long_moves_speed, CUR_LANE.long_moves_accel, True)
@@ -711,7 +750,7 @@ class afc:
             # Ensure filament reaches the toolhead.
             tool_attempts = 0
             if CUR_EXTRUDER.tool_start:
-                while not CUR_LANE.get_toolhead_sensor_state():
+                while not CUR_LANE.get_toolhead_pre_sensor_state():
                     tool_attempts += 1
                     CUR_LANE.move(CUR_LANE.short_move_dis, CUR_EXTRUDER.tool_load_speed, CUR_LANE.long_moves_accel)
                     if tool_attempts > 20:
@@ -723,6 +762,8 @@ class afc:
                             message += '\nOnce filament is fully loaded click resume to continue printing'
                         self.ERROR.handle_lane_failure(CUR_LANE, message)
                         return False
+
+            self.afcDeltaTime.log_with_time("Filament loaded to pre-sensor")
 
             # Synchronize lane's extruder stepper and finalize tool loading.
             CUR_LANE.status = 'Tool Loaded'
@@ -745,11 +786,15 @@ class afc:
                         self.ERROR.handle_lane_failure(CUR_LANE, message)
                         return False
 
+                self.afcDeltaTime.log_with_time("Filament loaded to post-sensor")
+
             # Adjust tool position for loading.
             pos = self.toolhead.get_position()
             pos[3] += CUR_EXTRUDER.tool_stn
             self.toolhead.manual_move(pos, CUR_EXTRUDER.tool_load_speed)
             self.toolhead.wait_moves()
+
+            self.afcDeltaTime.log_with_time("Filament loaded to nozzle")
 
             # Check if ramming is enabled, if it is go through ram load sequence.
             # Lane will load until Advance sensor is True
@@ -757,7 +802,7 @@ class afc:
             if CUR_EXTRUDER.tool_start == "buffer":
                 CUR_LANE.unsync_to_extruder()
                 load_checks = 0
-                while CUR_LANE.get_toolhead_sensor_state() == True:
+                while CUR_LANE.get_toolhead_pre_sensor_state() == True:
                     CUR_LANE.move( CUR_LANE.short_move_dis * -1, CUR_LANE.short_moves_speed, CUR_LANE.short_moves_accel )
                     load_checks += 1
                     self.reactor.pause(self.reactor.monotonic() + 0.1)
@@ -765,7 +810,7 @@ class afc:
                         msg = ''
                         msg += "Buffer did not become compressed after {} short moves.\n".format(self.tool_max_load_checks)
                         msg += "Tool may not be loaded"
-                        self.gcode.respond_info("<span class=warning--text>{}</span>".format(msg))
+                        self.logger.info("<span class=warning--text>{}</span>".format(msg))
                         break
                 CUR_LANE.sync_to_extruder()
             # Update tool and lane status.
@@ -777,14 +822,27 @@ class afc:
             if self.poop:
                 if purge_length is not None:
                     self.gcode.run_script_from_command("%s %s=%s" % (self.poop_cmd, 'PURGE_LENGTH', purge_length))
+
                 else:
                     self.gcode.run_script_from_command(self.poop_cmd)
+
+                self.afcDeltaTime.log_with_time("TOOL_LOAD: After poop")
+                self.FUNCTION.log_toolhead_pos()
+
                 if self.wipe:
                     self.gcode.run_script_from_command(self.wipe_cmd)
+                    self.afcDeltaTime.log_with_time("TOOL_LOAD: After first wipe")
+                    self.FUNCTION.log_toolhead_pos()
+
             if self.kick:
                 self.gcode.run_script_from_command(self.kick_cmd)
+                self.afcDeltaTime.log_with_time("TOOL_LOAD: After kick")
+                self.FUNCTION.log_toolhead_pos()
+
             if self.wipe:
                 self.gcode.run_script_from_command(self.wipe_cmd)
+                self.afcDeltaTime.log_with_time("TOOL_LOAD: After second wipe")
+                self.FUNCTION.log_toolhead_pos()
 
             # Update lane and extruder state for tracking.
             CUR_EXTRUDER.lane_loaded = CUR_LANE.name
@@ -792,6 +850,8 @@ class afc:
             self.FUNCTION.afc_led(CUR_LANE.led_tool_loaded, CUR_LANE.led_index)
             self.save_vars()
             self.current_state = State.IDLE
+            self.afcDeltaTime.log_major_delta("{} is now loaded in toolhead".format(CUR_LANE.name), False)
+
         else:
             # Handle errors if the hub is not clear or the lane is not ready for loading.
             if CUR_HUB.state:
@@ -827,6 +887,7 @@ class afc:
         Returns:
             None
         """
+        self.afcDeltaTime.set_start_time()
         # Check if the bypass filament sensor detects filament; if so unload filament and abort the tool load.
         if self._check_bypass(unload=True): return False
 
@@ -834,7 +895,7 @@ class afc:
         if lane == None:
             return
         if lane not in self.lanes:
-            self.gcode.respond_info('{} Unknown'.format(lane))
+            self.logger.info('{} Unknown'.format(lane))
             return
         CUR_LANE = self.lanes[lane]
         self.TOOL_UNLOAD(CUR_LANE)
@@ -865,7 +926,7 @@ class afc:
 
         self.current_state  = State.UNLOADING
         self.current_loading = CUR_LANE.name
-        self.gcode.respond_info("Unloading {}".format(CUR_LANE.name))
+        self.logger.info("Unloading {}".format(CUR_LANE.name))
         CUR_LANE.status = 'Tool Unloading'
         self.save_vars()
         # Lookup current extruder and hub objects using the lane's information.
@@ -873,7 +934,8 @@ class afc:
         CUR_EXTRUDER = CUR_LANE.extruder_obj
 
         # Prepare the extruder and heater for unloading.
-        self._check_extruder_temp( CUR_LANE )
+        if self._check_extruder_temp( CUR_LANE ):
+            self.afcDeltaTime.log_with_time("Done heating toolhead")
 
         # Quick pull to prevent oozing.
         pos = self.toolhead.get_position()
@@ -902,18 +964,31 @@ class afc:
         # Perform filament cutting and parking if specified.
         if self.tool_cut:
             self.gcode.run_script_from_command(self.tool_cut_cmd)
+            self.afcDeltaTime.log_with_time("TOOL_UNLOAD: After cut")
+            self.FUNCTION.log_toolhead_pos()
+
             if self.park:
                 self.gcode.run_script_from_command(self.park_cmd)
+                self.afcDeltaTime.log_with_time("TOOL_UNLOAD: After park")
+                self.FUNCTION.log_toolhead_pos()
 
         # Form filament tip if necessary.
         if self.form_tip:
             if self.park:
                 self.gcode.run_script_from_command(self.park_cmd)
+                self.afcDeltaTime.log_with_time("TOOL_UNLOAD: After form tip park")
+                self.FUNCTION.log_toolhead_pos()
+
             if self.form_tip_cmd == "AFC":
                 self.tip = self.printer.lookup_object('AFC_form_tip')
                 self.tip.tip_form()
+                self.afcDeltaTime.log_with_time("TOOL_UNLOAD: After afc form tip")
+                self.FUNCTION.log_toolhead_pos()
+
             else:
                 self.gcode.run_script_from_command(self.form_tip_cmd)
+                self.afcDeltaTime.log_with_time("TOOL_UNLOAD: After custom form tip")
+                self.FUNCTION.log_toolhead_pos()
 
         # Attempt to unload the filament from the extruder, retrying if needed.
         num_tries = 0
@@ -929,7 +1004,7 @@ class afc:
                     msg = ''
                     msg += "Buffer did not become compressed after {} short moves.\n".format(self.tool_max_unload_attempts)
                     msg += "Increasing 'tool_max_unload_attempts' may improve loading reliablity"
-                    self.gcode.respond_info("<span class=warning--text>{}</span>".format(msg))
+                    self.logger.info("<span class=warning--text>{}</span>".format(msg))
                     break
             CUR_LANE.sync_to_extruder(False)
             pos = self.toolhead.get_position()
@@ -938,7 +1013,7 @@ class afc:
                 self.toolhead.manual_move(pos, CUR_EXTRUDER.tool_unload_speed)
                 self.toolhead.wait_moves()
         else:
-            while CUR_LANE.get_toolhead_sensor_state():
+            while CUR_LANE.get_toolhead_pre_sensor_state() or CUR_EXTRUDER.tool_end_state:
                 num_tries += 1
                 if num_tries > self.tool_max_unload_attempts:
                     # Handle failure if the filament cannot be unloaded.
@@ -957,6 +1032,8 @@ class afc:
                     self.toolhead.manual_move(pos, CUR_EXTRUDER.tool_unload_speed)
                     self.toolhead.wait_moves()
 
+        self.afcDeltaTime.log_with_time("Unloaded from toolhead")
+
         # Move filament past the sensor after the extruder, if applicable.
         if CUR_EXTRUDER.tool_sensor_after_extruder > 0:
             pos = self.toolhead.get_position()
@@ -964,6 +1041,9 @@ class afc:
             with CUR_LANE.assist_move(CUR_EXTRUDER.tool_unload_speed, True, CUR_LANE.assisted_unload):
                 self.toolhead.manual_move(pos, CUR_EXTRUDER.tool_unload_speed)
                 self.toolhead.wait_moves()
+
+            self.afcDeltaTime.log_with_time("Tool sensor after extruder move done")
+
         self.save_vars()
         # Synchronize and move filament out of the hub.
         CUR_LANE.unsync_to_extruder()
@@ -971,6 +1051,8 @@ class afc:
             CUR_LANE.move(CUR_HUB.afc_bowden_length * -1, CUR_LANE.long_moves_speed, CUR_LANE.long_moves_accel, True)
         else:
             CUR_LANE.move(CUR_LANE.dist_hub * -1, CUR_LANE.dist_hub_move_speed, CUR_LANE.dist_hub_move_accel, CUR_LANE.dist_hub > 200)
+
+        self.afcDeltaTime.log_with_time("Long retract done")
 
         # Clear toolhead's loaded state for easier error handling later.
         CUR_LANE.set_unloaded()
@@ -994,11 +1076,13 @@ class afc:
                 self.ERROR.handle_lane_failure(CUR_LANE, message)
                 return False
 
+        self.afcDeltaTime.log_with_time("Hub cleared")
+
         #Move to make sure hub path is clear based on the move_clear_dis var
         if CUR_LANE.hub !='direct':
             CUR_LANE.move( CUR_HUB.hub_clear_move_dis * -1, CUR_LANE.short_moves_speed, CUR_LANE.short_moves_accel, True)
 
-        # Cut filament at the hub, if configured.
+            # Cut filament at the hub, if configured.
             if CUR_HUB.cut:
                 if CUR_HUB.cut_cmd == 'AFC':
                     CUR_HUB.hub_cut(CUR_LANE)
@@ -1015,6 +1099,8 @@ class afc:
                         self.ERROR.handle_lane_failure(CUR_LANE, message)
                         return False
 
+                self.afcDeltaTime.log_with_time("Hub cut done")
+
         # Finalize unloading and reset lane state.
         CUR_LANE.loaded_to_hub = True
         self.FUNCTION.afc_led(CUR_LANE.led_ready, CUR_LANE.led_index)
@@ -1026,7 +1112,7 @@ class afc:
 
         CUR_LANE.do_enable(False)
         self.save_vars()
-        self.gcode.respond_info("LANE {} unload done".format(CUR_LANE.name))
+        self.afcDeltaTime.log_major_delta("Lane {} unload done".format(CUR_LANE.name))
         self.current_state = State.IDLE
         return True
 
@@ -1036,7 +1122,6 @@ class afc:
         This function handles the tool change process. It retrieves the lane specified by the 'LANE' parameter,
         checks the filament sensor, saves the current position, and performs the tool change by unloading the
         current lane and loading the new lane.
-
         Optionally setting PURGE_LENGTH parameter to pass a value into poop macro.
 
         Usage: `CHANGE_TOOL LANE=<lane> PURGE_LENGTH=<purge_length>(optional value)`
@@ -1052,7 +1137,7 @@ class afc:
         Returns:
             None
         """
-
+        self.afcDeltaTime.set_start_time()
         # Check if the bypass filament sensor detects filament; if so, abort the tool change.
         if self._check_bypass(unload=False): return
 
@@ -1109,10 +1194,10 @@ class afc:
             # Check if the lane has completed the preparation process required for tool changes.
             if CUR_LANE._afc_prep_done:
                 # Log the tool change operation for debugging or informational purposes.
-                self.gcode.respond_info("Tool Change - {} -> {}".format(self.current, CUR_LANE.name))
+                self.logger.info("Tool Change - {} -> {}".format(self.current, CUR_LANE.name))
                 if not self.error_state and self.number_of_toolchanges != 0 and self.current_toolchange != self.number_of_toolchanges:
                     self.current_toolchange += 1
-                    self.gcode.respond_raw("//      Change {} out of {}".format(self.current_toolchange, self.number_of_toolchanges))
+                    self.logger.raw("//      Change {} out of {}".format(self.current_toolchange, self.number_of_toolchanges))
 
                 # If a current lane is loaded, unload it first.
                 if self.current is not None:
@@ -1125,15 +1210,16 @@ class afc:
                         msg = (' UNLOAD ERROR NOT CLEARED')
                         self.ERROR.fix(msg, self.lanes[c_lane])  #send to error handling
                         return
+
             # Load the new lane and restore the toolhead position if successful.
             if self.TOOL_LOAD(CUR_LANE, purge_length) and not self.error_state:
-                self.gcode.respond_info("{} is now loaded in toolhead".format(CUR_LANE.name))
+                self.afcDeltaTime.log_total_time("Total change time:")
                 self.restore_pos()
                 self.in_toolchange = False
                 # Setting next lane load as none since toolchange was successful
                 self.next_lane_load = None
         else:
-            self.gcode.respond_info("{} already loaded".format(CUR_LANE.name))
+            self.logger.info("{} already loaded".format(CUR_LANE.name))
             if not self.error_state and self.number_of_toolchanges != 0 and self.current_toolchange != self.number_of_toolchanges:
                 self.current_toolchange += 1
 
@@ -1150,6 +1236,8 @@ class afc:
         str["number_of_toolchanges"]    = self.number_of_toolchanges
         str['spoolman']                 = self.spoolman
         str['error_state']              = self.error_state
+        str["bypass_state"]             = bool(self._get_bypass_state())
+
         unitdisplay =[]
         for UNIT in self.units.keys():
             CUR_UNIT=self.units[UNIT]
@@ -1232,7 +1320,7 @@ class afc:
                 lane_msg = ''
                 if self.current != None:
                     if self.current == CUR_LANE.name:
-                        if not CUR_LANE.get_toolhead_sensor_state() or not CUR_LANE.hub_obj.state:
+                        if not CUR_LANE.get_toolhead_pre_sensor_state() or not CUR_LANE.hub_obj.state:
                             lane_msg += '<span class=warning--text>{:<{}} </span>'.format(CUR_LANE.name, max_lane_length)
                         else:
                             lane_msg += '<span class=success--text>{:<{}} </span>'.format(CUR_LANE.name, max_lane_length)
@@ -1262,11 +1350,47 @@ class afc:
                     extruder_msg = '  Tool: <span class=success--text><-></span>'
             else:
                 if CUR_LANE.tool_loaded and CUR_LANE.extruder_obj.lane_loaded in self.units[UNIT]:
-                    if CUR_LANE.get_toolhead_sensor_state() == True:
+                    if CUR_LANE.get_toolhead_pre_sensor_state() == True:
                         extruder_msg = '  Tool: <span class=success--text><-></span>'
 
             status_msg += extruder_msg
             if CUR_LANE.extruder_obj.tool_start == 'buffer':
                 status_msg += '\n<span class=info--text>Ram sensor enabled</span>\n'
 
-        self.gcode.respond_raw(status_msg)
+        self.logger.raw(status_msg)
+
+    cmd_TURN_OFF_AFC_LED_help = "Turns off all LEDs for AFC_led configurations"
+    def cmd_TURN_OFF_AFC_LED(self, gcmd):
+        """
+        This macro handles turning off all LEDs for AFC_led configurations. Color for LEDs are saved if colors are changed while they are turned off.
+
+        Usage: `TURN_OFF_AFC_LED`
+        Example: `TURN_OFF_AFC_LED`
+
+        Args:
+            gcmd: The G-code command object containing the parameters for the command.
+                  Expected parameter:
+
+        Returns:
+            None
+        """
+        for led in self.led_obj.values():
+            led.turn_off_leds()
+
+    cmd_TURN_ON_AFC_LED_help = "Turns on all LEDs for AFC_led configurations and restores state"
+    def cmd_TURN_ON_AFC_LED(self, gcmd):
+        """
+        This macro handles turning on all LEDs for AFC_led configurations. LEDs are restored to last previous state.
+
+        Usage: `TURN_ON_AFC_LED`
+        Example: `TURN_ON_AFC_LED`
+
+        Args:
+            gcmd: The G-code command object containing the parameters for the command.
+                  Expected parameter:
+
+        Returns:
+            None
+        """
+        for led in self.led_obj.values():
+            led.turn_on_leds()

--- a/extras/AFC_buffer.py
+++ b/extras/AFC_buffer.py
@@ -16,54 +16,55 @@ TRAILING_STATE_NAME = "Advancing"
 class AFCtrigger:
 
     def __init__(self, config):
-        self.printer = config.get_printer()
-        self.AFC = self.printer.lookup_object('AFC')
-        self.reactor = self.AFC.reactor
-        self.gcode = self.AFC.gcode
+        self.printer    = config.get_printer()
+        self.AFC        = self.printer.lookup_object('AFC')
+        self.reactor    = self.AFC.reactor
+        self.gcode      = self.AFC.gcode
+        self.logger     = self.AFC.logger
 
-        self.name = config.get_name().split(' ')[-1]
-        self.lanes = {}
+        self.name       = config.get_name().split(' ')[-1]
+        self.lanes      = {}
         self.turtleneck = False
-        self.belay = False
+        self.belay      = False
         self.last_state = "Unknown"
-        self.enable = False
-        self.current = ''
+        self.enable     = False
+        self.current    = ''
         self.advance_state = False
         self.trailing_state = False
 
-        self.debug = config.getboolean("debug", False)
-        self.buttons = self.printer.load_object(config, "buttons")
-        self.enable_sensors_in_gui = config.getboolean("enable_sensors_in_gui", self.AFC.enable_sensors_in_gui)  # Set to True toolhead sensors switches as filament sensors in mainsail/fluidd gui, overrides value set in AFC.cfg
+        self.debug                  = config.getboolean("debug", False)
+        self.enable_sensors_in_gui  = config.getboolean("enable_sensors_in_gui", self.AFC.enable_sensors_in_gui)  # Set to True toolhead sensors switches as filament sensors in mainsail/fluidd gui, overrides value set in AFC.cfg
+        self.buttons                = self.printer.load_object(config, "buttons")
 
         # LED SETTINGS
-        self.led_index = config.get('led_index', None)
-        self.led = False
-        self.led_advancing = config.get('led_buffer_advancing','0,0,1,0')
-        self.led_trailing = config.get('led_buffer_trailing','0,1,0,0')
-        self.led_buffer_disabled = config.get('led_buffer_disable', '0,0,0,0.25')
+        self.led                    = False
+        self.led_index              = config.get('led_index', None)
+        self.led_advancing          = config.get('led_buffer_advancing','0,0,1,0')
+        self.led_trailing           = config.get('led_buffer_trailing','0,1,0,0')
+        self.led_buffer_disabled    = config.get('led_buffer_disable', '0,0,0,0.25')
 
         if self.led_index is not None:
             self.led = True
             self.led_index = config.get('led_index')
 
         # Try and get one of each pin to see how user has configured buffer
-        self.advance_pin = config.get('advance_pin', None)
-        self.buffer_distance = config.getfloat('distance', None)
+        self.advance_pin        = config.get('advance_pin', None)
+        self.buffer_distance    = config.getfloat('distance', None)
 
         if self.advance_pin is not None and self.buffer_distance is not None:
             # Throw an error as this is not a valid configuration, only Turtle neck or buffer can be configured not both
             msg = "Turtle neck or buffer can be configured not both, please fix buffer configuration"
-            self.gcode._respond_error( msg )
+            self.logger.error( msg )
             raise error( msg )
 
         # Pull config for Turtleneck style buffer (advance and training switches)
         if self.advance_pin is not None:
-            self.turtleneck = True
-            self.advance_pin = config.get('advance_pin') # Advance pin for buffer
-            self.trailing_pin = config.get('trailing_pin') # Trailing pin for buffer
-            self.multiplier_high = config.getfloat("multiplier_high", default=1.1, minval=1.0)
-            self.multiplier_low = config.getfloat("multiplier_low", default=0.9, minval=0.0, maxval=1.0)
-            self.velocity = config.getfloat('velocity', 0) # Velocity for forward assist
+            self.turtleneck         = True
+            self.advance_pin        = config.get('advance_pin') # Advance pin for buffer
+            self.trailing_pin       = config.get('trailing_pin') # Trailing pin for buffer
+            self.multiplier_high    = config.getfloat("multiplier_high", default=1.1, minval=1.0)
+            self.multiplier_low     = config.getfloat("multiplier_low", default=0.9, minval=0.0, maxval=1.0)
+            self.velocity           = config.getfloat('velocity', 0) # Velocity for forward assist
 
             if self.enable_sensors_in_gui:
                 self.adv_filament_switch_name = "filament_switch_sensor {}_{}".format(self.name, "expanded")
@@ -74,16 +75,16 @@ class AFCtrigger:
 
         # Pull config for Belay style buffer (single switch)
         elif self.buffer_distance is not None:
-            self.belay = True
-            self.pin = config.get('pin')
-            self.buffer_distance = config.getfloat('distance', 0)
-            self.velocity = config.getfloat('velocity', 0)
-            self.accel = config.getfloat('accel', 0)
+            self.belay              = True
+            self.pin                = config.get('pin')
+            self.buffer_distance    = config.getfloat('distance', 0)
+            self.velocity           = config.getfloat('velocity', 0)
+            self.accel              = config.getfloat('accel', 0)
 
         # Error if buffer is not configured correctly
         else:
             msg = "Buffer is not configured correctly, please fix configuration"
-            self.gcode._respond_error( msg )
+            self.logger.error( msg )
             raise error( msg )
 
         self.printer.register_event_handler("klippy:ready", self._handle_ready)
@@ -133,7 +134,7 @@ class AFCtrigger:
 
         if state:
             if LANE.status != 'unloading':
-                if self.debug: self.gcode.respond_info("Buffer Triggered, Moving Lane {} forward {}mm".format(LANE.name, self.buffer_distance))
+                if self.debug: self.logger.info("Buffer Triggered, Moving Lane {} forward {}mm".format(LANE.name, self.buffer_distance))
                 LANE.move(self.buffer_distance, self.velocity ,self.accel)
 
     def enable_buffer(self):
@@ -147,15 +148,15 @@ class AFCtrigger:
             else:
                 multiplier = self.multiplier_high
             self.set_multiplier( multiplier )
-            if self.debug: self.gcode.respond_info("{} buffer enabled".format(self.name))
+            if self.debug: self.logger.info("{} buffer enabled".format(self.name))
         elif self.belay:
             self.enable = True
-            if self.debug: self.gcode.respond_info("{} buffer enabled".format(self.name))
+            if self.debug: self.logger.info("{} buffer enabled".format(self.name))
             self.belay_move_lane(self.last_state)
 
     def disable_buffer(self):
         self.enable = False
-        if self.debug: self.gcode.respond_info("{} buffer disabled".format(self.name))
+        if self.debug: self.logger.info("{} buffer disabled".format(self.name))
         if self.led:
             self.AFC.FUNCTION.afc_led(self.led_buffer_disabled, self.led_index)
         if self.turtleneck:
@@ -178,16 +179,16 @@ class AFCtrigger:
                 self.AFC.FUNCTION.afc_led(self.led_advancing, self.led_index)
         if self.debug:
             stepper = cur_stepper.extruder_stepper.stepper
-            self.gcode.respond_info("New rotation distance after applying factor: {:.4f}".format(stepper.get_rotation_distance()[0]))
+            self.logger.info("New rotation distance after applying factor: {:.4f}".format(stepper.get_rotation_distance()[0]))
 
     def reset_multiplier(self):
-        if self.debug: self.gcode.respond_info("Buffer multiplier reset")
+        if self.debug: self.logger.info("Buffer multiplier reset")
 
         cur_stepper = self.AFC.FUNCTION.get_current_lane_obj()
         if cur_stepper is None: return
 
         cur_stepper.update_rotation_distance( 1 )
-        self.gcode.respond_info("Rotation distance reset : {:.4f}".format(cur_stepper.extruder_stepper.stepper.get_rotation_distance()[0]))
+        self.logger.info("Rotation distance reset : {:.4f}".format(cur_stepper.extruder_stepper.stepper.get_rotation_distance()[0]))
 
     def advance_callback(self, eventime, state):
         self.advance_state = state
@@ -199,7 +200,7 @@ class AFCtrigger:
                 self.reactor.pause(self.reactor.monotonic() + 1)
                 CUR_LANE.assist(0)
                 self.set_multiplier( self.multiplier_low )
-                if self.debug: self.gcode.respond_info("Buffer Triggered State: Advanced")
+                if self.debug: self.logger.info("Buffer Triggered State: Advanced")
         self.last_state = ADVANCE_STATE_NAME
 
     def trailing_callback(self, eventime, state):
@@ -212,7 +213,7 @@ class AFCtrigger:
                 self.reactor.pause(self.reactor.monotonic() + 1)
                 CUR_LANE.assist(0)
                 self.set_multiplier( self.multiplier_high )
-                if self.debug: self.gcode.respond_info("Buffer Triggered State: Trailing")
+                if self.debug: self.logger.info("Buffer Triggered State: Trailing")
         self.last_state = TRAILING_STATE_NAME
 
     def buffer_status(self):
@@ -250,24 +251,24 @@ class AFCtrigger:
             if cur_stepper != None and self.enable:
                 chg_multiplier = gcmd.get('MULTIPLIER', None)
                 if chg_multiplier == None:
-                    self.gcode.respond_info("Multiplier must be provided, HIGH or LOW")
+                    self.logger.info("Multiplier must be provided, HIGH or LOW")
                     return
                 chg_factor = gcmd.get_float('FACTOR')
                 if chg_factor <= 0:
-                    self.gcode.respond_info("FACTOR must be greater than 0")
+                    self.logger.info("FACTOR must be greater than 0")
                     return
                 if chg_multiplier == "HIGH" and chg_factor > 1:
                     self.multiplier_high = chg_factor
                     self.set_multiplier(chg_factor)
-                    self.gcode.respond_info("multiplier_high set to {}".format(chg_factor))
-                    self.gcode.respond_info('multiplier_high: {} MUST be updated under buffer config for value to be saved'.format(chg_factor))
+                    self.logger.info("multiplier_high set to {}".format(chg_factor))
+                    self.logger.info('multiplier_high: {} MUST be updated under buffer config for value to be saved'.format(chg_factor))
                 elif chg_multiplier == "LOW" and chg_factor < 1:
                     self.multiplier_low = chg_factor
                     self.set_multiplier(chg_factor)
-                    self.gcode.respond_info("multiplier_low set to {}".format(chg_factor))
-                    self.gcode.respond_info('multiplier_low: {} MUST be updated under buffer config for value to be saved'.format(chg_factor))
+                    self.logger.info("multiplier_low set to {}".format(chg_factor))
+                    self.logger.info('multiplier_low: {} MUST be updated under buffer config for value to be saved'.format(chg_factor))
                 else:
-                    self.gcode.respond_info('multiplier_high must be greater than 1, multiplier_low must be less than 1')
+                    self.logger.info('multiplier_high must be greater than 1, multiplier_low must be less than 1')
 
     cmd_LANE_ROT_FACTOR_help = "change rotation distance by factor specified"
     def cmd_SET_ROTATION_FACTOR(self, gcmd):
@@ -299,17 +300,17 @@ class AFCtrigger:
             if cur_stepper != None and self.enable:
                 change_factor = gcmd.get_float('FACTOR', 1.0)
                 if change_factor <= 0:
-                    self.gcode.respond_info("FACTOR must be greater than 0")
+                    self.logger.info("FACTOR must be greater than 0")
                     return
                 elif change_factor == 1.0:
                     self.set_multiplier ( 1 )
-                    self.gcode.respond_info("Rotation distance reset to base value")
+                    self.logger.info("Rotation distance reset to base value")
                 else:
                     self.set_multiplier( change_factor )
             else:
-                self.gcode.respond_info("BUFFER {} NOT ENABLED".format(self.name))
+                self.logger.info("BUFFER {} NOT ENABLED".format(self.name))
         else:
-            self.gcode.respond_info("BUFFER {} CAN'T CHANGE ROTATION DISTANCE".format(self.name))
+            self.logger.info("BUFFER {} CAN'T CHANGE ROTATION DISTANCE".format(self.name))
 
     cmd_QUERY_BUFFER_help = "Report Buffer sensor state"
     def cmd_QUERY_BUFFER(self, gcmd):
@@ -342,7 +343,7 @@ class AFCtrigger:
                 rotation_dist = stepper.get_rotation_distance()[0]
                 state_info += ("\n{} Rotation distance: {:.4f}".format(LANE.name, rotation_dist))
 
-        self.gcode.respond_info("{} : {}".format(self.name, state_info))
+        self.logger.info("{} : {}".format(self.name, state_info))
 
     cmd_SET_BUFFER_VELOCITY_help = "Set buffer velocity realtime for forward assist"
     def cmd_SET_BUFFER_VELOCITY(self, gcmd):
@@ -361,7 +362,7 @@ class AFCtrigger:
         """
         old_velocity = self.velocity
         self.velocity = gcmd.get_float('VELOCITY', 0.0)
-        self.gcode.respond_info("VELOCITY for {} was updated from {} to {}".format(self.name, old_velocity, self.velocity))
+        self.logger.info("VELOCITY for {} was updated from {} to {}".format(self.name, old_velocity, self.velocity))
 
     def cmd_ENABLE_BUFFER(self, gcmd):
         self.enable_buffer()
@@ -374,6 +375,7 @@ class AFCtrigger:
         self.response['state'] = self.last_state
         self.response['lanes'] = [lane.name for lane in self.lanes.values()]
         self.response['enabled'] = self.enable
+        self.response['belay'] = self.belay
         return self.response
 
 def load_config_prefix(config):

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -24,6 +24,7 @@ class afcError:
         and assigns it to the instance variable `self.AFC`.
         """
         self.AFC = self.printer.lookup_object('AFC')
+        self.logger = self.AFC.logger
         # Constant variable for renaming RESUME macro
         self.BASE_RESUME_NAME       = 'RESUME'
         self.AFC_RENAME_RESUME_NAME = '_AFC_RENAMED_{}_'.format(self.BASE_RESUME_NAME)
@@ -47,7 +48,7 @@ class afcError:
         return error_handled
 
     def ToolHeadFix(self, CUR_LANE):
-        if CUR_LANE.get_toolhead_sensor_state():   #toolhead has filament
+        if CUR_LANE.get_toolhead_pre_sensor_state():   #toolhead has filament
             if CUR_LANE.extruder_obj.lane_loaded == CUR_LANE.name:   #var has right lane loaded
                 if CUR_LANE.load_state == False: #Lane has filament
                     self.PauseUserIntervention('Filament not loaded in Lane')
@@ -75,7 +76,7 @@ class afcError:
 
     def PauseUserIntervention(self,message):
         #pause for user intervention
-        self.AFC.gcode._respond_error(message)
+        self.logger.error(message)
         if self.AFC.FUNCTION.is_homed() and not self.AFC.FUNCTION.is_paused():
             self.AFC.save_pos()
             if self.pause:
@@ -87,8 +88,10 @@ class afcError:
         the base pause command
         """
         self.set_error_state( True )
-        self.AFC.gcode.respond_info ('PAUSING')
+        self.logger.info ('PAUSING')
         self.AFC.gcode.run_script_from_command('PAUSE')
+        self.logger.debug("After User Pause")
+        self.AFC.FUNCTION.log_toolhead_pos()
 
     def set_error_state(self, state=False):
         logging.warning("AFC debug: setting error state {}".format(state))
@@ -102,7 +105,7 @@ class afcError:
         # Print to logger since respond_raw does not write to logger
         logging.warning(msg)
         # Handle AFC errors
-        self.AFC.gcode.respond_raw( "!! {}".format(msg) )
+        self.logger.error( "{}".format(msg) )
         if pause: self.pause_print()
 
 
@@ -139,6 +142,8 @@ class afcError:
             None
         """
         self.AFC.in_toolchange = False
+        self.logger.debug("Before User Restore")
+        self.AFC.FUNCTION.log_toolhead_pos()
         self.AFC.gcode.run_script_from_command(self.AFC_RENAME_RESUME_NAME)
 
         #The only time our resume should restore position is if there was an error that caused the pause

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -11,30 +11,32 @@ except:
 
 class AFCextruder:
     def __init__(self, config):
-        self.printer = config.get_printer()
+        self.printer    = config.get_printer()
+        buttons         = self.printer.load_object(config, "buttons")
+        self.AFC        = self.printer.lookup_object('AFC')
+        self.gcode      = self.printer.lookup_object('gcode')
+        self.logger     = self.AFC.logger
         self.printer.register_event_handler("klippy:connect", self.handle_connect)
-        buttons = self.printer.load_object(config, "buttons")
-        self.AFC = self.printer.lookup_object('AFC')
 
-        self.name = config.get_name().split(' ')[-1]
-        self.tool_stn = config.getfloat("tool_stn", 72)
-        self.tool_stn_unload = config.getfloat("tool_stn_unload", 100)
-        self.tool_sensor_after_extruder = config.getfloat("tool_sensor_after_extruder", 0)
-        self.tool_unload_speed = config.getfloat("tool_unload_speed", 25)
-        self.tool_load_speed = config.getfloat("tool_load_speed", 25)
-        self.tool_start = config.get('pin_tool_start', None)
-        self.tool_end = config.get('pin_tool_end', None)
-        self.lane_loaded = None
-        self.lanes = {}
-        self.buffer_name = config.get('buffer', None)
+        self.fullname                   = config.get_name()
+        self.name                       = self.fullname.split(' ')[-1]
+        self.tool_start                 = config.get('pin_tool_start', None)                                            # Pin for sensor before(pre) extruder gears
+        self.tool_end                   = config.get('pin_tool_end', None)                                              # Pin for sensor after(post) extruder gears (optional)
+        self.tool_stn                   = config.getfloat("tool_stn", 72)                                               # Distance in mm from the toolhead sensor to the tip of the nozzle in mm, if `tool_end` is defined then distance is from this sensor
+        self.tool_stn_unload            = config.getfloat("tool_stn_unload", 100)                                       # Distance to move in mm while unloading toolhead
+        self.tool_sensor_after_extruder = config.getfloat("tool_sensor_after_extruder", 0)                              # Extra distance to move in mm once pre/post sensors are clear. Useful for when only using post sensor, so this distance can be the amout to move to clear extruder gears
+        self.tool_unload_speed          = config.getfloat("tool_unload_speed", 25)                                      # Unload speed in mm/s when unloading toolhead. Default is 25mm/s.
+        self.tool_load_speed            = config.getfloat("tool_load_speed", 25)                                        # Load speed in mm/s when unloading toolhead. Default is 25mm/s.
+        self.buffer_name                = config.get('buffer', None)                                                    # Buffer to use for extruder, this variable can be overridden per lane
+        self.enable_sensors_in_gui      = config.getboolean("enable_sensors_in_gui", self.AFC.enable_sensors_in_gui)    # Set to True toolhead sensors switches as filament sensors in mainsail/fluidd gui, overrides value set in AFC.cfg
 
-        self.gcode = self.printer.lookup_object('gcode')
-        self.enable_sensors_in_gui = config.getboolean("enable_sensors_in_gui", self.AFC.enable_sensors_in_gui) # Set to True toolhead sensors switches as filament sensors in mainsail/fluidd gui, overrides value set in AFC.cfg
+        self.lane_loaded                = None
+        self.lanes                      = {}
 
         self.tool_start_state = False
         if self.tool_start is not None:
             if self.tool_start == "buffer":
-                self.gcode.respond_info("Setting up as buffer")
+                self.logger.info("Setting up as buffer")
             else:
                 self.tool_start_state = False
                 buttons.register_buttons([self.tool_start], self.tool_start_callback)
@@ -48,6 +50,9 @@ class AFCextruder:
             if self.enable_sensors_in_gui:
                 self.tool_end_state_filament_switch_name = "filament_switch_sensor {}".format("tool_end")
                 self.fila_avd = add_filament_switch(self.tool_end_state_filament_switch_name, self.tool_end, self.printer )
+
+        self.common_save_msg = "\nRun SAVE_EXTRUDER_VALUES EXTRUDER={} once done to update values in config".format(self.name)
+
     def handle_connect(self):
         """
         Handle the connection event.
@@ -57,6 +62,9 @@ class AFCextruder:
         self.reactor = self.AFC.reactor
         self.AFC.tools[self.name] = self
 
+        self.AFC.gcode.register_mux_command('UPDATE_TOOLHEAD_SENSORS',  "EXTRUDER", self.name, self.cmd_UPDATE_TOOLHEAD_SENSORS,desc=self.cmd_UPDATE_TOOLHEAD_SENSORS_help)
+        self.AFC.gcode.register_mux_command('SAVE_EXTRUDER_VALUES',     "EXTRUDER", self.name, self.cmd_SAVE_EXTRUDER_VALUES,   desc=self.cmd_SAVE_EXTRUDER_VALUES_help)
+
     def tool_start_callback(self, eventtime, state):
         self.tool_start_state = state
 
@@ -65,6 +73,107 @@ class AFCextruder:
 
     def tool_end_callback(self, eventtime, state):
         self.tool_end_state = state
+
+    def _update_tool_stn(self, length):
+        """
+        Helper function to set tool_stn length
+
+        :param length: Length to set to tool_stn parameter
+        """
+        if length > 0:
+            msg = "tool_stn updated old: {}, new: {}".format(self.tool_stn, length)
+            msg += self.common_save_msg
+            self.tool_stn = length
+            self.logger.info(msg)
+        else:
+            self.logger.error("tool_stn length should be greater than zero")
+
+    def _update_tool_stn_unload(self, length):
+        """
+        Helper function to set tool_stn_unload length
+
+        :param length: Length to set to tool_stn_unload parameter
+        """
+        if length > 0:
+            msg = "tool_stn_unload updated old: {}, new: {}".format(self.tool_stn_unload, length)
+            msg += self.common_save_msg
+            self.tool_stn_unload = length
+            self.logger.info(msg)
+        else:
+            self.logger.error("tool_stn_unload length should be greater than zero")
+
+    def _update_tool_after_extr(self, length):
+        """
+        Helper function to set tool_sensor_after_extruder length
+
+        :param length: Length to set to tool_sensor_after_extruder parameter
+        """
+        if length > 0:
+            msg = "tool_sensor_after_extruder updated old: {}, new: {}".format(self.tool_sensor_after_extruder, length)
+            msg += self.common_save_msg
+            self.tool_sensor_after_extruder = length
+            self.logger.info(msg)
+        else:
+            self.logger.error("tool_sensor_after_extruder length should be greater than zero")
+
+    cmd_UPDATE_TOOLHEAD_SENSORS_help = "Gives ability to update tool_stn\tool_stn_unload\tool_sensor_after_extruder values without restarting klipper"
+    def cmd_UPDATE_TOOLHEAD_SENSORS(self, gcmd):
+        """
+        Macro call to adjust `tool_stn`\`tool_stn_unload`\`tool_sensor_after_extruder` lengths for specified extruder without having to update config file and restart klipper.  <nl>
+          <nl>
+        tool_stn length is the length from the sensor before extruder gears (tool_start) to nozzle. If sensor after extruder gears(tool_end)
+        is set then the value if from tool_end sensor.  <nl>
+          <nl>
+        tool_stn_unload length is the length to unload so that filament is not in extruder gears anymore.  <nl>
+          <nl>
+        tool_sensor_after_extruder length is mainly used for those that have a filament sensor after extruder gears, target this
+        length to retract filament enough so that it's not in the extruder gears anymore.  <nl>
+          <nl>
+        Please pause print if you need to adjust this value while printing
+
+        Usage: `UPDATE_TOOLHEAD_SENSORS EXTRUDER=<extruder> TOOL_STN=<length> TOOL_STN_UNLOAD=<length> TOOL_AFTER_EXTRUDER=<length>`
+        Example: `UPDATE_TOOLHEAD_SENSORS EXTRUDER=extruder TOOL_STN=100`
+
+        Args:
+            gcmd: The G-code command object containing the parameters for the command.
+                  Expected parameters:
+                  - EXTRUDER: The name of the extruder to adjust value for.
+                  - LENGTH: The length adjustment value.
+
+        Returns:
+            None
+        """
+        tool_stn                    = gcmd.get_float("TOOL_STN",            self.tool_stn)
+        tool_stn_unload             = gcmd.get_float("TOOL_STN_UNLOAD",     self.tool_stn_unload)
+        tool_sensor_after_extruder  = gcmd.get_float("TOOL_AFTER_EXTRUDER", self.tool_sensor_after_extruder)
+
+        if tool_stn != self.tool_stn:
+            self._update_tool_stn( tool_stn )
+        if tool_stn_unload != self.tool_stn_unload:
+            self._update_tool_stn_unload( tool_stn_unload )
+        if tool_sensor_after_extruder != self.tool_sensor_after_extruder:
+            self._update_tool_after_extr( tool_sensor_after_extruder )
+
+    cmd_SAVE_EXTRUDER_VALUES_help = "Saves tool_stn, tool_stn_unload and tool_sensor_after_extruder values to config file "
+    def cmd_SAVE_EXTRUDER_VALUES(self, gcmd):
+        """
+        Macro call to write tool_stn, tool_stn_unload and tool_sensor_after_extruder variables to config file for specified extruder.
+
+        Usage: `SAVE_EXTRUDER_VALUES EXTRUDER=<extruder>`
+        Example: `SAVE_EXTRUDER_VALUES EXTRUDER=extruder`
+
+        Args:
+            gcmd: The G-code command object containing the parameters for the command.
+                  Expected parameters:
+                  - EXTRUDER: The name of the extruder to save values to in config file.
+                  - LENGTH: The length adjustment value.
+
+        Returns:
+            None
+        """
+        self.AFC.FUNCTION.ConfigRewrite(self.fullname, 'tool_stn',                   self.tool_stn, '')
+        self.AFC.FUNCTION.ConfigRewrite(self.fullname, 'tool_stn_unload',            self.tool_stn_unload, '')
+        self.AFC.FUNCTION.ConfigRewrite(self.fullname, 'tool_sensor_after_extruder', self.tool_sensor_after_extruder, '')
 
     def get_status(self, eventtime=None):
         self.response = {}

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -7,6 +7,7 @@
 import os
 import re
 from configfile import error
+from datetime import datetime
 try:
     from extras.AFC_respond import AFCprompt
 except:
@@ -50,11 +51,12 @@ class afcFunction:
         and assigns it to the instance variable `self.AFC`.
         """
         self.AFC = self.printer.lookup_object('AFC')
+        self.logger = self.AFC.logger
         self.AFC.gcode.register_command('CALIBRATE_AFC'  , self.cmd_CALIBRATE_AFC  , desc=self.cmd_CALIBRATE_AFC_help)
         self.AFC.gcode.register_command('AFC_CALIBRATION', self.cmd_AFC_CALIBRATION, desc=self.cmd_AFC_CALIBRATION_help)
         self.AFC.gcode.register_command('ALL_CALIBRATION', self.cmd_ALL_CALIBRATION, desc=self.cmd_ALL_CALIBRATION_help)
 
-    def ConfigRewrite(self, rawsection, rawkey, rawvalue, msg=None):
+    def ConfigRewrite(self, rawsection, rawkey, rawvalue, msg=""):
         taskdone = False
         sectionfound = False
         # Creating regex pattern based off rawsection
@@ -72,11 +74,17 @@ class afcFunction:
                         if re.match(pattern, line) is not None: sectionfound = True
                         if sectionfound == True and line.startswith(rawkey):
                             comments = ""
+                            comment_index = 0
                             try:
-                                comments = line.index('#')
-                            except:
+                                comment_index = line.index('#')
+                                comments = line[comment_index:-1]
+                            except ValueError:
                                 pass
-                            line = "{}: {}{}\n".format(rawkey, rawvalue, comments )
+                            line = "{}: {}".format(rawkey, rawvalue )
+                            # Left justifying comment with spaces so its in original position
+                            line = line.ljust(comment_index - 1, " ")
+
+                            line = "{} {}\n".format(line, comments)
                             sectionfound = False
                             taskdone = True
                         dataout += line
@@ -86,10 +94,10 @@ class afcFunction:
                     f.close
                     taskdone = False
                     msg +='\n<span class=info--text>Saved {}:{} in {} section to configuration file</span>'.format(rawkey, rawvalue, rawsection)
-                    self.AFC.gcode.respond_info(msg)
+                    self.logger.info(msg)
                     return
         msg +='\n<span class=info--text>Key {} not found in section {}, cannot update</span>'.format(rawkey, rawsection)
-        self.AFC.gcode.respond_info(msg)
+        self.logger.info(msg)
 
     def TcmdAssign(self, CUR_LANE):
         if CUR_LANE.map == 'NONE' :
@@ -102,7 +110,7 @@ class afcFunction:
         try:
             self.AFC.gcode.register_command(CUR_LANE.map, self.AFC.cmd_CHANGE_TOOL, desc=self.AFC.cmd_CHANGE_TOOL_help)
         except:
-            self.AFC.gcode.respond_info("Error trying to map lane {lane} to {tool_macro}, please make sure there are no macros already setup for {tool_macro}".format(lane=[CUR_LANE.name], tool_macro=CUR_LANE.map), )
+            self.logger.info("Error trying to map lane {lane} to {tool_macro}, please make sure there are no macros already setup for {tool_macro}".format(lane=[CUR_LANE.name], tool_macro=CUR_LANE.map), )
         self.AFC.save_vars()
 
     def is_homed(self):
@@ -216,7 +224,7 @@ class afcFunction:
         if led is not None:
             led.led_change(int(idx.split(':')[1]), status)
         else:
-            self.AFC.gcode.respond_info( error_string )
+            self.logger.info( error_string )
 
     def get_filament_status(self, CUR_LANE):
         if CUR_LANE.prep_state:
@@ -265,8 +273,17 @@ class afcFunction:
             cur_lane_loaded.unsync_to_extruder()
             cur_lane_loaded.set_unloaded()
             self.AFC.FUNCTION.handle_activate_extruder()
-            self.AFC.gcode.respond_info("Manually removing {} loaded from toolhead".format(cur_lane_loaded.name))
+            self.logger.info("Manually removing {} loaded from toolhead".format(cur_lane_loaded.name))
             self.AFC.save_vars()
+
+    def log_toolhead_pos(self):
+        msg = "Position: {}".format(self.AFC.toolhead.get_position())
+        msg += " base_position: {}".format(self.AFC.gcode_move.base_position)
+        msg += " last_position: {}".format(self.AFC.gcode_move.last_position)
+        msg += " homing_position: {}".format(self.AFC.gcode_move.homing_position)
+        msg += " speed: {}".format(self.AFC.gcode_move.speed)
+        msg += " absolute_coord: {}\n".format(self.AFC.gcode_move.absolute_coord)
+        self.logger.debug(msg, only_debug=True)
 
     def HexConvert(self,tmp):
         led=tmp.split(',')
@@ -299,7 +316,7 @@ class afcFunction:
         Returns:
             None
         """
-        prompt = AFCprompt(gcmd)
+        prompt = AFCprompt(gcmd, self.logger)
         buttons = []
         title = 'AFC Calibration'
         text = ('The following prompts will lead you through the calibration of your AFC unit(s).'
@@ -330,7 +347,7 @@ class afcFunction:
         Returns:
             None
         """
-        prompt = AFCprompt(gcmd)
+        prompt = AFCprompt(gcmd, self.logger)
         footer = []
         title = 'Calibrate all'
         text = ('Press Yes to confirm calibrating all lanes in all units')
@@ -374,7 +391,7 @@ class afcFunction:
         unit   = gcmd.get(      'UNIT'     , None)
 
         if self.AFC.current is not None and afc_bl is not None:
-            self.AFC.gcode.respond_info('Tool must be unloaded to calibrate Bowden length')
+            self.logger.info('Tool must be unloaded to calibrate Bowden length')
             return
 
         cal_msg = ''
@@ -393,7 +410,7 @@ class afcFunction:
 
         # Determine if a specific lane is provided
         if lanes is not None:
-            self.AFC.gcode.respond_info('Starting AFC distance Calibrations')
+            self.logger.info('Starting AFC distance Calibrations')
             cal_msg += 'AFC Calibration distances +/-{}mm'.format(tol)
             if unit is None:
                 if lanes != 'all':
@@ -416,7 +433,7 @@ class afcFunction:
                     cal_msg += msg
                 else:
                     CUR_UNIT = self.AFC.units[unit]
-                    self.AFC.gcode.respond_info('{}'.format(CUR_UNIT.name))
+                    self.logger.info('{}'.format(CUR_UNIT.name))
                     # Calibrate all lanes if no specific lane is provided
                     for CUR_LANE in CUR_UNIT.lanes.values():
                         # Calibrate the specific lane
@@ -424,19 +441,34 @@ class afcFunction:
                         if(not checked): return
                         cal_msg += msg
 
-            self.AFC.gcode.respond_info("Lane calibration Done!")
+            self.logger.info("Lane calibration Done!")
 
         else:
-            self.AFC.gcode.respond_info('No lanes selected to calibrate dist_hub')
+            self.logger.info('No lanes selected to calibrate dist_hub')
 
         # Calibrate Bowden length with specified lane
         if afc_bl is not None:
-            self.AFC.gcode.respond_info('Starting AFC distance Calibrations')
+            set_tool_start_back_to_none = False
+            CUR_LANE=self.AFC.lanes[afc_bl]
+
+            # Setting tool start to buffer if only tool_end is set and user has buffer so calibration can run
+            if CUR_LANE.extruder_obj.tool_start is None and CUR_LANE.extruder_obj.tool_end is not None and CUR_LANE.buffer_obj is not None:
+                self.logger.info("Cannot run calibration using post extruder sensor, using buffer to calibrate bowden length")
+                CUR_LANE.extruder_obj.tool_start = "buffer"
+                set_tool_start_back_to_none = True
+            else:
+                # Cannot calibrate
+                self.AFC.ERROR.AFC_error("Cannot calibrate with only post extruder sensor and no turtleneck buffer defined in config", pause=False)
+                return
+
+            self.logger.info('Starting AFC distance Calibrations')
             cal_msg += 'AFC Calibration distances +/-{}mm'.format(tol)
             cal_msg += '\n<span class=info--text>Update values in AFC_Hardware.cfg</span>'
-            CUR_LANE=self.AFC.lanes[afc_bl]
             CUR_LANE.unit_obj.calibrate_bowden(CUR_LANE, dis, tol)
-            self.AFC.gcode.respond_info("Bowden length calibration Done!")
+            self.logger.info("Bowden length calibration Done!")
+
+            if set_tool_start_back_to_none:
+                CUR_LANE.extruder_obj.tool_start = None
 
     cmd_SET_BOWDEN_LENGTH_help = "Helper to dynamically set length of bowden between hub and toolhead. Pass in HUB if using multiple box turtles"
     def cmd_SET_BOWDEN_LENGTH(self, gcmd):
@@ -466,7 +498,7 @@ class afcFunction:
             CUR_LANE = self.AFC.lanes[self.current]
             hub     = CUR_LANE.hub_obj.name
         elif hub is None and self.current is None:
-            self.AFC.gcode.respond_info("A lane is not loaded please specify hub to adjust bowden length")
+            self.logger.info("A lane is not loaded please specify hub to adjust bowden length")
             return
 
         CUR_HUB = self.AFC.hubs[hub]
@@ -487,7 +519,7 @@ class afcFunction:
         msg += '//   Previous Bowden Length: {}\n'.format(config_bowden)
         msg += '//   New Bowden Length:      {}\n'.format(bowden_length)
         msg += '\n// TO SAVE BOWDEN LENGTH afc_bowden_length MUST BE UPDATED IN AFC_Hardware.cfg for each hub if there are multiple'
-        self.AFC.gcode.respond_raw(msg)
+        self.logger.raw(msg)
 
     cmd_HUB_CUT_TEST_help = "Test the cutting sequence of the hub cutter, expects LANE=laneN"
     def cmd_HUB_CUT_TEST(self, gcmd):
@@ -508,14 +540,14 @@ class afcFunction:
             None
         """
         lane = gcmd.get('LANE', None)
-        self.AFC.gcode.respond_info('Testing Hub Cut on Lane: ' + lane)
+        self.logger.info('Testing Hub Cut on Lane: ' + lane)
         if lane not in self.AFC.lanes:
-            self.AFC.gcode.respond_info('{} Unknown'.format(lane))
+            self.logger.info('{} Unknown'.format(lane))
             return
         CUR_LANE = self.AFC.lanes[lane]
         CUR_HUB = CUR_LANE.hub_obj
         CUR_HUB.hub_cut(CUR_LANE)
-        self.AFC.gcode.respond_info('Hub cut Done!')
+        self.logger.info('Hub cut Done!')
 
     cmd_TEST_help = "Test Assist Motors"
     def cmd_TEST(self, gcmd):
@@ -541,23 +573,56 @@ class afcFunction:
         if lane == None:
             self.AFC.ERROR.AFC_error('Must select LANE', False)
             return
-        self.AFC.gcode.respond_info('TEST ROUTINE')
+        self.logger.info('TEST ROUTINE')
         if lane not in self.AFC.lanes:
-            self.AFC.gcode.respond_info('{} Unknown'.format(lane))
+            self.logger.info('{} Unknown'.format(lane))
             return
         CUR_LANE = self.AFC.lanes[lane]
-        self.AFC.gcode.respond_info('Testing at full speed')
+        self.logger.info('Testing at full speed')
         CUR_LANE.assist(-1)
         self.AFC.reactor.pause(self.AFC.reactor.monotonic() + 1)
         if CUR_LANE.afc_motor_rwd.is_pwm:
-            self.AFC.gcode.respond_info('Testing at 50 percent speed')
+            self.logger.info('Testing at 50 percent speed')
             CUR_LANE.assist(-.5)
             self.AFC.reactor.pause(self.AFC.reactor.monotonic() + 1)
-            self.AFC.gcode.respond_info('Testing at 30 percent speed')
+            self.logger.info('Testing at 30 percent speed')
             CUR_LANE.assist(-.3)
             self.AFC.reactor.pause(self.AFC.reactor.monotonic() + 1)
-            self.AFC.gcode.respond_info('Testing at 10 percent speed')
+            self.logger.info('Testing at 10 percent speed')
             CUR_LANE.assist(-.1)
             self.AFC.reactor.pause(self.AFC.reactor.monotonic() + 1)
-        self.AFC.gcode.respond_info('Test routine complete')
+        self.logger.info('Test routine complete')
         CUR_LANE.assist(0)
+
+class afcDeltaTime:
+    def __init__(self, AFC):
+        self.logger = AFC.logger
+        self.start_time = None
+        self.last_time  = None
+
+    def set_start_time(self):
+        self.major_delta_time = self.last_time = self.start_time = datetime.now()
+
+    def log_with_time(self, msg, debug=True):
+        curr_time = datetime.now()
+        delta_time = (curr_time - self.last_time ).total_seconds()
+        total_time = (curr_time - self.start_time).total_seconds()
+        msg = "{} (Δt:{:.3f}s, t:{:.3f})".format( msg, delta_time, total_time )
+        if debug:
+            self.logger.debug( msg )
+        else:
+            self.logger.info( msg )
+        self.last_time = curr_time
+
+    def log_major_delta(self, msg, debug=True):
+        curr_time = datetime.now()
+        delta_time = (curr_time - self.major_delta_time ).total_seconds()
+        msg = "{} t:{:.3f}".format( msg, delta_time )
+        self.logger.info( msg )
+        self.major_delta_time = curr_time
+
+    def log_total_time(self, msg):
+        total_time = (datetime.now() - self.start_time).total_seconds()
+        msg = "{} t:{:.3f}".format( msg, total_time )
+
+        self.logger.info( msg )

--- a/extras/AFC_hub.py
+++ b/extras/AFC_hub.py
@@ -23,25 +23,25 @@ class afc_hub:
 
         # HUB Cut variables
         # Next two variables are used in AFC
-        self.cut = config.getboolean("cut", False)                                  # Set True if Hub cutter installed (e.g. Snappy)
-        self.cut_cmd = config.get('cut_cmd', None)                                  # Macro to use for cut.
-        self.cut_servo_name = config.get('cut_servo_name', 'cut')                   # Name of servo to use for cutting
-        self.cut_dist = config.getfloat("cut_dist", 50)                             # How much filament to cut off (in mm).
-        self.cut_clear = config.getfloat("cut_clear", 120)                          # How far the filament should retract back from the hub (in mm).
-        self.cut_min_length = config.getfloat("cut_min_length", 200)                # Minimum length of filament to cut off
-        self.cut_servo_pass_angle = config.getfloat("cut_servo_pass_angle", 0)      # Servo angle to align the Bowden tube with the hole for loading the toolhead.
-        self.cut_servo_clip_angle = config.getfloat("cut_servo_clip_angle", 160)    # Servo angle for cutting the filament.
-        self.cut_servo_prep_angle = config.getfloat("cut_servo_prep_angle", 75)     # Servo angle to prepare the filament for cutting (aligning the exit hole).
-        self.cut_confirm = config.getboolean("cut_confirm", 0)                      # Set True to cut filament twice
+        self.switch_pin             = config.get('switch_pin', None)                # Pin hub sensor it connected to
+        self.hub_clear_move_dis     = config.getfloat("hub_clear_move_dis", 25)     # How far to move filament so that it's not block the hub exit
+        self.afc_bowden_length      = config.getfloat("afc_bowden_length", 900)     # Length of the Bowden tube from the hub to the toolhead sensor in mm.
+        self.assisted_retract       = config.getboolean("assisted_retract", False)  # if True, retracts are assisted to prevent loose windings on the spool
+        self.move_dis               = config.getfloat("move_dis", 50)               # Distance to move the filament within the hub in mm.
+        # Servo settings
+        self.cut                    = config.getboolean("cut", False)               # Set True if Hub cutter installed (e.g. Snappy)
+        self.cut_cmd                = config.get('cut_cmd', None)                   # Macro to use for cut.
+        self.cut_servo_name         = config.get('cut_servo_name', 'cut')           # Name of servo to use for cutting
+        self.cut_dist               = config.getfloat("cut_dist", 50)               # How much filament to cut off (in mm).
+        self.cut_clear              = config.getfloat("cut_clear", 120)             # How far the filament should retract back from the hub (in mm).
+        self.cut_min_length         = config.getfloat("cut_min_length", 200)        # Minimum length of filament to cut off
+        self.cut_servo_pass_angle   = config.getfloat("cut_servo_pass_angle", 0)    # Servo angle to align the Bowden tube with the hole for loading the toolhead.
+        self.cut_servo_clip_angle   = config.getfloat("cut_servo_clip_angle", 160)  # Servo angle for cutting the filament.
+        self.cut_servo_prep_angle   = config.getfloat("cut_servo_prep_angle", 75)   # Servo angle to prepare the filament for cutting (aligning the exit hole).
+        self.cut_confirm            = config.getboolean("cut_confirm", 0)           # Set True to cut filament twice
 
-        self.move_dis = config.getfloat("move_dis", 50)                             # Distance to move the filament within the hub in mm.
-
-        self.hub_clear_move_dis = config.getfloat("hub_clear_move_dis", 25)         # How far to move filament so that it's not block the hub exit
-        self.assisted_retract = config.getboolean("assisted_retract", False)        # if True, retracts are assisted to prevent loose windings on the spool
-        self.afc_bowden_length = config.getfloat("afc_bowden_length", 900)          # Length of the Bowden tube from the hub to the toolhead sensor in mm.
-        self.config_bowden_length = self.afc_bowden_length                          # Used by SET_BOWDEN_LENGTH macro
-        self.switch_pin = config.get('switch_pin', None)                            # Pin hub sensor it connected to
-        self.enable_sensors_in_gui = config.getboolean("enable_sensors_in_gui", self.AFC.enable_sensors_in_gui) # Set to True to show hub sensor switche as filament sensor in mainsail/fluidd gui, overrides value set in AFC.cfg
+        self.config_bowden_length   = self.afc_bowden_length                        # Used by SET_BOWDEN_LENGTH macro
+        self.enable_sensors_in_gui  = config.getboolean("enable_sensors_in_gui", self.AFC.enable_sensors_in_gui) # Set to True to show hub sensor switche as filament sensor in mainsail/fluidd gui, overrides value set in AFC.cfg
 
         buttons = self.printer.load_object(config, "buttons")
         if self.switch_pin is not None:
@@ -121,6 +121,7 @@ class afc_hub:
         self.response['cut_servo_clip_angle'] = self.cut_servo_clip_angle
         self.response['cut_servo_prep_angle'] = self.cut_servo_prep_angle
         self.response['lanes'] = [lane.name for lane in self.lanes.values()]
+        self.response['afc_bowden_length'] = self.afc_bowden_length
 
         return self.response
 

--- a/extras/AFC_led.py
+++ b/extras/AFC_led.py
@@ -12,8 +12,12 @@ RESET_MIN_TIME = .000050
 MAX_MCU_SIZE = 500  # Sanity check on LED chain length
 class AFCled:
     def __init__(self, config):
-        self.printer = printer = config.get_printer()
-        self.mutex = printer.get_reactor().mutex()
+        self.printer    = printer = config.get_printer()
+        self.mutex      = printer.get_reactor().mutex()
+        self.fullname   = config.get_name()
+        self.name       = self.fullname.split()[-1]
+        self.AFC        = self.printer.lookup_object('AFC')
+        self.AFC.led_obj[self.name] = self
         # Configure neopixel
         ppins = printer.lookup_object('pins')
         pin_params = ppins.lookup_pin(config.get('pin'))
@@ -44,6 +48,8 @@ class AFCled:
         self.old_color_data = bytearray([d ^ 1 for d in self.color_data])
         # Register callbacks
         printer.register_event_handler("klippy:connect", self.send_data)
+        self.last_led_color = {}
+        self.keep_leds_off = False
 
     def build_config(self):
         bmt = self.mcu.seconds_to_clock(BIT_MAX_TIME)
@@ -109,7 +115,10 @@ class AFCled:
     def get_status(self, eventtime=None):
         return self.led_helper.get_status(eventtime)
 
-    def led_change(self, index, status):
+    def led_change(self, index, status, update_last=True):
+        if update_last: self.last_led_color[str(index)] = status
+        if self.keep_leds_off: return
+
         colors=list(map(float,status.split(',')))
         transmit = 1
         def lookahead_bgfunc(print_time):
@@ -124,6 +133,16 @@ class AFCled:
                 check_transmit_fn(print_time)
         toolhead = self.printer.lookup_object('toolhead')
         toolhead.register_lookahead_callback(lookahead_bgfunc)
+
+    def turn_off_leds(self):
+        for i in range(self.led_helper.get_led_count()):
+            self.led_change( i, "0,0,0,0", False)
+        self.keep_leds_off = True
+
+    def turn_on_leds(self):
+        self.keep_leds_off = False
+        for index, value in self.last_led_color.items():
+            self.led_change( int(index), value, False )
 
 def load_config_prefix(config):
     return AFCled(config)

--- a/extras/AFC_logger.py
+++ b/extras/AFC_logger.py
@@ -1,0 +1,89 @@
+# Armored Turtle Automated Filament Control
+#
+# Copyright (C) 2024 Armored Turtle
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+try:
+    from .. import APP_NAME
+except:
+    APP_NAME = "Klipper"
+import logging
+import re
+import os
+from queuelogger import QueueListener, QueueHandler
+from pathlib import Path
+from webhooks import GCodeHelper
+
+class AFC_QueueListener(QueueListener):
+    def __init__(self, filename):
+        if APP_NAME == "Kalico":
+            super().__init__(filename, False)
+        else:
+            super().__init__(filename)
+
+        logging.handlers.TimedRotatingFileHandler.__init__(
+            self, filename, when="S", interval=60 * 60 * 24, backupCount=5
+        )
+
+        logging.handlers.TimedRotatingFileHandler.doRollover(self)
+
+class AFC_logger:
+    def __init__(self, printer):
+        self.reactor = printer.reactor
+        self.gcode   = printer.lookup_object('gcode')
+        self.webhooks = printer.lookup_object('webhooks')
+
+        log_path = printer.start_args['log_file']
+        dirname = Path(log_path).parent
+        log_file = Path(dirname).joinpath("AFC.log")
+        logger_name = os.path.splitext(os.path.basename(log_file))[0]
+
+        self.afc_ql = AFC_QueueListener(log_file)
+        self.afc_ql.setFormatter(logging.Formatter('%(asctime)s %(message)s', datefmt='%H:%M:%S'))
+        self.afc_queue_handler = QueueHandler(self.afc_ql.bg_queue)
+        self.logger = logging.getLogger(logger_name)
+        self.logger.propagate = False               # Stops logs from going into klippy.log
+        self.logger.addHandler(self.afc_queue_handler)
+        self.logger.setLevel(logging.DEBUG)
+        self.print_debug_console = False
+
+    def _add_monotonic(self, message):
+        return "{:10.3f} {}".format(self.reactor.monotonic(), message)
+
+    def _remove_tags(self, message):
+        return re.sub("<.*?>", "", message)
+
+    def _format(self, message):
+        s = self._remove_tags(message.lstrip())
+        return self._add_monotonic(s)
+
+    def send_callback(self, msg):
+        for cb in self.gcode.output_callbacks:
+            if isinstance(cb.__self__, GCodeHelper): cb(msg.lstrip())
+
+    def raw(self, message):
+        for line in message.lstrip().rstrip().split("\n"):
+            self.logger.info(self._format(line))
+        self.send_callback(message)
+
+    def info(self, message, console_only=False):
+        if not console_only:
+            for line in message.lstrip().split("\n"):
+                self.logger.info(self._format(line))
+        self.send_callback(message)
+
+    def debug(self, message, only_debug=False):
+        for line in message.lstrip().rstrip().split("\n"):
+            self.logger.debug(self._format("DEBUG: {}".format(line)))
+
+        if self.print_debug_console and not only_debug:
+            self.send_callback(message)
+
+    def error(self, message):
+        for line in message.lstrip().rstrip().split("\n"):
+            self.logger.error( self._format("ERROR: {}".format(line)))
+        self.send_callback( "!! {}".format(message) )
+
+    def set_debug(self, debug ):
+        self.print_debug_console = debug

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -11,9 +11,9 @@ class afcPrep:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.printer.register_event_handler("klippy:connect", self.handle_connect)
-        self.delay = config.getfloat('delay_time', 0.1, minval=0.0)                 # Time to delay when moving extruders and spoolers during PREP routine
-        self.enable = config.getboolean("enable", False)                            # Set True to disable PREP checks
-        self.dis_unload_macro = config.getboolean("disable_unload_filament_remapping", False) # Set to True to disable remapping UNLOAD_FILAMENT macro to TOOL_UNLOAD macro
+        self.delay              = config.getfloat('delay_time', 0.1, minval=0.0)                # Time to delay when moving extruders and spoolers during PREP routine
+        self.enable             = config.getboolean("enable", False)                            # Set True to disable PREP checks
+        self.dis_unload_macro   = config.getboolean("disable_unload_filament_remapping", False) # Set to True to disable remapping UNLOAD_FILAMENT macro to TOOL_UNLOAD macro
 
         # Flag to set once resume rename as occurred for the first time
         self.rename_occurred = False
@@ -28,6 +28,7 @@ class afcPrep:
         """
         self.AFC = self.printer.lookup_object('AFC')
         self.AFC.gcode.register_command('PREP', self.PREP, desc=None)
+        self.logger = self.AFC.logger
 
     def _rename(self, base_name, rename_name, rename_macro, rename_help):
         """
@@ -39,7 +40,7 @@ class afcPrep:
             pdesc = "Renamed builtin of '%s'" % (base_name,)
             self.AFC.gcode.register_command(rename_name, prev_cmd, desc=pdesc)
         else:
-            self.AFC.gcode.respond_info("{}Existing command {} not found in gcode_macros{}".format("<span class=warning--text>", base_name, "</span>",))
+            self.logger.info("{}Existing command {} not found in gcode_macros{}".format("<span class=warning--text>", base_name, "</span>",))
         self.AFC.gcode.register_command(base_name, rename_macro, desc=rename_help)
 
     def _rename_macros(self):
@@ -61,7 +62,7 @@ class afcPrep:
         while self.printer.state_message != 'Printer is ready':
             self.AFC.reactor.pause(self.AFC.reactor.monotonic() + 1)
         self._rename_macros()
-        self.AFC.print_version()
+        self.AFC.print_version(console_only=True)
 
         ## load Unit stored variables
         units={}
@@ -104,6 +105,8 @@ class afcPrep:
                     # Check for loaded_to_hub as this is how its being saved version > 1030
                     if 'loaded_to_hub' in units[CUR_LANE.unit][CUR_LANE.name]: CUR_LANE.loaded_to_hub = units[CUR_LANE.unit][CUR_LANE.name]['loaded_to_hub']
                     if 'tool_loaded' in units[CUR_LANE.unit][CUR_LANE.name]: CUR_LANE.tool_loaded = units[CUR_LANE.unit][CUR_LANE.name]['tool_loaded']
+                    # Commenting out until there is better handling of this variable as it could cause someone to not be able to load their lane if klipper crashes
+                    # if 'status' in units[CUR_LANE.unit][CUR_LANE.name]: CUR_LANE.status = units[CUR_LANE.unit][CUR_LANE.name]['status']
 
         for UNIT in self.AFC.units.keys():
             try: CUR_UNIT = self.AFC.units[UNIT]
@@ -111,7 +114,7 @@ class afcPrep:
                 error_string = 'Error: ' + UNIT + '  Unit not found in  config section.'
                 self.AFC.ERROR.AFC_error(error_string, False)
                 return
-            self.AFC.gcode.respond_info(CUR_UNIT.type + ' ' + UNIT +' Prepping lanes')
+            self.logger.info(CUR_UNIT.type + ' ' + UNIT +' Prepping lanes')
             lanes_for_first_hub = []
             hub_name = ""
             LaneCheck = True
@@ -125,18 +128,18 @@ class afcPrep:
                     LaneCheck = False
             # Warn user if multiple hubs were found and hub was not assigned to unit/stepper
             if len(lanes_for_first_hub) != 0:
-                self.AFC.gcode.respond_raw("<span class=warning--text>No hub defined in lanes or unit for {unit}. Defaulting to {hub}</span>".format(
+                self.logger.raw("<span class=warning--text>No hub defined in lanes or unit for {unit}. Defaulting to {hub}</span>".format(
                                             unit=" ".join(CUR_UNIT.full_name), hub=hub_name))
 
             if LaneCheck:
-                self.AFC.gcode.respond_raw(CUR_UNIT.logo)
+                self.logger.raw(CUR_UNIT.logo)
             else:
-                self.AFC.gcode.respond_raw(CUR_UNIT.logo_error)
+                self.logger.raw(CUR_UNIT.logo_error)
         try:
-            bypass = self.printer.lookup_object('filament_switch_sensor bypass').runout_helper
-            if bypass.filament_present == True:
-              self.AFC.gcode.respond_info("Filament loaded in bypass, not doing toolchange")
-        except: bypass = None
+            if self.AFC._get_bypass_state():
+                self.logger.info("Filament loaded in bypass, toolchanges deactivated")
+        except:
+            pass
 
         # Defaulting to no active spool, putting at end so endpoint has time to register
         if self.AFC.current is None:

--- a/extras/AFC_respond.py
+++ b/extras/AFC_respond.py
@@ -5,49 +5,50 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
 class AFCprompt:
-    def __init__(self, gcmd):
+    def __init__(self, gcmd, logger):
         self.gcode = gcmd
+        self.logger     = logger
 
     # Prompt begin action
     def p_begin(self, prompt_name):
-        self.gcode.respond_raw("// action:prompt_begin {}".format(prompt_name))
+        self.logger.raw("// action:prompt_begin {}".format(prompt_name))
 
     # Prompt text action
     def p_text(self, text):
-        self.gcode.respond_raw("// action:prompt_text {}".format(text))
+        self.logger.raw("// action:prompt_text {}".format(text))
 
     # Prompt button action (with style options)
     def p_button(self, label, command, style=None):
         if style:
-            self.gcode.respond_raw("// action:prompt_button {}|{}|{}".format(label, command, style))
+            self.logger.raw("// action:prompt_button {}|{}|{}".format(label, command, style))
         else:
-            self.gcode.respond_raw("// action:prompt_button {}|{}".format(label, command))
+            self.logger.raw("// action:prompt_button {}|{}".format(label, command))
 
     # Prompt footer button action (4 max allowed)
     def p_footer_button(self, label, command, style=None):
         if style:
-            self.gcode.respond_raw("// action:prompt_footer_button {}|{}|{}".format(label, command, style))
+            self.logger.raw("// action:prompt_footer_button {}|{}|{}".format(label, command, style))
         else:
-            self.gcode.respond_raw("// action:prompt_footer_button {}|{}".format(label, command))
+            self.logger.raw("// action:prompt_footer_button {}|{}".format(label, command))
 
     def p_cancel_button(self):
         self.p_footer_button('Cancel', "RESPOND TYPE=command MSG=action:prompt_end", 'warning')
 
     # Show prompt action
     def p_show(self):
-        self.gcode.respond_raw("// action:prompt_show")
+        self.logger.raw("// action:prompt_show")
 
     # Close prompt action
     def p_end(self):
-        self.gcode.respond_raw("// action:prompt_end")
+        self.logger.raw("// action:prompt_end")
 
     # Button group start
     def p_button_group_start(self):
-        self.gcode.respond_raw("// action:prompt_button_group_start")
+        self.logger.raw("// action:prompt_button_group_start")
 
     # Button group end
     def p_button_group_end(self):
-        self.gcode.respond_raw("// action:prompt_button_group_end")
+        self.logger.raw("// action:prompt_button_group_end")
 
     # Method to create a custom prompt
     def create_custom_p(self, prompt_name, text=None, buttons=None, cancel=False, groups=None, footer_buttons=None):

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -9,10 +9,11 @@ from extras.AFC_respond import AFCprompt
 
 class afcUnit:
     def __init__(self, config):
-        self.printer    = config.get_printer()
-        self.gcode      = self.printer.lookup_object('gcode')
+        self.printer        = config.get_printer()
+        self.gcode          = self.printer.lookup_object('gcode')
         self.printer.register_event_handler("klippy:connect", self.handle_connect)
-        self.AFC = self.printer.lookup_object('AFC')
+        self.AFC            = self.printer.lookup_object('AFC')
+        self.logger         = self.AFC.logger
 
         self.lanes      = {}
 
@@ -46,6 +47,7 @@ class afcUnit:
         self.n20_break_delay_time = config.getfloat("n20_break_delay_time", self.AFC.n20_break_delay_time) # Time to wait between breaking n20 motors(nSleep/FWD/RWD all 1) and then releasing the break to allow coasting. Setting value here overrides values set in AFC.cfg file
 
         self.assisted_unload    = config.getboolean("assisted_unload", self.AFC.assisted_unload)    # If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool. Setting value here overrides values set in AFC.cfg file
+        self.unload_on_runout   = config.getboolean("unload_on_runout", self.AFC.unload_on_runout)  # When True AFC will unload lane and then pause when runout is triggered and spool to swap to is not set(infinite spool). Setting value here overrides values set in AFC.cfg file
 
     def handle_connect(self):
         """

--- a/templates/AFC_Hardware-AFC.cfg
+++ b/templates/AFC_Hardware-AFC.cfg
@@ -4,11 +4,11 @@ enable_force_move: True
 [AFC_extruder extruder]
 pin_tool_start: enter_tool_pin
 #pin_tool_end: None
-tool_stn: 72                    # Distance from the toolhead sensor to the tip of the nozzle in mm.
-tool_stn_unload: 100            # Unload distance for the toolhead in mm.
-tool_sensor_after_extruder: 0   # Distance in mm.
-tool_unload_speed: 25           # Unload speed in mm/s. Default is 25mm/s.
-tool_load_speed: 25             # Load speed in mm/s. Default is 25mm/s.
+tool_stn: 72                    # Distance in mm from the toolhead sensor to the tip of the nozzle in mm, if `tool_end` is defined then distance is from this sensor
+tool_stn_unload: 100            # Distance to move in mm while unloading toolhead
+tool_sensor_after_extruder: 0   # Extra distance to move in mm once pre/post sensors are clear. Useful for when only using post sensor, so this distance can be the amout to move to clear extruder gears
+tool_unload_speed: 25           # Unload speed in mm/s when unloading toolhead. Default is 25mm/s.
+tool_load_speed: 25             # Load speed in mm/s when unloading toolhead. Default is 25mm/s.
 
 #[filament_switch_sensor bypass]
 #switch_pin: turtleneck:PB5

--- a/utilities/generate_docs.py
+++ b/utilities/generate_docs.py
@@ -76,10 +76,10 @@ def format_markdown(cmd_functions):
         "\n"
     ]
     for name, docstring in cmd_functions:
-        description = docstring.split('\n\n')[0]
+        description = docstring.split('\n\n')[0].replace("<nl>", "")
         command_name = name[4:].upper()  # Remove 'cmd_' prefix and convert to uppercase
         markdown_lines.append(f"### {command_name}\n")
-        markdown_lines.append(f"_Description_: {description}  \n")
+        markdown_lines.append(f"_Description_: {description}  \n  \n")
 
         # Extract usage and example from docstring if available
         usage = ""


### PR DESCRIPTION
## Major Changes in this PR
- Added logging of delta time and total time for how long toolchanges take
- Added AFC logger so all AFC messages now get logged to AFC.log in same place of users klippy.log
- Added `default_material_type` variable to assign to spool when loaded into lane
- Added `pause_when_bypass_active` variable to pause print if bypass is active, defaults to false
- Added `unload_on_runout` variable to unload lane when runout happens and another lane is not setup to change to, default to false
- Updated calibration to use buffer as tool_pin_start if only tool_pin_end is defined and buffer is also defined
- Added ability to change tool_stn/tool_stn_unload/tool_sensor_after_extruder without restarting
- Added check to make sure buffer configures as belay is not configure for extruder pin_start
- Added ability to turn off/on AFC LEDs
- Fixed issue where filament was not unloading correctly when only tool_pin_end is only defined
- Fixed issue where prep logic would try to unload forever if only tool_pin_end was defined
- Fixed ConfigRewrite as it was putting in the comment index instead of the actual comment

## Notes to Code Reviewers
- Seems like alot of changes, but most changes are changing lines over to use new logger

## How the changes in this PR are tested
- Manually tested new commands and tested unloading filament when rollover lane is not selected

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
