### PR TITLE
Cali dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-03-02]
+
+### Fixed
+- Fixed calibration to error out at excessive distances
+    - Calibration uses default config values plus fixed distances to be able to error out distances
+
 ## [2025-02-28]
 
 ### Added

--- a/docs/command_reference.md
+++ b/docs/command_reference.md
@@ -13,6 +13,14 @@ allows the option to calibrate all lanes across all units.
 Usage: ``AFC_CALIBRATION``  
 Example: ``AFC_CALIBRATION``  
 
+### AFC_RESET
+_Description_: This function opens a prompt allowing the user to select a loaded lane for reset. It displays a list of loaded lanes
+and provides a reset button for each lane. If no lanes are loaded, an informative message is displayed indicating
+that a lane must be loaded to proceed with resetting.  
+  
+Usage: ``AFC_RESET DISTANCE=<distance>``  
+Example: `AFC_RESET LANE=lane1`  
+
 ### AFC_RESUME
 _Description_: This function clears the error state of the AFC system, sets the in_toolchange flag to False,
 runs the resume script, and restores the toolhead position to the last saved position.  
@@ -74,6 +82,14 @@ several checks and movements to ensure the lane is properly loaded.
 Usage: ``HUB_LOAD LANE=<lane>``  
 Example: ``HUB_LOAD LANE=lane1``  
 
+### LANE_RESET
+_Description_: This function resets a specified lane to the hub position in the AFC system. It checks for various error conditions,
+such as whether the toolhead is loaded or whether the hub is already clear. The function moves the lane back to the
+hub based on the specified or default distances, ensuring the lane's correct state before completing the reset.  
+  
+Usage: ``LANE_RESET LANE=<lane> DISTANCE=<distance>``  
+Example: `LANE_RESET LANE=lane1`  
+
 ### LANE_UNLOAD
 _Description_: This function handles the unloading of a specified lane from the extruder. It performs
 several checks and movements to ensure the lane is properly unloaded.  
@@ -123,7 +139,7 @@ Example: ``SET_AFC_TOOLCHANGES TOOLCHANGES=100``
 
 ### SET_BOWDEN_LENGTH
 _Description_: This function adjusts the length of the Bowden tube between the hub and the toolhead.
-It retrieves the hub specified by the 'HUB' parameter and the length adjustment specified
+It retrieves the hub specified by the 'HUB' parameter and the length adjustment specified++
 by the 'LENGTH' parameter. If the hub is not specified and a lane is currently loaded,
 it uses the hub of the current lane.  
   

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -9,10 +9,6 @@ try:
     from extras.AFC_unit import afcUnit
 except:
     raise error("Error trying to import AFC_unit, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper")
-try:
-    from extras.AFC_respond import AFCprompt
-except:
-    raise error("Error trying to import AFC_respond, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper")
 
 class afcBoxTurtle(afcUnit):
     def __init__(self, config):
@@ -139,7 +135,7 @@ class afcBoxTurtle(afcUnit):
             if CUR_EXTRUDER.tool_start != 'buffer':
                 bow_pos, checkpoint, success = self.calc_position(CUR_LANE, lambda: CUR_LANE.get_toolhead_pre_sensor_state(), bow_pos,
                                                         CUR_LANE.short_move_dis, tol, 100, "retract from toolhead sensor")
-            
+
             if not success:
                 msg = 'Failed {} after {}mm'.format(checkpoint, bow_pos)
                 return False, msg, bow_pos
@@ -184,11 +180,11 @@ class afcBoxTurtle(afcUnit):
         
         tuned_hub_pos, checkpoint, success = self.calc_position(CUR_LANE, lambda: CUR_LANE.hub_obj.state, hub_pos,
                                             CUR_LANE.short_move_dis, tol, CUR_LANE.dist_hub + 500, checkpoint)
-        
+
         if not success:
             msg = 'failed {} after {}mm'.format(checkpoint, tuned_hub_pos)
             return False, msg, tuned_hub_pos
-        
+
         return True, tuned_hub_pos, tuned_hub_pos
 
     def move_until_state(self, CUR_LANE, state, move_dis, tolerance, short_move, pos=0, fault_dis=250, checkpoint=None):
