### PR TITLE
Refactor string concatenation to use .format()

### DIFF
--- a/extras/AFC_assist.py
+++ b/extras/AFC_assist.py
@@ -19,14 +19,14 @@ class AFCassistMotor:
         # Determine pin type
         self.is_pwm = config.getboolean('pwm', False)
         if self.is_pwm:
-            self.mcu_pin = ppins.setup_pin('pwm', config.get('afc_motor_'+type))
+            self.mcu_pin = ppins.setup_pin('pwm', config.get('afc_motor_{}'.format(type)))
             cycle_time = config.getfloat('cycle_time', 0.100, above=0.,
                                          maxval=MAX_SCHEDULE_TIME)
             hardware_pwm = config.getboolean('hardware_pwm', False)
             self.mcu_pin.setup_cycle_time(cycle_time, hardware_pwm)
             self.scale = config.getfloat('scale', 1., above=0.)
         else:
-            self.mcu_pin = ppins.setup_pin('digital_out', config.get('afc_motor_'+type))
+            self.mcu_pin = ppins.setup_pin('digital_out', config.get('afc_motor_{}'.format(type)))
             self.scale = 1.
         self.last_print_time = 0.
         # Support mcu checking for maximum duration

--- a/extras/AFC_buffer.py
+++ b/extras/AFC_buffer.py
@@ -125,7 +125,7 @@ class AFCTrigger:
             if self.printer.state_message == 'Printer is ready' and self.enable:
                 CUR_LANE = self.AFC.FUNCTION.get_current_lane_obj()
                 if CUR_LANE is not None:
-                    CUR_EXTRUDER = self.printer.lookup_object('AFC_extruder ' + CUR_LANE.extruder_name)
+                    CUR_EXTRUDER = self.printer.lookup_object('AFC_extruder {}'.format(CUR_LANE.extruder_name))
                     if CUR_EXTRUDER.tool_start_state:
                         self.belay_move_lane(state)
         self.last_state = state

--- a/extras/AFC_form_tip.py
+++ b/extras/AFC_form_tip.py
@@ -137,7 +137,7 @@ class afc_tip_form:
         pheaters = self.printer.lookup_object('heaters')
         current_temp = extruder.get_heater().target_temp     # Saving current temp so it can be set back when done if toolchange_temp is not zero
         if self.ramming_volume > 0:
-            self.logger.info('AFC-TIP-FORM: Step ' + str(step) + ': Ramming')
+            self.logger.info('AFC-TIP-FORM: Step {0}: Ramming'.format(step))
             ratio = self.ramming_volume / 23
             self.afc_extrude(0.5784 * ratio, 299 / 60)
             self.afc_extrude(0.5834 * ratio, 302 / 60)
@@ -154,7 +154,7 @@ class afc_tip_form:
             self.afc_extrude(0.5956 * ratio, 544 / 60)
             self.afc_extrude(1.0662 * ratio, 552 / 60)
             step +=1
-        self.logger.info('AFC-TIP-FORM: Step ' + str(step) + ': Retraction & Nozzle Separation')
+        self.logger.info('AFC-TIP-FORM: Step {0}: Retraction & Nozzle Separation'.format(step))
         total_retraction_distance = self.cooling_tube_position + self.cooling_tube_length - 15
         self.afc_extrude(-15, self.unloading_speed_start)
         if total_retraction_distance > 0:
@@ -170,7 +170,7 @@ class afc_tip_form:
             self.logger.info("AFC-TIP-FORM: Waiting for temperature to get to {}".format(self.toolchange_temp))
             pheaters.set_temperature(extruder.get_heater(), self.toolchange_temp, wait)
         step +=1
-        self.logger.info('AFC-TIP-FORM: Step ' + str(step) + ': Cooling Moves')
+        self.logger.info('AFC-TIP-FORM: Step {0}: Cooling Moves'.format(step))
         speed_inc = (self.final_cooling_speed - self.initial_cooling_speed) / (2 * self.cooling_moves - 1)
         for move in range(self.cooling_moves):
             speed = self.initial_cooling_speed + speed_inc * move * 2
@@ -178,7 +178,7 @@ class afc_tip_form:
             self.afc_extrude(self.cooling_tube_length * -1, (speed + speed_inc))
         step += 1
         if self.use_skinnydip:
-            self.logger.info('AFC-TIP-FORM: Step ' + str(step) + ': Skinny Dipping')
+            self.logger.info('AFC-TIP-FORM: Step {0}: Skinny Dipping'.format(step))
             self.afc_extrude(self.skinnydip_distance, self.dip_insertion_speed)
             self.reactor.pause(self.reactor.monotonic() + self.melt_zone_pause)
             self.afc_extrude(self.skinnydip_distance * -1, self.dip_extraction_speed)

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -108,7 +108,7 @@ class afcFunction:
     def TcmdAssign(self, CUR_LANE):
         if CUR_LANE.map == 'NONE' :
             for x in range(99):
-                cmd = 'T'+str(x)
+                cmd = 'T{0}'.format(x)
                 if cmd not in self.AFC.tool_cmds:
                     CUR_LANE.map = cmd
                     break
