### PR TITLE
Adding better message when hub calibration errors out

### DIFF
--- a/docs/command_reference.md
+++ b/docs/command_reference.md
@@ -122,6 +122,12 @@ _Description_: Macro call to write tool_stn, tool_stn_unload and tool_sensor_aft
 Usage: ``SAVE_EXTRUDER_VALUES EXTRUDER=<extruder>``  
 Example: ``SAVE_EXTRUDER_VALUES EXTRUDER=extruder``  
 
+### SAVE_HUB_DIST
+_Description_: Macro call to write dist_hub variable to config file for specified lane.  
+  
+Usage: ``SAVE_HUB_DIST LANE=<lane_name>``  
+Example: ``SAVE_HUB_DIST LANE=lane1``  
+
 ### SAVE_SPEED_MULTIPLIER
 _Description_: Macro call to write fwd_speed_multiplier and rwd_speed_multiplier variables to config file for specified lane.  
   
@@ -177,6 +183,14 @@ specified by the 'LANE' parameter and sets its color to the value provided by th
 Usage: ``SET_COLOR LANE=<lane> COLOR=<color>``  
 Example: ``SET_COLOR LANE=lane1 COLOR=FF0000``  
 
+### SET_HUB_DIST
+_Description_: This function adjusts the distance between a lanes extruder and hub. Adding +/- in front of the length will
+increase/decrease length by that amount. To reset length back to config value, pass in `reset` for length to
+reset to value in config file.  
+  
+Usage: ``SET_HUB_DIST LANE=<lane_name> LENGTH=+/-<fwd_multiplier>``  
+Example: ``SET_HUB_DIST LANE=lane1 LENGTH=+100``  
+
 ### SET_LANE_LOADED
 _Description_: This macro handles manually setting a lane loaded into the toolhead. This is useful when manually loading lanes
 during prints after AFC detects an error when loading/unloading and pauses. If there is a lane already loaded this macro
@@ -217,9 +231,9 @@ Example: ``SET_RUNOUT LANE=lane1 RUNOUT=lane4``
 ### SET_SPEED_MULTIPLIER
 _Description_: Macro call to update fwd_speed_multiplier or rwd_speed_multiplier values without having to set in config and restart klipper. This macro allows adjusting
 these values while printing. Multiplier values must be between 0.0 - 1.0  
-  
+    
 Use FWD variable to set forward multiplier, use RWD to set reverse multiplier  
-  
+    
 After running this command run SAVE_SPEED_MULTIPLIER LANE=<lane_name> to save value to config file  
   
 Usage: ``SET_SPEED_MULTIPLIER LANE=<lane_name> FWD=<fwd_multiplier> RWD=<rwd_multiplier>``  

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -183,12 +183,15 @@ class afcBoxTurtle(afcUnit):
 
         if not success:
             # fault if check is not successful
-            msg = 'failed {} after {}mm'.format(checkpoint, hub_pos)
+            msg = 'Failed to calibrate dist_hub for {}. Failed after {}mm'.format(CUR_LANE.name, hub_fault_dis)
+            msg += '\n if filament stopped short of the hub during calibration use the following command to increase dist_hub value'
+            msg += '\n SET_HUB_DIST LANE={} LENGTH=+(distance the filament was short from the hub)'.format(CUR_LANE.name)
             return False, msg, hub_pos
 
+        hub_dist = CUR_LANE.dist_hub + 500
         # verify hub distance
         tuned_hub_pos, checkpoint, success = self.calc_position(CUR_LANE, lambda: CUR_LANE.hub_obj.state, hub_pos,
-                                            CUR_LANE.short_move_dis, tol, CUR_LANE.dist_hub + 500, checkpoint)
+                                            CUR_LANE.short_move_dis, tol, hub_dist, checkpoint)
 
         if not success:
             # fault if check is not successful

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -728,32 +728,32 @@ class afcFunction:
 
         self.AFC.gcode.respond_info('{} reset to hub, take necessary action'.format(lane))
 
-    def _calc_bowden_length(self, config_length, current_length, new_length):
+    def _calc_length(self, config_length, current_length, new_length):
         """
-        Common function to calculate bowden length for afc_bowden_length and afc_unload_bowden_length
+        Common function to calculate length for afc_bowden_length, afc_unload_bowden_length, and hub_dist
 
         :param config_length: Current configuration length thats in config file
-        :param current_length: Current length for bowden
+        :param current_length: Current length for bowden or hub_dist
         :param new_length: New length to set, increase(+), decrease(-), or reset to config value
 
-        :returns bowden_length: Calculated bowden length value
+        :returns length: Calculated length value
         """
-        bowden_length = 0.0
+        length = 0.0
 
         if new_length.lower() == 'reset':
-            bowden_length = config_length
+            length = config_length
         else:
             if new_length[0] in ('+', '-'):
                 try:
                     bowden_value = float(new_length)
-                    bowden_length = current_length + bowden_value
+                    length = current_length + bowden_value
                 except ValueError:
-                    bowden_length = current_length
+                    length = current_length
                     self.logger.error("Invalid length: {}".format(new_length))
             else:
-                bowden_length = float(new_length)
+                length = float(new_length)
 
-        return bowden_length
+        return length
 
     cmd_SET_BOWDEN_LENGTH_help = "Helper to dynamically set length of bowden between hub and toolhead. Pass in HUB if using multiple box turtles"
     def cmd_SET_BOWDEN_LENGTH(self, gcmd):
@@ -795,10 +795,10 @@ class afcFunction:
         cur_unload_bowden_len   = CUR_HUB.afc_unload_bowden_length
 
         if length_param is not None:
-            CUR_HUB.afc_bowden_length = self._calc_bowden_length(CUR_HUB.config_bowden_length, cur_bowden_len, length_param)
+            CUR_HUB.afc_bowden_length = self._calc_length(CUR_HUB.config_bowden_length, cur_bowden_len, length_param)
 
         if unload_length is not None:
-            CUR_HUB.afc_unload_bowden_length = self._calc_bowden_length(CUR_HUB.config_unload_bowden_length, cur_unload_bowden_len, unload_length)
+            CUR_HUB.afc_unload_bowden_length = self._calc_length(CUR_HUB.config_unload_bowden_length, cur_unload_bowden_len, unload_length)
 
         msg =  '// Hub : {}\n'.format( hub )
         msg += '// afc_bowden_length:\n'


### PR DESCRIPTION
## Major Changes in this PR
- Added a message to tell users to increase their hub distance if calibration errors out
- Added `SET_HUB_DIST` macro to set distance between extruder and hub for a lane
- Added `SAVE_HUB_DIST` macro to save dist_hub for a lane

## Notes to Code Reviewers

## How the changes in this PR are tested
Message printing out
![image](https://github.com/user-attachments/assets/20f5c3ba-0383-47cd-9d5e-aa6677f9a0b0)
Setting and saving dist_hub to config
![image](https://github.com/user-attachments/assets/8599bb81-c214-415d-ad04-9a402279b7c5)

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
