### PR TITLE
fix afc-debug script if no serial devices found

### DIFF
--- a/troubleshooting/afc-debug.sh
+++ b/troubleshooting/afc-debug.sh
@@ -230,7 +230,7 @@ DISTRO=$(strings /etc/*-release 2>/dev/null || echo "Unknown")
 KERNEL=$(uname -a)
 UPTIME=$(uptime)
 LSUSB=$(lsusb | tr -d '\0')
-SERIAL_IDS=$(ls -l /dev/serial/by-id/)
+SERIAL_IDS=$(ls -l /dev/serial/by-id/ || echo "No serial devices found.")
 
 get_afc_version
 get_klipper_version


### PR DESCRIPTION
## Major Changes in this PR

This pull request includes a small but important change to the `troubleshooting/afc-debug.sh` script. The change ensures that a message is displayed when no serial devices are found, improving the script's robustness and user feedback.

* [`troubleshooting/afc-debug.sh`](diffhunk://#diff-f90bf2ef443900b47139a1df1cf4fed2ee7afaea3274ba701e86d8905f704d54L233-R233): Modified the `SERIAL_IDS` command to display "No serial devices found." if no serial devices are present.

## Notes to Code Reviewers

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
