### PR TITLE
Fixing resume logic and couple other minor bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-03-10]
+### Added
+- Reporting error messages in AFC status so they can be shown in AFC integration panel
+
+### Fixed
+- Issue where resuming position could crash into object/purge tower
+- Issue where creating filament_switch_sensor in AFC would cause klipper to error out when AFC include is before `[pause_resume]` and user has `recover_velocity` defined
+- Issue where passing in `+-<number>` for length when calling `SET_BOWDEN_LENGTH` would crash klipper 
+
 ## [2025-03-07]
 ### Added
 - Added variable_z_purge_move to Poop macro. Setting this to False will allow pooping with no z movement

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -744,8 +744,12 @@ class afcFunction:
             bowden_length = config_length
         else:
             if new_length[0] in ('+', '-'):
-                bowden_value = float(new_length)
-                bowden_length = current_length + bowden_value
+                try:
+                    bowden_value = float(new_length)
+                    bowden_length = current_length + bowden_value
+                except ValueError:
+                    bowden_length = current_length
+                    self.logger.error("Invalid length: {}".format(new_length))
             else:
                 bowden_length = float(new_length)
 

--- a/extras/AFC_logger.py
+++ b/extras/AFC_logger.py
@@ -29,8 +29,9 @@ class AFC_QueueListener(QueueListener):
         logging.handlers.TimedRotatingFileHandler.doRollover(self)
 
 class AFC_logger:
-    def __init__(self, printer):
+    def __init__(self, printer, afc_obj):
         self.reactor = printer.reactor
+        self.AFC     = afc_obj
         self.gcode   = printer.lookup_object('gcode')
         self.webhooks = printer.lookup_object('webhooks')
 
@@ -84,6 +85,8 @@ class AFC_logger:
         for line in message.lstrip().rstrip().split("\n"):
             self.logger.error( self._format("ERROR: {}".format(line)))
         self.send_callback( "!! {}".format(message) )
+
+        self.AFC.message = (message, "error")
 
     def set_debug(self, debug ):
         self.print_debug_console = debug

--- a/extras/AFC_utils.py
+++ b/extras/AFC_utils.py
@@ -23,6 +23,7 @@ def add_filament_switch( switch_name, switch_pin, printer ):
     filament_switch_config = configparser.RawConfigParser()
     filament_switch_config.add_section( switch_name )
     filament_switch_config.set( switch_name, 'switch_pin', switch_pin)
+    filament_switch_config.set( switch_name, 'pause_on_runout', 'False')
 
     cfg_wrap = configfile.ConfigWrapper( printer, filament_switch_config, {}, switch_name)
 


### PR DESCRIPTION
## Major Changes in this PR
- Fixed issue where resuming position could crash into object/purge tower
- Fixed issue where creating filament_switch_sensor in AFC would cause klipper to error out when AFC include is before `[pause_resume]` and user has `recover_velocity` defined
- Fixed issue where passing in `+-<number>` for length when calling `SET_BOWDEN_LENGTH` would crash klipper
- Added error messages to AFC status so errors would show up in AFC integration panel

## Notes to Code Reviewers

## How the changes in this PR are tested
- Created a custom macro to run through some of the same sequences when doing a toolchange, was able to reproduce the issue reported and verified fix will now not move back down in z when moving XY to object/purgetower.
 
## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
