### PR TITLE
Add support for IDEX dual_carriage in the config macros.

### DIFF
--- a/config/AFC_Macro_Vars.cfg
+++ b/config/AFC_Macro_Vars.cfg
@@ -100,11 +100,13 @@ variable_safe_margin_xy           : 30, 30    # Approx toolhead width +5mm, heig
 
 # Enable if layer shifts occur when cutting
 # variable_cut_current_stepper_x: 0
+# variable_cut_current_dual_carriage: 0
 # variable_cut_current_stepper_y: 0
 # variable_cut_current_stepper_z: 0
 
 # Change these to match the entries in printer.cfg if needed
 # variable_conf_name_stepper_x: "tmc2209 stepper_x"
+# variable_conf_name_dual_carriage: "tmc2209 dual_carriage"
 # variable_conf_name_stepper_y: "tmc2209 stepper_y"
 # variable_conf_name_stepper_z: "tmc2209 stepper_z"
 

--- a/config/macros/Brush.cfg
+++ b/config/macros/Brush.cfg
@@ -16,8 +16,22 @@ gcode:
     {% set brush_count = vars['brush_count']|int %}
 
     # Get printer bounds to make sure none of our cleaning moves fall outside of them
-    {% set x_max = printer.toolhead.axis_maximum.x %}
-    {% set x_min = printer.toolhead.axis_minimum.x %}
+    # Check for IDEX
+    {% if printer.dual_carriage is defined %}
+      {% if printer.dual_carriage.carriage_0 == "INACTIVE" %}
+        # Carriage_1 is active, use its axis limits
+        {% set x_max = printer.configfile.config.dual_carriage.position_max|float|round(3) %}
+        {% set x_min = printer.configfile.config.dual_carriage.position_min|float|round(3) %}
+      {% else %}
+        # Carriage_0 is active, use its axis limits
+        {% set x_max = printer.toolhead.axis_maximum.x %}
+        {% set x_min = printer.toolhead.axis_minimum.x %}
+      {% endif %}
+    {% else %}
+      # Non-IDEX printer, grab the X axis limits
+      {% set x_max = printer.toolhead.axis_maximum.x %}
+      {% set x_min = printer.toolhead.axis_minimum.x %}
+    {% endif %}
     {% set y_max = printer.toolhead.axis_maximum.y %}
     {% set y_min = printer.toolhead.axis_minimum.y %}
 

--- a/config/macros/Cut.cfg
+++ b/config/macros/Cut.cfg
@@ -21,6 +21,7 @@ gcode:
     {% set y_cut = vars['y_cut']|default(false)|lower == 'true' %}
 
     {% set cut_current_x = vars['cut_current_stepper_x']|default(0)|float %}
+    {% set cut_current_dc = vars['cut_current_dual_carriage']|default(0)|float %}
     {% set cut_current_y = vars['cut_current_stepper_y']|default(0)|float %}
     {% set cut_current_z = vars['cut_current_stepper_z']|default(0)|float %}
 
@@ -101,10 +102,26 @@ gcode:
           RESPOND TYPE=command MSG='AFC_Cut: Cut Move...'
     {% endif %}
 
-    {% if cut_current_x > 0 %}
-        {% set conf_name = vars['conf_name_stepper_x']|default('tmc2209 stepper_x') %}
-        {% set conf_current_x = printer.configfile.settings[conf_name].run_current|float %}
-        SET_TMC_CURRENT STEPPER=stepper_x CURRENT={cut_current_x}
+    {% if cut_current_x > 0 or cut_current_dc > 0 %}
+        # Check for IDEX
+        {% if printer.dual_carriage is defined %}
+            {% if printer.dual_carriage.carriage_0 == "INACTIVE" %}
+                # Second toolhead in use
+                {% set conf_name = vars['conf_name_dual_carriage']|default('tmc2209 dual_carriage') %}
+                {% set conf_current_dc = printer.configfile.settings[conf_name].run_current|float %}
+                SET_TMC_CURRENT STEPPER=dual_carriage CURRENT={cut_current_dc}
+            {% else %}
+                # First toolhead in use
+                {% set conf_name = vars['conf_name_stepper_x']|default('tmc2209 stepper_x') %}
+                {% set conf_current_x = printer.configfile.settings[conf_name].run_current|float %}
+                SET_TMC_CURRENT STEPPER=stepper_x CURRENT={cut_current_x}
+            {% endif %}
+        {% else %}
+            # Not running on IDEX, do normal things
+            {% set conf_name = vars['conf_name_stepper_x']|default('tmc2209 stepper_x') %}
+            {% set conf_current_x = printer.configfile.settings[conf_name].run_current|float %}
+            SET_TMC_CURRENT STEPPER=stepper_x CURRENT={cut_current_x}
+        {% endif %}
     {% endif %}
     {% if cut_current_y > 0 %}
         {% set conf_name = vars['conf_name_stepper_y']|default('tmc2209 stepper_y') %}
