### PR TITLE
Validate DISTANCE parameter in BT_LANE_MOVE macro to ensure only nume…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-03-30]
+### Fixed
+- The `BT_LANE_MOVE` macro now correctly only accepts positive or negative values for the `distance` parameter.
+
 ## [2025-03-29]
 ### Added
 - The `install-afc.sh` script now has the ability to rename existing units.

--- a/config/macros/AFC_macros.cfg
+++ b/config/macros/AFC_macros.cfg
@@ -24,10 +24,27 @@ gcode:
 description: Move the specified lane the specified amount. Lane parameter is an integer and defaults to 1. Distance parameter is and integer and defaults to 20. Distance over 200 uses long load speeds. ex `BT_LANE_MOVE LANE=2 DISTANCE=100`
 gcode:
   {% set lane_num = params.LANE|default(1)|int %}
-  {% set dist = params.DISTANCE|default(20)|float %}
+  {% set dist_str = params.DISTANCE|default('20')|string %}
   {% set stepper = printer['gcode_macro _AFC_GLOBAL_VARS'].stepper_name|string %}
 
-  LANE_MOVE LANE={stepper ~ lane_num} DISTANCE={dist}
+  {% set valid_chars = '0123456789' %}
+  {% set is_valid = true %}
+
+  {% if dist_str|length > 0 %}
+    {% if dist_str[-1] not in valid_chars %}
+      {% set is_valid = false %}
+    {% endif %}
+  {% else %}
+    {% set is_valid = false %}
+  {% endif %}
+
+  {% if is_valid %}
+    {% set dist = dist_str|float %}
+    LANE_MOVE LANE={stepper ~ lane_num} DISTANCE={dist}
+  {% else %}
+    { action_respond_info("Error: Invalid DISTANCE parameter: " ~ dist_str) }
+  {% endif %}
+
 
 [gcode_macro BT_RESUME]
 description: Resume the print after an error, using normal resume will also call AFC_RESUME


### PR DESCRIPTION
## Major Changes in this PR

This pull request includes changes to the `CHANGELOG.md` and `config/macros/AFC_macros.cfg` files to fix a macro and validate input parameters. The most important changes are:

### Fixes:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R11): Documented a fix for the `BT_LANE_MOVE` macro to ensure it only accepts positive or negative values for the `distance` parameter.

### Input Validation:

* [`config/macros/AFC_macros.cfg`](diffhunk://#diff-65bd1a2e3bdf6c195f9cdae0f1bd7fc010e018dace3e9ce78025be2c6b25a1f2L27-R47): Updated the `BT_LANE_MOVE` macro to validate the `DISTANCE` parameter as a string and check for valid characters before converting it to a float. If the validation fails, an error message is returned.

## Notes to Code Reviewers

## How the changes in this PR are tested

![image](https://github.com/user-attachments/assets/44907e8e-d813-4c27-9e92-133deeb04c54)


## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
