### PR TITLE
fix update notification bug

### DIFF
--- a/include/update_commands.sh
+++ b/include/update_commands.sh
@@ -137,7 +137,7 @@ remove_t_macros() {
   local t_macro
   local t_macros
 
-  t_macros=$(grep -o -E 'T[0-9]+' "${afc_config_dir}/macros/AFC_macros.cfg")
+  t_macros=$(grep -o -E 'T[0-9]+' "${afc_config_dir}/macros/AFC_macros.cfg" || true)
 
   for t_macro in $t_macros; do
     crudini --del "${afc_config_dir}"/macros/AFC_macros.cfg "gcode_macro $t_macro"


### PR DESCRIPTION
## Major Changes in this PR

This pull request includes a small change to the `remove_t_macros` function in the `include/update_commands.sh` file. The change ensures that the `grep` command does not cause the script to fail if no matches are found.

* [`include/update_commands.sh`](diffhunk://#diff-099b67b29c8a62896f77c4c580e5e97c9a49aa782bdd6c1fed1fb2cdbc9f7675L140-R140): Modified `t_macros` assignment to use `grep` with `|| true` to prevent script failure when no matches are found.

## Notes to Code Reviewers

## How the changes in this PR are tested

Tested locally. `grep` will return an exit code of 1, which will break the shell script if the T macros aren't found, which we don't want. 

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
