### PR TITLE
Updating documentation and fixes for direct loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-04-09]
+
+## Added
+- Added check in prep to make sure printer is homed when using direct loading
+
+## Fixed
+- For direct loading, fixed logic to use load sensor for unloading and then retract back more
+  to make sure filament was fully out of extruder gears
+- Fixed error where start time was not correctly getting set for direct loads
+- Fixed error where unsyncing lanes for HTLF units was still syncing back
+
 ## [2025-04-08]
 
 ### Added

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -24,7 +24,7 @@ except: raise error("Error trying to import afcDeltaTime, please rerun install-a
 try: from extras.AFC_utils import add_filament_switch
 except: raise error("Error trying to import AFC_utils, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper")
 
-AFC_VERSION="1.0.9"
+AFC_VERSION="1.0.10"
 
 # Class for holding different states so its clear what all valid states are
 class State:

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1228,8 +1228,9 @@ class afc:
         CUR_LANE.status = None
 
         if CUR_LANE.hub =='direct':
-            while CUR_LANE.prep_state:
+            while CUR_LANE.load_state:
                 CUR_LANE.move( CUR_LANE.short_move_dis * -1, CUR_LANE.short_moves_speed, CUR_LANE.short_moves_accel, True)
+            CUR_LANE.move( CUR_LANE.short_move_dis * -5, CUR_LANE.short_moves_speed, CUR_LANE.short_moves_accel)
 
         CUR_LANE.do_enable(False)
         CUR_LANE.unit_obj.return_to_home()

--- a/extras/AFC_HTLF.py
+++ b/extras/AFC_HTLF.py
@@ -73,7 +73,7 @@ class AFC_HTLF(afcBoxTurtle):
         super().handle_connect()
 
         self.logo = '<span class=success--text>HTLF Ready\n</span>'
-        self.logo_error = '<span class=error--te\n"xt>HTLF Not Ready</span>\n'
+        self.logo_error = '<span class=error--text>HTLF Not Ready</span>\n'
 
     def system_Test(self, cur_lane, delay, assignTcmd, enable_movement):
         cur_lane.prep_state = cur_lane.load_state
@@ -85,24 +85,23 @@ class AFC_HTLF(afcBoxTurtle):
 
     def home_callback(self, eventtime, state):
         """
-        Callback when home switch is triggered/detriggered
+        Callback when home switch is triggered/untriggered
         """
         self.home_state = state
 
     def cmd_HOME_UNIT(self, gcmd):
         """
-        Moves unit lobes back to home position
+        Moves unit lane selection back to home position
 
-        Usage: `HOME_UNIT UNIT=<unit_name>`
-        Example: `HOME_UNIT UNIT=HTLF_1`
+        Usage
+        -----
+        `HOME_UNIT UNIT=<unit_name>`
 
-        Args:
-            gcmd: The G-code command object containing the parameters for the command.
-                  Expected parameters:
-                  - UNIT: The name of the unit to move back to the home position
-
-        Returns:
-            None
+        Example:
+        -----
+        ```
+        HOME_UNIT UNIT=HTLF_1
+        ```
         """
         self.return_to_home()
 

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -950,25 +950,34 @@ class afcDeltaTime:
         self.major_delta_time = self.last_time = self.start_time = datetime.now()
 
     def log_with_time(self, msg, debug=True):
-        curr_time = datetime.now()
-        delta_time = (curr_time - self.last_time ).total_seconds()
-        total_time = (curr_time - self.start_time).total_seconds()
-        msg = "{} (Δt:{:.3f}s, t:{:.3f})".format( msg, delta_time, total_time )
-        if debug:
-            self.logger.debug( msg )
-        else:
-            self.logger.info( msg )
-        self.last_time = curr_time
+        try:
+            curr_time = datetime.now()
+            delta_time = (curr_time - self.last_time ).total_seconds()
+            total_time = (curr_time - self.start_time).total_seconds()
+            msg = "{} (Δt:{:.3f}s, t:{:.3f})".format( msg, delta_time, total_time )
+            if debug:
+                self.logger.debug( msg )
+            else:
+                self.logger.info( msg )
+            self.last_time = curr_time
+        except Exception as e:
+            self.logger.debug("Error in log_with_time function {}".format(e))
 
     def log_major_delta(self, msg, debug=True):
-        curr_time = datetime.now()
-        delta_time = (curr_time - self.major_delta_time ).total_seconds()
-        msg = "{} t:{:.3f}".format( msg, delta_time )
-        self.logger.info( msg )
-        self.major_delta_time = curr_time
+        try:
+            curr_time = datetime.now()
+            delta_time = (curr_time - self.major_delta_time ).total_seconds()
+            msg = "{} t:{:.3f}".format( msg, delta_time )
+            self.logger.info( msg )
+            self.major_delta_time = curr_time
+        except Exception as e:
+            self.logger.debug("Error in log_major_delta function {}".format(e))
 
     def log_total_time(self, msg):
-        total_time = (datetime.now() - self.start_time).total_seconds()
-        msg = "{} t:{:.3f}".format( msg, total_time )
+        try:
+            total_time = (datetime.now() - self.start_time).total_seconds()
+            msg = "{} t:{:.3f}".format( msg, total_time )
 
-        self.logger.info( msg )
+            self.logger.info( msg )
+        except Exception as e:
+            self.logger.debug("Error in log_total_time function {}".format(e))

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -494,6 +494,10 @@ class AFCExtruderStepper:
         if self.prep_active:
             return
 
+        if self.hub =='direct' and not self.AFC.FUNCTION.is_homed():
+            self.AFC.ERROR.AFC_error("Please home printer before directly loading to toolhead", False)
+            return False
+
         self.prep_active = True
 
         # Checking to make sure printer is ready and making sure PREP has been called before trying to load anything
@@ -530,6 +534,7 @@ class AFCExtruderStepper:
                     # Verify that load state is still true as this would still trigger if prep sensor was triggered and then filament was removed
                     #   This is only really a issue when using direct and still using load sensor
                     if self.hub == 'direct' and self.prep_state:
+                        self.AFC.afcDeltaTime.set_start_time()
                         self.AFC.TOOL_LOAD(self)
                         self.material = self.AFC.default_material_type
                         break


### PR DESCRIPTION
## Major Changes in this PR
- Updating documentation format
- Added check in prep to make sure printer is homed when using direct loading
- For direct loading, fixed logic to use load sensor for unloading and then retract back more to make sure filament was fully out of extruder gears
- Fixed error where start time was not correctly getting set for direct loads
- Fixed error where unsyncing lanes for HTLF units was still syncing back

## Notes to Code Reviewers

## How the changes in this PR are tested
Tested direct loading to make sure all changes worked correctly

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
