### PR TITLE
AFC-60 - Adding runout/infinite spool support for HTLF unit type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2025-04-08]
 
 ### Added
-- Added function to check if in absolute mode and set absolute if in relative mode since
+- Function to check if in absolute mode and set absolute if in relative mode since
   AFC does movement base off being in absolute mode
+- Runout/infinite spool support for HTLF unit type
   
 ### Fixed
 - Fixed error where restore_pos was not calculating base position correctly for extruder,

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1273,6 +1273,7 @@ class afc:
                 purge_length = purge_length[1:]
 
         command_line = gcmd.get_commandline()
+        self.logger.debug("CHANGE_TOOL: cmd-{}".format(command_line))
 
         # Remove everything after ; since it could contain strings like CHANGE in a comment and should be ignored
         command = re.sub( ';.*', '', command_line)

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -278,18 +278,23 @@ class afcBoxTurtle(afcUnit):
             return False, msg, 0
 
         self.logger.info('Calibrating {}'.format(CUR_LANE.name))
+        CUR_LANE.status = "calibrating"
         # reset to extruder
         pos, checkpoint, success = self.calc_position(CUR_LANE, lambda: CUR_LANE.load_state, 0, CUR_LANE.short_move_dis,
                                               tol, CUR_LANE.dist_hub + 100, "retract to extruder")
 
         if not success:
             msg = 'Lane failed to calibrate {} after {}mm'.format(checkpoint, pos)
+            CUR_LANE.status = None
+            CUR_LANE.unit_obj.return_to_home()
             return False, msg, 0
 
         else:
             success, message, hub_pos = self.calibrate_hub(CUR_LANE, tol)
 
             if not success:
+                CUR_LANE.status = None
+                CUR_LANE.unit_obj.return_to_home()
                 return False, message, hub_pos
 
             if CUR_HUB.state:
@@ -301,6 +306,8 @@ class afcBoxTurtle(afcUnit):
             CUR_LANE.do_enable(False)
             CUR_LANE.dist_hub = cal_dist
             self.AFC.FUNCTION.ConfigRewrite(CUR_LANE.fullname, "dist_hub", cal_dist, cal_msg)
+            CUR_LANE.status = None
+            CUR_LANE.unit_obj.return_to_home()
             return True, cal_msg, cal_dist
 
 def load_config_prefix(config):

--- a/extras/AFC_HTLF.py
+++ b/extras/AFC_HTLF.py
@@ -160,7 +160,7 @@ class AFC_HTLF(afcBoxTurtle):
                 self.current_selected_lane = lane
             else:
                 return False
-    
+
     def check_runout(self, cur_lane):
         """
         Function to check if runout logic should be triggered

--- a/extras/AFC_HTLF.py
+++ b/extras/AFC_HTLF.py
@@ -141,7 +141,7 @@ class AFC_HTLF(afcBoxTurtle):
         :return float: Return movement in mm to move lobes
         """
         angle_movement = self.MAX_ANGLE_MOVEMENT - ( (lane_index-1) * self.cam_angle)
-        self.logger.debug("Lobe Movement angle : {}".format(angle_movement))
+        self.logger.debug("HTLF: Lobe Movement angle : {}".format(angle_movement))
         return (self.mm_move_per_rotation/360)*angle_movement
 
     def select_lane( self, lane ):
@@ -153,13 +153,21 @@ class AFC_HTLF(afcBoxTurtle):
         """
         self.failed_to_home = False
         if self.current_selected_lane != lane:
-            self.logger.info("{} Homing to endstop".format(self.name))
+            self.logger.debug("HTLF: {} Homing to endstop".format(self.name))
             if self.return_to_home():
                 self.selector_stepper_obj.move(self.calculate_lobe_movement( lane.index ), 50, 50, False)
-                self.logger.info("{} selected".format(lane))
+                self.logger.debug("HTLF: {} selected".format(lane))
                 self.current_selected_lane = lane
             else:
                 return False
+    
+    def check_runout(self, cur_lane):
+        """
+        Function to check if runout logic should be triggered
+
+        :return boolean: Returns true if current lane is loaded and printer is printing but lanes status is not ejecting or calibrating
+        """
+        return cur_lane.name == self.AFC.FUNCTION.get_current_lane() and self.AFC.FUNCTION.is_printing() and self.status != 'ejecting' and cur_lane.status != "calibrating"
 
 def load_config_prefix(config):
     return AFC_HTLF(config)

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -392,19 +392,78 @@ class AFCExtruderStepper:
         """
         self._afc_prep_done = True
 