@@ -215,7 +215,7 @@ class afcFunction:
         """
         error_string = ""
         led = None
-        afc_object = 'AFC_led '+ led_name.split(':')[0]
+        afc_object = 'AFC_led {}'.format(led_name.split(':')[0])
         try:
             led = self.printer.lookup_object(afc_object)
         except:
@@ -236,10 +236,10 @@ class afcFunction:
         if CUR_LANE.prep_state:
             if CUR_LANE.load_state:
                 if CUR_LANE.extruder_obj is not None and CUR_LANE.extruder_obj.lane_loaded == CUR_LANE.name:
-                    return 'In Tool:' + self.HexConvert(CUR_LANE.led_tool_loaded).split(':')[-1]
-                return "Ready:" + self.HexConvert(CUR_LANE.led_ready).split(':')[-1]
-            return 'Prep:' + self.HexConvert(CUR_LANE.led_prep_loaded).split(':')[-1]
-        return 'Not Ready:' + self.HexConvert(CUR_LANE.led_not_ready).split(':')[-1]
+                    return 'In Tool:{}'.format(self.HexConvert(CUR_LANE.led_tool_loaded).split(':')[-1])
+                return "Ready:{}".format(self.HexConvert(CUR_LANE.led_ready).split(':')[-1])
+            return 'Prep:{}'.format(self.HexConvert(CUR_LANE.led_prep_loaded).split(':')[-1])
+        return 'Not Ready:{}'.format(self.HexConvert(CUR_LANE.led_not_ready).split(':')[-1])
 
     def handle_activate_extruder(self):
         """
@@ -399,7 +399,7 @@ class afcFunction:
         prompt = AFCprompt(gcmd, self.logger)
         footer = []
         title = 'Calibrate all'
-        text = ('Press Yes to confirm calibrating all lanes in all units')
+        text = 'Press Yes to confirm calibrating all lanes in all units'
         footer.append(('Back', 'AFC_CALIBRATION', 'info'))
         footer.append(("Yes", "CALIBRATE_AFC LANE=all", "error"))
 
@@ -577,7 +577,7 @@ class afcFunction:
         prompt = AFCprompt(gcmd, self.logger)
         buttons = []
         title = 'AFC Calibration Completed'
-        text = ('Calibration was completed for {}, would you like to do more calibrations?').format(cali)
+        text = 'Calibration was completed for {}, would you like to do more calibrations?'.format(cali)
         buttons.append(("Yes", "AFC_Calibration", "primary"))
         buttons.append(("No", "AFC_HAPPY_P STEP='AFC Calibration'", "info"))
 
@@ -611,7 +611,7 @@ class afcFunction:
         buttons = None
         footer = []
         title = '{} Completed'.format(step)
-        text = ('Happy Printing!')
+        text = 'Happy Printing!'
         footer.append(('EXIT', 'prompt_end', 'info'))
         prompt.create_custom_p(title, text, buttons,
                                False, None, footer)
@@ -648,7 +648,7 @@ class afcFunction:
         buttons = []
         footer = []
         title = 'AFC Calibration Failed'
-        text = ('Calibration failed  for {}. First: reset lane, Second: review messages in console and take necessary action and re-run colibration.').format(cali)
+        text = 'Calibration failed  for {}. First: reset lane, Second: review messages in console and take necessary action and re-run colibration.'.format(cali)
         buttons.append(("Reset lane", "AFC_LANE_RESET LANE={} DISTANCE={}".format(cali, dis), "primary"))
         footer.append(('EXIT', 'prompt_end', 'info'))
 
@@ -682,7 +682,7 @@ class afcFunction:
         dis = gcmd.get("DISTANCE", None)
         buttons = []
         title = 'AFC RESET'
-        text = ('Select a loaded lane to reset')
+        text = 'Select a loaded lane to reset'
 
         # Create buttons for each loaded lane
         for index, LANE in enumerate(self.AFC.lanes.values()):
