### PR TITLE
Fixes to save/resume logic, other minor fixes as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-03-07]
+### Added
+- Added error checking to spool runout, before if a error happened during unload it could keep running the print
+- Added lane ejection when runout detected but rollover not setup
+- Added AFC_PAUSE function to override users pause macro so that necessary measures could be added to move in Z to avoid
+  hitting part if users pause macro moves toolhead
+- Added `afc_unload_bowden_length` parameter
+- Added moving Z to previous saved position +z hop when resuming to avoid hitting part when moving back
+
+### Fixed
+- Fixed error when trying to turn of LEDs
+- Fixed saving position as it was not saving correctly
+- Reworked rollover logic to restore position after lane has been ejected fully so that nozzle does not sit
+  on part while ejecting spool
+- Fixed error where user could put wrong lane for rollover and it would not error until runout logic is triggered
+- Fixed errors found in calibration routines
+
+
 ## [2025-03-02]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Once the plugin is updated, please uncomment the lines in your `printer.cfg` fil
 
 The `install-afc.sh` script will automatically install the majority of the plugin for you.
 
-Prior to starting Klipper, please review the configuration located at `~/printer_data/config/AFC/AFC_Hardware.cfg` and ensure all pins are correct for your specific hardware.
+Prior to starting Klipper, please review the configuration located at `~/printer_data/config/AFC/AFC_Turtle_(n).cfg` and ensure all pins are correct for your specific hardware.
 
 Additionally, review the following files for any changes that may be required:
 
@@ -284,7 +284,7 @@ Debug information about the respooler system can be found by visiting the follow
 
 ## LEDs not displaying correct color
 
-If your leds are not displaying the correct color update the following value under your `AFC_led` section in `~/printer_data/config/AFC/AFC_hardware.cfg` file.
+If your leds are not displaying the correct color update the following value under your `AFC_led` section in `~/printer_data/config/AFC/AFC_Turtle_(n).cfg` file.
 
 - color_order: change to match the color order for you leds. Different color orders are: RGB, RGBW, GRB, GRBW
 

--- a/docs/CONFIGURATION_OPTIONS.md
+++ b/docs/CONFIGURATION_OPTIONS.md
@@ -38,8 +38,8 @@
 - `tool_max_load_checks` (default: `4`): Max number of attempts to check to make sure filament is loaded into toolhead extruder when using buffer as ramming sensor
 - `z_hop` (default: `0`): Height to move up before and after a tool change completes
 - `xy_resume` (default: `False`): Need description or remove as this is currently an unused variable
-- `resume_speed` (default: `0`): Speed mm/s of resume move. Set to 0 to use gcode speed
-- `resume_z_speed` (default: `0`): Speed mm/s of resume move in Z. Set to 0 to use gcode speed
+- `resume_speed` (default: `25`): Speed mm/s of resume move. Set to 0 to use gcode speed
+- `resume_z_speed` (default: `25`): Speed mm/s of resume move in Z. Set to 0 to use gcode speed
 - `global_print_current` (default: `None`): Global variable to set steppers current to a specified current when printing. Going lower than 0.6 may result in TurtleNeck buffer's not working correctly
 - `enable_sensors_in_gui` (default: `False`): Set to True to show all sensor switches as filament sensors in mainsail/fluidd gui
 - `load_to_hub` (default: `True`): Fast loads filament to hub when inserted, set to False to disable. This is a global setting and can be overridden at AFC_stepper
@@ -71,6 +71,7 @@
 - `switch_pin` (default: `None`): Pin hub sensor it connected to
 - `hub_clear_move_dis` (default: `25`): How far to move filament so that it's not block the hub exit
 - `afc_bowden_length` (default: `900`): Length of the Bowden tube from the hub to the toolhead sensor in mm.
+- `afc_unload_bowden_length` (default: `afc_bowden_length`): Length to unload when retracting back from toolhead to hub in mm. Defaults to afc_bowden_length
 - `assisted_retract` (default: `False`): if True, retracts are assisted to prevent loose windings on the spool
 - `move_dis` (default: `50`): Distance to move the filament within the hub in mm.
 - `cut` (default: `False`): Set True if Hub cutter installed (e.g. Snappy)

