### PR TITLE
Issue in poop fan control when verbose is false

### DIFF
--- a/extras/AFC_poop.py
+++ b/extras/AFC_poop.py
@@ -78,7 +78,7 @@ class afc_poop:
         if self.full_fan:
             if self.verbose:
                 self.logger.info('AFC_Poop: ' + str(step) + ' Restore fan speed and feedrate')
-                self.gcode.run_script_from_command('M106 S0')
+            self.gcode.run_script_from_command('M106 S0')
 
 def load_config(config):
     return afc_poop(config)


### PR DESCRIPTION
Probably created wipe issues with hardened filament when brushing with full fan speed

## Major Changes in this PR
just fix that the fan is disabled as intended when verbose in not active.

## Notes to Code Reviewers

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [X] I have performed a self-review of my code
- [X] CHANGELOG.md is updated (if end-user facing)
- [X] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design channel requesting review
