### PR TITLE
AFC-67: Updating Poop and Kick macros so toolhead does not smush into large poops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-04-20]
+
+### Changed
+- Updated poop to do z lift based off last position so that toolhead does not smash into large poops.
+- Updated kick to move xy first and then move z so toolhead does not smash into poop.
+
 ## [2025-04-19]
 
 ### Changed

--- a/config/macros/Kick.cfg
+++ b/config/macros/Kick.cfg
@@ -56,8 +56,8 @@ gcode:
   {% if verbose > 1 %}
     RESPOND TYPE=command MSG='AFC_Kick: Move to Start Position'
   {% endif %}
-  G1 Z{kick_start_z} F{z_travel_speed}
   G1 X{kick_start_x} Y{kick_start_y} F{travel_speed}
+  G1 Z{kick_start_z} F{z_travel_speed}
 
   {% if verbose > 1 %}
     RESPOND TYPE=command MSG='AFC_Kick: Drop Z For Kick Move'

--- a/config/macros/Poop.cfg
+++ b/config/macros/Poop.cfg
@@ -115,12 +115,16 @@ gcode:
   {% endfor %}
 
   G90
+
+  {% set final_poop_height = purge_z + purge_start + (iterations * iteration_z_raise) %}
+  {% set new_z = final_poop_height + z_lift %}
+
   {% if verbose > 1 %}
-    RESPOND TYPE=command MSG='AFC_Poop: Fast Z Lift to keep poop from sticking'
+    RESPOND TYPE=command MSG='AFC_Poop: Lifting Z to {new_z} mm'
   {% endif %}
 
   {% if z_poop %}
-    G1 Z{z_lift} F{fast_z}21000
+    G1 Z{new_z} F{fast_z}
   {% endif %} 
 
   {% if verbose > 1 %}


### PR DESCRIPTION
## Major Changes in this PR
- Implementing macro changes based off changes from Trev1Ak, changes are so that after kick z movement is based off last position so that toolhead does not move into poop. Kick update is to move xy first before z so that toolhead also does not smush into poop.

## Notes to Code Reviewers

## How the changes in this PR are tested
- Manually tested macros

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [ ] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design channel requesting review