@@ -261,11 +257,11 @@ class afcBoxTurtle(afcUnit):
         # reset to extruder
         pos, checkpoint, success = self.calc_position(CUR_LANE, lambda: CUR_LANE.load_state, 0, CUR_LANE.short_move_dis,
                                               tol, CUR_LANE.dist_hub + 100, "retract to extruder")
-        
+
         if not success:
             msg = 'Lane failed to calibrate {} after {}mm'.format(checkpoint, pos)
             return False, msg, 0
-        
+
         else:
             success, hub_pos = self.calibrate_hub(CUR_LANE, tol)
 

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -115,7 +115,7 @@ class afcBoxTurtle(afcUnit):
         CUR_HUB = CUR_LANE.hub_obj
         self.AFC.gcode.respond_info('Calibrating Bowden Length with {}'.format(CUR_LANE.name))
         hub_pos, cp, success = self.move_until_state(CUR_LANE, lambda: CUR_HUB.state, CUR_HUB.move_dis, tol,
-                                                     CUR_LANE.short_move_dis, 0, CUR_LANE.dist_hub + 100, "Moving to hub")
+                                                     CUR_LANE.short_move_dis, 0, CUR_LANE.dist_hub + 500, "Moving to hub")
 
         if not success:
             msg = 'Failed {} after {}mm'.format(cp, hub_pos)
@@ -178,7 +178,7 @@ class afcBoxTurtle(afcUnit):
             return False, msg
         
         tuned_hub_pos, cp, success = self.calc_position(CUR_LANE, lambda: CUR_LANE.hub_obj.state, hub_pos,
-                                            CUR_LANE.short_move_dis, tol, CUR_LANE.dist_hub + 50, checkpoint)
+                                            CUR_LANE.short_move_dis, tol, CUR_LANE.dist_hub + 500, checkpoint)
         
         if not success:
             msg = 'failed {} after {}mm'.format(cp, tuned_hub_pos)

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -177,7 +177,7 @@ class afcBoxTurtle(afcUnit):
         if not success:
             msg = 'failed {} after {}mm'.format(checkpoint, hub_pos)
             return False, msg, hub_pos
-        
+
         tuned_hub_pos, checkpoint, success = self.calc_position(CUR_LANE, lambda: CUR_LANE.hub_obj.state, hub_pos,
                                             CUR_LANE.short_move_dis, tol, CUR_LANE.dist_hub + 500, checkpoint)
 

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -136,8 +136,9 @@ class afcBoxTurtle(afcUnit):
                     msg += '\n SET_BOWDEN_LENGTH HUB={} LENGTH=+(distance the filament was short from the toolhead)'.format(CUR_HUB.name)
                     return False, msg, bow_pos
 
-            bow_pos, checkpoint, success = self.calc_position(CUR_LANE, lambda: CUR_LANE.get_toolhead_pre_sensor_state(), bow_pos,
-                                                      CUR_LANE.short_move_dis, tol, 100, "retract from toolhead sensor")
+            if CUR_EXTRUDER.tool_start != 'buffer':
+                bow_pos, checkpoint, success = self.calc_position(CUR_LANE, lambda: CUR_LANE.get_toolhead_pre_sensor_state(), bow_pos,
+                                                        CUR_LANE.short_move_dis, tol, 100, "retract from toolhead sensor")
             
             if not success:
                 msg = 'Failed {} after {}mm'.format(checkpoint, bow_pos)
@@ -165,7 +166,7 @@ class afcBoxTurtle(afcUnit):
             self.AFC.FUNCTION.ConfigRewrite(CUR_HUB.fullname, "afc_bowden_length", bowden_dist, cal_msg)
             CUR_LANE.do_enable(False)
             self.AFC.save_vars()
-            return True, "afc_bowden_length successful"
+            return True, "afc_bowden_length successful", bowden_dist
         else:
             self.logger.info('CALIBRATE_AFC is not currently supported without tool start sensor')
 
@@ -188,7 +189,7 @@ class afcBoxTurtle(afcUnit):
             msg = 'failed {} after {}mm'.format(checkpoint, tuned_hub_pos)
             return False, msg, tuned_hub_pos
         
