### PR TITLE
Fixing z move and adding virtual bypass sensor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-03-12]
+### Added
+- Virtual bypass sensor, AFC adds this sensor if hardware bypass is not detected
+
+### Fixed
+- Issue where z would move back down when calling cut macro after z hop from AFC
+
 ## [2025-03-10]
 ### Added
 - Reporting error messages in AFC status so they can be shown in AFC integration panel

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -6,13 +6,17 @@ This file goes over the features that can be found in Armored Turtle Automated F
 AFC allows the use of using the TurtleNeck Buffers as a ram sensor for detecting when filament is loaded to the toolhead extruder. This can be used inplace of a toolhead filament sensor. To learn more about this feature please see [Buffer Ram Sensor](Buffer_Ram_Sensor.md) document
 
 ## Bypass
-You can enable AFC bypass by printing out [bypass](https://github.com/ArmoredTurtle/AFC-Accessories/tree/main/AFC_Bypass) accessory, connecting inline after your buffer and adding a bypass filament sensor to klipper config like below. Once filament is inserted into the bypass side, the switch disables AFC functionality so you can print like normal.
+By default if a hardware sensor is not setup for a bypass AFC will create a virtual bypass filament sensor. Enabling the virtual filament sensor disables AFC functionality and enabled state persists across reboots.
+
+You can also enable AFC bypass with a hardware sensor by printing out [bypass](https://github.com/ArmoredTurtle/AFC-Accessories/tree/main/AFC_Bypass) accessory, connecting inline after your buffer and adding a bypass filament sensor to klipper config like below. Once filament is inserted into the bypass side, the switch disables AFC functionality so you can print like normal.
 
 ```
 [filament_switch_sensor bypass]
 switch_pin: <replace with MCU pin that switch is connected to>
 pause_on_runout: False
 ```
+
+When either bypass is enabled/filament detect all AFC functionality with loading to the toolhead is disabled. Calling the `TOOL_UNLOAD` macro will call the `UNLOAD_FILAMENT` macro if it exists so that filament can still be manually unload from the toolhead.
 
 ## Lower stepper current when printing
 For longer prints you may want to have the ability to lower BoxTurtles steppers current as they can get hot when engaged for a long period of time.

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -179,8 +179,6 @@ class afcError:
         self.pause_resume.send_pause_command()
         # Move Z up by z-hop value
         self.AFC._move_z_pos( self.AFC.last_gcode_position[2] + self.AFC.z_hop )
-        # Update gcode move last position to current position
-        self.AFC.gcode_move.reset_last_position()
         # Call users PAUSE
         self.AFC.gcode.run_script_from_command(self.AFC_RENAME_PAUSE_NAME)
         # Set Idle timeout to 10 hours

--- a/extras/AFC_logger.py
+++ b/extras/AFC_logger.py
@@ -86,7 +86,7 @@ class AFC_logger:
             self.logger.error( self._format("ERROR: {}".format(line)))
         self.send_callback( "!! {}".format(message) )
 
-        self.AFC.message = (message, "error")
+        self.AFC.message_queue.append( (message, "error") )
 
     def set_debug(self, debug ):
         self.print_debug_console = debug

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -143,6 +143,11 @@ class afcPrep:
         except:
             pass
 
+        # Restore previous bypass state if virtual bypass is active
+        if 'virtual' in self.AFC.bypass.name:
+            if 'bypass' in units["system"]:
+                self.AFC.bypass.sensor_enabled = units["system"]["bypass"]["enabled"]
+
         # Defaulting to no active spool, putting at end so endpoint has time to register
         if self.AFC.current is None:
             self.AFC.SPOOL.set_active_spool( None )


### PR DESCRIPTION
## Major Changes in this PR
- Fixed another issue where z could move back down when calling macros and xye movements happen. Moved reset_last_position into the _move_z_pos function so it would always be called
- Added virtual bypass sensor, this sensor is added when the hardware bypass is not detected. Bypass state is persistent across reboots

## Notes to Code Reviewers

## How the changes in this PR are tested
Used manual macro with a CUT macro call to test z issue to make sure it was fixed

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
