### PR TITLE
Updating print assist to be based off filament usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-05-01]
+### Added
+- Print assist is now filament usage based and will activate spool after a specified amount of filament is used. This is enabled by default.
+
+### Removed
+- Removed velocity from AFC_buffer code and install code, please remove `velocity`  variable from AFC_buffer configuration
+
 ## [2025-04-27]
 
 ### Removed
-- Removed deprecated belay code. 
+- Removed deprecated belay code.
+
 ## [2025-04-25]
 ### Added
 - The AFC_CUT macro now supports a servo-activated pin. Set values for ``[servo tool_cut]`` in ``AFC_Hardware.cfg`` and enable ``tool_servo_enable`` in ``AFC_Macro_Vars.cfg``

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1057,6 +1057,8 @@ class afc:
         self.toolhead.manual_move(pos, CUR_EXTRUDER.tool_unload_speed)
         self.toolhead.wait_moves()
 
+        self.FUNCTION.log_toolhead_pos("TOOL_UNLOAD quick pull: ")
+
         # Perform Z-hop to avoid collisions during unloading.
         pos[2] += self.z_hop
         self._move_z_pos(pos[2])
@@ -1117,7 +1119,7 @@ class afc:
                 if num_tries > self.tool_max_unload_attempts:
                     msg = ''
                     msg += "Buffer did not become compressed after {} short moves.\n".format(self.tool_max_unload_attempts)
