### PR TITLE
Fixes for prep and logging toolhead position function

### DIFF
--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -23,7 +23,7 @@ except: raise error("Error trying to import afcDeltaTime, please rerun install-a
 try: from extras.AFC_utils import add_filament_switch
 except: raise error("Error trying to import AFC_utils, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper")
 
-AFC_VERSION="1.0.2"
+AFC_VERSION="1.0.3"
 
 # Class for holding different states so its clear what all valid states are
 class State:

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -281,7 +281,7 @@ class afcFunction:
             self.logger.info("Manually removing {} loaded from toolhead".format(cur_lane_loaded.name))
             self.AFC.save_vars()
 
-    def log_toolhead_pos(self, move_pre):
+    def log_toolhead_pos(self, move_pre=""):
         msg = "{}Position: {}".format(move_pre, self.AFC.toolhead.get_position())
         msg += " base_position: {}".format(self.AFC.gcode_move.base_position)
         msg += " last_position: {}".format(self.AFC.gcode_move.last_position)

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -75,7 +75,7 @@ class afcPrep:
         for EXTRUDER in self.AFC.tools.keys():
             PrinterObject=self.AFC.tools[EXTRUDER]
             self.AFC.tools[PrinterObject.name]=PrinterObject
-            if 'system' in units:
+            if 'system' in units and "extruders" in units["system"]:
                 # Check to see if lane_loaded is in dictionary and its its not an empty string
                 if PrinterObject.name in units["system"]["extruders"] and \
                   'lane_loaded' in units["system"]["extruders"][PrinterObject.name] and \
@@ -145,7 +145,7 @@ class afcPrep:
 
         # Restore previous bypass state if virtual bypass is active
         if 'virtual' in self.AFC.bypass.name:
-            if 'bypass' in units["system"]:
+            if "system" in units and 'bypass' in units["system"]:
                 self.AFC.bypass.sensor_enabled = units["system"]["bypass"]["enabled"]
 
         # Defaulting to no active spool, putting at end so endpoint has time to register


### PR DESCRIPTION
## Major Changes in this PR
-Adding check for system in prep when trying to set previous state for virtual bypass, without this AFC will error for all new installs
-Adding default value when calling log_toolhead_pos function

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
