### PR TITLE
Fix typo in tool loading speed config comment

### DIFF
--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -26,7 +26,7 @@ class AFCExtruder:
         self.tool_stn_unload            = config.getfloat("tool_stn_unload", 100)                                       # Distance to move in mm while unloading toolhead
         self.tool_sensor_after_extruder = config.getfloat("tool_sensor_after_extruder", 0)                              # Extra distance to move in mm once pre/post sensors are clear. Useful for when only using post sensor, so this distance can be the amout to move to clear extruder gears
         self.tool_unload_speed          = config.getfloat("tool_unload_speed", 25)                                      # Unload speed in mm/s when unloading toolhead. Default is 25mm/s.
-        self.tool_load_speed            = config.getfloat("tool_load_speed", 25)                                        # Load speed in mm/s when unloading toolhead. Default is 25mm/s.
+        self.tool_load_speed            = config.getfloat("tool_load_speed", 25)                                        # Load speed in mm/s when loading toolhead. Default is 25mm/s.
         self.buffer_name                = config.get('buffer', None)                                                    # Buffer to use for extruder, this variable can be overridden per lane
         self.enable_sensors_in_gui      = config.getboolean("enable_sensors_in_gui", self.afc.enable_sensors_in_gui)    # Set to True toolhead sensors switches as filament sensors in mainsail/fluidd gui, overrides value set in AFC.cfg
 

--- a/templates/AFC_Hardware-AFC.cfg
+++ b/templates/AFC_Hardware-AFC.cfg
@@ -8,7 +8,7 @@ tool_stn: 72                    # Distance in mm from the toolhead sensor to the
 tool_stn_unload: 100            # Distance to move in mm while unloading toolhead
 tool_sensor_after_extruder: 0   # Extra distance to move in mm once pre/post sensors are clear. Useful for when only using post sensor, so this distance can be the amout to move to clear extruder gears
 tool_unload_speed: 25           # Unload speed in mm/s when unloading toolhead. Default is 25mm/s.
-tool_load_speed: 25             # Load speed in mm/s when unloading toolhead. Default is 25mm/s.
+tool_load_speed: 25             # Load speed in mm/s when loading toolhead. Default is 25mm/s.
 
 #[filament_switch_sensor bypass]
 #switch_pin: turtleneck:PB5

--- a/templates/AFC_Hardware-HTLF.cfg
+++ b/templates/AFC_Hardware-HTLF.cfg
@@ -8,7 +8,7 @@ tool_stn: 72                    # Distance in mm from the toolhead sensor to the
 tool_stn_unload: 100            # Distance to move in mm while unloading toolhead
 tool_sensor_after_extruder: 0   # Extra distance to move in mm once pre/post sensors are clear. Useful for when only using post sensor, so this distance can be the amout to move to clear extruder gears
 tool_unload_speed: 25           # Unload speed in mm/s when unloading toolhead. Default is 25mm/s.
-tool_load_speed: 25             # Load speed in mm/s when unloading toolhead. Default is 25mm/s.
+tool_load_speed: 25             # Load speed in mm/s when loading toolhead. Default is 25mm/s.
 
 #[filament_switch_sensor bypass]
 #switch_pin: turtleneck:PB5


### PR DESCRIPTION
Fix use of "unloading" rather than "loading" in tool loading speed configuration comments

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [x] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design channel requesting review
