### PR TITLE
Fixing pause/resume and adding new macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-03-17]
+### Added
+- Added `SET_SPEED_MULTIPLIER` macro to allow user to change fwd/rwd speed multipliers during prints
+- Added `SAVE_SPEED_MULTIPLIER` macro to save updated multiplier to config file for specified lane
+
+### Fixed
+- Added check to AFC pause/resume functions to make sure printer was not paused/paused before doing any actions
+- Fixed issue where macro variables were not passed from AFC_PAUSE/AFC_RESUME to PAUSE/RESUME macros if user passed in variables when calling these macros  
+
 ## [2025-03-12]
 ### Added
 - Virtual bypass sensor, AFC adds this sensor if hardware bypass is not detected

--- a/docs/command_reference.md
+++ b/docs/command_reference.md
@@ -122,6 +122,12 @@ _Description_: Macro call to write tool_stn, tool_stn_unload and tool_sensor_aft
 Usage: ``SAVE_EXTRUDER_VALUES EXTRUDER=<extruder>``  
 Example: ``SAVE_EXTRUDER_VALUES EXTRUDER=extruder``  
 
+### SAVE_SPEED_MULTIPLIER
+_Description_: Macro call to write fwd_speed_multiplier and rwd_speed_multiplier variables to config file for specified lane.  
+  
+Usage: ``SAVE_SPEED_MULTIPLIER LANE=<lane_name>``  
+Example: ``SAVE_SPEED_MULTIPLIER LANE=lane1``  
+
 ### SET_AFC_TOOLCHANGES
 _Description_: This macro can be used to set total number of toolchanges from slicer. AFC will keep track of tool changes and print out
 current tool change number when a T(n) command is called from gcode.  
@@ -147,6 +153,14 @@ length will increase/decrease bowden length by that amount.
   
 Usage: ``SET_BOWDEN_LENGTH HUB=<hub> LENGTH=<length> UNLOAD_LENGTH=<length>``  
 Example: ``SET_BOWDEN_LENGTH HUB=Turtle_1 LENGTH=+100 UNLOAD_LENGTH=-100``  
+
+### SET_BUFFER_MULTIPLIER
+_Description_: This function handles the adjustment of the buffer multipliers for the turtleneck buffer.
+It retrieves the multiplier type ('HIGH' or 'LOW') and the factor to be applied. The function
+ensures that the factor is valid and updates the corresponding multiplier.  
+  
+Usage: `SET_BUFFER_MULTIPLIER BUFFER=<buffer_name> MULTIPLIER=<HIGH/LOW> FACTOR=<factor>`  
+Example: `SET_BUFFER_MULTIPLIER BUFFER=TN MULTIPLIER=HIGH FACTOR=1.2`  
 
 ### SET_BUFFER_VELOCITY
 _Description_: Allows users to tweak buffer velocity setting while printing. This setting is not
@@ -185,14 +199,6 @@ specified by the 'LANE' parameter and sets its material to the value provided by
 Usage: `SET_MATERIAL LANE=<lane> MATERIAL=<material>`  
 Example: `SET_MATERIAL LANE=lane1 MATERIAL=ABS`  
 
-### SET_MULTIPLIER
-_Description_: This function handles the adjustment of the buffer multipliers for the turtleneck buffer.
-It retrieves the multiplier type ('HIGH' or 'LOW') and the factor to be applied. The function
-ensures that the factor is valid and updates the corresponding multiplier.  
-  
-Usage: `SET_BUFFER_MULTIPLIER BUFFER=<buffer_name> MULTIPLIER=<HIGH/LOW> FACTOR=<factor>`  
-Example: `SET_BUFFER_MULTIPLIER BUFFER=TN MULTIPLIER=HIGH FACTOR=1.2`  
-
 ### SET_ROTATION_FACTOR
 _Description_: Adjusts the rotation distance of the current AFC stepper motor by applying a
 specified factor. If no factor is provided, it defaults to 1.0, which resets
@@ -207,6 +213,17 @@ specified by the 'LANE' parameter and updates its the lane to use if filament ru
   
 Usage: ``SET_RUNOUT LANE=<lane> RUNOUT=<lane>``  
 Example: ``SET_RUNOUT LANE=lane1 RUNOUT=lane4``  
+
+### SET_SPEED_MULTIPLIER
+_Description_: Macro call to update fwd_speed_multiplier or rwd_speed_multiplier values without having to set in config and restart klipper. This macro allows adjusting
+these values while printing. Multiplier values must be between 0.0 - 1.0  
+  
+Use FWD variable to set forward multiplier, use RWD to set reverse multiplier  
+  
+After running this command run SAVE_SPEED_MULTIPLIER LANE=<lane_name> to save value to config file  
+  
+Usage: ``SET_SPEED_MULTIPLIER LANE=<lane_name> FWD=<fwd_multiplier> RWD=<rwd_multiplier>``  
+Example: ``SET_SPEED_MULTIPLIER LANE=lane1 RWD=0.9``  
 
 ### SET_SPOOL_ID
 _Description_: This function handles setting the spool ID for a specified lane. It retrieves the lane
@@ -309,12 +326,12 @@ Example: ``UNSET_LANE_LOADED``
 ### UPDATE_TOOLHEAD_SENSORS
 _Description_: Macro call to adjust `tool_stn`\`tool_stn_unload`\`tool_sensor_after_extruder` lengths for specified extruder without having to update config file and restart klipper.  
   
-tool_stn length is the length from the sensor before extruder gears (tool_start) to nozzle. If sensor after extruder gears(tool_end)
+`tool_stn length` is the length from the sensor before extruder gears (tool_start) to nozzle. If sensor after extruder gears(tool_end)
 is set then the value if from tool_end sensor.  
   