--- a/docs/command_reference.md
+++ b/docs/command_reference.md
@@ -139,12 +139,14 @@ Example: ``SET_AFC_TOOLCHANGES TOOLCHANGES=100``
 
 ### SET_BOWDEN_LENGTH
 _Description_: This function adjusts the length of the Bowden tube between the hub and the toolhead.
-It retrieves the hub specified by the 'HUB' parameter and the length adjustment specified++
-by the 'LENGTH' parameter. If the hub is not specified and a lane is currently loaded,
-it uses the hub of the current lane.  
+It retrieves the hub specified by the 'HUB' parameter and the length adjustment specified
+by the 'LENGTH' parameter. UNLOAD_LENGTH adjusts unload Bowden length. If the hub is not specified
+and a lane is currently loaded, it uses the hub of the current lane. To reset length back to config
+value, pass in `reset` for each length to reset to value in config file. Adding +/- in front of the
+length will increase/decrease bowden length by that amount.  
   
-Usage: ``SET_BOWDEN_LENGTH HUB=<hub> LENGTH=<length>``  
-Example: ``SET_BOWDEN_LENGTH HUB=Turtle_1 LENGTH=100``  
+Usage: ``SET_BOWDEN_LENGTH HUB=<hub> LENGTH=<length> UNLOAD_LENGTH=<length>``  
+Example: ``SET_BOWDEN_LENGTH HUB=Turtle_1 LENGTH=+100 UNLOAD_LENGTH=-100``  
 
 ### SET_BUFFER_VELOCITY
 _Description_: Allows users to tweak buffer velocity setting while printing. This setting is not

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -57,7 +57,7 @@ class afc:
         # Registering stepper callback so that mux macro can be set properly with valid lane names
         self.printer.register_event_handler("afc_stepper:register_macros",self.register_lane_macros)
         # Registering for sdcard reset file so that error_state can be reset when starting a print
-        self.printer.register_event_handler("virtual_sdcard:reset_file",self.ERROR.set_error_state)
+        self.printer.register_event_handler("virtual_sdcard:reset_file",self.ERROR.reset_failure)
         # Registering webhooks endpoint for <ip_address>/printer/afc/status
         self.webhooks.register_endpoint("afc/status", self._webhooks_status)
 
@@ -68,6 +68,7 @@ class afc:
         self.next_lane_load = None
         self.error_state    = False
         self.current_state  = State.INIT
+        self.position_saved = False
         self.spoolman       = None
         self.prep_done      = False         # Variable used to hold of save_vars function from saving too early and overriding save before prep can be ran
 
@@ -152,8 +153,8 @@ class afc:
 
         self.z_hop                  = config.getfloat("z_hop", 0)                   # Height to move up before and after a tool change completes
         self.xy_resume              = config.getboolean("xy_resume", False)         # Need description or remove as this is currently an unused variable
-        self.resume_speed           = config.getfloat("resume_speed", 0)            # Speed mm/s of resume move. Set to 0 to use gcode speed
-        self.resume_z_speed         = config.getfloat("resume_z_speed", 0)          # Speed mm/s of resume move in Z. Set to 0 to use gcode speed
+        self.resume_speed           = config.getfloat("resume_speed", self.speed)   # Speed mm/s of resume move. Set to 0 to use gcode speed
+        self.resume_z_speed         = config.getfloat("resume_z_speed", self.speed) # Speed mm/s of resume move in Z. Set to 0 to use gcode speed
 
         self.global_print_current   = config.getfloat("global_print_current", None) # Global variable to set steppers current to a specified current when printing. Going lower than 0.6 may result in TurtleNeck buffer's not working correctly
 
@@ -436,16 +437,44 @@ class afc:
         CUR_LANE.do_enable(False)
         self.current_state = State.IDLE
 
