### PR TITLE
On set_color with # in the color code

### DIFF
--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -113,7 +113,7 @@ class afcSpool:
             self.logger.info('{} Unknown'.format(lane))
             return
         CUR_LANE = self.AFC.lanes[lane]
-        CUR_LANE.color = '#' + color
+        CUR_LANE.color = '#' + color.replace('#','')
         self.AFC.save_vars()
 
     cmd_SET_WEIGHT_help = "Sets filaments weight for a lane"


### PR DESCRIPTION
## Major Changes in this PR
Passing color code by custom gcode from slicer like this

SET_COLOR LANE=lane1 COLOR="{filament_colour[0]}"

in final gcode it looks like this

SET_COLOR LANE=lane1 COLOR="#0033FF"

so this change replace the extra "#" if it was send by color code already

## Notes to Code Reviewers
--
## How the changes in this PR are tested
calling macro

SET_COLOR LANE=lane1 COLOR="#FFFFFF"
SET_COLOR LANE=lane2 COLOR="FFFFFF"
SET_COLOR LANE=lane3 COLOR=FFFFFF

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [X] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [X] Sent notification to software-design channel requesting review