+    def _perform_infinite_runout(self):
+        """
+        Common function for infinite spool runout
+            - Unloads current lane and loads the next lane as specified by runout variable.
+            - Swaps mapping between current lane and runout lane so correct lane is loaded with T(n) macro
+            - Once changeover is successful print is automatically resumed
+        """
+        self.status = None
+        self.AFC.FUNCTION.afc_led(self.AFC.led_not_ready, self.led_index)
+        self.logger.info("Infinite Spool triggered for {}".format(self.name))
+        empty_LANE = self.AFC.lanes[self.AFC.current]
+        change_LANE = self.AFC.lanes[self.runout_lane]
+        # Pause printer with manual command
+        self.AFC.ERROR.pause_resume.send_pause_command()
+        # Saving position after printer is paused
+        self.AFC.save_pos()
+        # Change Tool and don't restore position. Position will be restored after lane is unloaded
+        #  so that nozzle does not sit on print while lane is unloading
+        self.AFC.CHANGE_TOOL(change_LANE, restore_pos=False)
+        # Change Mapping
+        self.gcode.run_script_from_command('SET_MAP LANE={} MAP={}'.format(change_LANE.name, empty_LANE.map))
+        # Only continue if a error did not happen
+        if not self.AFC.error_state:
+            # Eject lane from BT
+            self.gcode.run_script_from_command('LANE_UNLOAD LANE={}'.format(empty_LANE.name))
+            # Resume pos
+            self.AFC.restore_pos()
+            # Resume with manual issued command
+            self.AFC.ERROR.pause_resume.send_resume_command()
+            # Set LED to not ready
+            self.AFC.FUNCTION.afc_led(self.led_not_ready, self.led_index)
+    
+    def _perform_pause_runout(self):
+        """
+        Common function to pause print when runout occurs, fully unloads and ejects spool if specified by user
+        """
+        # Unload if user has set AFC to unload on runout
+        if self.unit_obj.unload_on_runout:
+            # Pause printer
+            self.AFC.ERROR.pause_resume.send_pause_command()
+            self.AFC.save_pos()
+            # self.gcode.run_script_from_command('PAUSE')
+            self.AFC.TOOL_UNLOAD(self)
+            if not self.AFC.error_state:
+                self.AFC.LANE_UNLOAD(self)
+        # Pause print
+        self.status = None
+        msg = "Runout triggered for lane {} and runout lane is not setup to switch to another lane".format(self.name)
+        msg += "\nPlease manually load next spool into toolhead and then hit resume to continue"
+        self.AFC.FUNCTION.afc_led(self.AFC.led_not_ready, self.led_index)
+        self.AFC.ERROR.AFC_error(msg)
+
     def load_callback(self, eventtime, state):
         self.load_state = state
         if self.printer.state_message == 'Printer is ready' and self.unit_obj.type == "HTLF":
             self.prep_state = state
-            # TODO: need runout functionality added, but also need to add a check to see if user is running calibration
+
             if self.load_state:
                 self.AFC.FUNCTION.afc_led(self.led_ready, self.led_index)
             else:
-                self.AFC.FUNCTION.afc_led(self.led_not_ready, self.led_index)
-                self.status = None
-                self.loaded_to_hub = False
-                self.AFC.SPOOL._clear_values(self)
-                self.AFC.FUNCTION.afc_led(self.AFC.led_not_ready, self.led_index)
+                if self.unit_obj.check_runout(self):
+                    # Checking to make sure runout_lane is set and does not equal 'NONE'
+                    if  self.runout_lane != 'NONE':
+                        self._perform_runout()
+                    else:
+                        self._perform_pause_runout()
+                elif self.status != "calibrating":
+                    self.AFC.FUNCTION.afc_led(self.led_not_ready, self.led_index)
+                    self.status = None
+                    self.loaded_to_hub = False
+                    self.AFC.SPOOL._clear_values(self)
+                    self.AFC.FUNCTION.afc_led(self.AFC.led_not_ready, self.led_index)
 
         self.AFC.save_vars()
 
