### PR TITLE
AFC-62 readable error for varfile

### DIFF
--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -71,13 +71,17 @@ class afcPrep:
         units={}
         if os.path.exists(self.AFC.VarFile + '.unit') and os.stat(self.AFC.VarFile + '.unit').st_size > 0:
             units=json.load(open(self.AFC.VarFile + '.unit'))
+        else:
+            error_string = 'Error: ' + self.AFC.VarFile + '.unit file not found. Please check the path in the'
+            error_string += 'AFC.cfg file and make sure the file exists.'
+            self.AFC.ERROR.AFC_error(error_string, False)
 
-        # check if Lane is suppose to be loaded in tool head from saved file
+        # check if Lane is supposed to be loaded in tool head from saved file
         for EXTRUDER in self.AFC.tools.keys():
             PrinterObject=self.AFC.tools[EXTRUDER]
             self.AFC.tools[PrinterObject.name]=PrinterObject
             if 'system' in units and "extruders" in units["system"]:
-                # Check to see if lane_loaded is in dictionary and its its not an empty string
+                # Check to see if lane_loaded is in dictionary and its not an empty string
                 if PrinterObject.name in units["system"]["extruders"] and \
                   'lane_loaded' in units["system"]["extruders"][PrinterObject.name] and \
                   units["system"]["extruders"][PrinterObject.name]['lane_loaded']:


### PR DESCRIPTION
## Major Changes in this PR

This pull request makes a minor update to the `PREP` method in `extras/AFC_prep.py` to improve error handling and fix some typos in comments.

Error handling improvements:
* Added a check for the existence of the `.unit` file. If the file is missing, an error message is generated and logged using the `AFC_error` method.

Comment corrections:
* Fixed typos in comments, such as changing "suppose" to "supposed" and correcting "its its" to "it's".

## Notes to Code Reviewers

Do we need changelog entries for minor bugfixes like this?

## How the changes in this PR are tested

Make a bad path in the `AFC.cfg` file for the `VarFile` and start up Klipper. It should fail and also `return` out of the function. Otherwise, the `PREP` function would continue, which would result in an internal error. 

![image](https://github.com/user-attachments/assets/1cb41bc7-dbdb-4eb1-9fed-0b53abb0c023)

Fix the path, and it works like normal

![image](https://github.com/user-attachments/assets/c82335f7-fb5c-4f84-a5e6-c21bfc727a21)


## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design channel requesting review
