### PR TITLE
update calibration and macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2025-03-07]
 ### Added
+- Added variable_z_purge_move to Poop macro. Setting this to False will allow pooping with no z movement
+- Added variable_z_move to brush macro. this value will set a positive Z move at the end of the brush to move the nozzle away from the brush
+
+### Fixed
+- Fixed error that occurs when all lanes are calibrated
+
+## [2025-03-07]
+### Added
 - Added error checking to spool runout, before if a error happened during unload it could keep running the print
 - Added lane ejection when runout detected but rollover not setup
 - Added AFC_PAUSE function to override users pause macro so that necessary measures could be added to move in Z to avoid

--- a/config/AFC_Macro_Vars.cfg
+++ b/config/AFC_Macro_Vars.cfg
@@ -119,6 +119,7 @@ gcode: # Leave empty
 
 variable_purge_loc_xy             : -1, -1    # (x,y) Location of where to purge
 variable_purge_spd                : 6.5       # Speed, in mm/s, of the purge.
+variable_z_purge_move             : True      # Set to False to not move in Z during poop
 
 # Speed, in mm/s to lift z after the purge is completed. Its a faster lift to keep it from 
 # sticking to the toolhead
@@ -192,6 +193,9 @@ variable_brush_width              : 30        # Total width in mm of the brush i
 variable_brush_depth              : 10        # Total depth in mm of the brush in the Y direction
 variable_y_brush                  : True      # True - Brush along Y axis first then X. False - Only brush along x
 variable_brush_count              : 4         # Number of passes to make on the brush.
+
+# Move in Z after brush to avoid bed if brush is at Z0 (Set z to -1 if you dont want a z move)
+variable_z_move                   : -1
 
 
 #--=================================================================================-

--- a/config/macros/Brush.cfg
+++ b/config/macros/Brush.cfg
@@ -1,19 +1,20 @@
 [gcode_macro AFC_BRUSH]
 description: Wipe the nozzle on the brush
 gcode:
-    {% set gVars = printer['gcode_macro _AFC_GLOBAL_VARS'] %}
-    {% set accel = gVars['accel']|float %}
-    {% set travel_speed = gVars['travel_speed'] * 60|float %}
-    {% set z_travel_speed = gVars['z_travel_speed'] * 60|float %}
-    {% set verbose = gVars['verbose']|int %}
-    {% set vars = printer['gcode_macro _AFC_BRUSH_VARS'] %}
-    {% set Bx, By, Bz = vars.brush_loc|map('float') %}
+    {% set gVars             = printer['gcode_macro _AFC_GLOBAL_VARS'] %}
+    {% set accel             = gVars['accel']|float %}
+    {% set travel_speed      = gVars['travel_speed'] * 60|float %}
+    {% set z_travel_speed    = gVars['z_travel_speed'] * 60|float %}
+    {% set verbose           = gVars['verbose']|int %}
+    {% set vars              = printer['gcode_macro _AFC_BRUSH_VARS'] %}
+    {% set Bx, By, Bz        = vars.brush_loc|map('float') %}
     {% set brush_clean_accel = vars['brush_clean_accel']|float %}
-    {% set y_brush = vars['y_brush']|default(false)|lower == 'true' %}
+    {% set y_brush           = vars['y_brush']|default(false)|lower == 'true' %}
     {% set brush_clean_speed = vars['brush_clean_speed'] * 60|float %}
-    {% set brush_width = vars['brush_width']|float %}
-    {% set brush_depth = vars['brush_depth']|float %}
-    {% set brush_count = vars['brush_count']|int %}
+    {% set brush_width       = vars['brush_width']|float %}
+    {% set brush_depth       = vars['brush_depth']|float %}
+    {% set brush_count       = vars['brush_count']|int %}
+    {% set z_move            = vars['z_move']     |float %}
 
     # Get printer bounds to make sure none of our cleaning moves fall outside of them
     {% set x_max = printer.toolhead.axis_maximum.x %}
@@ -47,6 +48,8 @@ gcode:
     {% if verbose > 1 %}
       RESPOND TYPE=command MSG='AFC_Brush: Move to Brush.'
     {% endif %}
+
+    G90
     
     G1 X{Bx} Y{By} F{travel_speed}
 
