### PR TITLE
moved back_afc_config to a more convenient location

### DIFF
--- a/include/menus/install_menu.sh
+++ b/include/menus/install_menu.sh
@@ -212,7 +212,12 @@ fi
         export message ;;
       Q) exit_afc_install ;;
       M) main_menu ;;
-      I) install_afc ;;
+      I)
+        # only backup the existing config files when a new system is installed
+        if [ "$force_update" == "True" ] && [ "$prior_installation" == "True" ]; then
+          backup_afc_config
+        fi
+        install_afc ;;
       *) echo "Invalid selection" ;;
     esac
   done

--- a/include/menus/main_menu.sh
+++ b/include/menus/main_menu.sh
@@ -90,9 +90,6 @@ completed you will not be able to use this assisted process for any future updat
         export message="To change the moonraker address, please re-run this script with a '-a <address>' option.\n"
         export message+="To change the moonraker port, please re-run this script with a '-n <moonraker port>' option." ;;
       I)
-        if [ "$force_update" == "True" ] && [ "$prior_installation" == "True" ]; then
-          backup_afc_config
-        fi
         install_menu ;;
       U)
         update_menu ;;


### PR DESCRIPTION
## Major Changes in this PR
This PR just moves existing code to prevent the call backup_afc_config when hitting I (Install) instead of U (Update) in the main menu.
The backup the config is only done when installing a new system. It went from main menu to install menu.

## Notes to Code Reviewers
I am not sure if the force_update check is required at the new location.

## How the changes in this PR are tested
[Testing is conducted after my current print]

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [X] I have performed a self-review of my code
- [X] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design channel requesting review
