### PR TITLE
Add support for led range per lane

### DIFF
--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -232,7 +232,7 @@ class afcFunction:
 
         error_string, led = self.verify_led_object(idx)
         if led is not None:
-            led.led_change(int(idx.split(':')[1]), status)
+            led.led_change(idx.split(':')[1], status)
         else:
             self.logger.info( error_string )
 

--- a/extras/AFC_led.py
+++ b/extras/AFC_led.py
@@ -128,7 +128,12 @@ class AFCled:
             else:
                 set_color_fn = self.led_helper.set_color
                 check_transmit_fn = self.led_helper.check_transmit
-            set_color_fn(index, colors)
+            if isinstance(index, str) and "-" in index:
+                start, end = map(int, index.split("-"))
+                for i in range(start, end + 1):
+                    set_color_fn(i, colors)
+            else:
+                set_color_fn(int(index), colors)
             if transmit:
                 check_transmit_fn(print_time)
         toolhead = self.printer.lookup_object('toolhead')
@@ -142,7 +147,7 @@ class AFCled:
     def turn_on_leds(self):
         self.keep_leds_off = False
         for index, value in self.last_led_color.items():
-            self.led_change( int(index), value, False )
+            self.led_change(index, value, False)
 
 def load_config_prefix(config):
     return AFCled(config)


### PR DESCRIPTION
## Major Changes in this PR
Gives the user the option to use multi pixel led boards for each lane while keeping the existing behavior in tact.
![PXL_20250505_064542275 MP](https://github.com/user-attachments/assets/4ef7a242-21a3-4218-8f91-516fd00aad43)

## Notes to Code Reviewers

## How the changes in this PR are tested
Add a `-` between the first and last pixel number. For example: ```led_index: AFC_Indicator:1-21```
## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design channel requesting review