@@ -471,46 +530,9 @@ class AFCExtruderStepper:
                 elif self.prep_state == False and self.name == self.AFC.current and self.AFC.FUNCTION.is_printing() and self.load_state and self.status != 'ejecting':
                     # Checking to make sure runout_lane is set and does not equal 'NONE'
                     if  self.runout_lane != 'NONE':
-                        self.status = None
-                        self.AFC.FUNCTION.afc_led(self.AFC.led_not_ready, self.led_index)
-                        self.logger.info("Infinite Spool triggered for {}".format(self.name))
-                        empty_LANE = self.AFC.lanes[self.AFC.current]
-                        change_LANE = self.AFC.lanes[self.runout_lane]
-                        # Pause printer with manual command
-                        self.AFC.ERROR.pause_resume.send_pause_command()
-                        # Saving position after printer is paused
-                        self.AFC.save_pos()
-                        # Change Tool and don't restore position. Position will be restored after lane is unloaded
-                        #  so that nozzle does not sit on print while lane is unloading
-                        self.AFC.CHANGE_TOOL(change_LANE, restore_pos=False)
-                        # Change Mapping
-                        self.gcode.run_script_from_command('SET_MAP LANE={} MAP={}'.format(change_LANE.name, empty_LANE.map))
-                        # Only continue if a error did not happen
-                        if not self.AFC.error_state:
-                            # Eject lane from BT
-                            self.gcode.run_script_from_command('LANE_UNLOAD LANE={}'.format(empty_LANE.name))
-                            # Resume pos
-                            self.AFC.restore_pos()
-                            # Resume with manual issued command
-                            self.AFC.ERROR.pause_resume.send_resume_command()
-                            # Set LED to not ready
-                            self.AFC.FUNCTION.afc_led(self.led_not_ready, self.led_index)
+                        self._perform_runout()
                     else:
-                        # Unload if user has set AFC to unload on runout
-                        if self.unit_obj.unload_on_runout:
-                            # Pause printer
-                            self.AFC.ERROR.pause_resume.send_pause_command()
-                            self.AFC.save_pos()
-                            # self.gcode.run_script_from_command('PAUSE')
-                            self.AFC.TOOL_UNLOAD(self)
-                            if not self.AFC.error_state:
-                                self.AFC.LANE_UNLOAD(self)
-                        # Pause print
-                        self.status = None
-                        msg = "Runout triggered for lane {} and runout lane is not setup to switch to another lane".format(self.name)
-                        msg += "\nPlease manually load next spool into toolhead and then hit resume to continue"
-                        self.AFC.FUNCTION.afc_led(self.AFC.led_not_ready, self.led_index)
-                        self.AFC.ERROR.AFC_error(msg)
+                        self._perform_pause_runout()
 
                 elif self.prep_state == True and self.load_state == True and not self.AFC.FUNCTION.is_printing():
                     message = 'Cannot load {} load sensor is triggered.'.format(self.name)

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -423,7 +423,7 @@ class AFCExtruderStepper:
             self.AFC.ERROR.pause_resume.send_resume_command()
             # Set LED to not ready
             self.AFC.FUNCTION.afc_led(self.led_not_ready, self.led_index)
-    
+
     def _perform_pause_runout(self):
         """
         Common function to pause print when runout occurs, fully unloads and ejects spool if specified by user

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -250,6 +250,12 @@ class afcUnit:
         Funtion to home unit if unit has homing sensor
         """
         return
+    
+    def check_runout(self):
+        """
+        Function to check if runout logic should be triggered, override in specific unit
+        """
+        return False
 
     # Functions are below are placeholders so the function exists for all units, override these function in your unit files
     def _print_function_not_defined(self, name):

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -250,7 +250,7 @@ class afcUnit:
         Funtion to home unit if unit has homing sensor
         """
         return
-    
+
     def check_runout(self):
         """
         Function to check if runout logic should be triggered, override in specific unit


### PR DESCRIPTION
## Major Changes in this PR
- Added runout/infinite spool support for HTLF, broke runout logic into separate function calls so the logic can be called from both prep and load callbacks

## Notes to Code Reviewers
Logic for runout/infinite spool is exactly the same, just moved the code to specific function so the logic can easily be called from multiple places

## How the changes in this PR are tested
Testing of runout
![image](https://github.com/user-attachments/assets/510cde17-980e-4acc-aca9-5823dcdeef86)

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
