### PR TITLE
AFC-32/59 - Fixing message when filament fails to to retract from toolhead and error when spooler rwd is not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-04-05]
+
+### Changed
+- Updated wording for when `TOOL_UNLOAD` fails and filament is still in toolhead. Added instruction for user to run `UNSET_LANE_LOADED` before running the correct `T(n)` macro
+
+### Fixed
+- Issue when user tries to run `TEST` macro and `afc_motor_rwd` is not defined in config. Affects configs that don't use spooler motors.
+
 ## [2025-04-01]
 
 ### Added

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -23,7 +23,7 @@ except: raise error("Error trying to import afcDeltaTime, please rerun install-a
 try: from extras.AFC_utils import add_filament_switch
 except: raise error("Error trying to import AFC_utils, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper")
 
-AFC_VERSION="1.0.8"
+AFC_VERSION="1.0.9"
 
 # Class for holding different states so its clear what all valid states are
 class State:
@@ -1109,6 +1109,7 @@ class afc:
                         message += "\n  and then use LANE_MOVE to fully retract behind hub so its not triggered anymore."
                         # Check to make sure next_lane_loaded is not None before adding instructions on how to manually load next lane
                         if self.next_lane_load is not None:
+                            message += "\nThen Manually run UNSET_LANE_LOADED to let AFC know nothing is loaded into toolhead"
                             message += "\nThen manually load {} with {} macro".format(self.next_lane_load, self.lanes[self.next_lane_load].map)
                             message += "\nOnce lane is loaded click resume to continue printing"
                     self.ERROR.handle_lane_failure(CUR_LANE, message)

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -882,11 +882,20 @@ class afcFunction:
         if lane == None:
             self.AFC.ERROR.AFC_error('Must select LANE', False)
             return
+
         self.logger.info('TEST ROUTINE')
         if lane not in self.AFC.lanes:
             self.logger.info('{} Unknown'.format(lane))
             return
+
         CUR_LANE = self.AFC.lanes[lane]
+        if CUR_LANE.afc_motor_rwd is None:
+            message = "afc_motor_rwd is not defined in config for {}, cannot perform test.\n".format(lane)
+            message += "If your unit does not have spooler motors then you can ignore this message.\n"
+            message += "If your unit has spooler motors please verify your config is setup properly"
+            self.logger.info(message)
+            return
+
         self.logger.info('Testing at full speed')
         CUR_LANE.assist(-1)
         self.AFC.reactor.pause(self.AFC.reactor.monotonic() + 1)


### PR DESCRIPTION
## Major Changes in this PR
- Updated message and added instructions for user to run `UNSET_LANE_LOADED` before running the next T(n) macro
- Added check to make sure users config has `afc_motor_rwd` before trying to check to see if spooler motors have pwm enabled

## How the changes in this PR are tested
Tested running `TEST` macro when `afc_motor_rwd` is not defined
![image](https://github.com/user-attachments/assets/4f52acbd-4f1f-49a2-a93b-918d7ee2a057)

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