+    def _get_resume_speed(self):
+        """
+        Common function for return resume speed
+        """
+        return self.resume_speed if self.resume_speed > 0 else self.speed
+
+    def _get_resume_speedz(self):
+        """
+        Common function for return resume z speed
+        """
+        return self.resume_z_speed if self.resume_z_speed > 0 else self.speed
+
+    def _move_z_pos(self, z_amount):
+        """
+        Common function helper to move z, also does a check for max z so toolhead does not exceed max height
+
+        :param base_pos: position to apply z amount to
+        :param z_amount: amount to add to the base position
+        """
+        max_z = self.toolhead.get_status(0)['axis_maximum'][2]
+        newpos = self.toolhead.get_position()
+
+        # Determine z movement, get the min value to not exceed max z movement
+        newpos[2] = min(max_z, z_amount)
+
+        self.gcode_move.move_with_transform(newpos, self._get_resume_speedz())
+
     def save_pos(self):
         """
         Only save previous location on the first toolchange call to keep an error state from overwriting the location
         """
         if self.in_toolchange == False:
-            if self.error_state == False:
+            if self.error_state == False and self.FUNCTION.is_paused() == False and self.position_saved == False:
+                self.position_saved         = True
                 self.last_toolhead_position = self.toolhead.get_position()
-                self.base_position          = self.gcode_move.base_position
-                self.last_gcode_position    = self.gcode_move.last_position
-                self.homing_position        = self.gcode_move.homing_position
+                self.base_position          = list(self.gcode_move.base_position)
+                self.last_gcode_position    = list(self.gcode_move.last_position)
+                self.homing_position        = list(self.gcode_move.homing_position)
                 self.speed                  = self.gcode_move.speed
                 self.absolute_coord         = self.gcode_move.absolute_coord
                 msg = "Saving position {}".format(self.last_toolhead_position)
@@ -456,10 +485,12 @@ class afc:
                 msg += " absolute_coord: {}\n".format(self.absolute_coord)
                 self.logger.debug(msg)
 
-    def restore_pos(self):
+    def restore_pos(self, move_z_first=True):
         """
         restore_pos function restores the previous saved position, speed and coord type. The resume uses
         the z_hop value to lift, move to previous x,y coords, then lower to saved z position.
+
+        :param move_z_first: Enable to move z before moving x,y
         """
         msg = "Restoring Postion {}".format(self.last_toolhead_position)
         msg += " Base position: {}".format(self.base_position)
@@ -471,13 +502,10 @@ class afc:
 
         self.current_state = State.RESTORING_POS
         newpos = self.toolhead.get_position()
-        newpos[2] = self.last_gcode_position[2] + self.z_hop
 
         # Restore absolute coords
         self.gcode_move.absolute_coord = self.absolute_coord
 
-        speed = self.resume_speed if self.resume_speed > 0 else self.speed
-        speedz = self.resume_z_speed if self.resume_z_speed > 0 else self.speed
         # Update GCODE STATE variables
         self.gcode_move.base_position = self.base_position
         self.gcode_move.last_position[:3] = self.last_gcode_position[:3]
@@ -488,16 +516,18 @@ class afc:
         self.gcode_move.base_position[3] += e_diff
 
         # Move toolhead to previous z location with zhop added
-        self.gcode_move.move_with_transform(newpos, speedz)
+        if move_z_first:
+            self._move_z_pos(self.last_gcode_position[2] + self.z_hop)
 
         # Move to previous x,y location
         newpos[:2] = self.last_gcode_position[:2]
-        self.gcode_move.move_with_transform(newpos, speed)
+        self.gcode_move.move_with_transform(newpos, self._get_resume_speed() )
 
         # Drop to previous z
         newpos[2] = self.last_gcode_position[2]
-        self.gcode_move.move_with_transform(newpos, speedz)
+        self.gcode_move.move_with_transform(newpos, self._get_resume_speedz() )
         self.current_state = State.IDLE
