### PR TITLE
Fix python check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-04-07]
+
+### Fixed
+- Fixed detection for python version check to appropriately check for both python minor and major version.
+
 ## [2025-04-06]
 - Update kick macro to ensure we are in absolute position mode (G90) before doing moves
 

--- a/include/check_commands.sh
+++ b/include/check_commands.sh
@@ -170,7 +170,7 @@ check_python_version() {
       return 1
   fi
 
-  if [[ ${VERSION%%.*} -lt ${minimum_python_minor} || ( ${VERSION%%.*} -eq ${minimum_python_major} && ${VERSION##*.} -lt $minimum_python_minor ) ]]; then
+  if [[ $(echo -e "${VERSION}\n${minimum_python_major}.${minimum_python_minor}" | sort -V | head -n1) != "${minimum_python_major}.${minimum_python_minor}" ]]; then
       echo "Your available Klipper venv Python version $VERSION is too old. The BoxTurtle AFC software requires at least Python ${minimum_python_major}.${minimum_python_minor}."
       exit 1
   fi


### PR DESCRIPTION
## Major Changes in this PR

This pull request includes changes to fix the detection for the python version check. The most important changes include updating the `CHANGELOG.md` file and modifying the python version check logic in the `check_commands.sh` script.

### Fixes:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R12): Documented the fix for the python version detection to appropriately check for both python minor and major versions.

* [`include/check_commands.sh`](diffhunk://#diff-91f04686173d0b0c6fe7b66c8e14e887f57ce6a144b68023c53d291a81e6fcc0L173-R173): Updated the `check_python_version` function to use a more reliable method for comparing the python version against the required minimum version.

## Notes to Code Reviewers

## How the changes in this PR are tested

Actually installed Klipper with the wrong version

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
