### PR TITLE
Remove deprecated velocity settings from AFC configuration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-05-11]
+### Changed
+
+- The `install-afc.sh` script will remove any `velocity` settings present in the `[AFC_buffer <buffer_name>]` 
+  section of the configuration files as they are no longer needed.
+
 ## [2025-05-01]
 ### Added
 - Print assist is now filament usage based and will activate spool after a specified amount of filament is used. This is enabled by default.

--- a/include/update_functions.sh
+++ b/include/update_functions.sh
@@ -31,9 +31,22 @@ AFC Macros update failed.
   fi
   link_extensions
   remove_t_macros
+  remove_velocity
   update_message+="""
 AFC Klipper Add-On updated successfully.
 """
   export update_message
   files_updated_or_installed="True"
+}
+
+remove_velocity() {
+  local files config_file
+  files=$(grep -rlP '^\[AFC_buffer ' "${afc_config_dir}"/*.cfg)
+  for config_file in $files; do
+    section=$(grep -oP '^\[AFC_buffer \K[^\]]+' "$config_file")
+    crudini --del "$config_file" "AFC_buffer $section" velocity
+    export update_message+="""
+Removed deprecated velocity setting from $config_file.
+    """
+  done
 }


### PR DESCRIPTION
Addresses issue #350 

## Major Changes in this PR

This pull request introduces changes to remove deprecated `velocity` settings from configuration files in the `[AFC_buffer <buffer_name>]` section. The changes include updating the `install-afc.sh` script and adding a new function, `remove_velocity`, to the update process.

### Updates to configuration management:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R13): Documented that the `install-afc.sh` script will now remove any `velocity` settings from the `[AFC_buffer <buffer_name>]` section of configuration files, as these settings are no longer needed.

* [`include/update_functions.sh`](diffhunk://#diff-e640ec65703f5a9486beb53f428b150d6d1f3b3f7956b24766b783061f5d5ddeR34-R52): Added a new function, `remove_velocity`, which identifies configuration files containing `[AFC_buffer <buffer_name>]` sections and removes the `velocity` setting using the `crudini` tool. This function is now part of the update process.

## Notes to Code Reviewers

## How the changes in this PR are tested
```
grep velocity ~/printer_data/config/AFC/*
/home/eric/printer_data/config/AFC/AFC_Hardware.cfg:velocity: 1
/home/eric/printer_data/config/AFC/AFC_Hardware1.cfg:velocity: 2
```
Run install script and select upgrade functionality.
...
```
▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
█                                    AFC Script Help                                  █
▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀

Removed deprecated velocity setting from /home/eric/printer_data/config/AFC/AFC_Hardware.cfg.

Removed deprecated velocity setting from /home/eric/printer_data/config/AFC/AFC_Hardware1.cfg.

AFC Klipper Add-On updated successfully.
```
Check to make sure not present
```
grep velocity ~/printer_data/config/AFC/*
grep: /home/eric/printer_data/config/AFC/config: Is a directory
grep: /home/eric/printer_data/config/AFC/macros: Is a directory
grep: /home/eric/printer_data/config/AFC/mcu: Is a directory
```

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design channel requesting review