-        return True, tuned_hub_pos
+        return True, tuned_hub_pos, tuned_hub_pos
 
     def move_until_state(self, CUR_LANE, state, move_dis, tolerance, short_move, pos=0, fault_dis=250, checkpoint=None):
         while state() == False:

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -725,7 +725,7 @@ class afcFunction:
     def cmd_SET_BOWDEN_LENGTH(self, gcmd):
         """
         This function adjusts the length of the Bowden tube between the hub and the toolhead.
-        It retrieves the hub specified by the 'HUB' parameter and the length adjustment specified++
+        It retrieves the hub specified by the 'HUB' parameter and the length adjustment specified
         by the 'LENGTH' parameter. If the hub is not specified and a lane is currently loaded,
         it uses the hub of the current lane.
 

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -406,17 +406,14 @@ class afcFunction:
         calibrated = []
         # Check to make sure lane and unit is valid
         if lanes is not None and lanes != 'all' and lanes not in self.AFC.lanes:
-            prompt.p_end()
             self.AFC.ERROR.AFC_error("'{}' is not a valid lane".format(lanes), pause=False)
             return
 
         if unit is not None and unit not in self.AFC.units:
-            prompt.p_end()
             self.AFC.ERROR.AFC_error("'{}' is not a valid unit".format(unit), pause=False)
             return
 
         if afc_bl is not None and afc_bl not in self.AFC.lanes:
-            prompt.p_end()
             self.AFC.ERROR.AFC_error("'{}' is not a valid lane to calibrate bowden length".format(afc_bl), pause=False)
             return
 
@@ -448,7 +445,6 @@ class afcFunction:
                     CUR_LANE = self.AFC.lanes[lanes]
                     checked, msg, pos = CUR_LANE.unit_obj.calibrate_lane(CUR_LANE, tol)
                     if(not checked):
-                        prompt.p_end()
                         self.AFC.ERROR.AFC_error(msg, False)
                         self.AFC.gcode.run_script_from_command('AFC_CALI_FAIL FAIL={} DISTANCE={}'.format(CUR_LANE, pos))
                         return
@@ -461,7 +457,6 @@ class afcFunction:
                         # Calibrate the specific lane
                         checked, msg, pos = CUR_UNIT.calibrate_lane(CUR_LANE, tol)
                         if(not checked):
-                            prompt.p_end()
                             self.AFC.ERROR.AFC_error(msg, False)
                             self.AFC.gcode.run_script_from_command('AFC_CALI_FAIL FAIL={} DISTANCE={}'.format(CUR_LANE, pos))
                             return
@@ -478,8 +473,8 @@ class afcFunction:
             CUR_LANE=self.AFC.lanes[afc_bl]
 
             # Setting tool start to buffer if only tool_end is set and user has buffer so calibration can run
-            if CUR_LANE.extruder_obj.tool_start is None and CUR_LANE.extruder_obj.tool_end is not None:
-                if CUR_LANE.buffer_obj is not None:
+            if CUR_LANE.extruder_obj.tool_start is None:
+                if CUR_LANE.extruder_obj.tool_end is not None and CUR_LANE.buffer_obj is not None:
                     self.logger.info("Cannot run calibration using post extruder sensor, using buffer to calibrate bowden length")
                     CUR_LANE.extruder_obj.tool_start = "buffer"
                     set_tool_start_back_to_none = True
@@ -492,7 +487,6 @@ class afcFunction:
 
             checked, msg, pos = CUR_LANE.unit_obj.calibrate_bowden(CUR_LANE, dis, tol)
             if not checked:
-                prompt.p_end()
                 self.AFC.ERROR.AFC_error('{} failed to calibrate bowden length {}'.format(afc_bl, msg), pause=False)
                 self.AFC.gcode.run_script_from_command('AFC_CALI_FAIL FAIL={} DISTANCE={}'.format(afc_bl, pos))
                 return

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -402,7 +402,6 @@ class afcFunction:
             self.logger.info('Tool must be unloaded to calibrate Bowden length')
             return
 
-        cal_msg = ''
         calibrated = []
         # Check to make sure lane and unit is valid
         if lanes is not None and lanes != 'all' and lanes not in self.AFC.lanes:

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -5,7 +5,10 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
 from configfile import error
-from extras.AFC_respond import AFCprompt
+try:
+    from extras.AFC_respond import AFCprompt
+except:
+    raise error("Error trying to import AFC_respond, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper")
 
 class afcUnit:
     def __init__(self, config):
@@ -119,7 +122,7 @@ class afcUnit:
         Returns:
             None
         """
