### PR TITLE
Implementing AFCLaneState to replace "custom" strings

### DIFF
--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -676,7 +676,7 @@ class afc:
             cur_lane.move(cur_hub.move_dis, cur_lane.short_moves_speed, cur_lane.short_moves_accel)
         while cur_hub.state:
             cur_lane.move(cur_hub.move_dis * -1, cur_lane.short_moves_speed, cur_lane.short_moves_accel)
-        cur_lane.status = None
+        cur_lane.status = AFCLaneState.NONE
         cur_lane.do_enable(False)
         cur_lane.loaded_to_hub = True
         self.save_vars()
@@ -731,7 +731,7 @@ class afc:
                cur_lane.move(cur_hub.move_dis * -1, cur_lane.short_moves_speed, cur_lane.short_moves_accel, True)
             cur_lane.move(cur_hub.move_dis * -5, cur_lane.short_moves_speed, cur_lane.short_moves_accel)
             cur_lane.do_enable(False)
-            cur_lane.status = None
+            cur_lane.status = AFCLaneState.NONE
             cur_lane.unit_obj.return_to_home()
             # Put CAM back to lane if its loaded to toolhead
             self.function.select_loaded_lane()
@@ -1227,7 +1227,7 @@ class afc:
         # Finalize unloading and reset lane state.
         cur_lane.loaded_to_hub = True
         self.function.afc_led(cur_lane.led_ready, cur_lane.led_index)
-        cur_lane.status = None
+        cur_lane.status = AFCLaneState.NONE
 
         if cur_lane.hub == 'direct':
             while cur_lane.load_state:

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -9,6 +9,8 @@ import re
 from configfile import error
 from typing import Any
 
+from extras.AFC_lane import AFCLaneState
+
 try:
     from urllib.request import urlopen
 except:
@@ -663,7 +665,7 @@ class afc:
         cur_lane = self.lanes[lane]
         cur_hub = cur_lane.hub_obj
         if not cur_lane.prep_state: return
-        cur_lane.status = 'HUB Loading'
+        cur_lane.status = AFCLaneState.HUB_LOADING
         if not cur_lane.load_state:
             cur_lane.do_enable(True)
             while not cur_lane.load_state:
@@ -719,7 +721,7 @@ class afc:
             # Setting status as ejecting so if filament is removed and de-activates the prep sensor while
             # extruder motors are still running it does not trigger infinite spool or pause logic
             # once user removes filament lanes status will go to None
-            cur_lane.status = 'ejecting'
+            cur_lane.status = AFCLaneState.EJECTING
             self.save_vars()
             cur_lane.do_enable(True)
             if cur_lane.loaded_to_hub:
@@ -816,7 +818,7 @@ class afc:
         self.current_loading = cur_lane.name
 
         # Set the lane status to 'loading' and activate the loading LED.
-        cur_lane.status = 'Tool Loading'
+        cur_lane.status = AFCLaneState.TOOL_LOADING
         self.save_vars()
         self.function.afc_led(cur_lane.led_loading, cur_lane.led_index)
 
@@ -877,7 +879,7 @@ class afc:
             self.afcDeltaTime.log_with_time("Filament loaded to pre-sensor")
 
             # Synchronize lane's extruder stepper and finalize tool loading.
-            cur_lane.status = 'Tool Loaded'
+            cur_lane.status = AFCLaneState.TOOL_LOADED
             self.save_vars()
             cur_lane.sync_to_extruder()
 
@@ -1037,7 +1039,7 @@ class afc:
         self.current_state  = State.UNLOADING
         self.current_loading = cur_lane.name
         self.logger.info("Unloading {}".format(cur_lane.name))
-        cur_lane.status = 'Tool Unloading'
+        cur_lane.status = AFCLaneState.TOOL_UNLOADING
         self.save_vars()
 
         # Verify that printer is in absolute mode

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -5,6 +5,9 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
 from configparser import Error as error
+
+from extras.AFC_lane import AFCLaneState
+
 try:
     from extras.AFC_unit import afcUnit
 except:
@@ -72,7 +75,7 @@ class afcBoxTurtle(afcUnit):
                 self.afc.function.afc_led(cur_lane.led_not_ready, cur_lane.led_index)
                 succeeded = False
             else:
-                cur_lane.status = 'Loaded'
+                cur_lane.status = AFCLaneState.LOADED
                 msg +="<span class=success--text> AND LOADED</span>"
 
                 if cur_lane.tool_loaded:
@@ -87,7 +90,7 @@ class afcBoxTurtle(afcUnit):
                             if self.afc.function.get_current_lane() == cur_lane.name:
                                 self.afc.spool.set_active_spool(cur_lane.spool_id)
                                 self.afc.function.afc_led(cur_lane.led_tool_loaded, cur_lane.led_index)
-                                cur_lane.status = 'Tooled'
+                                cur_lane.status = AFCLaneState.TOOLED
 
                             cur_lane.enable_buffer()
                         else:
@@ -278,7 +281,7 @@ class afcBoxTurtle(afcUnit):
             return False, msg, 0
 
         self.logger.info('Calibrating {}'.format(cur_lane.name))
-        cur_lane.status = "calibrating"
+        cur_lane.status = AFCLaneState.CALIBRATING
         # reset to extruder
         pos, checkpoint, success = self.calc_position(cur_lane, lambda: cur_lane.load_state, 0, cur_lane.short_move_dis,
                                                       tol, cur_lane.dist_hub + 100, "retract to extruder")

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -288,7 +288,7 @@ class afcBoxTurtle(afcUnit):
 
         if not success:
             msg = 'Lane failed to calibrate {} after {}mm'.format(checkpoint, pos)
-            cur_lane.status = None
+            cur_lane.status = AFCLaneState.NONE
             cur_lane.unit_obj.return_to_home()
             return False, msg, 0
 
@@ -296,7 +296,7 @@ class afcBoxTurtle(afcUnit):
             success, message, hub_pos = self.calibrate_hub(cur_lane, tol)
 
             if not success:
-                cur_lane.status = None
+                cur_lane.status = AFCLaneState.NONE
                 cur_lane.unit_obj.return_to_home()
                 return False, message, hub_pos
 
@@ -309,7 +309,7 @@ class afcBoxTurtle(afcUnit):
             cur_lane.do_enable(False)
             cur_lane.dist_hub = cal_dist
             self.afc.function.ConfigRewrite(cur_lane.fullname, "dist_hub", cal_dist, cal_msg)
-            cur_lane.status = None
+            cur_lane.status = AFCLaneState.NONE
             cur_lane.unit_obj.return_to_home()
             return True, cal_msg, cal_dist
 

--- a/extras/AFC_HTLF.py
+++ b/extras/AFC_HTLF.py
@@ -169,7 +169,7 @@ class AFC_HTLF(afcBoxTurtle):
 
         :return boolean: Returns true if current lane is loaded and printer is printing but lanes status is not ejecting or calibrating
         """
-        return cur_lane.name == self.afc.function.get_current_lane() and self.afc.function.is_printing() and self.status != 'ejecting' and cur_lane.status != AFCLaneState.CALIBRATING
+        return cur_lane.name == self.afc.function.get_current_lane() and self.afc.function.is_printing() and cur_lane.status != AFCLaneState.EJECTING and cur_lane.status != AFCLaneState.CALIBRATING
 
 def load_config_prefix(config):
     return AFC_HTLF(config)

--- a/extras/AFC_HTLF.py
+++ b/extras/AFC_HTLF.py
@@ -4,6 +4,9 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 from configparser import Error as error
+
+from extras.AFC_lane import AFCLaneState
+
 try:
     from extras.AFC_BoxTurtle import afcBoxTurtle
 except:
@@ -166,7 +169,7 @@ class AFC_HTLF(afcBoxTurtle):
 
         :return boolean: Returns true if current lane is loaded and printer is printing but lanes status is not ejecting or calibrating
         """
-        return cur_lane.name == self.afc.function.get_current_lane() and self.afc.function.is_printing() and self.status != 'ejecting' and cur_lane.status != "calibrating"
+        return cur_lane.name == self.afc.function.get_current_lane() and self.afc.function.is_printing() and self.status != 'ejecting' and cur_lane.status != AFCLaneState.CALIBRATING
 
 def load_config_prefix(config):
     return AFC_HTLF(config)

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -6,6 +6,8 @@
 
 import logging
 from extras.AFC import State
+from extras.AFC_lane import AFCLaneState
+
 
 def load_config(config):
     return afcError(config)
@@ -230,7 +232,7 @@ class afcError:
     def handle_lane_failure(self, cur_lane, message, pause=True):
         # Disable the stepper for this lane
         cur_lane.do_enable(False)
-        cur_lane.status = 'Error'
+        cur_lane.status = AFCLaneState.ERROR
         msg = "{} {}".format(cur_lane.name, message)
         self.AFC_error(msg, pause)
         self.afc.function.afc_led(self.afc.led_fault, cur_lane.led_index)

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -416,7 +416,7 @@ class AFCLane:
                         self._perform_pause_runout()
                 elif self.status != "calibrating":
                     self.afc.function.afc_led(self.led_not_ready, self.led_index)