+        self.position_saved = False
 
     def save_vars(self):
         """
@@ -604,6 +634,9 @@ class afc:
             self.logger.info('{} Unknown'.format(lane))
             return
         CUR_LANE = self.lanes[lane]
+        self.LANE_UNLOAD( CUR_LANE )
+
+    def LANE_UNLOAD(self, CUR_LANE):
         CUR_HUB = CUR_LANE.hub_obj
 
         self.current_state = State.EJECTING_LANE
@@ -945,7 +978,7 @@ class afc:
 
         # Perform Z-hop to avoid collisions during unloading.
         pos[2] += self.z_hop
-        self.toolhead.manual_move(pos, CUR_EXTRUDER.tool_unload_speed)
+        self._move_z_pos(pos[2])
         self.toolhead.wait_moves()
 
         # Disable the buffer if it's active.
@@ -1048,7 +1081,7 @@ class afc:
         # Synchronize and move filament out of the hub.
         CUR_LANE.unsync_to_extruder()
         if CUR_LANE.hub !='direct':
-            CUR_LANE.move(CUR_HUB.afc_bowden_length * -1, CUR_LANE.long_moves_speed, CUR_LANE.long_moves_accel, True)
+            CUR_LANE.move(CUR_HUB.afc_unload_bowden_length * -1, CUR_LANE.long_moves_speed, CUR_LANE.long_moves_accel, True)
         else:
             CUR_LANE.move(CUR_LANE.dist_hub * -1, CUR_LANE.dist_hub_move_speed, CUR_LANE.dist_hub_move_accel, CUR_LANE.dist_hub > 200)
 
@@ -1064,7 +1097,7 @@ class afc:
         while CUR_HUB.state:
             CUR_LANE.move(CUR_LANE.short_move_dis * -1, CUR_LANE.short_moves_speed, CUR_LANE.short_moves_accel, True)
             num_tries += 1
-            if num_tries > (CUR_HUB.afc_bowden_length / CUR_LANE.short_move_dis):
+            if num_tries > (CUR_HUB.afc_unload_bowden_length / CUR_LANE.short_move_dis):
                 # Handle failure if the filament doesn't clear the hub.
                 message = 'Hub is not clearing, filament may be stuck in hub'
                 message += '\nPlease check to make sure filament has not broken off and caused the sensor to stay stuck'
@@ -1094,7 +1127,7 @@ class afc:
                     CUR_LANE.move(CUR_LANE.short_move_dis * -1, CUR_LANE.short_moves_speed, CUR_LANE.short_moves_accel, True)
                     num_tries += 1
                     # TODO: Figure out max number of tries
-                    if num_tries > (CUR_HUB.afc_bowden_length / CUR_LANE.short_move_dis):
+                    if num_tries > (CUR_HUB.afc_unload_bowden_length / CUR_LANE.short_move_dis):
                         message = 'HUB NOT CLEARING after hub cut\n'
                         self.ERROR.handle_lane_failure(CUR_LANE, message)
                         return False
@@ -1178,7 +1211,7 @@ class afc:
 
         self.CHANGE_TOOL(self.lanes[self.tool_cmds[Tcmd]], purge_length)
 
-    def CHANGE_TOOL(self, CUR_LANE, purge_length=None):
+    def CHANGE_TOOL(self, CUR_LANE, purge_length=None, restore_pos=True):
         # Check if the bypass filament sensor detects filament; if so, abort the tool change.
         if self._check_bypass(unload=False): return
 
@@ -1214,7 +1247,8 @@ class afc:
             # Load the new lane and restore the toolhead position if successful.
             if self.TOOL_LOAD(CUR_LANE, purge_length) and not self.error_state:
                 self.afcDeltaTime.log_total_time("Total change time:")
-                self.restore_pos()
+                if restore_pos:
+                    self.restore_pos()
                 self.in_toolchange = False
                 # Setting next lane load as none since toolchange was successful
                 self.next_lane_load = None
@@ -1237,6 +1271,7 @@ class afc:
         str['spoolman']                 = self.spoolman
         str['error_state']              = self.error_state
         str["bypass_state"]             = bool(self._get_bypass_state())
+        str["position_saved"]           = self.position_saved
 
         unitdisplay =[]
         for UNIT in self.units.keys():

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -147,11 +147,10 @@ class afcBoxTurtle(afcUnit):
 
             CUR_LANE.move(bow_pos * -1, CUR_LANE.long_moves_speed, CUR_LANE.long_moves_accel, True)
 
-            success, hub_dis, pos = self.calibrate_hub(CUR_LANE, tol)
+            success, message, hub_dis = self.calibrate_hub(CUR_LANE, tol)
 
             if not success:
-                msg = '{}'.format(hub_dis)
-                return False, msg, pos
+                return False, message, hub_dis
 
             if CUR_HUB.state:
                 # reset at hub
@@ -175,6 +174,7 @@ class afcBoxTurtle(afcUnit):
     # Helper functions for movement and calibration
     def calibrate_hub(self, CUR_LANE, tol):
         hub_pos = 0
+        msg = ''
         hub_fault_dis = CUR_LANE.dist_hub + 150
         checkpoint = 'hub calibration {}'.format(CUR_LANE.name)
         # move until hub sensor is triggered and get information
@@ -196,7 +196,7 @@ class afcBoxTurtle(afcUnit):
             return False, msg, tuned_hub_pos
 
         # when successful return values to calibration macro
-        return True, tuned_hub_pos, tuned_hub_pos
+        return True, msg, tuned_hub_pos
 
     def move_until_state(self, CUR_LANE, state, move_dis, tolerance, short_move, pos=0, fault_dis=250, checkpoint=None):
         # moves filament until specified sensor, returns values for further czlibration
@@ -284,11 +284,10 @@ class afcBoxTurtle(afcUnit):
             return False, msg, 0
 
         else:
-            success, hub_pos = self.calibrate_hub(CUR_LANE, tol)
+            success, message, hub_pos = self.calibrate_hub(CUR_LANE, tol)
 
             if not success:
-                msg = '{}'.format(hub_pos)
-                return False, msg, hub_pos
+                return False, message, hub_pos
 
             if CUR_HUB.state:
                 CUR_LANE.move(CUR_HUB.move_dis * -1, CUR_LANE.short_moves_speed, CUR_LANE.short_moves_accel, True)

--- a/extras/AFC_buffer.py
+++ b/extras/AFC_buffer.py
@@ -107,6 +107,9 @@ class AFCtrigger:
 
         self.AFC.buffers[self.name] = self
 
+    def __str__(self):
+        return self.name
+
     def _handle_ready(self):
         self.min_event_systime = self.reactor.monotonic() + 2.
 

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -23,11 +23,14 @@ class afcError:
         This function is called when the printer connects. It looks up AFC info
         and assigns it to the instance variable `self.AFC`.
         """
