### PR TITLE
Night mode support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-05-15]
+### Added
+- added night mode support. `night_moves_speed` on `AFC.cfg` dictates the max speed when night mode is enabled.
+- new macro `NIGHT_MODE ENABLE=1/0 SPEED=<max_speed>` to allow modifying `night_moves_speed` and enable/disable night mode.
+
 ## [2025-05-12]
 ### Added
 - new variable `tool_homing_distance` in `[AFC]` to make the distance over which toolhead homing is attempted.

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -634,7 +634,7 @@ class afc:
 
     def _get_move_speed(self, speed):
         if self.night_mode == True and speed > self.night_moves_speed:
-            return self.night_moves_speed 
+            return self.night_moves_speed
         else:
             return speed
 


### PR DESCRIPTION
## Minor Changes in this PR
### Added
- added night mode support. `
- night_moves_speed` on `AFC.cfg` dictates the max speed when night mode is enabled. it is only a global speed as it should be low enough to allow all lanes to be able to operate it.
- new macro `NIGHT_MODE ENABLE=1 SPEED=<max_speed>` to allow modifying `night_moves_speed` and enable/disable night mode.

## Notes to Code Reviewers
i think i got all the instances when moves are made during printing. main objective it to have night mode during printing, any other moves, e.g. calibration  or afc_lane_reset, i left out. i did however include LANE_MOVE, as it is a call i use to clear jams during prints.

would it be alright if i will update/create a PR on the doc repo if and when this has be approved? so that i can push the right submodule pointer in one go? 

## How the changes in this PR are tested
on my quattrobox

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design channel requesting review
