### PR TITLE
Fix `unset_lane_loaded` docstring

### DIFF
--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -394,8 +394,6 @@ class afc:
 
         Mainly this would be used if AFC thinks that there is a lane loaded into the toolhead but nothing is actually
         loaded.
-        Retrieves the lane specified by the 'LANE' parameter and sets the appropriate values in AFC to continue using
-        the lane.
 
         Usage
         -------


### PR DESCRIPTION
## Major Changes in this PR

This pull request includes a change to the `cmd_UNSET_LANE_LOADED` method in the `extras/AFC.py` file. The change removes a couple of lines from the method's docstring that described the retrieval and setting of lane values. 

Changes to method documentation:

* [`extras/AFC.py`](diffhunk://#diff-749740ba904c224003143ed84a943eb5885a486b4ec55cd658a5beeea1cd1ff4L397-L398): Removed the lines in the docstring that explained how the lane specified by the 'LANE' parameter is retrieved and set in AFC.

## Notes to Code Reviewers

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [x] Sent notification to software-design channel requesting review