-        self.AFC = self.printer.lookup_object('AFC')
+        self.AFC            = self.printer.lookup_object('AFC')
+        self.pause_resume   = self.printer.lookup_object("pause_resume")
         self.logger = self.AFC.logger
         # Constant variable for renaming RESUME macro
         self.BASE_RESUME_NAME       = 'RESUME'
         self.AFC_RENAME_RESUME_NAME = '_AFC_RENAMED_{}_'.format(self.BASE_RESUME_NAME)
+        self.BASE_PAUSE_NAME        = 'PAUSE'
+        self.AFC_RENAME_PAUSE_NAME  = '_AFC_RENAMED_{}_'.format(self.BASE_PAUSE_NAME)
 
         self.AFC.gcode.register_command('RESET_FAILURE', self.cmd_RESET_FAILURE, desc=self.cmd_RESET_FAILURE_help)
         self.AFC.gcode.register_command('AFC_RESUME', self.cmd_AFC_RESUME, desc=self.cmd_AFC_RESUME_help)
@@ -123,8 +126,15 @@ class afcError:
         Returns:
             None
         """
+        self.reset_failure()
+
+    def reset_failure(self):
+        """
+        Common function to reset error_state, pause, and position_saved variables
+        """
         self.set_error_state(False)
-        self.pause = False
+        self.pause              = False
+        self.AFC.position_saved = False
 
     cmd_AFC_RESUME_help = "Clear error state and restores position before resuming the print"
     def cmd_AFC_RESUME(self, gcmd):
@@ -141,16 +151,40 @@ class afcError:
         Returns:
             None
         """