-                    self.status = None
+                    self.status = AFCLaneState.NONE
                     self.loaded_to_hub = False
                     self.afc.spool._clear_values(self)
                     self.afc.function.afc_led(self.afc.led_not_ready, self.led_index)
@@ -629,7 +629,7 @@ class AFCLane:
         """
         self.tool_loaded = False
         self.extruder_obj.lane_loaded = ""
-        self.status = None
+        self.status = AFCLaneState.NONE
         self.afc.current = None
         self.afc.current_loading = None
         self.afc.spool.set_active_spool(None)

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -21,8 +21,8 @@ class AFCLaneState:
     TOOLED           = "Tooled"
     TOOL_LOADED      = "Tool Loaded"
     TOOL_LOADING     = "Tool Loading"
-    TOOL_UNLOADING   = "Tool unloading"
-    HUB_LOADING      = "HUB loading"
+    TOOL_UNLOADING   = "Tool Unloading"
+    HUB_LOADING      = "HUB Loading"
     EJECTING         = "Ejecting"
     CALIBRATING      = "Calibrating"
 

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -19,6 +19,7 @@ class AFCLaneState:
     LOADED           = "Loaded"
     TOOLED           = "Tooled"
     TOOL_LOADED      = "Tool loaded"
+    TOOL_LOADING     = "Tool Loading"
     TOOL_UNLOADING   = "Tool unloading"
     HUB_LOADING      = "HUB loading"
     EJECTING         = "Ejecting"
@@ -463,9 +464,9 @@ class AFCLane:
                             msg = (' FAILED TO LOAD, CHECK FILAMENT AT TRIGGER\n||==>--||----||------||\nTRG   LOAD   HUB    TOOL')
                             self.afc.error.AFC_error(msg, False)
                             self.afc.function.afc_led(self.afc.led_fault, self.led_index)
-                            self.status=''
+                            self.status = None
                             break
-                    self.status=''
+                    self.status = None
 
                     # Verify that load state is still true as this would still trigger if prep sensor was triggered and then filament was removed
                     #   This is only really a issue when using direct and still using load sensor
@@ -482,7 +483,7 @@ class AFCLane:
 
                     self.do_enable(False)
                     if self.load_state == True and self.prep_state == True:
-                        self.status = 'Loaded'
+                        self.status = AFCLaneState.LOADED
                         self.afc.function.afc_led(self.afc.led_ready, self.led_index)
                         self.material = self.afc.default_material_type
 
@@ -618,7 +619,7 @@ class AFCLane:
         self.tool_loaded = True
         self.afc.current = self.extruder_obj.lane_loaded = self.name
         self.afc.current_loading = None
-        self.status = 'Tooled'
+        self.status = AFCLaneState.TOOLED
         self.afc.spool.set_active_spool(self.spool_id)
 
     def set_unloaded(self):

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -19,7 +19,7 @@ class AFCLaneState:
     ERROR            = "Error"
     LOADED           = "Loaded"
     TOOLED           = "Tooled"
-    TOOL_LOADED      = "Tool loaded"
+    TOOL_LOADED      = "Tool Loaded"
     TOOL_LOADING     = "Tool Loading"
     TOOL_UNLOADING   = "Tool unloading"
     HUB_LOADING      = "HUB loading"

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -13,6 +13,17 @@ try:
 except:
     raise error("Error trying to import AFC_utils, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper")
 
+# Class for holding different states so its clear what all valid states are
+class AFCLaneState:
+    ERROR            = "Error"
+    LOADED           = "Loaded"
+    TOOLED           = "Tooled"
+    TOOL_LOADED      = "Tool loaded"
+    TOOL_UNLOADING   = "Tool unloading"
+    HUB_LOADING      = "HUB loading"
+    EJECTING         = "Ejecting"
+    CALIBRATING      = "Calibrating"
+
 class AFCLane:
     def __init__(self, config):
         self.printer            = config.get_printer()


### PR DESCRIPTION
## Major Changes in this PR
Replace string comparision by defining AFCLaneState to replace the values of AFCLane.status.

## Notes to Code Reviewers
Not sure if i caught everything. Since the strings have not changed, even the missed ones should not have an impact on the functionality.

## How the changes in this PR are tested
Currently waiting my printer to finish before pushing the PR to my printer.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [X] I have performed a self-review of my code
- [X] CHANGELOG.md is updated (if end-user facing)
- [X] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design channel requesting review