-tool_stn_unload length is the length to unload so that filament is not in extruder gears anymore.  
+`tool_stn_unload` length is the length to unload so that filament is not in extruder gears anymore.  
   
-tool_sensor_after_extruder length is mainly used for those that have a filament sensor after extruder gears, target this
+`tool_sensor_after_extruder` length is mainly used for those that have a filament sensor after extruder gears, target this
 length to retract filament enough so that it's not in the extruder gears anymore.  
   
 Please pause print if you need to adjust this value while printing  

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -23,7 +23,7 @@ except: raise error("Error trying to import afcDeltaTime, please rerun install-a
 try: from extras.AFC_utils import add_filament_switch
 except: raise error("Error trying to import AFC_utils, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper")
 
-AFC_VERSION="1.0.3"
+AFC_VERSION="1.0.4"
 
 # Class for holding different states so its clear what all valid states are
 class State:

--- a/extras/AFC_buffer.py
+++ b/extras/AFC_buffer.py
@@ -103,7 +103,7 @@ class AFCtrigger:
             self.buttons.register_buttons([self.trailing_pin], self.trailing_callback)
 
             self.gcode.register_mux_command("SET_ROTATION_FACTOR",      "BUFFER", self.name, self.cmd_SET_ROTATION_FACTOR,  desc=self.cmd_LANE_ROT_FACTOR_help)
-            self.gcode.register_mux_command("SET_BUFFER_MULTIPLIER",    "BUFFER", self.name, self.cmd_SET_MULTIPLIER,       desc=self.cmd_SET_MULTIPLIER_help)
+            self.gcode.register_mux_command("SET_BUFFER_MULTIPLIER",    "BUFFER", self.name, self.cmd_SET_BUFFER_MULTIPLIER,desc=self.cmd_SET_BUFFER_MULTIPLIER_help)
 
         self.AFC.buffers[self.name] = self
 
@@ -230,8 +230,8 @@ class AFCtrigger:
                 state_info += "expanded"
         return state_info
 
-    cmd_SET_MULTIPLIER_help = "live adjust buffer high and low multiplier"
-    def cmd_SET_MULTIPLIER(self, gcmd):
+    cmd_SET_BUFFER_MULTIPLIER_help = "live adjust buffer high and low multiplier"
+    def cmd_SET_BUFFER_MULTIPLIER(self, gcmd):
         """
         This function handles the adjustment of the buffer multipliers for the turtleneck buffer.
         It retrieves the multiplier type ('HIGH' or 'LOW') and the factor to be applied. The function

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -124,12 +124,12 @@ class AFCextruder:
         """
         Macro call to adjust `tool_stn`\`tool_stn_unload`\`tool_sensor_after_extruder` lengths for specified extruder without having to update config file and restart klipper.  <nl>
           <nl>
-        tool_stn length is the length from the sensor before extruder gears (tool_start) to nozzle. If sensor after extruder gears(tool_end)
+        `tool_stn length` is the length from the sensor before extruder gears (tool_start) to nozzle. If sensor after extruder gears(tool_end)
         is set then the value if from tool_end sensor.  <nl>
           <nl>
-        tool_stn_unload length is the length to unload so that filament is not in extruder gears anymore.  <nl>
+        `tool_stn_unload` length is the length to unload so that filament is not in extruder gears anymore.  <nl>
           <nl>
-        tool_sensor_after_extruder length is mainly used for those that have a filament sensor after extruder gears, target this
+        `tool_sensor_after_extruder` length is mainly used for those that have a filament sensor after extruder gears, target this
         length to retract filament enough so that it's not in the extruder gears anymore.  <nl>
           <nl>
         Please pause print if you need to adjust this value while printing
@@ -169,7 +169,6 @@ class AFCextruder:
             gcmd: The G-code command object containing the parameters for the command.
                   Expected parameters:
                   - EXTRUDER: The name of the extruder to save values to in config file.
-                  - LENGTH: The length adjustment value.
 
         Returns:
             None

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -809,7 +809,7 @@ class afcFunction:
         msg += '//   Config Bowden Length:   {}\n'.format(CUR_HUB.config_unload_bowden_length)
         msg += '//   Previous Bowden Length: {}\n'.format(cur_unload_bowden_len)
         msg += '//   New Bowden Length:      {}\n'.format(CUR_HUB.afc_unload_bowden_length)
-        msg += '\n// TO SAVE BOWDEN LENGTH afc_bowden_length MUST BE UPDATED IN AFC_Hardware.cfg for each hub if there are multiple'
+        msg += '\n// TO SAVE BOWDEN LENGTH afc_bowden_length MUST BE UPDATED IN AFC_Turtle_(n).cfg for each AFC_hub if there are multiple'
         self.logger.raw(msg)
 
     cmd_HUB_CUT_TEST_help = "Test the cutting sequence of the hub cutter, expects LANE=laneN"


### PR DESCRIPTION
## Major Changes in this PR
- Added `SET_SPEED_MULTIPLIER` macro to allow user to change fwd/rwd speed multipliers during prints
- Added `SAVE_SPEED_MULTIPLIER` macro to save updated multiplier to config file for specified lane
- Added check to AFC pause/resume functions to make sure printer was not paused/paused before doing any actions
- Fixed issue where macro variables were not passed from AFC_PAUSE/AFC_RESUME to PAUSE/RESUME macros if user passed in variables when calling these macros

## Notes to Code Reviewers

## How the changes in this PR are tested
Manually testing macros and passing in Z variable into PAUSE
![image](https://github.com/user-attachments/assets/afd2e57b-14da-4cc9-a832-91849a1a38a9)

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