-        self.AFC.in_toolchange = False
+        # Save current pause state
+        temp_is_paused = self.AFC.FUNCTION.is_paused()
+        curr_pos = self.AFC.toolhead.get_position()
+
+        # Check if current position is below saved gcode position, if its lower first raise z above last saved
+        #   position so that toolhead does not crash into part
+        if (curr_pos[2] <= self.AFC.last_gcode_position[2]):
+            self.AFC._move_z_pos( self.AFC.last_gcode_position[2] + self.AFC.z_hop )
+
         self.logger.debug("Before User Restore")
         self.AFC.FUNCTION.log_toolhead_pos()
         self.AFC.gcode.run_script_from_command(self.AFC_RENAME_RESUME_NAME)
 
         #The only time our resume should restore position is if there was an error that caused the pause
-        if self.AFC.error_state:
+        if self.AFC.error_state or temp_is_paused or self.AFC.position_saved:
             self.set_error_state(False)
-            self.AFC.restore_pos()
+            self.AFC.restore_pos(False)
             self.pause = False
+
+    cmd_AFC_RESUME_help = "Pauses print, raises z by z-hop amount, and then calls users pause macro"
+    def cmd_AFC_PAUSE(self, gcmd):
+        self.logger.debug("AFC_PAUSE")
+        # Save position
+        self.AFC.save_pos()
+        # Need to pause as soon as possible to stop more gcode from executing, this needs to be done before movement in Z
+        self.pause_resume.send_pause_command()
+        # Move Z up by z-hop value
+        self.AFC._move_z_pos( self.AFC.last_gcode_position[2] + self.AFC.z_hop )
+        # Update gcode move last position to current position
+        self.AFC.gcode_move.reset_last_position()
+        # Call users PAUSE
+        self.AFC.gcode.run_script_from_command(self.AFC_RENAME_PAUSE_NAME)
+        # Set Idle timeout to 10 hours
+        self.AFC.gcode.run_script_from_command("SET_IDLE_TIMEOUT TIMEOUT=36000")
 
     handle_lane_failure_help = "Get load errors, stop stepper and respond error"
     def handle_lane_failure(self, CUR_LANE, message, pause=True):

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -53,6 +53,9 @@ class AFCextruder:
 
         self.common_save_msg = "\nRun SAVE_EXTRUDER_VALUES EXTRUDER={} once done to update values in config".format(self.name)
 
+    def __str__(self):
+        return self.name
+
     def handle_connect(self):
         """
         Handle the connection event.

--- a/extras/AFC_hub.py
+++ b/extras/AFC_hub.py
@@ -26,6 +26,7 @@ class afc_hub:
         self.switch_pin             = config.get('switch_pin', None)                # Pin hub sensor it connected to
         self.hub_clear_move_dis     = config.getfloat("hub_clear_move_dis", 25)     # How far to move filament so that it's not block the hub exit
         self.afc_bowden_length      = config.getfloat("afc_bowden_length", 900)     # Length of the Bowden tube from the hub to the toolhead sensor in mm.
+        self.afc_unload_bowden_length= config.getfloat("afc_unload_bowden_length", self.afc_bowden_length) # Length to unload when retracting back from toolhead to hub in mm. Defaults to afc_bowden_length
         self.assisted_retract       = config.getboolean("assisted_retract", False)  # if True, retracts are assisted to prevent loose windings on the spool
         self.move_dis               = config.getfloat("move_dis", 50)               # Distance to move the filament within the hub in mm.
         # Servo settings
@@ -41,6 +42,7 @@ class afc_hub:
         self.cut_confirm            = config.getboolean("cut_confirm", 0)           # Set True to cut filament twice
 
         self.config_bowden_length   = self.afc_bowden_length                        # Used by SET_BOWDEN_LENGTH macro
+        self.config_unload_bowden_length = self.afc_unload_bowden_length
         self.enable_sensors_in_gui  = config.getboolean("enable_sensors_in_gui", self.AFC.enable_sensors_in_gui) # Set to True to show hub sensor switche as filament sensor in mainsail/fluidd gui, overrides value set in AFC.cfg
 
         buttons = self.printer.load_object(config, "buttons")
@@ -55,6 +57,9 @@ class afc_hub:
 
         # Adding self to AFC hubs
         self.AFC.hubs[self.name]=self
+
+    def __str__(self):
+        return self.name
 
     def handle_connect(self):
         """

--- a/extras/AFC_led.py
+++ b/extras/AFC_led.py
@@ -135,7 +135,7 @@ class AFCled:
         toolhead.register_lookahead_callback(lookahead_bgfunc)
 
     def turn_off_leds(self):