@@ -90,6 +93,17 @@ gcode:
         G1 X{Bx} F{brush_clean_speed}
             
     {% endfor %}
+
+    {% if z_move >= 0 %}
+      {% if verbose > 1 %}
+        RESPOND TYPE=command MSG='AFC_Brush: Finish z_move.'
+      {% endif %}
+      G91
+      G1 Z{z_move} F{z_travel_speed}
+      G90
+    {% endif %}
+
+    G90
 
     # Reset acceleration values to what it was before
     SET_VELOCITY_LIMIT ACCEL={saved_accel}

--- a/config/macros/Park.cfg
+++ b/config/macros/Park.cfg
@@ -24,5 +24,7 @@ gcode:
     RESPOND TYPE=command MSG='AFC_Park: Park Toolhead'
   {% endif %}
 
+  G90
+
   G1 Z{z_safe} F{z_travel_speed}
   G1 X{Px} Y{Py} F{travel_speed}

--- a/config/macros/Poop.cfg
+++ b/config/macros/Poop.cfg
@@ -8,22 +8,23 @@ variable_pressure_release_time: 1000
 variable_purge_z: 0
 
 gcode:
-  {% set gVars = printer['gcode_macro _AFC_GLOBAL_VARS'] %}
-  {% set travel_speed = gVars['travel_speed'] * 60|float %}
-  {% set z_travel_speed = gVars['z_travel_speed'] * 60|float %}
-  {% set verbose = gVars['verbose']|int %}
-  {% set vars = printer['gcode_macro _AFC_POOP_VARS'] %}
-  {% set purge_x, purge_y = vars.purge_loc_xy|map('float') %}
-  {% set purge_spd = vars['purge_spd'] * 60|float %}
-  {% set fast_z = vars['fast_z'] * 60|float %}
-  {% set z_lift = vars['z_lift']|float %}
-  {% set part_cooling_fan = vars['part_cooling_fan']|default(true)|lower == 'true' %}
+  {% set gVars                  = printer['gcode_macro _AFC_GLOBAL_VARS'] %}
+  {% set travel_speed           = gVars['travel_speed'] * 60|float %}
+  {% set z_travel_speed         = gVars['z_travel_speed'] * 60|float %}
+  {% set verbose                = gVars['verbose']|int %}
+  {% set vars                   = printer['gcode_macro _AFC_POOP_VARS'] %}
+  {% set purge_x, purge_y       = vars.purge_loc_xy|map('float') %}
+  {% set purge_spd              = vars['purge_spd'] * 60|float %}
+  {% set z_poop                 = vars['z_purge_move']|default(true)|lower == 'true' %}
+  {% set fast_z                 = vars['fast_z'] * 60|float %}
+  {% set z_lift                 = vars['z_lift']|float %}
+  {% set part_cooling_fan       = vars['part_cooling_fan']|default(true)|lower == 'true' %}
   {% set part_cooling_fan_speed = vars['part_cooling_fan_speed']|default(1.0)|float %}
-  {% set purge_cool_time = vars['purge_cool_time'] * 1000|float %}
-  {% set purge_length = vars['purge_length']|float %}
-  {% set purge_length_minimum = vars['purge_length_minimum']|float %}
-  {% set purge_start = vars['purge_start']|float %}
-  {% set restore_position = vars['restore_position']|default(true)|lower == 'true' %}
+  {% set purge_cool_time        = vars['purge_cool_time'] * 1000|float %}
+  {% set purge_length           = vars['purge_length']|float %}
+  {% set purge_length_minimum   = vars['purge_length_minimum']|float %}
+  {% set purge_start            = vars['purge_start']|float %}
+  {% set restore_position       = vars['restore_position']|default(true)|lower == 'true' %}
 
   {% if verbose > 0 %}
     RESPOND TYPE=command MSG='AFC_Poop: Starting poop'
@@ -57,7 +58,13 @@ gcode:
   {% endif %}
   
   G1 X{purge_x} Y{purge_y} F{travel_speed}