-        prompt = AFCprompt(gcmd)
+        prompt = AFCprompt(gcmd, self.logger)
         buttons = []
         title = '{} Calibration'.format(self.name)
         text = 'Select to calibrate the distance from extruder to hub or bowden length'
@@ -146,7 +149,7 @@ class afcUnit:
         Returns:
             None
         """
-        prompt = AFCprompt(gcmd)
+        prompt = AFCprompt(gcmd, self.logger)
         buttons = []
         group_buttons = []
         title = '{} Lane Calibration'.format(self.name)
@@ -199,7 +202,7 @@ class afcUnit:
         Returns:
             None
         """
-        prompt = AFCprompt(gcmd)
+        prompt = AFCprompt(gcmd, self.logger)
         buttons = []
         group_buttons = []
         title = 'Bowden Calibration {}'.format(self.name)

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -148,22 +148,34 @@ class afcUnit:
         buttons = []
         group_buttons = []
         title = '{} Lane Calibration'.format(self.name)
-        text  = ('Select a lane from {} to calibrate length from extruder to hub. '
+        text  = ('Select a loaded lane from {} to calibrate length from extruder to hub. '
                  'Config option: dist_hub').format(self.name)
 
         # Create buttons for each lane and group every 4 lanes together
         for index, LANE in enumerate(self.lanes):
-            button_label = "{}".format(LANE)
-            button_command = "CALIBRATE_AFC LANE={}".format(LANE)
-            button_style = "primary" if index % 2 == 0 else "secondary"
-            group_buttons.append((button_label, button_command, button_style))
+            CUR_LANE = self.lanes[LANE]
+            if CUR_LANE.load_state:
+                button_label = "{}".format(LANE)
+                button_command = "CALIBRATE_AFC LANE={}".format(LANE)
+                button_style = "primary" if index % 2 == 0 else "secondary"
+                group_buttons.append((button_label, button_command, button_style))
 
-            # Add group to buttons list after every 4 lanes
-            if (index + 1) % 2 == 0 or index == len(self.lanes) - 1:
-                buttons.append(list(group_buttons))
-                group_buttons = []
+                # Add group to buttons list after every 4 lanes
+                if (index + 1) % 2 == 0 or index == len(self.lanes) - 1:
+                    buttons.append(list(group_buttons))
+                    group_buttons = []
 
-        all_lanes = [('All lanes', 'CALIBRATE_AFC LANE=all UNIT={}'.format(self.name), 'default')]
+        if group_buttons:
+            buttons.append(list(group_buttons))
+
+        total_buttons = sum(len(group) for group in buttons)
+        if total_buttons > 1:
+            all_lanes = [('All lanes', 'CALIBRATE_AFC LANE=all UNIT={}'.format(self.name), 'default')]
+        else:
+            all_lanes = None
+        if total_buttons == 0:
+            text = 'No lanes are loaded, please load before calibration'
+
         # 'Back' button
         back = [('Back', 'UNIT_CALIBRATION UNIT={}'.format(self.name), 'info')]
 
@@ -189,21 +201,30 @@ class afcUnit:
         buttons = []
         group_buttons = []
         title = 'Bowden Calibration {}'.format(self.name)
-        text = ('Select a lane from {} to measure Bowden length. '
+        text = ('Select a loaded lane from {} to measure Bowden length. '
                 'ONLY CALIBRATE BOWDEN USING 1 LANE PER UNIT. '
                 'Config option: afc_bowden_length').format(self.name)
 
         for index, LANE in enumerate(self.lanes):
-            # Create a button for each lane
-            button_label = "{}".format(LANE)
-            button_command = "CALIBRATE_AFC BOWDEN={}".format(LANE)
-            button_style = "primary" if index % 2 == 0 else "secondary"
-            group_buttons.append((button_label, button_command, button_style))
+            CUR_LANE = self.lanes[LANE]
+            if CUR_LANE.load_state:
+                # Create a button for each lane
+                button_label = "{}".format(LANE)
+                button_command = "CALIBRATE_AFC BOWDEN={}".format(LANE)
+                button_style = "primary" if index % 2 == 0 else "secondary"
+                group_buttons.append((button_label, button_command, button_style))
 
-            # Add group to buttons list after every 4 lanes
-            if (index + 1) % 2 == 0 or index == len(self.lanes) - 1:
-                buttons.append(list(group_buttons))
-                group_buttons = []
+                # Add group to buttons list after every 4 lanes
+                if (index + 1) % 2 == 0 or index == len(self.lanes) - 1:
+                    buttons.append(list(group_buttons))
+                    group_buttons = []
+
+        if group_buttons:
+            buttons.append(list(group_buttons))
+
+        total_buttons = sum(len(group) for group in buttons)
+        if total_buttons == 0:
+            text = 'No lanes are loaded, please load before calibration'
 
         back = [('Back', 'UNIT_CALIBRATION UNIT={}'.format(self.name), 'info')]
 

--- a/templates/AFC_Hardware-MMB.cfg
+++ b/templates/AFC_Hardware-MMB.cfg
@@ -118,10 +118,12 @@ tool_load_speed: 25             # Load speed in mm/s. Default is 25mm/s.
 # buffer: TN2                    # Buffer to use (if available)
 
 [AFC_hub Turtle_1]
-Type: Box_Turtle
+switch_pin: ^AFC:HUB            # Pin for the hub switch
 afc_bowden_length: 940          # Length of the Bowden tube from the hub to the toolhead sensor in mm.
 move_dis: 50                    # Distance to move the filament within the hub in mm.
+#hub_clear_move_dis: 25         # Distance after hub switch becomes fast to retract to insure hub is clear
 cut: False                      # Hub has Cutter
+
 #--=================================================================================--
 #------- Hub Cut ---------------------------------------------------------------------
 #--=================================================================================--
@@ -134,7 +136,7 @@ cut_min_length: 300.0
 cut_servo_pass_angle: 10        # Servo angle to align the Bowden tube with the hole for loading the toolhead.
 cut_servo_clip_angle: 180       # Servo angle for cutting the filament.
 cut_servo_prep_angle: 80        # Servo angle to prepare the filament for cutting (aligning the exit hole).
-switch_pin: ^AFC:HUB
+
 
 [AFC_led AFC_Indicator]
 pin: AFC:RGB1

--- a/templates/AFC_Turtle_1.cfg
+++ b/templates/AFC_Turtle_1.cfg
@@ -113,9 +113,12 @@ run_current: 0.8
 sense_resistor: 0.110
 
 [AFC_hub Turtle_1]
+switch_pin: ^Turtle_1:HUB   # Pin for the hub switch
 afc_bowden_length: 1725     # Length of the Bowden tube from the hub to the toolhead sensor in mm.
 move_dis: 50                # Distance to move the filament within the hub in mm.
+#hub_clear_move_dis: 25     # Distance after hub switch becomes fast to retract to insure hub is clear
 cut: False                  # Hub cutter installed (e.g. Snappy)
+
 #--=================================================================================--#
 ######### Hub Cut #####################################################################
 #--=================================================================================--#
@@ -127,7 +130,6 @@ cut_min_length: 300.0
 cut_servo_pass_angle: 10    # Servo angle to align the Bowden tube with the hole for loading the toolhead.
 cut_servo_clip_angle: 180   # Servo angle for cutting the filament.
 cut_servo_prep_angle: 80    # Servo angle to prepare the filament for cutting (aligning the exit hole).
-switch_pin: ^Turtle_1:HUB
 
 #[AFC_screen Turtle_1]
 #mac_address: None


### PR DESCRIPTION
## Major Changes in this PR
- Added calibration error out distances
- Added additional prompts to improve the user experience 
- Changes prompts to only show loaded lanes
- Added `AFC_RESET` function which opens a prompt to select a lane to reset
- Added `AFC_LANE_RESET` function takes to rest a lane to the hub, can have a distance defined to move a fixed distance 

## Notes to Code Reviewers

## How the changes in this PR are tested
- Test Calibration and verify successful calibration 
- Cause intentional error in calibration so test fault states

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