-        for i in range(self.led_helper.get_led_count()):
+        for i in range(self.led_helper.led_count):
             self.led_change( i, "0,0,0,0", False)
         self.keep_leds_off = True
 

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -40,21 +40,23 @@ class afcPrep:
             pdesc = "Renamed builtin of '%s'" % (base_name,)
             self.AFC.gcode.register_command(rename_name, prev_cmd, desc=pdesc)
         else:
-            self.logger.info("{}Existing command {} not found in gcode_macros{}".format("<span class=warning--text>", base_name, "</span>",))
+            self.logger.debug("{}Existing command {} not found in gcode_macros{}".format("<span class=warning--text>", base_name, "</span>",))
         self.AFC.gcode.register_command(base_name, rename_macro, desc=rename_help)
 
     def _rename_macros(self):
         """
         Helper function to rename multiple macros and substitute with AFC macros.
-        - Replaces stock RESUME macro and reassigns to AFC_resume function
+        - Replaces stock RESUME macro and reassigns to AFC_RESUME function
         - Replaces stock UNLOAD macro and reassigns to TOOL_UNLOAD function. This can be disabled in AFC_prep config
+        - Replaces stock/users PAUSE macro and reassigns to AFC_PAUSE function.
         """
         # Checking to see if rename has already been done, don't want to rename again if prep was already ran
         if not self.rename_occurred:
             self.rename_occurred = True
             self._rename( self.AFC.ERROR.BASE_RESUME_NAME, self.AFC.ERROR.AFC_RENAME_RESUME_NAME, self.AFC.ERROR.cmd_AFC_RESUME, self.AFC.ERROR.cmd_AFC_RESUME_help )
+            self._rename( self.AFC.ERROR.BASE_PAUSE_NAME,  self.AFC.ERROR.AFC_RENAME_PAUSE_NAME,  self.AFC.ERROR.cmd_AFC_PAUSE,  self.AFC.ERROR.cmd_AFC_RESUME_help )
 
-            # Check to see if the user does not want to rename UNLOAD_FILAMENT macor
+            # Check to see if the user does not want to rename UNLOAD_FILAMENT macro
             if not self.dis_unload_macro:
                 self._rename( self.AFC.BASE_UNLOAD_FILAMENT,   self.AFC.RENAMED_UNLOAD_FILAMENT,      self.AFC.cmd_TOOL_UNLOAD,      self.AFC.cmd_TOOL_UNLOAD_help )
 

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -297,10 +297,21 @@ class afcSpool:
         if lane == None:
             self.logger.info("No LANE Defined")
             return
+
         runout = gcmd.get('RUNOUT', '')
-        if lane not in self.AFC.lanes:
-            self.logger.info('{} Unknown'.format(lane))
+        # Check to make sure runout does not equal lane
+        if lane == runout:
+            self.logger.error("Lane({}) and runout({}) cannot be the same".format(lane, runout))
             return
+        # Check to make sure specified lane exists
+        if lane not in self.AFC.lanes:
+            self.logger.error('Unknown lane: {}'.format(lane))
+            return
+        # Check to make sure specified runout lane exists as long as runout is not set as 'NONE'
+        if runout != 'NONE' and runout not in self.AFC.lanes:
+            self.logger.error('Unknown runout lane: {}'.format(runout))
+            return
+
         CUR_LANE = self.AFC.lanes[lane]
         CUR_LANE.runout_lane = runout
         self.AFC.save_vars()

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -187,6 +187,9 @@ class AFCExtruderStepper:
         self.prep_active = False
         self.last_prep_time = 0
 