-  G1 Z{purge_z + purge_start} F{z_travel_speed}
+
+  RESPOND TYPE=command MSG='AFC_Poop: z_poop {z_poop}'
+
+  {% if z_poop %}
+    RESPOND TYPE=command MSG='AFC_Poop: why the fuck am I here? '
+    G1 Z{purge_z + purge_start} F{z_travel_speed}
+  {% endif %}
     
   {% set iterations = (purge_len / max_iteration_length)|round(0, 'ceil')|int %}
 
@@ -70,7 +77,9 @@ gcode:
     # Calculate current iteration in current blob
     {% set step = n % max_iterations_per_blob %}
     {% if step == 0 %}
-      G1 Z{purge_z + purge_start} F{z_travel_speed}
+      {% if z_poop %}
+        G1 Z{purge_z + purge_start} F{z_travel_speed}
+      {% endif %}
     {% endif %}
 
     {% set purge_amount_left = purge_len - (max_iteration_length * n) %}
@@ -86,9 +95,14 @@ gcode:
     {% set raise_z = [raise_z, 0]|max %}
 
     {% set duration = extrude_amount / purge_spd %} 
-    {% set speed = raise_z / duration %}
 
-    G1 Z{raise_z} E{extrude_amount} F{speed}
+    {% if z_poop %}
+      {% set speed = raise_z / duration %}
+      G1 Z{raise_z} E{extrude_amount} F{speed}
+    {% else %}
+      G1 E{extrude_amount} F{purge_spd}
+    {% endif %}
+
 
     {% set max_iterations_reached = step == max_iterations_per_blob - 1 %}
     {% set purge_length_reached = purge_len - max_iteration_length * (n + 1) <= 0 %}
@@ -103,7 +117,10 @@ gcode:
   {% if verbose > 1 %}
     RESPOND TYPE=command MSG='AFC_Poop: Fast Z Lift to keep poop from sticking'
   {% endif %}
-  G1 Z{z_lift} F{fast_z}21000
+
+  {% if z_poop %}
+    G1 Z{z_lift} F{fast_z}21000
+  {% endif %} 
 
   {% if verbose > 1 %}
     RESPOND TYPE=command MSG='AFC_Poop: Restore fan speed and feedrate'

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -433,6 +433,9 @@ class afcFunction:
                 else:
                     # Calibrate all lanes if no specific lane is provided
                     for CUR_LANE in self.AFC.lanes.values():
+                        if not CUR_LANE.load_state or not CUR_LANE.prep_state:
+                            self.logger.info("{} not loaded skipping to next loaded lane".format(CUR_LANE.name))
+                            continue
                         # Calibrate the specific lane
                         checked, msg, pos = CUR_LANE.unit_obj.calibrate_lane(CUR_LANE, tol)
                         if(not checked):
@@ -454,6 +457,9 @@ class afcFunction:
                     self.logger.info('{}'.format(CUR_UNIT.name))
                     # Calibrate all lanes if no specific lane is provided
                     for CUR_LANE in CUR_UNIT.lanes.values():
+                        if not CUR_LANE.load_state or  not CUR_LANE.prep_state:
+                            self.logger.info("{} not loaded skipping to next loaded lane".format(CUR_LANE.name))
+                            continue
                         # Calibrate the specific lane
                         checked, msg, pos = CUR_UNIT.calibrate_lane(CUR_LANE, tol)
                         if(not checked):
@@ -498,7 +504,8 @@ class afcFunction:
                 CUR_LANE.extruder_obj.tool_start = None
 
         if checked:
-            self.AFC.gcode.run_script_from_command('AFC_CALI_COMP CALI={}'.format(calibrated))
+            lanes_calibrated = ','.join(calibrated)
+            self.AFC.gcode.run_script_from_command('AFC_CALI_COMP CALI={}'.format(lanes_calibrated))
 
     cmd_AFC_CALI_COMP_help = 'Opens prompt after calibration is complete'
     def cmd_AFC_CALI_COMP(self, gcmd):


### PR DESCRIPTION
## Major Changes in this PR
- Update park macro with a G90
- Update poop macro to allow pooping with no Z movement
- Update brush macro to allow positive z movement after brush for those with brushes at bed height
- Fixed calibration so no error when all lanes are calibrated

## Notes to Code Reviewers

## How the changes in this PR are tested
- adjust macro values
- Run calibration for all lanes

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [ ] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Sent notification to software-design channel requesting review
