### PR TITLE
Moving restore last position after z-hop in resume

### DIFF
--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -281,8 +281,8 @@ class afcFunction:
             self.logger.info("Manually removing {} loaded from toolhead".format(cur_lane_loaded.name))
             self.AFC.save_vars()
 
-    def log_toolhead_pos(self):
-        msg = "Position: {}".format(self.AFC.toolhead.get_position())
+    def log_toolhead_pos(self, move_pre):
+        msg = "{}Position: {}".format(move_pre, self.AFC.toolhead.get_position())
         msg += " base_position: {}".format(self.AFC.gcode_move.base_position)
         msg += " last_position: {}".format(self.AFC.gcode_move.last_position)
         msg += " homing_position: {}".format(self.AFC.gcode_move.homing_position)


### PR DESCRIPTION
## Major Changes in this PR
Moved restore last position after z-hop so that klipper has the correct last position before resuming file gcode, before this fix AFC would return correctly to the last position but klippers internal last position was not being updated. So when resuming z would hop back up.
## How the changes in this PR are tested
Manually tested and another user confirmed changes fixed the problem
## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
