### PR TITLE
AFC-66 Fixing error where BT extruder can sequel when resuming position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2025-04-07]
 
+### Added
+- Added function to check if in absolute mode and set absolute if in relative mode since
+  AFC does movement base off being in absolute mode
+
 ### Fixed
 - Fixed detection for python version check to appropriately check for both python minor and major version.
+- Fixed error where restore_pos was not calculating base position correctly for extruder,
+  matched how RESTORE_STATE does it
+
 
 ## [2025-04-06]
+
+### Fixed
 - Update kick macro to ensure we are in absolute position mode (G90) before doing moves
 
 ## [2025-04-06]

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -93,8 +93,11 @@ class afc:
         self.last_gcode_position = [0.0, 0.0, 0.0, 0.0]
         self.last_toolhead_position = [0.0, 0.0, 0.0, 0.0]
         self.homing_position = [0.0, 0.0, 0.0, 0.0]
-        self.speed = 25.
-        self.absolute_coord = True
+        self.speed              = 25.
+        self.speed_factor       = 1./60.
+        self.absolute_coord     = True
+        self.absolute_extrude   = True
+        self.extrude_factor     = 1.
 
         # Config get section
         self.moonraker_port         = config.get("moonraker_port", None)             # Port to connect to when interacting with moonraker. Used when there are multiple moonraker/klipper instances on a single host
@@ -516,13 +519,19 @@ class afc:
                 self.last_gcode_position    = list(self.gcode_move.last_position)
                 self.homing_position        = list(self.gcode_move.homing_position)
                 self.speed                  = self.gcode_move.speed
+                self.speed_factor           = self.gcode_move.speed_factor
                 self.absolute_coord         = self.gcode_move.absolute_coord
+                self.absolute_extrude       = self.gcode_move.absolute_extrude
+                self.extrude_factor         = self.gcode_move.extrude_factor
                 msg = "Saving position {}".format(self.last_toolhead_position)
                 msg += " Base position: {}".format(self.base_position)
                 msg += " last_gcode_position: {}".format(self.last_gcode_position)
                 msg += " homing_position: {}".format(self.homing_position)
                 msg += " speed: {}".format(self.speed)
-                msg += " absolute_coord: {}\n".format(self.absolute_coord)
+                msg += " speed_factor: {}".format(self.speed_factor)
+                msg += " absolute_coord: {}".format(self.absolute_coord)
+                msg += " absolute_extrude: {}".format(self.absolute_extrude)
+                msg += " extrude_factor: {}\n".format(self.extrude_factor)
                 self.logger.debug(msg)
             else:
                 self.FUNCTION.log_toolhead_pos("Not Saving, Error State: {}, Is Paused {}, Position_saved {}, POS: ".format(self.error_state, self.FUNCTION.is_paused(), self.position_saved ))
@@ -542,15 +551,15 @@ class afc:
         msg += " last_gcode_position: {}".format(self.last_gcode_position)
         msg += " homing_position: {}".format(self.homing_position)
         msg += " speed: {}".format(self.speed)
-        msg += " absolute_coord: {}\n".format(self.absolute_coord)
+        msg += " speed_factor: {}".format(self.speed_factor)
+        msg += " absolute_coord: {}".format(self.absolute_coord)
+        msg += " absolute_extrude: {}".format(self.absolute_extrude)
+        msg += " extrude_factor: {}\n".format(self.extrude_factor)
         self.logger.debug(msg)
         self.FUNCTION.log_toolhead_pos("Resume initial pos: ")
 
         self.current_state = State.RESTORING_POS
         newpos = self.toolhead.get_position()
-
-        # Restore absolute coords
-        self.gcode_move.absolute_coord = self.absolute_coord
 
         # Move toolhead to previous z location with zhop added
         if move_z_first:
@@ -562,16 +571,25 @@ class afc:
         self.FUNCTION.log_toolhead_pos("Resume prev xy: ")
 
         # Update GCODE STATE variables
-        self.gcode_move.base_position = list(self.base_position)
-        self.gcode_move.homing_position = list(self.homing_position)
-        self.gcode_move.last_position[:3] = self.last_gcode_position[:3]
+        self.gcode_move.base_position       = list(self.base_position)
+        self.gcode_move.homing_position     = list(self.homing_position)
+
+        # Restore absolute coords
+        self.gcode_move.absolute_coord      = self.absolute_coord
+        self.gcode_move.absolute_extrude    = self.absolute_extrude
+        self.gcode_move.extrude_factor      = self.extrude_factor
+        self.gcode_move.speed               = self.speed
+        self.gcode_move.speed_factor        = self.speed_factor
 
         # Restore the relative E position
-        e_diff = newpos[3] - self.last_gcode_position[3]
+        e_diff = self.gcode_move.last_position[3] - self.last_gcode_position[3]
         self.gcode_move.base_position[3] += e_diff
+        self.gcode_move.last_position[:3] = self.last_gcode_position[:3]
+
         # Return to previous xyz
         self.gcode_move.move_with_transform(self.gcode_move.last_position, self._get_resume_speedz() )
         self.FUNCTION.log_toolhead_pos("Resume final z, Error State: {}, Is Paused {}, Position_saved {}, in toolchange: {}, POS: ".format(self.error_state, self.FUNCTION.is_paused(), self.position_saved, self.in_toolchange ))