@@ -127,9 +144,20 @@ gcode:
 
     # Do a rip on final cut pass
     _DO_CUT_MOTION PIN_PARK_X_LOC={pin_park_x_loc} PIN_PARK_Y_LOC={pin_park_y_loc} RIP_LENGTH={rip_length}
-    
-    {% if cut_current_x > 0 %}
-        SET_TMC_CURRENT STEPPER=stepper_x CURRENT={conf_current_x}
+    {% if cut_current_x > 0 or cut_current_dc > 0 %}
+        # Check for IDEX
+        {% if printer.dual_carriage is defined %}
+            {% if printer.dual_carriage.carriage_0 == "INACTIVE" %}
+                # Second toolhead in use
+                SET_TMC_CURRENT STEPPER=dual_carriage CURRENT={conf_current_dc}
+            {% else %}
+                # First toolhead in use
+                SET_TMC_CURRENT STEPPER=stepper_x CURRENT={conf_current_x}
+            {% endif %}
+        {% else %}
+            # Not running on IDEX, do normal things
+            SET_TMC_CURRENT STEPPER=stepper_x CURRENT={conf_current_x}
+        {% endif %}
     {% endif %}
     {% if cut_current_y > 0 %}
         SET_TMC_CURRENT STEPPER=stepper_y CURRENT={conf_current_y}
@@ -205,8 +233,22 @@ gcode:
     {% set rip_speed = vars['rip_speed'] * 60|float %}
 
     # Get printer bounds to make sure none of our cut moves fall outside of them
-    {% set x_max = printer.toolhead.axis_maximum.x %}
-    {% set x_min = printer.toolhead.axis_minimum.x %}
+    # Check for IDEX
+    {% if printer.dual_carriage is defined %}
+      {% if printer.dual_carriage.carriage_0 == "INACTIVE" %}
+        # Carriage_1 is active, use its axis limits
+        {% set x_max = printer.configfile.config.dual_carriage.position_max|float|round(3) %}
+        {% set x_min = printer.configfile.config.dual_carriage.position_min|float|round(3) %}
+      {% else %}
+        # Carriage_0 is active, use its axis limits
+        {% set x_max = printer.toolhead.axis_maximum.x %}
+        {% set x_min = printer.toolhead.axis_minimum.x %}
+      {% endif %}
+    {% else %}
+        # Non-IDEX printer, grab the X axis limits
+        {% set x_max = printer.toolhead.axis_maximum.x %}
+        {% set x_min = printer.toolhead.axis_minimum.x %}
+    {% endif %}
     {% set y_max = printer.toolhead.axis_maximum.y %}
     {% set y_min = printer.toolhead.axis_minimum.y %}
 

--- a/config/macros/Kick.cfg
+++ b/config/macros/Kick.cfg
@@ -15,8 +15,22 @@ gcode:
   {% set kick_accel = vars['kick_accel']|float %}
 
   # Get printer bounds to make sure none of our kick moves fall outside of them
-  {% set x_max = printer.toolhead.axis_maximum.x %}
-  {% set x_min = printer.toolhead.axis_minimum.x %}
+  # Check for IDEX
+  {% if printer.dual_carriage is defined %}
+    {% if printer.dual_carriage.carriage_0 == "INACTIVE" %}
+      # Carriage_1 is active, use its axis limits
+      {% set x_max = printer.configfile.config.dual_carriage.position_max|float|round(3) %}
+      {% set x_min = printer.configfile.config.dual_carriage.position_min|float|round(3) %}
+    {% else %}
+      # Carriage_0 is active, use its axis limits
+      {% set x_max = printer.toolhead.axis_maximum.x %}
+      {% set x_min = printer.toolhead.axis_minimum.x %}
+    {% endif %}
+  {% else %}
+    # Non-IDEX printer, grab the X axis limits
+    {% set x_max = printer.toolhead.axis_maximum.x %}
+    {% set x_min = printer.toolhead.axis_minimum.x %}
+  {% endif %}
   {% set y_max = printer.toolhead.axis_maximum.y %}
   {% set y_min = printer.toolhead.axis_minimum.y %}
 


### PR DESCRIPTION
## Major Changes in this PR:
Adds checks for dual_carriage used in IDEX printers, while maintaining compatibility with single carriage printers.

## Notes to Code Reviewers:
This should not affect a standard printer, if [dual_carriage] is not present in printer.cfg then the changes will be skipped.

## How the changes in this PR are tested
Tested on my IDEX printer.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [X] I have performed a self-review of my code
- [X] CHANGELOG.md is updated (if end-user facing)
- [ ] Sent notification to software-design channel requesting review