-                    msg += "Increasing 'tool_max_unload_attempts' may improve loading reliablity"
+                    msg += "Increasing 'tool_max_unload_attempts' may improve loading reliability"
                     self.logger.info("<span class=warning--text>{}</span>".format(msg))
                     break
             CUR_LANE.sync_to_extruder(False)

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -24,7 +24,7 @@ except: raise error("Error trying to import afcDeltaTime, please rerun install-a
 try: from extras.AFC_utils import add_filament_switch
 except: raise error("Error trying to import AFC_utils, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper")
 
-AFC_VERSION="1.0.11"
+AFC_VERSION="1.0.12"
 
 # Class for holding different states so its clear what all valid states are
 class State:

--- a/extras/AFC_assist.py
+++ b/extras/AFC_assist.py
@@ -3,56 +3,58 @@
 # Copyright (C) 2024 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+import math
 
 #respooler
 PIN_MIN_TIME = 0.100
 RESEND_HOST_TIME = 0.300 + PIN_MIN_TIME
 MAX_SCHEDULE_TIME = 5.0
 
-
 class AFCassistMotor:
     def __init__(self, config, type):
         self.printer = config.get_printer()
-        ppins = self.printer.lookup_object('pins')
+        ppins = self.printer.lookup_object("pins")
         # Determine pin type
-        self.is_pwm = config.getboolean('pwm', False)
-        if self.is_pwm:
-            self.mcu_pin = ppins.setup_pin('pwm', config.get('afc_motor_{}'.format(type)))
-            cycle_time = config.getfloat('cycle_time', 0.100, above=0.,
+        self.is_pwm = config.getboolean("pwm", False)
+        if self.is_pwm and type != "enb":
+            self.mcu_pin = ppins.setup_pin("pwm", config.get("afc_motor_{}".format(type)))
+            cycle_time = config.getfloat("cycle_time", 0.100, above=0.,
                                          maxval=MAX_SCHEDULE_TIME)
-            hardware_pwm = config.getboolean('hardware_pwm', False)
+            hardware_pwm = config.getboolean("hardware_pwm", False)
             self.mcu_pin.setup_cycle_time(cycle_time, hardware_pwm)
-            self.scale = config.getfloat('scale', 1., above=0.)
+            self.scale = config.getfloat("scale", 1., above=0.)
         else:
-            self.mcu_pin = ppins.setup_pin('digital_out', config.get('afc_motor_{}'.format(type)))
+            self.mcu_pin = ppins.setup_pin("digital_out", config.get("afc_motor_{}".format(type)))
             self.scale = 1.
+            self.is_pwm = False
+
         self.last_print_time = 0.
         # Support mcu checking for maximum duration
         self.reactor = self.printer.get_reactor()
         self.resend_timer = None
         self.resend_interval = 0.
-        max_mcu_duration = config.getfloat('maximum_mcu_duration', 0.,
+        max_mcu_duration = config.getfloat("maximum_mcu_duration", 0.,
                                            minval=0.500,
                                            maxval=MAX_SCHEDULE_TIME)
         self.mcu_pin.setup_max_duration(max_mcu_duration)
         if max_mcu_duration:
-            config.deprecate('maximum_mcu_duration')
+            config.deprecate("maximum_mcu_duration")
             self.resend_interval = max_mcu_duration - RESEND_HOST_TIME
         # Determine start and shutdown values
-        static_value = config.getfloat('static_value', None,
+        static_value = config.getfloat("static_value", None,
                                        minval=0., maxval=self.scale)
         if static_value is not None:
-            config.deprecate('static_value')
+            config.deprecate("static_value")
             self.last_value = self.shutdown_value = static_value / self.scale
         else:
             self.last_value = config.getfloat(
-                'value', 0., minval=0., maxval=self.scale) / self.scale
+                "value", 0., minval=0., maxval=self.scale) / self.scale
             self.shutdown_value = config.getfloat(
-                'shutdown_value', 0., minval=0., maxval=self.scale) / self.scale
+                "shutdown_value", 0., minval=0., maxval=self.scale) / self.scale
         self.mcu_pin.setup_start_value(self.last_value, self.shutdown_value)
 
     def get_status(self, eventtime):
-        return {'value': self.last_value}
+        return {"value": self.last_value}
 
     def _set_pin(self, print_time, value, is_resend=False):
         if value == self.last_value and not is_resend:
@@ -81,3 +83,486 @@ class AFCassistMotor:
             return systime + time_diff
         self._set_pin(print_time + PIN_MIN_TIME, self.last_value, True)
         return systime + self.resend_interval
+
+class Espooler_values:
+    """
+    This class holds the common values for espooler assist, it consists of setters and getters for the values so that
+    some values can easily hold a raw value and also return the value scaled.
+
+    Parameters
+    ----------------
+    config : object
+        Configuration object containing settings
+
+    """
+    def __init__(self, config):
+        # Time in seconds to enable spooler at full speed to help with getting the spool to spin. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
+        self._kick_start_time        = config.getfloat("kick_start_time",       None)
+        # Distance per full rotation in mm. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
+        self._mm_per_rotation        = config.getfloat("mm_per_rotation",       None)
+        # Cycles per rotation in milliseconds. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
+        self._cycles_per_rotation    = config.getfloat("cycles_per_rotation",   None)
+        # PWM cycle time. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
+        self._pwm_value              = config.getfloat("pwm_value",             None)
+        # Delta amount in mm from last move to trigger assist. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
+        self._delta_movement         = config.getfloat("delta_movement",        None)
+        # Amount to move in mm once filament has moved by delta movement amount. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
+        self._mm_movement            = config.getfloat("mm_movement",           None)
+        # Scaling factor for the following variables: kick_start_time, mm_per_rotation, cycles_per_rotation, pwm_value, delta_movement, mm_movement. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
+        self._scaling                = config.getfloat("spoolrate",             None)
+
+    def calculate_cruise_time(self, mm_movement):
+        """
+        This function calculates cruise time which is the amount of time to enable motors to rotate spool mm movement amount
+
+        :param mm_movement: Amount to move spool in mm
+        :return float: Amount of time to be enabled to move mm amount
+        """
+        rotations = mm_movement / self.mm_per_rotation
+        correction_factor = 1.0 + ( 1.68 * math.exp(-rotations * 5.0) )
+        cruise_time = rotations * self.cycles_per_rotation * correction_factor
+
+        return cruise_time/1000
+
+    def handle_connect(self, unit_obj):
+        """
+        Should only be called during handle_connect callback to update values from unit. If values are not set per
+        lane this function will update values from their unit.
+        """
+        if self._kick_start_time     is None: self.kick_start_time      = unit_obj.kick_start_time
+        if self._mm_per_rotation     is None: self.mm_per_rotation      = unit_obj.mm_per_rotation
+        if self._cycles_per_rotation is None: self.cycles_per_rotation  = unit_obj.cycles_per_rotation
+        if self._pwm_value           is None: self.pwm_value            = unit_obj.pwm_value
+        if self._mm_movement         is None: self.mm_movement          = unit_obj.mm_movement
+        if self._delta_movement      is None: self.delta_movement       = unit_obj.delta_movement
+        if self._scaling             is None: self.scaling              = unit_obj.scaling
+
+        # Since cruise time is always going to be the same, calculate it now instead of everytime inside the timer callback
+        self._cruise_time            = self.calculate_cruise_time(self.mm_movement)
+
+    @property
+    def cruise_time(self):
+        """
+        Returns calculated cruise time
+        """
+        return self._cruise_time
+    @cruise_time.setter
+    def cruise_time(self, value):
+        self._cruise_time = value
+
+    @property
+    def kick_start_time(self):
+        """
+        Returns software kick start time, this value is scaled by scaling factor
+        """
+        return self._kick_start_time * self._scaling
+    @kick_start_time.setter
+    def kick_start_time(self, value):
+        self._kick_start_time = value
+
+    @property
+    def mm_per_rotation(self):
+        """
+        Returns mm per rotation, this value is scaled by scaling factor
+        """
+        return self._mm_per_rotation * self._scaling
+    @mm_per_rotation.setter
+    def mm_per_rotation(self, value):
+        self._mm_per_rotation = value
+
+    @property
+    def cycles_per_rotation(self):
+        """
+        Returns cycles per rotation, this value is scaled by scaling factor
+        """
+        return self._cycles_per_rotation * self._scaling
+    @cycles_per_rotation.setter
+    def cycles_per_rotation(self, value):
+        self._cycles_per_rotation = value
+
+    @property
+    def pwm_value(self):
+        """
+        Returns pwm value, this value is scaled by scaling factor
+        """
+        return self._pwm_value * self._scaling
+    @pwm_value.setter
+    def pwm_value(self, value):
+        self._pwm_value = value
+
+    @property
+    def mm_movement(self):
+        """
+        Returns mm movement, this value is scaled by scaling factor
+        """
+        return self._mm_movement * self._scaling
+    @mm_movement.setter
+    def mm_movement(self, value):
+        self._mm_movement = value
+
+    @property
+    def delta_movement(self):
+        """
+        Returns delta movement, this value is scaled by scaling factor
+        """
+        return self._delta_movement * self._scaling
+    @delta_movement.setter
+    def delta_movement(self, value):
+        self._delta_movement = value
+
+    @property
+    def scaling(self):
+        """
+        Return scaling factor
+        """
+        return self._scaling
+    @scaling.setter
+    def scaling(self, value):
+        self._scaling = value
+
+class Espooler:
+    """
+    This class is used to drive espooler for a lane when loading/unloading and has print forward assist logic.
+
+    Parameters
+    ----------------
+    name: string
+        Lane name of espooler
+    config : object
+        Configuration object containing settings
+
+    """
+    def __init__(self, name, config):
+        self.name                   = name
+        self.printer                = config.get_printer()
+        self.AFC                    = self.printer.lookup_object("AFC")
+        self.logger                 = self.AFC.logger
+        self.reactor                = self.printer.get_reactor()
+        self.callback_timer         = self.reactor.register_timer( self.timer_callback )    # Defaults to never trigger
+
+        self.afc_motor_rwd          = config.get("afc_motor_rwd", None)                     # Reverse pin on MCU for spoolers
+        self.afc_motor_fwd          = config.get("afc_motor_fwd", None)                     # Forwards pin on MCU for spoolers
+        self.afc_motor_enb          = config.get("afc_motor_enb", None)                     # Enable pin on MCU for spoolers
+
+        # Forward multiplier to apply to rpm
+        self.rwd_speed_multi        = config.getfloat("rwd_speed_multiplier",   0.5)
+        # Reverse multiplier to apply to rpm
+        self.fwd_speed_multi        = config.getfloat("fwd_speed_multiplier",   0.5)
+        # Time to wait between breaking n20 motors(nSleep/FWD/RWD all 1) and then releasing the break to allow coasting. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
+        self.n20_break_delay_time   = config.getfloat("n20_break_delay_time",   None)
+        # Number of seconds to wait before checking filament movement for espooler assist. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
+        self.timer_delay            = config.getfloat("timer_delay",            None)
+        # Setting to True enables espooler assist while printing. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
+        self.enable_assist          = config.getboolean("enable_assist",        None)
+        # Turns on/off debug messages to console. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
+        self.debug                  = config.getboolean("debug",                None)
+        # Setting to True enables full speed espoolers for kick_start_time amount. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
+        self.enable_kick_start      = config.getboolean("enable_kick_start",    None)
+
+        self.past_extruder_position = -1
+
+        self.espooler_values        = Espooler_values(config)
+
+        if self.afc_motor_rwd is not None:
+            self.afc_motor_rwd = AFCassistMotor(config, "rwd")
+        if self.afc_motor_fwd is not None:
+            self.afc_motor_fwd = AFCassistMotor(config, "fwd")
+            # Only register macros if forward pin is defined
+            self.AFC.gcode.register_mux_command("SET_ESPOOLER_VALUES"       , "LANE", self.name, self.cmd_SET_ESPOOLER_VALUES,      desc=self.cmd_SET_ESPOOLER_VALUES_help)
+            self.AFC.gcode.register_mux_command("TEST_ESPOOLER_ASSIST"      , "LANE", self.name, self.cmd_TEST_ESPOOLER_ASSIST,     desc=self.cmd_TEST_ESPOOLER_ASSIST_help)
+            self.AFC.gcode.register_mux_command("ENABLE_ESPOOLER_ASSIST"    , "LANE", self.name, self.cmd_ENABLE_ESPOOLER_ASSIST,   desc=self.cmd_ENABLE_ESPOOLER_ASSIST_help)
+            self.AFC.gcode.register_mux_command("DISABLE_ESPOOLER_ASSIST"   , "LANE", self.name, self.cmd_DISABLE_ESPOOLER_ASSIST,  desc=self.cmd_DISABLE_ESPOOLER_ASSIST_help)
+        if self.afc_motor_enb is not None:
+            self.afc_motor_enb = AFCassistMotor(config, "enb")
+
+    def handle_connect(self, unit_obj):
+        """
+        Should only be called during handle_connect callback to update values from unit. If values are not set per
+        lane this function will update values from their unit.
+        """
+        self.espooler_values.handle_connect(unit_obj)
+
+        if self.n20_break_delay_time    is None: self.n20_break_delay_time  = unit_obj.n20_break_delay_time
+        if self.timer_delay             is None: self.timer_delay           = unit_obj.timer_delay
+        if self.enable_assist           is None: self.enable_assist         = unit_obj.enable_assist
+        if self.debug                   is None: self.debug                 = unit_obj.debug
+        if self.enable_kick_start       is None: self.enable_kick_start     = unit_obj.enable_kick_start
+
+    def timer_callback(self, eventtime):
+        """
+        Callback function that checks to see how far filament moved since last check. If filament has moved more than delta_movement
+        espooler is activated.
+
+        :param eventtime: Reactor time when callback was called
+        :return float   : Time when to call the callback again
+        """
+        if self.enable_assist and self.AFC.FUNCTION.in_print() and not self.AFC.FUNCTION.is_paused() and not self.AFC.in_toolchange:
+            extruder_pos = self.AFC.FUNCTION.get_extruder_pos( eventtime, self.past_extruder_position )
+            delta_length = extruder_pos - self.past_extruder_position
+
+            if -1 == self.past_extruder_position:
+                self.past_extruder_position = extruder_pos
+
+            elif delta_length > self.espooler_values.delta_movement:
+                self.past_extruder_position = extruder_pos
+                self.do_assist_move()
+
+            if self.debug:
+                self.logger.info(f"Timer Callback {eventtime:0.03f} e:{extruder_pos:0.03f} d:{delta_length:0.03f} p:{self.past_extruder_position:0.03f}")
+
+        return self.reactor.monotonic() + self.timer_delay
+
+    def _kick_start(self, reverse=False):
+        """
+        Helper function to perform a kick start to help with spool movement
+
+        :param reverse: When set to True, moves espooler in reverse direction
+        :return float: Print time with kick_start_time offset
+        """
+        print_time = self.AFC.toolhead.get_last_move_time()
+
+        if reverse:
+            self.move_reverse(print_time, 1)
+        else:
+            self.move_forwards(print_time, 1)
+        print_time += self.espooler_values.kick_start_time
+
+        return print_time
+
+    def set_enable_pin(self, print_time, value):
+        """
+        Helper function to set enable pin if its defined
+
+        :param print_time: This value should be a float and is a time when to set the pin
+        :param value: This value should be either 0 to disable or 1 to enable pin
+        """
+        if self.afc_motor_enb is not None:
+            self.afc_motor_enb._set_pin( print_time, value)
+
+    def do_assist_move(self, movement=100):
+        """
+        Helper function to perform assist move while printing
+
+        :param movement: Amount in mm to move spool
+        """
+        print_time = self._kick_start()
+        time = print_time
+
+        self.move_forwards( print_time, self.espooler_values.pwm_value )
+        print_time += self.espooler_values.cruise_time
+
+        self.afc_motor_fwd._set_pin( print_time, 0)
+        self.set_enable_pin( print_time, 0)
+
+        if self.debug:
+            self.logger.debug(f"Cruise time: {self.espooler_values.cruise_time:0.03f} {time:0.03f} {print_time:0.03f}")
+
+    def move_forwards(self, print_time, value):
+        """
+        Helper function to set PWM value to forward pin
+
+        :param print_time: This value should be a float and is a time when to set the pin
+        :param value: This value should be a float between 0.0 and 1.0
+        """
+        self.set_enable_pin(print_time, 1)
+        self.afc_motor_fwd._set_pin(print_time, value)
+
+    def move_reverse(self, print_time, value):
+        """
+        Helper function to set PWM value to reverse pin
+
+        :param print_time: This value should be a float and is a time when to set the pin
+        :param value: This value should be a float between 0.0 and 1.0
+        """
+        self.set_enable_pin(print_time, 1)
+        self.afc_motor_rwd._set_pin(print_time, value)
+
+    def assist(self, value):
+        """
+        This function is for setting espooler FWD/RWD/EN signals. FWD/RWD is dependent on the value that is
+        passed in.  < 0 for RWD, > 0 for FWD and 0 for disable
+
+        :param value: Direction and PWM value to set espooler pins. < 0 RWD, > 0 FWD and 0 disable and enable espooler braking
+        """
+        reverse = False
+        print_time = self.AFC.toolhead.get_last_move_time()
+        if self.afc_motor_rwd is None:
+            return
+
+        if value < 0:
+            value *= -1
+            assist_motor=self.afc_motor_rwd
+            reverse = True
+        elif value > 0:
+            if self.afc_motor_fwd is None:
+                return
+            assist_motor=self.afc_motor_fwd
+        elif value == 0:
+            self.break_espooler()
+            return
+
+        value /= assist_motor.scale
+        if not assist_motor.is_pwm and value not in [0., 1.]:
+            if value > 0: value = 1
+        if self.afc_motor_enb is not None:
+            enable = 1 if value != 0 else 0
+
+            self.afc_motor_enb._set_pin(print_time, enable)
+
+        if self.enable_kick_start:
+            print_time = self._kick_start(reverse)
+        assist_motor._set_pin(print_time, value)
+
+    def break_espooler(self):
+        """
+        Helper function to "brake" n20 motors to hopefully help with keeping down backfeeding into MCU board
+        """
+        print_time = self.AFC.toolhead.get_last_move_time()
+        if self.afc_motor_enb is not None:
+            self.afc_motor_rwd._set_pin(print_time, 1)
+            self.set_enable_pin(print_time, 1)
+            if self.afc_motor_fwd is not None:
+                self.afc_motor_fwd._set_pin(print_time, 1)
+
+            # Forward predict delay time instead of adding reactor pause in code
+            print_time += self.n20_break_delay_time
+
+            self.set_enable_pin(print_time, 0)
+            self.afc_motor_rwd._set_pin(print_time, 0)
+            if self.afc_motor_fwd is not None:
+                self.afc_motor_fwd._set_pin(print_time, 0)
+        else:
+            self.afc_motor_rwd._set_pin(print_time, 0)
+
+    def enable_timer(self):
+        """
+        Enables espooler timer if enable_assist variable is True. This should be called after loading a lane
+        into toolhead.
+        """
+
+        # Checking to see if forward pin is defined, return if it's not defined
+        if self.afc_motor_fwd is None: return
+
+        self.past_extruder_position = -1
+        if self.enable_assist:
+            if self.debug: self.logger.info(f"{self.name} espooler timer enabled")
+            self.reactor.update_timer( self.callback_timer, self.reactor.monotonic() + self.timer_delay )
+
+    def disable_timer(self):
+        """
+        Disables callback function for moving espooler. This should be called before unload a lane.
+        """
+
+        # Checking to see if forward pin is defined, return if it's not defined
+        if self.afc_motor_fwd is None: return
+
+        self.past_extruder_position = -1
+        self.reactor.update_timer( self.callback_timer, self.reactor.NEVER)
+
+    ### MACROS ###
+    cmd_TEST_ESPOOLER_ASSIST_help="Test espooler print assist for a specified lane"
+    def cmd_TEST_ESPOOLER_ASSIST(self, gcmd):
+        """
+        Macro call to test espooler print assist to see how current values work
+
+        USAGE
+        -----
+        `TEST_ESPOOLER_ASSIST LANE=<lane_name>`
+
+        Example
+        -----
+        ```
+        TEST_ESPOOLER_ASSIST LANE=lane1
+        ```
+        """
+        self.do_assist_move(100)
+
+    cmd_ENABLE_ESPOOLER_ASSIST_help="Enabled espooler print assist for a specified lane, this can be used while printing"
+    def cmd_ENABLE_ESPOOLER_ASSIST(self, gcmd):
+        """
+        Macro call to enable espooler print assist
+
+        USAGE
+        -----
+        `ENABLE_ESPOOLER_ASSIST LANE=<lane_name>`
+
+        Example
+        -----
+        ```
+        ENABLE_ESPOOLER_ASSIST LANE=lane1
+        ```
+        """
+
+        self.enable_assist = True
+        if self.AFC.FUNCTION.get_current_lane() == self.name:
+            self.enable_timer()
+            self.logger.info(f"Espooler assist enabled for {self.name}")
+        else:
+            self.logger.info(f"{self.name} currently not loaded only enabling assist, not enabling timer")
+
+    cmd_DISABLE_ESPOOLER_ASSIST_help="Disables espooler print assist for a specified lane, this can be used while printing"
+    def cmd_DISABLE_ESPOOLER_ASSIST(self, gcmd):
+        """
+        Macro call to disable espooler print assist
+
+        USAGE
+        -----
+        `DISABLE_ESPOOLER_ASSIST LANE=<lane_name>`
+
+        Example
+        -----
+        ```
+        DISABLE_ESPOOLER_ASSIST LANE=lane1
+        ```
+        """
+        self.disable_timer()
+        self.enable_assist = False
+        self.logger.info(f"Espooler assist disabled for {self.name}")
+
+    cmd_SET_ESPOOLER_VALUES_help="Macro for setting/updating espooler values without having to restart klipper."
+    def cmd_SET_ESPOOLER_VALUES( self, gcmd ):
+        """
+        Macro to allow updating espooler print assist values. If optional value is not passed, current values will be used.
+
+        Optional Values
+        ----
+        BREAK_DELAY - Time in seconds to wait between breaking n20 motors(nSleep/FWD/RWD all 1) and then releasing the break to allow coasting.
+        KICK_START_TIME - Time in seconds to enable spooler at full speed to help with getting the spool to spin
+        MM_PER_ROTATION - Distance per full rotation in mm
+        CYCLES_PER_ROTATION - Cycles per rotation in milliseconds
+        PWM_VALUE - PWM cycle time
+        MM_MOVEMENT - Amount to move in mm once filament has moved by delta movement amount
+        DELTA_MOVEMENT - Delta amount in mm from last move to trigger assist
+        SPOOLRATE - Scaling factor for the following variables: kick_start_time, mm_per_rotation, cycles_per_rotation, pwm_value, delta_movement, mm_movement
+        TIMER_DELAY - Number of seconds to wait before checking filament movement for espooler assist
+        ENABLE_ASSIST - Setting to True enables espooler assist while printing
+        DEBUG - Turns on/off debug messages to console
+        ENABLE_KICK_START - Setting to True enables full speed espoolers for kick_start_time amount
+
+        USAGE
+        -----
+        `SET_ESPOOLER_VALUES LANE=<lane_name> DEBUG=<True/False> ENABLE_ASSIST=<True/False> ...(other optional values)`
+
+        Example
+        -----
+        ```
+        `SET_ESPOOLER_VALUES LANE=lane1 DEBUG=True ENABLE_ASSIST=True`
+        ```
+        """
+        self.n20_break_delay_time                   = gcmd.get_float("BREAK_DELAY"          , self.n20_break_delay_time)
+        self.espooler_values.kick_start_time        = gcmd.get_float("KICK_START_TIME"      , self.espooler_values._kick_start_time)
+        self.espooler_values.mm_per_rotation        = gcmd.get_float("MM_PER_ROTATION"      , self.espooler_values._mm_per_rotation)
+        self.espooler_values.cycles_per_rotation    = gcmd.get_float("CYCLES_PER_ROTATION"  , self.espooler_values._cycles_per_rotation)
+        self.espooler_values.pwm_value              = gcmd.get_float("PWM_VALUE"            , self.espooler_values._pwm_value)
+        self.espooler_values.mm_movement            = gcmd.get_float("MM_MOVEMENT"          , self.espooler_values._mm_movement)
+        self.espooler_values.delta_movement         = gcmd.get_float("DELTA_MOVEMENT"       , self.espooler_values._delta_movement)
+        self.espooler_values.scaling                = gcmd.get_float("SPOOLRATE"            , self.espooler_values._scaling)
+        self.timer_delay                            = gcmd.get_float("TIMER_DELAY"          , self.timer_delay)
+        self.enable_assist                          = bool(gcmd.get_int("ENABLE_ASSIST"     , self.enable_assist))
+        self.debug                                  = bool(gcmd.get_int("DEBUG"             , self.debug))
+        self.enable_kick_start                      = bool(gcmd.get_int("ENABLE_KICK_START" , self.enable_kick_start))
+
+        # update cruise time with new values
+        self.espooler_values.cruise_time = self.espooler_values.calculate_cruise_time( self.espooler_values._mm_movement )
+
+        self.logger.info(f"Espooler values updated for {self.name}, please manually save values in config file.")

--- a/extras/AFC_buffer.py
+++ b/extras/AFC_buffer.py
@@ -56,7 +56,6 @@ class AFCTrigger:
         self.trailing_pin       = config.get('trailing_pin') # Trailing pin for buffer
         self.multiplier_high    = config.getfloat("multiplier_high", default=1.1, minval=1.0)
         self.multiplier_low     = config.getfloat("multiplier_low", default=0.9, minval=0.0, maxval=1.0)
-        self.velocity           = config.getfloat('velocity', 0) # Velocity for forward assist
 
         if self.enable_sensors_in_gui:
             self.adv_filament_switch_name = "filament_switch_sensor {}_{}".format(self.name, "expanded")
@@ -67,7 +66,6 @@ class AFCTrigger:
 
         self.printer.register_event_handler("klippy:ready", self._handle_ready)
         self.gcode.register_mux_command("QUERY_BUFFER",         "BUFFER", self.name, self.cmd_QUERY_BUFFER,         desc=self.cmd_QUERY_BUFFER_help)
-        self.gcode.register_mux_command("SET_BUFFER_VELOCITY",  "BUFFER", self.name, self.cmd_SET_BUFFER_VELOCITY,  desc=self.cmd_SET_BUFFER_VELOCITY_help)
         self.gcode.register_mux_command("ENABLE_BUFFER",        "BUFFER", self.name, self.cmd_ENABLE_BUFFER)
         self.gcode.register_mux_command("DISABLE_BUFFER",       "BUFFER", self.name, self.cmd_DISABLE_BUFFER)
 
@@ -148,9 +146,6 @@ class AFCTrigger:
             CUR_LANE = self.AFC.FUNCTION.get_current_lane_obj()
 
             if CUR_LANE is not None and state:
-                CUR_LANE.assist(CUR_LANE.calculate_pwm_value(self.AFC.gcode_move.speed * (self.velocity / 10)))
-                self.reactor.pause(self.reactor.monotonic() + 1)
-                CUR_LANE.assist(0)
                 self.set_multiplier( self.multiplier_low )
                 if self.debug: self.logger.info("Buffer Triggered State: Advanced")
         self.last_state = ADVANCE_STATE_NAME
@@ -161,9 +156,6 @@ class AFCTrigger:
             CUR_LANE = self.AFC.FUNCTION.get_current_lane_obj()
 
             if CUR_LANE is not None and state:
-                CUR_LANE.assist(CUR_LANE.calculate_pwm_value(self.AFC.gcode_move.speed * (self.velocity / 10)))
-                self.reactor.pause(self.reactor.monotonic() + 1)
-                CUR_LANE.assist(0)
                 self.set_multiplier( self.multiplier_high )
                 if self.debug: self.logger.info("Buffer Triggered State: Trailing")
         self.last_state = TRAILING_STATE_NAME
@@ -302,33 +294,6 @@ class AFCTrigger:
                 state_info += ("\n{} Rotation distance: {:.4f}".format(LANE.name, rotation_dist))
 
         self.logger.info("{} : {}".format(self.name, state_info))
-
-    cmd_SET_BUFFER_VELOCITY_help = "Set buffer velocity realtime for forward assist"
-    def cmd_SET_BUFFER_VELOCITY(self, gcmd):
-        """
-        Allows users to tweak buffer velocity setting while printing. This setting is not
-        saved in configuration. Please update your configuration file once you find a velocity that
-        works for your setup.
-
-        Behavior:
-
-        - Updates the value that the respooler use for forward assist during printing.
-        - Setting value to zero disables forward assist during printing.
-        - Velocity is not saved to configuration file, needs to be manually updated.
-
-        Usage
-        -----
-        `SET_BUFFER_VELOCITY BUFFER=<buffer_name> VELOCITY=<value>`
-
-        Example
-        -----
-        ```
-        SET_BUFFER_VELOCITY BUFFER=TN2 VELOCITY=100
-        ```
-        """
-        old_velocity = self.velocity
-        self.velocity = gcmd.get_float('VELOCITY', 0.0)
-        self.logger.info("VELOCITY for {} was updated from {} to {}".format(self.name, old_velocity, self.velocity))
 
     def cmd_ENABLE_BUFFER(self, gcmd):
         """

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -24,8 +24,8 @@ class afcFunction:
         self.printer.register_event_handler("afc_hub:register_macros",self.register_hub_macros)
         self.errorLog = {}
         self.pause    = False
-        self.afc = self.printer.lookup_object('AFC')
-        self.logger = self.afc.logger
+        self.afc      = None
+        self.logger   = None
 
     def register_lane_macros(self, lane_obj):
         """
@@ -52,6 +52,8 @@ class afcFunction:
         This function is called when the printer connects. It looks up AFC info
         and assigns it to the instance variable `self.afc`.
         """
+        self.afc = self.printer.lookup_object('AFC')
+        self.logger = self.afc.logger
         self.mcu = self.printer.lookup_object('mcu')
         self.afc.gcode.register_command('CALIBRATE_AFC',   self.cmd_CALIBRATE_AFC,   desc=self.cmd_CALIBRATE_AFC_help)
         self.afc.gcode.register_command('AFC_CALIBRATION', self.cmd_AFC_CALIBRATION, desc=self.cmd_AFC_CALIBRATION_help)

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -26,6 +26,7 @@ class afcFunction:
         self.pause    = False
         self.afc      = None
         self.logger   = None
+        self.mcu      = None
 
     def register_lane_macros(self, lane_obj):
         """

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -107,16 +107,7 @@ class AFCExtruderStepper:
             buttons.register_buttons([self.load], self.load_callback)
         else: self.load_state = True
 
-        # Respoolers
-        self.afc_motor_rwd = config.get('afc_motor_rwd', None)                                      # Reverse pin on MCU for spoolers
-        self.afc_motor_fwd = config.get('afc_motor_fwd', None)                                      # Forwards pin on MCU for spoolers
-        self.afc_motor_enb = config.get('afc_motor_enb', None)                                      # Enable pin on MCU for spoolers
-        if self.afc_motor_rwd is not None:
-            self.afc_motor_rwd = AFC_assist.AFCassistMotor(config, 'rwd')
-        if self.afc_motor_fwd is not None:
-            self.afc_motor_fwd = AFC_assist.AFCassistMotor(config, 'fwd')
-        if self.afc_motor_enb is not None:
-            self.afc_motor_enb = AFC_assist.AFCassistMotor(config, 'enb')
+        self.espooler = AFC_assist.Espooler(self.name, config)
 
         # self.filament_diameter = config.getfloat("filament_diameter", 1.75)                         # Diameter of filament being used
         # self.filament_density = config.getfloat("filament_density", 1.24)                           # Density of filament being used
@@ -245,22 +236,23 @@ class AFCExtruderStepper:
 
         self.get_steppers()
 
-        if self.led_name is None: self.led_name = self.unit_obj.led_name
-        if self.led_fault is None: self.led_fault = self.unit_obj.led_fault
-        if self.led_ready is None: self.led_ready = self.unit_obj.led_ready
-        if self.led_not_ready is None: self.led_not_ready = self.unit_obj.led_not_ready
-        if self.led_loading is None: self.led_loading = self.unit_obj.led_loading
-        if self.led_prep_loaded is None: self.led_prep_loaded = self.unit_obj.led_prep_loaded
-        if self.led_unloading is None: self.led_unloading = self.unit_obj.led_unloading
-        if self.led_tool_loaded is None: self.led_tool_loaded = self.unit_obj.led_tool_loaded
+        if self.led_name            is None: self.led_name          = self.unit_obj.led_name
+        if self.led_fault           is None: self.led_fault         = self.unit_obj.led_fault
+        if self.led_ready           is None: self.led_ready         = self.unit_obj.led_ready
+        if self.led_not_ready       is None: self.led_not_ready     = self.unit_obj.led_not_ready
+        if self.led_loading         is None: self.led_loading       = self.unit_obj.led_loading
+        if self.led_prep_loaded     is None: self.led_prep_loaded   = self.unit_obj.led_prep_loaded
+        if self.led_unloading       is None: self.led_unloading     = self.unit_obj.led_unloading
+        if self.led_tool_loaded     is None: self.led_tool_loaded   = self.unit_obj.led_tool_loaded
 
-        if self.long_moves_speed is None: self.long_moves_speed = self.unit_obj.long_moves_speed
-        if self.long_moves_accel is None: self.long_moves_accel = self.unit_obj.long_moves_accel
-        if self.short_moves_speed is None: self.short_moves_speed = self.unit_obj.short_moves_speed
-        if self.short_moves_accel is None: self.short_moves_accel = self.unit_obj.short_moves_accel
-        if self.short_move_dis is None: self.short_move_dis = self.unit_obj.short_move_dis
-        if self.max_move_dis is None: self.max_move_dis = self.unit_obj.max_move_dis
-        if self.n20_break_delay_time is None: self.n20_break_delay_time = self.unit_obj.n20_break_delay_time
+        if self.long_moves_speed    is None: self.long_moves_speed  = self.unit_obj.long_moves_speed
+        if self.long_moves_accel    is None: self.long_moves_accel  = self.unit_obj.long_moves_accel
+        if self.short_moves_speed   is None: self.short_moves_speed = self.unit_obj.short_moves_speed
+        if self.short_moves_accel   is None: self.short_moves_accel = self.unit_obj.short_moves_accel
+        if self.short_move_dis      is None: self.short_move_dis    = self.unit_obj.short_move_dis
+        if self.max_move_dis        is None: self.max_move_dis      = self.unit_obj.max_move_dis
+
+        self.espooler.handle_connect(self.unit_obj)
 
         # Set hub loading speed depending on distance between extruder and hub
         self.dist_hub_move_speed = self.long_moves_speed if self.dist_hub >= 200 else self.short_moves_speed
@@ -290,55 +282,6 @@ class AFCExtruderStepper:
             self.selector_stepper   = self.unit_obj.selector_stepper_obj
             self.extruder_stepper   = self.drive_stepper.extruder_stepper
 
-    def brake_n20(self):
-        '''
-        Helper function to "brake" n20 motors to hopefully help with keeping down backfeeding into MCU board
-        '''
-        self.AFC.toolhead.register_lookahead_callback(lambda print_time: self.afc_motor_rwd._set_pin(print_time, 1))
-        self.AFC.toolhead.register_lookahead_callback(lambda print_time: self.afc_motor_enb._set_pin(print_time, 1))
-        if self.afc_motor_fwd is not None:
-            self.AFC.toolhead.register_lookahead_callback(lambda print_time: self.afc_motor_fwd._set_pin(print_time, 1))
-
-        self.AFC.reactor.pause(self.AFC.reactor.monotonic() + self.n20_break_delay_time)
-
-        self.AFC.toolhead.register_lookahead_callback(lambda print_time: self.afc_motor_rwd._set_pin(print_time, 0))
-        self.AFC.toolhead.register_lookahead_callback(lambda print_time: self.afc_motor_enb._set_pin(print_time, 0))
-        if self.afc_motor_fwd is not None:
-            self.AFC.toolhead.register_lookahead_callback(lambda print_time: self.afc_motor_fwd._set_pin(print_time, 0))
-
-    def assist(self, value, is_resend=False):
-        if self.afc_motor_rwd is None:
-            return
-        if value < 0:
-            value *= -1
-            assit_motor=self.afc_motor_rwd
-        elif value > 0:
-            if self.afc_motor_fwd is None:
-                return
-            else:
-                assit_motor=self.afc_motor_fwd
-        elif value == 0:
-            if self.afc_motor_enb is not None:
-                self.brake_n20()
-            else:
-                self.AFC.toolhead.register_lookahead_callback(lambda print_time: self.afc_motor_rwd._set_pin(print_time, value))
-
-            return
-        value /= assit_motor.scale
-        if not assit_motor.is_pwm and value not in [0., 1.]:
-            if value > 0:
-                value = 1
-        if self.afc_motor_enb is not None:
-            if value != 0:
-                enable = 1
-            else:
-                enable = 0
-            self.AFC.toolhead.register_lookahead_callback(
-            lambda print_time: self.afc_motor_enb._set_pin(print_time, enable))
-
-        self.AFC.toolhead.register_lookahead_callback(
-            lambda print_time: assit_motor._set_pin(print_time, value))
-
     @contextmanager
     def assist_move(self, speed, rewind, assist_active=True):
         """
@@ -360,12 +303,12 @@ class AFCExtruderStepper:
             if value > 1:
                 value = 1
 
-            self.assist(value)
+            self.espooler.assist(value)
         try:
             yield
         finally:
             if assist_active:
-                self.assist(0)
+                self.espooler.assist(0)
 
     def move(self, distance, speed, accel, assist_active=False):
         """
@@ -617,6 +560,7 @@ class AFCExtruderStepper:
         """
         if self.buffer_obj is not None:
             self.buffer_obj.enable_buffer()
+        self.espooler.enable_timer()
 
     def disable_buffer(self):
         """
@@ -625,6 +569,7 @@ class AFCExtruderStepper:
         """
         if self.buffer_obj is not None:
             self.buffer_obj.disable_buffer()
+        self.espooler.disable_timer()
 
     def buffer_status(self):
         """

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -147,16 +147,7 @@ class AFCExtruderStepper:
             buttons.register_buttons([self.load], self.load_callback)
         else: self.load_state = True
 
-        # Respoolers
-        self.afc_motor_rwd = config.get('afc_motor_rwd', None)                                      # Reverse pin on MCU for spoolers
-        self.afc_motor_fwd = config.get('afc_motor_fwd', None)                                      # Forwards pin on MCU for spoolers
-        self.afc_motor_enb = config.get('afc_motor_enb', None)                                      # Enable pin on MCU for spoolers
-        if self.afc_motor_rwd is not None:
-            self.afc_motor_rwd = AFC_assist.AFCassistMotor(config, 'rwd')
-        if self.afc_motor_fwd is not None:
-            self.afc_motor_fwd = AFC_assist.AFCassistMotor(config, 'fwd')
-        if self.afc_motor_enb is not None:
-            self.afc_motor_enb = AFC_assist.AFCassistMotor(config, 'enb')
+        self.espooler = AFC_assist.Espooler(self.name, config)
 
         self.tmc_print_current = config.getfloat("print_current", self.AFC.global_print_current)    # Current to use while printing, set to a lower current to reduce stepper heat when printing. Defaults to global_print_current, if not specified current is not changed.
         self._get_tmc_values( config )
@@ -290,22 +281,23 @@ class AFCExtruderStepper:
             # Assigning buffer name just in case stepper is using buffer defined in units/extruder config
             self.buffer_name = self.buffer_obj.name
 
-        if self.led_name is None: self.led_name = self.unit_obj.led_name
-        if self.led_fault is None: self.led_fault = self.unit_obj.led_fault
-        if self.led_ready is None: self.led_ready = self.unit_obj.led_ready
-        if self.led_not_ready is None: self.led_not_ready = self.unit_obj.led_not_ready
-        if self.led_loading is None: self.led_loading = self.unit_obj.led_loading
-        if self.led_prep_loaded is None: self.led_prep_loaded = self.unit_obj.led_prep_loaded
-        if self.led_unloading is None: self.led_unloading = self.unit_obj.led_unloading
-        if self.led_tool_loaded is None: self.led_tool_loaded = self.unit_obj.led_tool_loaded
+        if self.led_name            is None: self.led_name          = self.unit_obj.led_name
+        if self.led_fault           is None: self.led_fault         = self.unit_obj.led_fault
+        if self.led_ready           is None: self.led_ready         = self.unit_obj.led_ready
+        if self.led_not_ready       is None: self.led_not_ready     = self.unit_obj.led_not_ready
+        if self.led_loading         is None: self.led_loading       = self.unit_obj.led_loading
+        if self.led_prep_loaded     is None: self.led_prep_loaded   = self.unit_obj.led_prep_loaded
+        if self.led_unloading       is None: self.led_unloading     = self.unit_obj.led_unloading
+        if self.led_tool_loaded     is None: self.led_tool_loaded   = self.unit_obj.led_tool_loaded
 
-        if self.long_moves_speed is None: self.long_moves_speed = self.unit_obj.long_moves_speed
-        if self.long_moves_accel is None: self.long_moves_accel = self.unit_obj.long_moves_accel
-        if self.short_moves_speed is None: self.short_moves_speed = self.unit_obj.short_moves_speed
-        if self.short_moves_accel is None: self.short_moves_accel = self.unit_obj.short_moves_accel
-        if self.short_move_dis is None: self.short_move_dis = self.unit_obj.short_move_dis
-        if self.max_move_dis is None: self.max_move_dis = self.unit_obj.max_move_dis
-        if self.n20_break_delay_time is None: self.n20_break_delay_time = self.unit_obj.n20_break_delay_time
+        if self.long_moves_speed    is None: self.long_moves_speed  = self.unit_obj.long_moves_speed
+        if self.long_moves_accel    is None: self.long_moves_accel  = self.unit_obj.long_moves_accel
+        if self.short_moves_speed   is None: self.short_moves_speed = self.unit_obj.short_moves_speed
+        if self.short_moves_accel   is None: self.short_moves_accel = self.unit_obj.short_moves_accel
+        if self.short_move_dis      is None: self.short_move_dis    = self.unit_obj.short_move_dis
+        if self.max_move_dis        is None: self.max_move_dis      = self.unit_obj.max_move_dis
+
+        self.espooler.handle_connect(self.unit_obj)
 
         # Set hub loading speed depending on distance between extruder and hub
         self.dist_hub_move_speed = self.long_moves_speed if self.dist_hub >= 200 else self.short_moves_speed
@@ -337,55 +329,6 @@ class AFCExtruderStepper:
 
         self.tmc_load_current = self.tmc_driver.getfloat('run_current')
 
-    def brake_n20(self):
-        '''
-        Helper function to "brake" n20 motors to hopefully help with keeping down backfeeding into MCU board
-        '''
-        self.AFC.toolhead.register_lookahead_callback(lambda print_time: self.afc_motor_rwd._set_pin(print_time, 1))
-        self.AFC.toolhead.register_lookahead_callback(lambda print_time: self.afc_motor_enb._set_pin(print_time, 1))
-        if self.afc_motor_fwd is not None:
-            self.AFC.toolhead.register_lookahead_callback(lambda print_time: self.afc_motor_fwd._set_pin(print_time, 1))
-
-        self.AFC.reactor.pause(self.AFC.reactor.monotonic() + self.n20_break_delay_time)
-
-        self.AFC.toolhead.register_lookahead_callback(lambda print_time: self.afc_motor_rwd._set_pin(print_time, 0))
-        self.AFC.toolhead.register_lookahead_callback(lambda print_time: self.afc_motor_enb._set_pin(print_time, 0))
-        if self.afc_motor_fwd is not None:
-            self.AFC.toolhead.register_lookahead_callback(lambda print_time: self.afc_motor_fwd._set_pin(print_time, 0))
-
-    def assist(self, value, is_resend=False):
-        if self.afc_motor_rwd is None:
-            return
-        if value < 0:
-            value *= -1
-            assit_motor=self.afc_motor_rwd
-        elif value > 0:
-            if self.afc_motor_fwd is None:
-                return
-            else:
-                assit_motor=self.afc_motor_fwd
-        elif value == 0:
-            if self.afc_motor_enb is not None:
-                self.brake_n20()
-            else:
-                self.AFC.toolhead.register_lookahead_callback(lambda print_time: self.afc_motor_rwd._set_pin(print_time, value))
-
-            return
-        value /= assit_motor.scale
-        if not assit_motor.is_pwm and value not in [0., 1.]:
-            if value > 0:
-                value = 1
-        if self.afc_motor_enb is not None:
-            if value != 0:
-                enable = 1
-            else:
-                enable = 0
-            self.AFC.toolhead.register_lookahead_callback(
-            lambda print_time: self.afc_motor_enb._set_pin(print_time, enable))
-
-        self.AFC.toolhead.register_lookahead_callback(
-            lambda print_time: assit_motor._set_pin(print_time, value))
-
     @contextmanager
     def assist_move(self, speed, rewind, assist_active=True):
         """
@@ -407,12 +350,12 @@ class AFCExtruderStepper:
             if value > 1:
                 value = 1
 
-            self.assist(value)
+            self.espooler.assist(value)
         try:
             yield
         finally:
             if assist_active:
-                self.assist(0)
+                self.espooler.assist(0)
 
     def _move(self, distance, speed, accel, assist_active=False):
         """
@@ -750,6 +693,7 @@ class AFCExtruderStepper:
         """
         if self.buffer_obj is not None:
             self.buffer_obj.enable_buffer()
+        self.espooler.enable_timer()
 
     def disable_buffer(self):
         """
@@ -758,6 +702,7 @@ class AFCExtruderStepper:
         """
         if self.buffer_obj is not None:
             self.buffer_obj.disable_buffer()
+        self.espooler.disable_timer()
 
     def buffer_status(self):
         """

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -41,16 +41,43 @@ class afcUnit:
         self.led_unloading      = config.get('led_unloading', self.AFC.led_unloading)               # LED color to set when lane is unloading           (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in AFC.cfg file
         self.led_tool_loaded    = config.get('led_tool_loaded', self.AFC.led_tool_loaded)           # LED color to set when lane is loaded into tool    (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in AFC.cfg file
 
-        self.long_moves_speed   = config.getfloat("long_moves_speed",  self.AFC.long_moves_speed)   # Speed in mm/s to move filament when doing long moves. Setting value here overrides values set in AFC.cfg file
-        self.long_moves_accel   = config.getfloat("long_moves_accel",  self.AFC.long_moves_accel)   # Acceleration in mm/s squared when doing long moves. Setting value here overrides values set in AFC.cfg file
+        self.long_moves_speed   = config.getfloat("long_moves_speed",   self.AFC.long_moves_speed)  # Speed in mm/s to move filament when doing long moves. Setting value here overrides values set in AFC.cfg file
+        self.long_moves_accel   = config.getfloat("long_moves_accel",   self.AFC.long_moves_accel)  # Acceleration in mm/s squared when doing long moves. Setting value here overrides values set in AFC.cfg file
         self.short_moves_speed  = config.getfloat("short_moves_speed",  self.AFC.short_moves_speed) # Speed in mm/s to move filament when doing short moves. Setting value here overrides values set in AFC.cfg file
         self.short_moves_accel  = config.getfloat("short_moves_accel",  self.AFC.short_moves_accel) # Acceleration in mm/s squared when doing short moves. Setting value here overrides values set in AFC.cfg file
-        self.short_move_dis     = config.getfloat("short_move_dis",  self.AFC.short_move_dis)       # Move distance in mm for failsafe moves. Setting value here overrides values set in AFC.cfg file
-        self.max_move_dis       = config.getfloat("max_move_dis", self.AFC.max_move_dis)            # Maximum distance to move filament. AFC breaks filament moves over this number into multiple moves. Useful to lower this number if running into timer too close errors when doing long filament moves. Setting value here overrides values set in AFC.cfg file
-        self.n20_break_delay_time = config.getfloat("n20_break_delay_time", self.AFC.n20_break_delay_time) # Time to wait between breaking n20 motors(nSleep/FWD/RWD all 1) and then releasing the break to allow coasting. Setting value here overrides values set in AFC.cfg file
+        self.short_move_dis     = config.getfloat("short_move_dis",     self.AFC.short_move_dis)    # Move distance in mm for failsafe moves. Setting value here overrides values set in AFC.cfg file
+        self.max_move_dis       = config.getfloat("max_move_dis",       self.AFC.max_move_dis)      # Maximum distance to move filament. AFC breaks filament moves over this number into multiple moves. Useful to lower this number if running into timer too close errors when doing long filament moves. Setting value here overrides values set in AFC.cfg file
+        self.debug              = config.getboolean("debug",            False)                      # Turns on/off debug messages to console
 
-        self.assisted_unload    = config.getboolean("assisted_unload", self.AFC.assisted_unload)    # If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool. Setting value here overrides values set in AFC.cfg file
-        self.unload_on_runout   = config.getboolean("unload_on_runout", self.AFC.unload_on_runout)  # When True AFC will unload lane and then pause when runout is triggered and spool to swap to is not set(infinite spool). Setting value here overrides values set in AFC.cfg file
+        # Espooler defines
+        # Time in seconds to wait between breaking n20 motors(nSleep/FWD/RWD all 1) and then releasing the break to allow coasting. Setting value here overrides values set in AFC.cfg file
+        self.n20_break_delay_time   = config.getfloat("n20_break_delay_time",   self.AFC.n20_break_delay_time)
+        # Setting to True enables espooler assist while printing
+        self.enable_assist          = config.getboolean("enable_assist",        True)
+        # Number of seconds to wait before checking filament movement for espooler assist
+        self.timer_delay            = config.getfloat("timer_delay",            5)
+        # Setting to True enables full speed espoolers for kick_start_time amount
+        self.enable_kick_start      = config.getboolean("enable_kick_start",    True)
+
+        # Time in seconds to enable spooler at full speed to help with getting the spool to spin
+        self.kick_start_time        = config.getfloat("kick_start_time",        0.070)
+        # Distance per full rotation in mm
+        self.mm_per_rotation        = config.getfloat("mm_per_rotation",        628.32)
+        # Cycles per rotation in milliseconds
+        self.cycles_per_rotation    = config.getfloat("cycles_per_rotation",    1275)
+        # PWM cycle time
+        self.pwm_value              = config.getfloat("pwm_value",              0.6706)
+        # Delta amount in mm from last move to trigger assist
+        self.delta_movement         = config.getfloat("delta_movement",         150)
+        # Amount to move in mm once filament has moved by delta movement amount
+        self.mm_movement            = config.getfloat("mm_movement",            150)
+        # Scaling factor for the following variables: kick_start_time, mm_per_rotation, cycles_per_rotation, pwm_value, delta_movement, mm_movement
+        self.scaling                = config.getfloat("spoolrate",              1.0)
+
+        # If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool. Setting value here overrides values set in AFC.cfg file
+        self.assisted_unload    = config.getboolean("assisted_unload", self.AFC.assisted_unload)
+        # When True AFC will unload lane and then pause when runout is triggered and spool to swap to is not set(infinite spool). Setting value here overrides values set in AFC.cfg file
+        self.unload_on_runout   = config.getboolean("unload_on_runout", self.AFC.unload_on_runout)
 
     def __str__(self):
         return self.name

--- a/include/buffer_configurations.sh
+++ b/include/buffer_configurations.sh
@@ -20,7 +20,6 @@ advance_pin: ${tn_advance_pin}    # set advance pin
 trailing_pin: ${tn_trailing_pin}  # set trailing pin
 multiplier_high: 1.05   # default 1.05, factor to feed more filament
 multiplier_low:  0.95   # default 0.95, factor to feed less filament
-velocity: 0
 EOF
 )
       buffer_name="Turtle_1"
@@ -33,7 +32,6 @@ trailing_pin: !turtleneck:TRAILING
 multiplier_high: 1.05   # default 1.05, factor to feed more filament
 multiplier_low:  0.95   # default 0.95, factor to feed less filament
 led_index: Buffer_Indicator:1
-velocity: 0
 
 [AFC_led Buffer_Indicator]
 pin: turtleneck:RGB

--- a/templates/AFC_Turtle_1.cfg
+++ b/templates/AFC_Turtle_1.cfg
@@ -7,6 +7,8 @@ canbus_uuid: <replace with your can UUID>
 [AFC_BoxTurtle Turtle_1]
 hub: Turtle_1
 extruder: extruder
+enable_assist: True        # Setting to True enables espooler assist while printing
+enable_kick_start: True    # Setting to True enables full speed espoolers for kick_start_time(0.070 ms default) amount
 # buffer: <buffer_name> # If not defined below from the install script, uncomment and add buffer name if using a buffer
 
 [temperature_sensor Turtle_1]


### PR DESCRIPTION
## Major Changes in this PR
- Print assist is now filament usage based and will activate spool after a specified amount of filament is used
- Removed velocity from AFC_buffer code and install code
- Updated templates

## Notes to Code Reviewers

## How the changes in this PR are tested
Multiple could hour long print with assist enabled, 
## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design channel requesting review