+
         self.current_state = State.IDLE
         self.position_saved = False
 
@@ -782,6 +800,9 @@ class afc:
         if self._check_bypass(): return False
 
         self.logger.info("Loading {}".format(CUR_LANE.name))
+
+        # Verify that printer is in absolute mode
+        self.FUNCTION.check_absolute_mode("TOOL_LOAD")
 
         # Lookup extruder and hub objects associated with the lane.
         CUR_HUB = CUR_LANE.hub_obj
@@ -1015,6 +1036,10 @@ class afc:
         self.logger.info("Unloading {}".format(CUR_LANE.name))
         CUR_LANE.status = 'Tool Unloading'
         self.save_vars()
+
+        # Verify that printer is in absolute mode
+        self.FUNCTION.check_absolute_mode("TOOL_UNLOAD")
+
         # Lookup current extruder and hub objects using the lane's information.
         CUR_HUB = CUR_LANE.hub_obj
         CUR_EXTRUDER = CUR_LANE.extruder_obj

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -162,6 +162,9 @@ class afcError:
         temp_is_paused = self.AFC.FUNCTION.is_paused()
         curr_pos = self.AFC.toolhead.get_position()
 
+        # Verify that printer is in absolute mode
+        self.AFC.FUNCTION.check_absolute_mode("AFC_RESUME")
+
         # Check if current position is below saved gcode position, if its lower first raise z above last saved
         #   position so that toolhead does not crash into part
         if (curr_pos[2] <= self.AFC.last_gcode_position[2]):
@@ -189,6 +192,8 @@ class afcError:
             self.AFC.save_pos()
             # Need to pause as soon as possible to stop more gcode from executing, this needs to be done before movement in Z
             self.pause_resume.send_pause_command()
+            # Verify that printer is in absolute mode
+            self.AFC.FUNCTION.check_absolute_mode("AFC_PAUSE")
             # Move Z up by z-hop value
             self.AFC._move_z_pos( self.AFC.last_gcode_position[2] + self.AFC.z_hop )
             # Call users PAUSE

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -296,13 +296,38 @@ class afcFunction:
             current_lane.unit_obj.select_lane(current_lane)
 
     def log_toolhead_pos(self, move_pre=""):
+        """
+        Helper function for printing postion data to log
+
+        :param move_pre: String that get appended before the position data
+        """
         msg = "{}Position: {}".format(move_pre, self.AFC.toolhead.get_position())
         msg += " base_position: {}".format(self.AFC.gcode_move.base_position)
         msg += " last_position: {}".format(self.AFC.gcode_move.last_position)
         msg += " homing_position: {}".format(self.AFC.gcode_move.homing_position)
         msg += " speed: {}".format(self.AFC.gcode_move.speed)
-        msg += " absolute_coord: {}\n".format(self.AFC.gcode_move.absolute_coord)
+        msg += " speed_factor: {}".format(self.AFC.gcode_move.speed_factor)
+        msg += " extrude_factor: {}".format(self.AFC.gcode_move.extrude_factor)
+        msg += " absolute_coord: {}".format(self.AFC.gcode_move.absolute_coord)
+        msg += " absolute_extrude: {}\n".format(self.AFC.gcode_move.absolute_extrude)
         self.logger.debug(msg, only_debug=True)
+
+    def check_absolute_mode( self, func_name:str="" ):
+        """
+        Function to verifies that coordinates and extruder is in absolute mode, sets back to absolute mode
+        if relative mode is set
+
+        :params func_name: String for name of function that function is being called from,
+                           this is added to debug log to aid in debugging
+        """
+        # Verify that printer is in absolute mode, and set True if in relative mode to prevent out of bound moves
+        self.log_toolhead_pos("{}: check absolute mode, POS:".format(func_name))
+        if not self.AFC.gcode_move.absolute_coord:
+            self.logger.debug("Printer coords not in absolute mode, setting to absolute mode")
+            self.AFC.gcode_move.absolute_coord = True
+        if not self.AFC.gcode_move.absolute_extrude:
+            self.logger.debug("Printer extruder not in absolute mode, setting to absolute mode")
+            self.AFC.gcode_move.absolute_extrude = True
 
     def HexConvert(self,tmp):
         led=tmp.split(',')


### PR DESCRIPTION
## Major Changes in this PR
- Fixed error where restore_pos was not calculating base position correctly for extruder, matched how RESTORE_STATE does it
- Added saving more variables so that AFC save/resume is like klippers save/resume state function
- Added function to check if in absolute mode and set absolute if in relative mode since AFC does movement base off being in absolute mode

## Notes to Code Reviewers
[These](https://github.com/ArmoredTurtle/AFC-Klipper-Add-On/pull/306/files#diff-749740ba904c224003143ed84a943eb5885a486b4ec55cd658a5beeea1cd1ff4R585) are the changes that are most important, line 585 of AFC.py

## How the changes in this PR are tested
Member from discord that had this issue tested and verified that this fixed their error

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