@@ -878,7 +878,7 @@ class afcFunction:
         ```
         """
         lane = gcmd.get('LANE', None)
-        self.logger.info('Testing Hub Cut on Lane: ' + lane)
+        self.logger.info('Testing Hub Cut on Lane: {}'.format(lane))
         if lane not in self.AFC.lanes:
             self.logger.info('{} Unknown'.format(lane))
             return

--- a/extras/AFC_poop.py
+++ b/extras/AFC_poop.py
@@ -33,7 +33,7 @@ class afc_poop:
         self.toolhead = self.printer.lookup_object('toolhead')
         step = 1
         if self.verbose:
-            self.logger.info('AFC_Poop: ' + str(step) + ' Move To Purge Location')
+            self.logger.info('AFC_Poop: {} Move To Purge Location'.format(step))
         pooppos = self.toolhead.get_position()
         pooppos[0] = float(self.purge_loc_xy.split(',')[0])
         pooppos[1] = float(self.purge_loc_xy.split(',')[1])
@@ -45,14 +45,14 @@ class afc_poop:
         step +=1
         if self.full_fan:
             if self.verbose:
-                self.logger.info('AFC_Poop: ' + str(step) + ' Set Cooling Fan to Full Speed')
+                self.logger.info('AFC_Poop: {} Set Cooling Fan to Full Speed'.format(step))
             # save fan current speed
             self.gcode.run_script_from_command('M106 S255')
             step += 1
         iteration=0
         while iteration < int(self.purge_length / self.max_iteration_length ):
             if self.verbose:
-                self.logger.info('AFC_Poop: ' + str(step) + ' Purge Iteration '+ str(iteration))
+                self.logger.info('AFC_Poop: {} Purge Iteration {}'.format(step, iteration))
             purge_amount_left = self.purge_length - (self.max_iteration_length * iteration)
             extrude_amount = purge_amount_left / self.max_iteration_length
             extrude_ratio = extrude_amount / self.max_iteration_length
@@ -69,7 +69,7 @@ class afc_poop:
             iteration += 1
         step += 1
         if self.verbose:
-            self.logger.info('AFC_Poop: ' + str(step) + ' Fast Z Lift to keep poop from sticking')
+            self.logger.info('AFC_Poop: {0} Fast Z Lift to keep poop from sticking'.format(step))
         pooppos = self.toolhead.get_position()
         pooppos[2] = self.z_lift
         self.toolhead.manual_move(pooppos, self.fast_z)
@@ -77,7 +77,7 @@ class afc_poop:
         step += 1
         if self.full_fan:
             if self.verbose:
-                self.logger.info('AFC_Poop: ' + str(step) + ' Restore fan speed and feedrate')
+                self.logger.info('AFC_Poop: {0} Restore fan speed and feedrate'.format(step))
                 self.gcode.run_script_from_command('M106 S0')
 
 def load_config(config):

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -69,8 +69,8 @@ class afcPrep:
 
         ## load Unit stored variables
         units={}
-        if os.path.exists(self.AFC.VarFile + '.unit') and os.stat(self.AFC.VarFile + '.unit').st_size > 0:
-            units=json.load(open(self.AFC.VarFile + '.unit'))
+        if os.path.exists('{}.unit'.format(self.AFC.VarFile)) and os.stat('{}.unit'.format(self.AFC.VarFile)).st_size > 0:
+            units=json.load(open('{}.unit'.format(self.AFC.VarFile)))
 
         # check if Lane is suppose to be loaded in tool head from saved file
         for EXTRUDER in self.AFC.tools.keys():
@@ -114,10 +114,10 @@ class afcPrep:
         for UNIT in self.AFC.units.keys():
             try: CUR_UNIT = self.AFC.units[UNIT]
             except:
-                error_string = 'Error: ' + UNIT + '  Unit not found in  config section.'
+                error_string = 'Error: {} Unit not found in  config section.'.format(UNIT)
                 self.AFC.ERROR.AFC_error(error_string, False)
                 return
-            self.logger.info(CUR_UNIT.type + ' ' + UNIT +' Prepping lanes')
+            self.logger.info('{} {} Prepping lanes'.format(CUR_UNIT.type, UNIT))
             lanes_for_first_hub = []
             hub_name = ""
             LaneCheck = True

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -70,7 +70,7 @@ class AFCSpool:
             return
         map_cmd = gcmd.get('MAP', None)
         lane_switch=self.AFC.tool_cmds[map_cmd]
-        self.logger.debug("lane to switch is " + lane_switch)
+        self.logger.debug("lane to switch is {}".format(lane_switch))
         if lane not in self.AFC.lanes:
             self.logger.info('{} Unknown'.format(lane))
             return
@@ -110,7 +110,7 @@ class AFCSpool:
             self.logger.info('{} Unknown'.format(lane))
             return
         CUR_LANE = self.AFC.lanes[lane]
-        CUR_LANE.color = '#' + color.replace('#','')
+        CUR_LANE.color = '#{}'.format(color.replace('#',''))
         self.AFC.save_vars()
 
     cmd_SET_WEIGHT_help = "Sets filaments weight for a lane"

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -612,10 +612,10 @@ class AFCExtruderStepper:
         self.sync_print_time()
         stepper_enable = self.printer.lookup_object('stepper_enable')
         if enable:
-            se = stepper_enable.lookup_enable('AFC_stepper ' + self.name)
+            se = stepper_enable.lookup_enable('AFC_stepper {}'.format(self.name))
             se.motor_enable(self.next_cmd_time)
         else:
-            se = stepper_enable.lookup_enable('AFC_stepper ' + self.name)
+            se = stepper_enable.lookup_enable('AFC_stepper {}'.format(self.name))
             se.motor_disable(self.next_cmd_time)
         self.sync_print_time()
 


### PR DESCRIPTION
## Major Changes in this PR
Just refactored string concat to be unified to .format() usage

## Notes to Code Reviewers

## How the changes in this PR are tested
changes are based only on strings from + concat to format as it is used in the rest of the project

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [X] I have performed a self-review of my code
- [X] CHANGELOG.md is updated (if end-user facing)
- [X] Documentation updated in AT-Documentation repository
- [] Sent notification to software-design channel requesting review