+    def __str__(self):
+        return self.name
+
     def _handle_ready(self):
         """
         Handles klippy:ready callback and verifies that steppers have units defined in their config
@@ -528,24 +531,35 @@ class AFCExtruderStepper:
                         self.logger.info("Infinite Spool triggered for {}".format(self.name))
                         empty_LANE = self.AFC.lanes[self.AFC.current]
                         change_LANE = self.AFC.lanes[self.runout_lane]
-                        # Pause printer
-                        self.gcode.run_script_from_command('PAUSE')
-                        # Change Tool
-                        self.AFC.CHANGE_TOOL(change_LANE)
+                        # Pause printer with manual command
+                        self.AFC.ERROR.pause_resume.send_pause_command()
+                        # Saving position after printer is paused
+                        self.AFC.save_pos()
+                        # Change Tool and don't restore position. Position will be restored after lane is unloaded
+                        #  so that nozzle does not sit on print while lane is unloading
+                        self.AFC.CHANGE_TOOL(change_LANE, restore_pos=False)
                         # Change Mapping
                         self.gcode.run_script_from_command('SET_MAP LANE={} MAP={}'.format(change_LANE.name, empty_LANE.map))
-                        # Eject lane from BT
-                        self.gcode.run_script_from_command('LANE_UNLOAD LANE={}'.format(empty_LANE.name))
-                        # Resume
-                        self.gcode.run_script_from_command('RESUME')
-                        # Set LED to not ready
-                        self.AFC.FUNCTION.afc_led(self.led_not_ready, self.led_index)
+                        # Only continue if a error did not happen
+                        if not self.AFC.error_state:
+                            # Eject lane from BT
+                            self.gcode.run_script_from_command('LANE_UNLOAD LANE={}'.format(empty_LANE.name))
+                            # Resume pos
+                            self.AFC.restore_pos()
+                            # Resume with manual issued command
+                            self.AFC.ERROR.pause_resume.send_resume_command()
+                            # Set LED to not ready
+                            self.AFC.FUNCTION.afc_led(self.led_not_ready, self.led_index)
                     else:
                         # Unload if user has set AFC to unload on runout
                         if self.unit_obj.unload_on_runout:
                             # Pause printer
-                            self.gcode.run_script_from_command('PAUSE')
+                            self.AFC.ERROR.pause_resume.send_pause_command()
+                            self.AFC.save_pos()
+                            # self.gcode.run_script_from_command('PAUSE')
                             self.AFC.TOOL_UNLOAD(self)
+                            if not self.AFC.error_state:
+                                self.AFC.LANE_UNLOAD(self)
                         # Pause print
                         self.status = None
                         msg = "Runout triggered for lane {} and runout lane is not setup to switch to another lane".format(self.name)

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -52,6 +52,9 @@ class afcUnit:
         self.assisted_unload    = config.getboolean("assisted_unload", self.AFC.assisted_unload)    # If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool. Setting value here overrides values set in AFC.cfg file
         self.unload_on_runout   = config.getboolean("unload_on_runout", self.AFC.unload_on_runout)  # When True AFC will unload lane and then pause when runout is triggered and spool to swap to is not set(infinite spool). Setting value here overrides values set in AFC.cfg file
 
+    def __str__(self):
+        return self.name
+
     def handle_connect(self):
         """
         Handles klippy:connect event, and does error checking to make sure users have hub/extruder/buffers sections if these variables are defined at the unit level


### PR DESCRIPTION
## Major Changes in this PR
Major focus was on fixing save/resume logic as it was not saving position correctly.

Additions:
- Added `afc_unload_bowden_length` parameter, updated set_bowden_length to be able to adjust unload value as well
- Added error checking to infinite spool rollover, before if a error happened during unload it could keep running the print
- Added lane ejection when unload on runout is set when runouts are detected and a lane is not set for rollover
- Added AFC_PAUSE function to override users pause macro so that necessary measures could be added to move in Z to avoid hitting part if users pause macro moves toolhead
- Added moving Z to previous saved position +z hop when resuming to avoid hitting part when moving back

Fixes:
- Fixed saving position as it was not saving correctly
- Fixed error where user could put wrong lane for rollover and it would not error until runout logic is triggered
- Fixed errors found in calibration routines
- Fixed error when trying to turn of LEDs
- Reworked rollover logic to restore position after lane has been ejected fully so that nozzle does not sit on part while ejecting spool

## Notes to Code Reviewers

## How the changes in this PR are tested
Tested both infinite spool and normal runout to make sure code worked as intended. And that pause/resume with saving and resuming position worked when z was adjusted outside of AFC.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
