### PR TITLE
Auto rerun install script for git updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `Type` parameter in the `AFC_<unit_type>.cfg` file is no longer required.
 
 - The `install-afc.sh` script will now check for updates, and if new updates are present, it will sync and git changes
-and re-run the script automatically. 
+and re-run the script automatically.
 
 ## [2025-04-12]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `Type` parameter in the `AFC_<unit_type>.cfg` file is no longer required.
 
 - The `install-afc.sh` script will now check for updates, and if new updates are present, it will sync and git changes
-and re-run the script automatically.
+and re-run the script automatically. 
 
 ## [2025-04-12]
 

--- a/include/constants.sh
+++ b/include/constants.sh
@@ -23,8 +23,8 @@ moonraker="${moonraker_address}:${moonraker_port}"
 
 
 # Git related constants
-gitrepo="https://github.com/ejsears/AFC-Klipper-Add-On.git"
-branch="auto-retun-install-script-for-git-updates"
+gitrepo="https://github.com/ArmoredTurtle/AFC-Klipper-Add-On.git"
+branch="main"
 
 # Misc constants
 prior_installation="False"

--- a/include/constants.sh
+++ b/include/constants.sh
@@ -23,8 +23,8 @@ moonraker="${moonraker_address}:${moonraker_port}"
 
 
 # Git related constants
-gitrepo="https://github.com/ArmoredTurtle/AFC-Klipper-Add-On.git"
-branch="main"
+gitrepo="https://github.com/ejsears/AFC-Klipper-Add-On.git"
+branch="auto-retun-install-script-for-git-updates"
 
 # Misc constants
 prior_installation="False"

--- a/install-afc.sh
+++ b/install-afc.sh
@@ -29,49 +29,48 @@ source include/update_functions.sh
 source include/utils.sh
 source include/unit_functions.sh
 
-###################### Main script logic below ######################
+main() {
+  ###################### Main script logic below ######################
 
-while getopts "a:k:s:m:n:b:p:y:u:th" arg; do
-  case ${arg} in
-  a) moonraker_address=${OPTARG} ;;
-  k) klipper_dir=${OPTARG} ;;
-  m) moonraker_config_file=${OPTARG} ;;
-  n) moonraker_port=${OPTARG} ;;
-  s) klipper_service=${OPTARG} ;;
-  b) branch=${OPTARG} ;;
-  p) printer_config_dir=${OPTARG} ;;
-  y) klipper_venv=${OPTARG} ;;
-  t) test_mode=True ;;
-  h) show_help
-    exit 0 ;;
-  *) exit 1 ;;
-  esac
-done
+  while getopts "a:k:s:m:n:b:p:y:u:th" arg; do
+    case ${arg} in
+    a) moonraker_address=${OPTARG} ;;
+    k) klipper_dir=${OPTARG} ;;
+    m) moonraker_config_file=${OPTARG} ;;
+    n) moonraker_port=${OPTARG} ;;
+    s) klipper_service=${OPTARG} ;;
+    b) branch=${OPTARG} ;;
+    p) printer_config_dir=${OPTARG} ;;
+    y) klipper_venv=${OPTARG} ;;
+    t) test_mode=True ;;
+    h) show_help
+      exit 0 ;;
+    *) exit 1 ;;
+    esac
+  done
 
-moonraker="${moonraker_address}:${moonraker_port}"
-# Make sure necessary directories exist
-echo "Ensuring we are not running as root.."
-check_root
-echo "Ensuring no conflicting software is present.."
-check_for_hh
-echo "Checking to ensure crudini and jq are present.."
-check_for_prereqs
-if [ "$test_mode" == "False" ]; then
-  check_python_version
-  clone_or_update_repo
-  updated=$?
-    if [[ $updated -ne 0 ]]; then
-    echo "⚠️  Repository was updated; restarting script…"
-    exec "$0" "$@"
+  moonraker="${moonraker_address}:${moonraker_port}"
+  # Make sure necessary directories exist
+  echo "Ensuring we are not running as root.."
+  check_root
+  echo "Ensuring no conflicting software is present.."
+  check_for_hh
+  echo "Checking to ensure crudini and jq are present.."
+  check_for_prereqs
+  if [ "$test_mode" == "False" ]; then
+    check_python_version
+    clone_and_maybe_restart
   fi
-fi
-check_existing_install
-check_version_and_set_force_update
-#set_install_version_if_missing
-if [ "$force_update_no_version" == "False" ]; then
+  check_existing_install
   check_version_and_set_force_update
-fi
-echo "Starting installation process.."
-sleep 2
-clear
-main_menu
+  #set_install_version_if_missing
+  if [ "$force_update_no_version" == "False" ]; then
+    check_version_and_set_force_update
+  fi
+  echo "Starting installation process.."
+  sleep 2
+  clear
+  main_menu
+}
+
+main "$@"

--- a/install-afc.sh
+++ b/install-afc.sh
@@ -5,7 +5,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
-set -ex
+set -e
 export LC_ALL=C
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/install-afc.sh
+++ b/install-afc.sh
@@ -5,7 +5,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
-set -e
+set -ex
 export LC_ALL=C
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -58,7 +58,12 @@ echo "Checking to ensure crudini and jq are present.."
 check_for_prereqs
 if [ "$test_mode" == "False" ]; then
   check_python_version
-  clone_repo
+  clone_or_update_repo
+  updated=$?
+    if [[ $updated -ne 0 ]]; then
+    echo "⚠️  Repository was updated; restarting script…"
+    exec "$0" "$@"
+  fi
 fi
 check_existing_install
 check_version_and_set_force_update


### PR DESCRIPTION
## Major Changes in this PR

This pull request introduces enhancements to the `install-afc.sh` script, refactors the repository cloning logic, and improves the script's structure for better maintainability and usability. The key changes include adding automatic update handling, replacing the `clone_repo` function with a more robust `clone_and_maybe_restart` function, and encapsulating the script's main logic in a `main` function.

### Enhancements to the installation script:
* The `install-afc.sh` script now checks for updates and, if new updates are available, automatically syncs changes and re-runs the script. (`CHANGELOG.md`, [CHANGELOG.mdR13-R15](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR13-R15))

### Refactoring of repository cloning logic:
* Replaced the `clone_repo` function with `clone_and_maybe_restart` in `include/utils.sh`. The new function:
  - Handles cloning with a shallow copy for efficiency.
  - Checks for uncommitted changes and provides instructions to resolve them.
  - Fetches updates and applies them via rebase if the local branch is behind, restarting the script after updates. (`include/utils.sh`, [include/utils.shL41-R79](diffhunk://#diff-9e64712e624ee22bf3a68f5ecd584c7f805f610eb1fb10ce184a3d3beb0b8352L41-R79))

### Structural improvements:
* Encapsulated the main logic of `install-afc.sh` in a `main` function for better organization and readability. (`install-afc.sh`, [[1]](diffhunk://#diff-808409cb3827534e4d3012fedbf1671577db5a220159b4b5d7b253bff3d890caR32) [[2]](diffhunk://#diff-808409cb3827534e4d3012fedbf1671577db5a220159b4b5d7b253bff3d890caR74-R76)
* Updated the installation flow to use `clone_and_maybe_restart` instead of the deprecated `clone_repo` function. (`install-afc.sh`, [install-afc.shL61-R62](diffhunk://#diff-808409cb3827534e4d3012fedbf1671577db5a220159b4b5d7b253bff3d890caL61-R62))
## Notes to Code Reviewers

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design channel requesting review
