### PR TITLE
Preserve original arguments when restarting the install script after …

### DIFF
--- a/include/utils.sh
+++ b/include/utils.sh
@@ -73,7 +73,7 @@ clone_and_maybe_restart() {
       echo "→ New commits detected; rebasing…"
       git -C "${afc_path}" pull --rebase --quiet
       echo "✓ Update applied. Restarting script…"
-      exec "$0" "$@"
+      exec "$0" "${original_args[@]}"
     else
       echo "✓ Already up to date."
     fi

--- a/install-afc.sh
+++ b/install-afc.sh
@@ -29,6 +29,8 @@ source include/update_functions.sh
 source include/utils.sh
 source include/unit_functions.sh
 
+original_args=("$@")
+
 main() {
   ###################### Main script logic below ######################
 


### PR DESCRIPTION
## Major Changes in this PR

This pull request updates the handling of script arguments to ensure the original arguments are preserved when the script is restarted after an update. The changes primarily involve introducing a new variable to store the original arguments and modifying the restart logic to use this variable.

### Argument handling improvements:

* [`include/utils.sh`](diffhunk://#diff-9e64712e624ee22bf3a68f5ecd584c7f805f610eb1fb10ce184a3d3beb0b8352L76-R76): Updated the `clone_and_maybe_restart` function to use the `original_args` array when restarting the script, ensuring that the original arguments are passed correctly.
* [`install-afc.sh`](diffhunk://#diff-808409cb3827534e4d3012fedbf1671577db5a220159b4b5d7b253bff3d890caR32-R33): Added a new `original_args` array to store the script's original arguments at the start of execution. This ensures the arguments are preserved for use in the restart logic.

## Notes to Code Reviewers

So using `getops` will consume the args as they are parsed, which caused a problem when trying to restart if a new version was found. This would result in an user on DEV being reverted back to main when the script restarted.

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design channel requesting review
