### PR TITLE
Update purge start variable description in config

### DIFF
--- a/config/AFC_Macro_Vars.cfg
+++ b/config/AFC_Macro_Vars.cfg
@@ -138,7 +138,7 @@ variable_z_lift                   : 10        # Z height to raise above the fina
 # If the toolhead returns to initial position after the poop is complete.
 variable_restore_position         : False     # True = return to initial position, False = don't return
 
-# The height to raise the nozzle above the tray before purging. This allows any built up 
+# The z height of the nozzle at the poop position (purge_loc_xy) before purging. This allows any built up
 # pressure to escape before the purge.
 variable_purge_start              : 0.6
 

--- a/config/AFC_Macro_Vars.cfg
+++ b/config/AFC_Macro_Vars.cfg
@@ -138,8 +138,9 @@ variable_z_lift                   : 10        # Z height to raise above the fina
 # If the toolhead returns to initial position after the poop is complete.
 variable_restore_position         : False     # True = return to initial position, False = don't return
 
-# The z height of the nozzle at the poop position (purge_loc_xy) before purging. This allows any built up
+# The z height of the nozzle at the purge position before purging. This allows any built up
 # pressure to escape before the purge.
+
 variable_purge_start              : 0.6
 
 # Set the part cooling fan speed. Disabling can help prevent the nozzle from cooling down 


### PR DESCRIPTION
Clarify the description of `variable_purge_start` to specify the nozzle's z height at the purge position.

## Major Changes in this PR

## Notes to Code Reviewers

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [X] I have performed a self-review of my code
- [X] CHANGELOG.md is updated (if end-user facing)
- [x] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design channel requesting review
