### PR TITLE
Add ability to update AFC macros when using update menu functionality.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-04-23]
+
+### Added
+- The `install-afc.sh` script will now prompt you if you want to update the AFC provided macros when updating the 
+  software. **WARNING** This will overwrite any existing macros present. 
+
 ## [2025-04-20]
 
 ### Changed

--- a/include/update_functions.sh
+++ b/include/update_functions.sh
@@ -6,9 +6,32 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
 update_afc() {
+  local macro update_macros confirm_update_macros
+  read -p "Do you want to update the AFC provided macros? (y/n): " update_macros
+  update_macros="${update_macros,,}"
+  if [[ "$update_macros" == "y" ]]; then
+    print_msg WARNING "Updating macros will overwrite any custom changes you have made to these macros."
+    print_msg WARNING "This includes the brush, cut, kick, park, afc_macros, and poop macros."
+    read -p "Please confirm you want to update these macros: (y/n): " confirm_update_macros
+    confirm_update_macros="${confirm_update_macros,,}"
+    if [[ "$confirm_update_macros" == "y" ]]; then
+      for macro in "Brush" "Cut" "Kick" "Park" "Poop" "AFC_macros"; do
+        rm -rf "${afc_config_dir}/macros/${macro}.cfg"
+      done
+      if cp "${afc_path}/config/macros/"*.cfg "${afc_config_dir}/macros/"; then
+        update_message+="""
+AFC Macros updated successfully.
+        """
+      else
+        update_message+="""
+AFC Macros update failed.
+        """
+      fi
+    fi
+  fi
   link_extensions
   remove_t_macros
-  update_message="""
+  update_message+="""
 AFC Klipper Add-On updated successfully.
 """
   export update_message


### PR DESCRIPTION
## Major Changes in this PR

This pull request introduces a new feature to the `update_afc` function in the `include/update_functions.sh` file, allowing users to update AFC-provided macros interactively. The update includes user prompts for confirmation and ensures that custom changes to macros are not overwritten without explicit consent.

### New functionality for updating AFC macros:
* Added user prompts to confirm whether to update AFC-provided macros, with warnings about overwriting custom changes. This includes macros such as `Brush`, `Cut`, `Kick`, `Park`, `AFC_macros`, and `Poop`.
* Implemented logic to delete existing macro configuration files and copy updated versions from the AFC configuration directory if the user confirms the update.
* Updated the `update_message` variable to reflect the success or failure of the macro update process.

## Notes to Code Reviewers

## How the changes in this PR are tested

I created a new macro in the `macros` directory and ran the update and verified the new macro now existed in my `printer_data/config/AFC/macros` directory.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design channel requesting review
