### PR TITLE
Set vs current temp fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-03-22]
+### Fixed
+- Fixed possible error if hotend current temp is below current temp. 
+
 ## [2025-03-17]
 ### Added
 - Added `SET_SPEED_MULTIPLIER` macro to allow user to change fwd/rwd speed multipliers during prints

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -23,7 +23,7 @@ except: raise error("Error trying to import afcDeltaTime, please rerun install-a
 try: from extras.AFC_utils import add_filament_switch
 except: raise error("Error trying to import AFC_utils, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper")
 
-AFC_VERSION="1.0.4"
+AFC_VERSION="1.0.5"
 
 # Class for holding different states so its clear what all valid states are
 class State:
@@ -318,6 +318,13 @@ class afc:
         if self.heater.can_extrude and self.FUNCTION.is_printing():
             return
         target_temp, using_min_value = self._get_default_material_temps(CUR_LANE)
+
+        current_temp = self.heater.get_temperature()
+
+        # Check if the current temp is below the set temp, if it is heat to set temp
+        if current_temp <= self.heater.target_temp:
+            wait = False
+            pheaters.set_temperature(extruder.get_heater(), current_temp, wait=wait)
 
         # Check to make sure temp is with +/-5 of target temp, not setting if temp is over target temp and using min_extrude_temp value
         if self.heater.target_temp <= (target_temp-5) or (self.heater.target_temp >= (target_temp+5) and not using_min_value):


### PR DESCRIPTION
## Major Changes in this PR
- Add a check to see if the hotend temp has been set, but the current temp is below the set temp. If the current temp is below the set temp, the hotend will heat first and not fail with a `Extrude below minimum temp` warning from klipper.

## Notes to Code Reviewers

## How the changes in this PR are tested
- Set extruder temp and then load or unload, temp will then heat to set temp before continuing.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
