### PR TITLE
Update check for minimum python required version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `install-afc.sh` script now has the ability to install NightOwl units. Thanks to @thomasfjen for the contribution.
 - The `install-afc.sh` script now has the ability to help install multiple units.
 
+### Fixed
+- The `install-afc.sh` script now correctly checked for a Python version >= Python 3.8.
 
 ## [2025-03-27]
 ### Added

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To install this plugin, you should have the following pre-requisites installed:
     ```bash
     sudo apt-get install jq crudini
     ```
-5. Python 3.x
+5. Python >= 3.8
    
 
 To install this plugin, you can use the following commands from the users home directory:

--- a/include/check_commands.sh
+++ b/include/check_commands.sh
@@ -170,8 +170,8 @@ check_python_version() {
       return 1
   fi
 
-  if [[ ${VERSION%%.*} -lt 3 ]]; then
-      echo "Python version $VERSION is too old. Need at least Python 3.x."
+  if [[ ${VERSION%%.*} -lt ${minimum_python_minor} || ( ${VERSION%%.*} -eq ${minimum_python_major} && ${VERSION##*.} -lt $minimum_python_minor ) ]]; then
+      echo "Your available Klipper venv Python version $VERSION is too old. The BoxTurtle AFC software requires at least Python ${minimum_python_major}.${minimum_python_minor}."
       exit 1
   fi
 

--- a/include/constants.sh
+++ b/include/constants.sh
@@ -38,6 +38,8 @@ files_updated_or_installed="False"
 test_mode="False"
 installation_options=("BoxTurtle (4-Lane)" "NightOwl")
 invalid_name="False"
+minimum_python_major="3"
+minimum_python_minor="8"
 
 # AFC default configs
 park_macro="True"


### PR DESCRIPTION
## Major Changes in this PR

This pull request includes updates to ensure compatibility with Python 3.8 or higher across various scripts and documentation. The most important changes include updating version checks, modifying documentation, and defining new constants.

### Compatibility updates for Python 3.8 or higher:

* [`include/check_commands.sh`](diffhunk://#diff-91f04686173d0b0c6fe7b66c8e14e887f57ce6a144b68023c53d291a81e6fcc0L173-R174): Updated the `check_python_version` function to correctly check for Python version >= 3.8.
* [`include/constants.sh`](diffhunk://#diff-136fe1bcdb8818f9c4dbd399c55de34fc1c3426774f0135576365b3152460627R41-R42): Added `minimum_python_major` and `minimum_python_minor` constants to define the minimum required Python version.

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-R30): Updated the prerequisites section to specify Python >= 3.8.
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R15): Added a new entry under the "Fixed" section to document the correction in Python version check for the `install-afc.sh` script.

## Notes to Code Reviewers

## How the changes in this PR are tested

Local testing.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
