### PR TITLE
Adding statistics tracking for tool load/unload, n20 runtime, number of cuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-05-18]
+### Added
+- Added statistics tracking for tool load/unload/total change, n20 runtime, number of cuts,
+  average load/unload/full toolchange times, and number of load per lane.
+- Added ability to track when last blade was changed and how many cuts since last changed
+- `AFC_STATS` macro added to print statistics out. Set `SHORT=1` to print out a skinny version
+- `AFC_CHANGE_BLADE` macro added for when users change blade as this reset count and updates date changed
+- Added common class for easily interacting with moonraker api
+- Updated to use moonrakers proxy when fetching spoolmans data
+- Added getting toolchange count from moonrakers file metadata, `SET_AFC_TOOLCHANGES` will be deprecated
+  Moonrakers version needs to be at least v0.9.3-64
+- Updated import error message to pull from a common error string in AFC_utils.py file
+- Clearing pause in klipper when starting a print
+- Warning message is outputted when number of cuts is within 1K of tool_cut_threshold value
+- Error message is outputted when number of cuts is over tool_cut_threshold
+
+### Fixed
+- Issue where virtual bypass was being set for newly installed instances of AFC
+
 ## [2025-05-01]
 ### Added
 - Print assist is now filament usage based and will activate spool after a specified amount of filament is used. This is enabled by default.

--- a/config/AFC.cfg
+++ b/config/AFC.cfg
@@ -69,6 +69,7 @@ led_buffer_disable: 0,0,0,0.25  # Buffer disable color    (R,G,B,W) 0 = off, 1 =
 
 # TOOL Cutting Settings
 tool_cut: True                  # Enable Cut macro.
+tool_cut_threshold: 10000       # Threshold value for message to change blade, warning starts at 1000k cuts before hitting this number
 tool_cut_cmd: AFC_CUT           # Cut macro name.
 
 # Park Settings

--- a/config/AFC.cfg
+++ b/config/AFC.cfg
@@ -25,6 +25,7 @@ load_to_hub: True               # Fast loads filament to hub when inserted, set 
 assisted_unload: True           # If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool. This is a global setting and can be overridden at the unit and stepper level.
 #pause_when_bypass_active: True  # When True AFC pauses print when change tool is called and bypass is loaded
 #unload_on_runout: True          # When True AFC will unload lane and then pause when runout is triggered and spool to swap to is not set(infinite spool)
+#print_short_stats: True          # Set to true to print AFC_STATS in short form instead of wide form, printing short form is better for consoles that are small in width
 #debug: True                     # Setting to True turns on more debugging to show on console
 
 #--=================================================================================-

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -539,7 +539,7 @@ class afc:
         if number_of_toolchanges > 0:
             warning_text  = "Please remove SET_AFC_TOOLCHANGES from your slicers 'Change Filament G-Code' section as SET_AFC_TOOLCHANGES "
             warning_text += "is now deprecated and number of toolchanges will be fetched from files metadata in moonraker when a print starts.\n"
-            warning_text += "Verify that moonrakers version is atleast v0.9.3-64 to utilize this feature."
+            warning_text += "Verify that moonrakers version is at least v0.9.3-64 to utilize this feature."
             self.logger.info(f"<span class=warning--text>{warning_text}</span>")
             self.message_queue.append((warning_text, "warning"))
 

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -28,7 +28,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 try: from extras.AFC_stats import AFCStats
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
 
-AFC_VERSION="1.0.12"
+AFC_VERSION="1.0.14"
 
 # Class for holding different states so its clear what all valid states are
 class State:

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -10,10 +10,11 @@ import traceback
 from configfile import error
 from typing import Any
 
-from extras.AFC_lane import AFCLaneState
-
 
 ERROR_STR = "Error trying to import {import_lib}, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper\n\n{trace}"
+
+try: from extras.AFC_lane import AFCLaneState
+except: raise error(ERROR_STR.format(import_lib="AFC_logger", trace=traceback.format_exc()))
 
 try: from extras.AFC_logger import AFC_logger
 except: raise error(ERROR_STR.format(import_lib="AFC_logger", trace=traceback.format_exc()))

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1405,7 +1405,7 @@ class afc:
                 self.afc_stats.reset_toolchange_wo_error()
         else:
             self.logger.info("{} already loaded".format(cur_lane.name))
-            if not self.error_state and self.current_toolchange == -1: #and self.number_of_toolchanges != 0 and self.current_toolchange != self.number_of_toolchanges:
+            if not self.error_state and self.current_toolchange == -1:
                 self.current_toolchange += 1
 
         self.function.log_toolhead_pos("Final Change Tool: Error State: {}, Is Paused {}, Position_saved {}, in toolchange: {}, POS: ".format(

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -60,7 +60,7 @@ class afc:
         # Registering stepper callback so that mux macro can be set properly with valid lane names
         self.printer.register_event_handler("afc_stepper:register_macros",self.register_lane_macros)
         # Registering for sdcard reset file so that error_state can be reset when starting a print
-        self.printer.register_event_handler("virtual_sdcard:reset_file", self.error.reset_failure)
+        self.printer.register_event_handler("virtual_sdcard:reset_file", self._reset_file_callback)
         # Registering webhooks endpoint for <ip_address>/printer/afc/status
         self.webhooks.register_endpoint("afc/status", self._webhooks_status)
 
@@ -306,7 +306,7 @@ class afc:
         # Remove timer from reactor
         self.reactor.unregister_timer(self.in_print_timer)
         # Check to see if printer is printing and return filament
-        in_print, print_filename = self.FUNCTION.in_print(return_file=True)
+        in_print, print_filename = self.function.in_print(return_file=True)
         self.logger.debug("In print: {}, Filename: {}".format(in_print, print_filename))
         if in_print:
             # Gather file filament change count from moonraker

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -178,6 +178,7 @@ class afc:
         self.assisted_unload        = config.getboolean("assisted_unload", True)    # If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool
         self.bypass_pause           = config.getboolean("pause_when_bypass_active", False) # When true AFC pauses print when change tool is called and bypass is loaded
         self.unload_on_runout       = config.getboolean("unload_on_runout", False)  # When True AFC will unload lane and then pause when runout is triggered and spool to swap to is not set(infinite spool)
+        self.short_stats            = config.getboolean("print_short_stats", False) # Set to true to print AFC_STATS in short form instead of wide form, printing short form is better for smaller in width consoles
 
         self.debug                  = config.getboolean('debug', False)             # Setting to True turns on more debugging to show on console
         # Get debug and cast to boolean
@@ -536,9 +537,9 @@ class afc:
         """
         number_of_toolchanges  = gcmd.get_int("TOOLCHANGES")
         if number_of_toolchanges > 0:
-            warning_text  = "SET_AFC_TOOLCHANGES is now deprecated as number of toolchanges will be "
-            warning_text += "fetched from files metadata in moonraker. Verify that moonrakers version is atleast v0.9.3-64"
-            warning_text += "to utilize this feature"
+            warning_text  = "Please remove SET_AFC_TOOLCHANGES from your slicers 'Change Filament G-Code' section as SET_AFC_TOOLCHANGES "
+            warning_text += "is now deprecated and number of toolchanges will be fetched from files metadata in moonraker when a print starts.\n"
+            warning_text += "Verify that moonrakers version is atleast v0.9.3-64 to utilize this feature."
             self.logger.info(f"<span class=warning--text>{warning_text}</span>")
             self.message_queue.append((warning_text, "warning"))
 
@@ -1664,7 +1665,8 @@ class afc:
 
         Optional Values
         ----
-        Set SHORT=1 to have a smaller print that fits better on smaller screens
+        Set SHORT=1 to have a smaller print that fits better on smaller screens. Setting `print_short_stats` variable in `[AFC]` section
+        in AFC.cfg file to True will always print statistics in short form
 
         Usage
         -----
@@ -1676,7 +1678,7 @@ class afc:
         AFC_STATS
         ```
         """
-        short = bool(gcmd.get_int("SHORT", 0))
+        short = bool(gcmd.get_int("SHORT", self.short_stats))
 
         self.afc_stats.print_stats(afc_obj=self, short=short)
 

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -306,6 +306,8 @@ class afc:
         self.in_print_timer = self.reactor.register_timer( self.in_print_reactor_timer, self.reactor.monotonic() + 5 )
         self.error.reset_failure()
         self.gcode.run_script_from_command("CLEAR_PAUSE")
+        self.number_of_toolchanges = 0
+        self.current_toolchange    = -1
 
     def in_print_reactor_timer(self, eventtime):
         """

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -7,10 +7,12 @@ import traceback
 
 from configparser import Error as error
 
-from extras.AFC_lane import AFCLaneState
 
+try: from extras.AFC_utils import ERROR_STR
+except: raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".format(trace=traceback.format_exc()))
 
-from extras.AFC_utils import ERROR_STR
+try: from extras.AFC_lane import AFCLaneState
+except: raise error(ERROR_STR.format(import_lib="AFC_lane", trace=traceback.format_exc()))
 
 try: from extras.AFC_unit import afcUnit
 except: raise error(ERROR_STR.format(import_lib="AFC_unit", trace=traceback.format_exc()))

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -3,12 +3,14 @@
 # Copyright (C) 2024 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+import traceback
 
 from configparser import Error as error
-try:
-    from extras.AFC_unit import afcUnit
-except:
-    raise error("Error trying to import AFC_unit, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper")
+
+from extras.AFC_utils import ERROR_STR
+
+try: from extras.AFC_unit import afcUnit
+except: raise error(ERROR_STR.format(import_lib="AFC_unit", trace=traceback.format_exc()))
 
 class afcBoxTurtle(afcUnit):
     def __init__(self, config):

--- a/extras/AFC_HTLF.py
+++ b/extras/AFC_HTLF.py
@@ -7,10 +7,11 @@ import traceback
 
 from configparser import Error as error
 
-from extras.AFC_lane import AFCLaneState
+try: from extras.AFC_utils import ERROR_STR
+except: raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".format(trace=traceback.format_exc()))
 
-
-from extras.AFC_utils import ERROR_STR
+try: from extras.AFC_lane import AFCLaneState
+except: raise error(ERROR_STR.format(import_lib="AFC_lane", trace=traceback.format_exc()))
 
 try: from extras.AFC_BoxTurtle import afcBoxTurtle
 except: raise error(ERROR_STR.format(import_lib="AFC_BoxTurtle", trace=traceback.format_exc()))

--- a/extras/AFC_HTLF.py
+++ b/extras/AFC_HTLF.py
@@ -3,16 +3,17 @@
 # Copyright (C) 2024 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-from configparser import Error as error
-try:
-    from extras.AFC_BoxTurtle import afcBoxTurtle
-except:
-    raise error("Error trying to import AFC_BoxTurtle, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper")
+import traceback
 
-try:
-    from extras.AFC_utils import add_filament_switch
-except:
-    raise error("Error trying to import AFC_utils, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper")
+from configparser import Error as error
+
+from extras.AFC_utils import ERROR_STR
+
+try: from extras.AFC_BoxTurtle import afcBoxTurtle
+except: raise error(ERROR_STR.format(import_lib="AFC_BoxTurtle", trace=traceback.format_exc()))
+
+try: from extras.AFC_utils import add_filament_switch
+except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.format_exc()))
 
 class AFC_HTLF(afcBoxTurtle):
     VALID_CAM_ANGLES = [30,45,60]

--- a/extras/AFC_NightOwl.py
+++ b/extras/AFC_NightOwl.py
@@ -3,11 +3,14 @@
 # Copyright (C) 2024 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+import traceback
+
 from configparser import Error as error
-try:
-    from extras.AFC_BoxTurtle import afcBoxTurtle
-except:
-    raise error("Error trying to import AFC_BoxTurtle, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper")
+
+from extras.AFC_utils import ERROR_STR
+
+try: from extras.AFC_BoxTurtle import afcBoxTurtle
+except: raise error(ERROR_STR.format(import_lib="AFC_BoxTurtle", trace=traceback.format_exc()))
 
 class afcNightOwl(afcBoxTurtle):
     def __init__(self, config):

--- a/extras/AFC_NightOwl.py
+++ b/extras/AFC_NightOwl.py
@@ -7,7 +7,8 @@ import traceback
 
 from configparser import Error as error
 
-from extras.AFC_utils import ERROR_STR
+try: from extras.AFC_utils import ERROR_STR
+except: raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".format(trace=traceback.format_exc()))
 
 try: from extras.AFC_BoxTurtle import afcBoxTurtle
 except: raise error(ERROR_STR.format(import_lib="AFC_BoxTurtle", trace=traceback.format_exc()))

--- a/extras/AFC_assist.py
+++ b/extras/AFC_assist.py
@@ -7,7 +7,8 @@ import math
 import traceback
 
 from configfile import error
-from extras.AFC_utils import ERROR_STR
+try: from extras.AFC_utils import ERROR_STR
+except: raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".format(trace=traceback.format_exc()))
 
 try: from extras.AFC_stats import AFCStats_var
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))

--- a/extras/AFC_assist.py
+++ b/extras/AFC_assist.py
@@ -4,6 +4,13 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math
+import traceback
+
+from configfile import error
+from extras.AFC_utils import ERROR_STR
+
+try: from extras.AFC_stats import AFCStats_var
+except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
 
 #respooler
 PIN_MIN_TIME = 0.100
@@ -83,6 +90,136 @@ class AFCassistMotor:
             return systime + time_diff
         self._set_pin(print_time + PIN_MIN_TIME, self.last_value, True)
         return systime + self.resend_interval
+
+class EspoolerDir:
+    FWD = "Forwards"
+    RWD = "Reverse"
+
+class AFCEspoolerStats:
+    """
+    Holds stats for Espooler forward/reverse runtime. Has functions for calculating runtime
+    for when spoolers are started and then stopped.
+
+    Parameters
+    ----------------
+    espooler_name:
+        espooler lane name to insert into database
+    espooler_obj:
+        Espooler object to easily get access to logger and moonraker objects
+    """
+    def __init__(self, espooler_name:str, espooler_obj:object):
+        afc_stats = espooler_obj.afc.moonraker.get_afc_stats()
+        if afc_stats is not None:
+            values = afc_stats["value"]
+        else:
+            values = None
+        self._n20_runtime_fwd   = AFCStats_var(espooler_name, "n20_runtime_fwd", values, espooler_obj.afc.moonraker)
+        self._n20_runtime_rwd   = AFCStats_var(espooler_name, "n20_runtime_rwd", values, espooler_obj.afc.moonraker)
+        self._fwd_updated       = False
+        self._rwd_updated       = False
+        self._direction         = None
+        self._direction_start   = None
+        self._direction_end     = None
+        self._delta             = None
+        self.logger = espooler_obj.logger
+
+    def _convert_value(self, value:int) -> tuple[int, str]:
+        """
+        Helper function for turning seconds into minutes and hours for printing
+        runtime to console
+
+        :param value
+        :return: Returns tuple of value, unit of converted value
+        """
+        unit = 's'
+        if value > 9999:
+            value /=60
+            unit = 'm'
+
+        if value > 9999:
+            value /= 60
+            unit = 'h'
+        return value, unit
+
+    @property
+    def n20_runtime_fwd(self):
+        val, unit = self._convert_value(self._n20_runtime_fwd.value)
+        return f"{val:.2f}{unit}"
+    @property
+    def n20_runtime_rwd(self):
+        val, unit = self._convert_value(self._n20_runtime_rwd.value)
+        return f"{val:.2f}{unit}"
+
+    @property
+    def direction(self):
+        return self._direction
+    @direction.setter
+    def direction(self, value):
+        """
+        Sets direction if direction has not already been set
+        """
+        if self._direction is None:
+            self._direction = value
+
+    @property
+    def start_time(self):
+        return self._direction_start
+    @start_time.setter
+    def start_time(self, eventtime):
+        """
+        Sets start time if time has not already been set
+        """
+        if self._direction_start is None:
+            self._direction_start = eventtime
+
+    @property
+    def end_time(self):
+        return self._direction_end
+    @end_time.setter
+    def end_time(self, eventtime):
+        """
+        End time setter for runtime, once this is called a delta of end_time - start-time
+        is calculated and applied to direction that espoolers were running. A flag is then
+        set to signify that respective direction has been updated. This does not automatically
+        push to moonrakers database.
+
+        Once calculation is done, direction start, end and direction is set back to None
+
+        :param eventtime: Current time to apply to end_time
+        """
+
+        # Checking to make sure all 3 variables are set
+        if self._direction is None and self._direction_end is None and \
+           self._direction_start is None:
+            return
+
+        self._direction_end = eventtime
+
+        # Only calculate if end time is greater than start time
+        if self._direction_end > self._direction_start:
+            self._delta = self._direction_end - self._direction_start
+
+            if self._direction == EspoolerDir.FWD:
+                self._n20_runtime_fwd.value += self._delta
+                self._fwd_updated      = True
+            else:
+                self._n20_runtime_rwd.value += self._delta
+                self._rwd_updated      = True
+
+        self._direction = self._direction_start = self._direction_end = None
+
+    def update_database(self):
+        """
+        Updates database for both forward and reverse directions if updated flag
+        is set
+        """
+        if self._fwd_updated:
+            self._n20_runtime_fwd.update_database()
+            self._fwd_updated = False
+
+        if self._rwd_updated:
+            self._n20_runtime_rwd.update_database()
+            self._rwd_updated = False
 
 class Espooler_values:
     """
@@ -238,6 +375,7 @@ class Espooler:
         self.logger                 = self.afc.logger
         self.reactor                = self.printer.get_reactor()
         self.callback_timer         = self.reactor.register_timer( self.timer_callback )    # Defaults to never trigger
+        self.stats_timer            = self.reactor.register_timer( self.timer_stats_callback )
 
         self.afc_motor_rwd          = config.get("afc_motor_rwd", None)                     # Reverse pin on MCU for spoolers
         self.afc_motor_fwd          = config.get("afc_motor_fwd", None)                     # Forwards pin on MCU for spoolers
@@ -261,6 +399,7 @@ class Espooler:
         self.past_extruder_position = -1
 
         self.espooler_values        = Espooler_values(config)
+        self.stats                  = None
 
         if self.afc_motor_rwd is not None:
             self.afc_motor_rwd = AFCassistMotor(config, "rwd")
@@ -274,18 +413,40 @@ class Espooler:
         if self.afc_motor_enb is not None:
             self.afc_motor_enb = AFCassistMotor(config, "enb")
 
+    def handle_ready(self):
+        """
+        Ready callback to check and either RWD of FWD pins are defined, if they are starts
+        timer_stats_callback timer.
+        """
+        if self.afc_motor_fwd is not None or self.afc_motor_rwd is not None:
+            self.reactor.update_timer( self.stats_timer, self.reactor.monotonic() + 30 )
+        else:
+            self.logger.info(f"Not starting timer for {self.name}")
+
     def handle_connect(self, lane_obj):
         """
         Should only be called during handle_connect callback to update values from unit. If values are not set per
         lane this function will update values from their unit.
         """
         self.espooler_values.handle_connect(lane_obj)
+        self.stats = AFCEspoolerStats(self.name, self)
 
         if self.n20_break_delay_time    is None: self.n20_break_delay_time  = lane_obj.unit_obj.n20_break_delay_time
         if self.timer_delay             is None: self.timer_delay           = lane_obj.unit_obj.timer_delay
         if self.enable_assist           is None: self.enable_assist         = lane_obj.unit_obj.enable_assist
         if self.debug                   is None: self.debug                 = lane_obj.unit_obj.debug
         if self.enable_kick_start       is None: self.enable_kick_start     = lane_obj.unit_obj.enable_kick_start
+
+    def timer_stats_callback(self, eventtime):
+        """
+        Callback function that runs every 30 seconds that checks and see if espooler
+        active time values need to be sent to moonraker. This function will not
+        send data to moonraker if printer is currently in a print and printing
+        """
+        if not self.afc.function.is_printing(True):
+            self.stats.update_database()
+
+        return self.reactor.monotonic() + 30
 
     def timer_callback(self, eventtime):
         """
@@ -337,6 +498,12 @@ class Espooler:
         """
         if self.afc_motor_enb is not None:
             self.afc_motor_enb._set_pin( print_time, value)
+            # Setting start/end time based on enable pin
+
+        if value == 0:
+            self.stats.end_time = print_time
+        else:
+            self.stats.start_time = print_time
 
     def do_assist_move(self, movement=100):
         """
@@ -363,6 +530,7 @@ class Espooler:
         :param print_time: This value should be a float and is a time when to set the pin
         :param value: This value should be a float between 0.0 and 1.0
         """
+        self.stats.direction = EspoolerDir.FWD
         self.set_enable_pin(print_time, 1)
         self.afc_motor_fwd._set_pin(print_time, value)
 
@@ -373,6 +541,7 @@ class Espooler:
         :param print_time: This value should be a float and is a time when to set the pin
         :param value: This value should be a float between 0.0 and 1.0
         """
+        self.stats.direction = EspoolerDir.RWD
         self.set_enable_pin(print_time, 1)
         self.afc_motor_rwd._set_pin(print_time, value)
 
@@ -392,12 +561,17 @@ class Espooler:
             value *= -1
             assist_motor=self.afc_motor_rwd
             reverse = True
+            self.stats.direction = EspoolerDir.RWD
+            self.stats.start_time  = print_time
         elif value > 0:
             if self.afc_motor_fwd is None:
                 return
+            self.stats.direction = EspoolerDir.FWD
+            self.stats.start_time = print_time
             assist_motor=self.afc_motor_fwd
         elif value == 0:
             self.break_espooler()
+            self.stats.end_time = print_time
             return
 
         value /= assist_motor.scale
@@ -457,6 +631,34 @@ class Espooler:
 
         self.past_extruder_position = -1
         self.reactor.update_timer( self.callback_timer, self.reactor.NEVER)
+
+    def get_spooler_stats(self, short=False):
+        """
+        Returns N20 active time in a format for printing to console. Only returns
+        forwards and reverse if pins are defined.
+
+        :param short: Set to True to return string for printing to console in shorter format
+        :return: String for reverse or forwards active time for espoolers
+        """
+        ret_str = "N20 active time:"
+
+        if self.afc_motor_fwd is None and self.afc_motor_rwd is None:
+            ret_str = ""
+
+        if self.afc_motor_fwd is not None:
+            if short:
+                ret_str += " fwd:"
+                ret_str = f"{ret_str:{' '}>31}{self.stats.n20_runtime_fwd:>8}   |\n"
+            else:
+                ret_str += f" fwd:{self.stats.n20_runtime_fwd:>8}"
+
+        if self.afc_motor_rwd is not None:
+            if short:
+                ret_str += "|" + f"{'rwd:':{' '}>31}{self.stats.n20_runtime_rwd:>8}   "
+            else:
+                ret_str += f" rwd:{self.stats.n20_runtime_rwd:>8}"
+
+        return ret_str
 
     ### MACROS ###
     cmd_TEST_ESPOOLER_ASSIST_help="Test espooler print assist for a specified lane"

--- a/extras/AFC_buffer.py
+++ b/extras/AFC_buffer.py
@@ -7,10 +7,8 @@ import traceback
 
 from configparser import Error as error
 
-from extras.AFC_utils import ERROR_STR
-
 try: from extras.AFC_utils import add_filament_switch
-except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.format_exc()))
+except: raise error("Error when trying to import AFC_utils.add_filament_switch\n{trace}".format(trace=traceback.format_exc()))
 
 ADVANCE_STATE_NAME = "Trailing"
 TRAILING_STATE_NAME = "Advancing"

--- a/extras/AFC_buffer.py
+++ b/extras/AFC_buffer.py
@@ -3,12 +3,14 @@
 # Copyright (C) 2024 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+import traceback
 
 from configparser import Error as error
-try:
-    from extras.AFC_utils import add_filament_switch
-except:
-    raise error("Error trying to import AFC_utils, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper")
+
+from extras.AFC_utils import ERROR_STR
+
+try: from extras.AFC_utils import add_filament_switch
+except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.format_exc()))
 
 ADVANCE_STATE_NAME = "Trailing"
 TRAILING_STATE_NAME = "Advancing"

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -3,11 +3,19 @@
 # Copyright (C) 2024 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-
+import traceback
 import logging
-from extras.AFC import State
-from extras.AFC_lane import AFCLaneState
 
+from configparser import Error as error
+
+try: from extras.AFC_utils import ERROR_STR
+except: raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".format(trace=traceback.format_exc()))
+
+try: from extras.AFC import State
+except: raise error(ERROR_STR.format(import_lib="AFC", trace=traceback.format_exc()))
+
+try: from extras.AFC_lane import AFCLaneState
+except: raise error(ERROR_STR.format(import_lib="AFC_lane", trace=traceback.format_exc()))
 
 def load_config(config):
     return afcError(config)

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -111,7 +111,6 @@ class afcError:
         self.logger.error( "{}".format(msg) )
         if pause: self.pause_print()
 
-
     cmd_RESET_FAILURE_help = "CLEAR STATUS ERROR"
     def cmd_RESET_FAILURE(self, gcmd):
         """

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -7,7 +7,8 @@ import traceback
 
 from configparser import Error as error
 
-from extras.AFC_utils import ERROR_STR
+try: from extras.AFC_utils import ERROR_STR
+except: raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".format(trace=traceback.format_exc()))
 
 try: from extras.AFC_utils import add_filament_switch
 except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.format_exc()))

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -3,11 +3,14 @@
 # Copyright (C) 2024 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+import traceback
+
 from configparser import Error as error
-try:
-    from extras.AFC_utils import add_filament_switch
-except:
-    raise error("Error trying to import AFC_utils, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper")
+
+from extras.AFC_utils import ERROR_STR
+
+try: from extras.AFC_utils import add_filament_switch
+except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.format_exc()))
 
 class AFCExtruder:
     def __init__(self, config):

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -11,7 +11,8 @@ import traceback
 from configfile import error
 from datetime import datetime
 
-from extras.AFC_utils import ERROR_STR
+try: from extras.AFC_utils import ERROR_STR
+except: raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".format(trace=traceback.format_exc()))
 
 try: from extras.AFC_respond import AFCprompt
 except: raise error(ERROR_STR.format(import_lib="AFC_respond", trace=traceback.format_exc()))

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -146,7 +146,7 @@ class afcFunction:
         idle_timeout = self.printer.lookup_object("idle_timeout")
         return idle_timeout.get_status(eventtime)["state"] == "Printing"
 
-    def in_print(self):
+    def in_print(self, return_file=False):
         """
         Helper function to help determine if printer is in a print by checking print_stats object. Printer is printing if state is not in standby or error
 
@@ -156,7 +156,12 @@ class afcFunction:
         eventtime = self.afc.reactor.monotonic()
         print_stats = self.printer.lookup_object("print_stats")
         print_state = print_stats.get_status(eventtime)["state"]
-        return print_state not in print_stats_idle_states
+
+        in_print = print_state not in print_stats_idle_states
+        if return_file:
+            return in_print, print_stats.get_status(eventtime)["filename"]
+        else:
+            return in_print
 
     def is_printing(self, check_movement=False):
         """

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -6,12 +6,15 @@
 
 import os
 import re
+import traceback
+
 from configfile import error
 from datetime import datetime
-try:
-    from extras.AFC_respond import AFCprompt
-except:
-    raise error("Error trying to import AFC_respond, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper")
+
+from extras.AFC_utils import ERROR_STR
+
+try: from extras.AFC_respond import AFCprompt
+except: raise error(ERROR_STR.format(import_lib="AFC_respond", trace=traceback.format_exc()))
 
 def load_config(config):
     return afcFunction(config)
@@ -150,6 +153,7 @@ class afcFunction:
         """
         Helper function to help determine if printer is in a print by checking print_stats object. Printer is printing if state is not in standby or error
 
+        :param return_file: Set to True to return current print filename if printer is in a print
         :return boolean: True if state is not standby or error
         """
         print_stats_idle_states = ['standby', 'error', 'complete', 'cancelled']
@@ -995,6 +999,7 @@ class afcDeltaTime:
             self.logger.debug("Error in log_with_time function {}".format(e))
 
     def log_major_delta(self, msg, debug=True):
+        delta_time = 0
         try:
             curr_time = datetime.now()
             delta_time = (curr_time - self.major_delta_time ).total_seconds()
@@ -1004,7 +1009,10 @@ class afcDeltaTime:
         except Exception as e:
             self.logger.debug("Error in log_major_delta function {}".format(e))
 
+        return delta_time
+
     def log_total_time(self, msg):
+        total_time = 0
         try:
             total_time = (datetime.now() - self.start_time).total_seconds()
             msg = "{} t:{:.3f}".format( msg, total_time )
@@ -1012,3 +1020,5 @@ class afcDeltaTime:
             self.logger.info( msg )
         except Exception as e:
             self.logger.debug("Error in log_total_time function {}".format(e))
+
+        return total_time

--- a/extras/AFC_hub.py
+++ b/extras/AFC_hub.py
@@ -7,7 +7,8 @@ import traceback
 
 from configparser import Error as error
 
-from extras.AFC_utils import ERROR_STR
+try: from extras.AFC_utils import ERROR_STR
+except: raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".format(trace=traceback.format_exc()))
 
 try: from extras.AFC_utils import add_filament_switch
 except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.format_exc()))

--- a/extras/AFC_hub.py
+++ b/extras/AFC_hub.py
@@ -3,11 +3,14 @@
 # Copyright (C) 2024 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+import traceback
+
 from configparser import Error as error
-try:
-    from extras.AFC_utils import add_filament_switch
-except:
-    raise error("Error trying to import AFC_utils, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper")
+
+from extras.AFC_utils import ERROR_STR
+
+try: from extras.AFC_utils import add_filament_switch
+except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.format_exc()))
 
 class afc_hub:
     def __init__(self, config):

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -9,9 +9,25 @@ from configfile import error
 
 from . import AFC_assist
 try:
-    from extras.AFC_utils import add_filament_switch
+    from extras.AFC_utils import (
+        add_filament_switch,
+        AFCStats_var
+    )
 except:
     raise error("Error trying to import AFC_utils, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper")
+class AFCLaneStats:
+    def __init__(self, lane_name, lane_obj):
+        afc_stats = lane_obj.afc.moonraker.get_afc_stats()
+        if afc_stats is not None:
+            values = ["values"]
+        else:
+            values = None
+        self.n20_runtime       = AFCStats_var(lane_name, "n20_runtime", values, lane_obj.afc.moonraker)
+        self.lane_change_count = AFCStats_var(lane_name, "change_count", values, lane_obj.afc.moonraker)
+    
+    def increment_lane_count(self):
+        self.lane_change_count.increase_count()
+        return
 
 class AFCLane:
     def __init__(self, config):
@@ -27,6 +43,7 @@ class AFCLane:
         self.hub_obj            = None
         self.buffer_obj         = None
         self.extruder_obj       = None
+        self.lane_stats         = None
 
         #stored status variables
         self.fullname           = config.get_name()
@@ -162,6 +179,8 @@ class AFCLane:
             # Registering lane name in unit
             self.unit_obj.lanes[self.name] = self
             self.afc.lanes[self.name] = self
+
+            self.lane_stats = AFCLaneStats(self.name, self)
 
         self.hub_obj = self.unit_obj.hub_obj
 

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -401,7 +401,7 @@ class AFCLane:
         if assist_active == AssistActive.YES:
             assist = True
         elif assist_active == AssistActive.DYNAMIC:
-            assist = distance > 200
+            assist = abs(distance) > 200
 
         self.move(distance, speed, accel, assist)
 

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -9,13 +9,11 @@ import traceback
 from contextlib import contextmanager
 from configfile import error
 
-from extras.AFC_utils import ERROR_STR
+try: from extras.AFC_utils import ERROR_STR, add_filament_switch
+except: raise error("Error when trying to import AFC_utils.ERROR_STR, add_filament_switch\n{trace}".format(trace=traceback.format_exc()))
 
 try: from extras import AFC_assist
 except: raise error(ERROR_STR.format(import_lib="AFC_assist", trace=traceback.format_exc()))
-
-try: from extras.AFC_utils import add_filament_switch
-except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.format_exc()))
 
 try: from extras.AFC_stats import AFCStats_var
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -45,7 +45,6 @@ class AFCLane:
         self.hub_obj            = None
         self.buffer_obj         = None
         self.extruder_obj       = None
-        self.lane_stats         = None
 
         #stored status variables
         self.fullname           = config.get_name()

--- a/extras/AFC_logger.py
+++ b/extras/AFC_logger.py
@@ -82,12 +82,24 @@ class AFC_logger:
         if self.print_debug_console and not only_debug:
             self.send_callback(message)
 
-    def error(self, message):
+    def error(self, message, traceback=None):
+        """
+        Prints error to console and log, also adds error to message queue when is then displayed
+        in mainsail/fluidd guis
+
+        :param message: Error message to print to console and log
+        :param traceback: Trackback to log to AFC.log file
+        """
         for line in message.lstrip().rstrip().split("\n"):
             self.logger.error( self._format("ERROR: {}".format(line)))
         self.send_callback( "!! {}".format(message) )
 
         self.afc.message_queue.append((message, "error"))
+
+        if traceback is not None:
+            for line in traceback.lstrip().rstrip().split("\n"):
+                self.logger.error( self._format("ERROR: {}".format(line)))
+
 
     def set_debug(self, debug ):
         self.print_debug_console = debug

--- a/extras/AFC_logger.py
+++ b/extras/AFC_logger.py
@@ -8,6 +8,7 @@ try:
     from .. import APP_NAME
 except:
     APP_NAME = "Klipper"
+
 import logging
 import re
 import os

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -159,11 +159,11 @@ class afcPrep:
         if 'virtual' in self.afc.bypass.name:
             bypass_name = "Virtual bypass"
             if "system" in units and 'bypass' in units["system"]:
-                self.afc.bypass.sensor_enabled = units["system"]["bypass"]["enabled"]
+                self.afc.bypass.filament_present = self.afc.bypass.sensor_enabled = units["system"]["bypass"]["enabled"]
             else:
-                self.afc.bypass.sensor_enabled = False
+                self.afc.bypass.filament_present = self.afc.bypass.sensor_enabled = False
         # Add warning message so users know that either bypass or virtual bypass is enabled
-        if self.afc.bypass.sensor_enabled:
+        if self.afc.bypass.filament_present:
             self.logger.raw(f"<span class=warning--text>{bypass_name} enabled</span>")
 
         self.afc.afc_stats.check_cut_threshold()

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -158,6 +158,10 @@ class afcPrep:
         if 'virtual' in self.afc.bypass.name:
             if "system" in units and 'bypass' in units["system"]:
                 self.afc.bypass.sensor_enabled = units["system"]["bypass"]["enabled"]
+            else:
+                self.afc.bypass.sensor_enabled = False
+
+        self.afc.afc_stats.check_cut_threshold()
 
         # Defaulting to no active spool, putting at end so endpoint has time to register
         if self.afc.current is None:

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -155,11 +155,16 @@ class afcPrep:
             current_lane.unit_obj.select_lane(current_lane)
 
         # Restore previous bypass state if virtual bypass is active
+        bypass_name = "Bypass"
         if 'virtual' in self.afc.bypass.name:
+            bypass_name = "Virtual bypass"
             if "system" in units and 'bypass' in units["system"]:
                 self.afc.bypass.sensor_enabled = units["system"]["bypass"]["enabled"]
             else:
                 self.afc.bypass.sensor_enabled = False
+        # Add warning message so users know that either bypass or virtual bypass is enabled
+        if self.afc.bypass.sensor_enabled:
+            self.logger.raw(f"<span class=warning--text>{bypass_name} enabled</span>")
 
         self.afc.afc_stats.check_cut_threshold()
 

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -4,14 +4,6 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
-import json
-try:
-    from urllib.request import urlopen
-    import urllib.parse as urlparse
-except:
-    # Python 2.7 support
-    from urllib2 import urlopen
-    import urlparse
 
 class AFCSpool:
     def __init__(self, config):

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -241,8 +241,7 @@ class AFCSpool:
         if self.afc.spoolman is not None:
             if SpoolID !='':
                 try:
-                    url =  urlparse.urljoin(self.afc.spoolman, '/api/v1/spool/{}'.format(SpoolID))
-                    result = json.load(urlopen(url))
+                    result = self.afc.moonraker.get_spool(SpoolID)
                     cur_lane.spool_id = SpoolID
 
                     cur_lane.material       = self._get_filament_values(result['filament'], 'material')

--- a/extras/AFC_stats.py
+++ b/extras/AFC_stats.py
@@ -3,8 +3,12 @@
 # Copyright (C) 2024 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+import traceback
 
-from extras.AFC_utils import check_and_return
+from configparser import Error as error
+
+try: from extras.AFC_utils import check_and_return
+except: raise error("Error when trying to import AFC_utils.check_and_return\n{trace}".format(trace=traceback.format_exc()))
 
 class AFCStats_var:
     """

--- a/extras/AFC_stats.py
+++ b/extras/AFC_stats.py
@@ -1,0 +1,307 @@
+# Armored Turtle Automated Filament Changer
+#
+# Copyright (C) 2024 Armored Turtle
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+from extras.AFC_utils import check_and_return
+
+class AFCStats_var:
+    """
+    Holds a single value for stat tracking. Also has common functions to
+    increment, reset, set time and average time for time values. This class also
+    has the ability to update moonrakers database with value.
+
+    Upon initializing this class, value is retrevied from dictionary if it exists
+    and sets internal value to this, or zero if it does not exist.
+
+    Parameters
+    ----------------
+    parent_name : string
+        Parents name to store value into moonraker database
+    name : string
+        Name to store value into moonrakers database
+    data : dictionary
+        Dictionary of current afc_stat values stored in moonraker database
+    moonraker : AFC_moonraker
+        AFC_moonraker class to easily post values to moonraker
+    """
+    def __init__(self, parent_name:str, name:str, data:dict, moonraker:object):
+        self.parent_name = parent_name
+        self.name        = name
+        self.moonraker   = moonraker
+
+        if data is not None and self.parent_name in data:
+            value = check_and_return( self.name, data[self.parent_name])
+            try:
+                self._value = int(value)
+            except ValueError:
+                try :
+                    self._value = float(value)
+                except:
+                    self._value = value
+        else:
+            self.moonraker.logger.error("Something happened data when getting data:{} {}".format( bool(data is not None), bool(self.parent_name in data)))
+            self._value = 0
+
+    def __str__(self):
+        return str(self._value)
+
+    @property
+    def value(self):
+        return self._value
+    @value.setter
+    def value(self, value):
+        self._value = value
+
+    def average_time(self, value:float):
+        """
+        Helper function for averaging time, moonrakers database is updated after
+        averaging numbers
+
+        :param value: Float value to average into current value
+        """
+        if self._value > 0:
+            self._value += value
+            self._value /= 2
+        else:
+            self._value = value
+        self.update_database()
+
+    def increase_count(self):
+        """
+        Helper function to easily increment count and updates moonrakers database
+        """
+        self._value += 1
+        self.update_database()
+
+    def reset_count(self):
+        """
+        Helper function to easily reset count and updates moonrakers database
+        """
+        self._value = 0
+        self.update_database()
+
+    def update_database(self):
+        """
+        Calls AFC_moonraker update_afc_stats function with correct key, value to update
+        value in moonrakers database
+        """
+        self.moonraker.update_afc_stats(f"{self.parent_name}.{self.name}", self._value)
+
+    def set_current_time(self):
+        """
+        Grabs current date/time, sets variable and updates in moonrakers database.
+        Use only for variables that are dates
+        """
+        from datetime import datetime
+        time = datetime.now()
+        self._value = time.strftime("%Y-%m-%d %H:%M")
+        self.update_database()
+
+class AFCStats:
+    """
+    This class holds the following AFC statistics:
+        toolchange count: total, unload, load, number of changes without errors,
+                            last time error occurred
+        cut counts: total, number of cuts since last blade change, date when blade was last changed
+        average time: total toolchange, unload, load
+
+    Parameters
+    ----------------
+    moonraker: AFC_moonraker
+        AFC_moonraker class is passed into AFCStats_var class for easily updating values in database
+    logger: AFC_logger
+        AFC_logger class for logging and printing to console
+    cut_threshold: integer
+        cut threshold set by user in AFC config
+    """
+    def __init__(self, moonraker, logger, cut_threshold):
+        self.moonraker  = moonraker
+        self.logger     = logger
+        afc_stats       = self.moonraker.get_afc_stats()
+
+        if afc_stats is not None:
+            values = afc_stats["value"]
+        else:
+            values = None
+
+        self.tc_total           = AFCStats_var("toolchange_count", "total",                 values, self.moonraker)
+        self.tc_tool_unload     = AFCStats_var("toolchange_count", "tool_unload",           values, self.moonraker)
+        self.tc_tool_load       = AFCStats_var("toolchange_count", "tool_load",             values, self.moonraker)
+        self.tc_without_error   = AFCStats_var("toolchange_count", "changes_without_error", values, self.moonraker)
+        self.tc_last_load_error = AFCStats_var("toolchange_count", "last_load_error",       values, self.moonraker)
+
+        if self.tc_last_load_error.value == 0:
+            self.tc_last_load_error.set_current_time()
+
+        self.cut_total                  = AFCStats_var("cut", "cut_total",                  values, self.moonraker)
+        self.cut_total_since_changed    = AFCStats_var("cut", "cut_total_since_changed",    values, self.moonraker)
+        self.last_blade_changed         = AFCStats_var("cut", "last_blade_changed",         values, self.moonraker)
+        self.cut_threshold_for_warning  = cut_threshold
+        self.threshold_warning_sent     = False
+        self.threshold_error_sent       = False
+
+        self.average_toolchange_time    = AFCStats_var("average_time", "tool_change", values, self.moonraker)
+        self.average_tool_unload_time   = AFCStats_var("average_time", "tool_unload", values, self.moonraker)
+        self.average_tool_load_time     = AFCStats_var("average_time", "tool_load",   values, self.moonraker)
+
+    def check_cut_threshold(self):
+        """
+        Function checks current cut value against users threshold value, outputs warning when cut is within
+        1k cuts of threshold. Outputs errors once number of cuts exceed threshold
+        """
+        send_message = False
+        message_type = None
+        blade_changed_date_string = self.last_blade_changed
+        span_start = "<span class=warning--text>"
+        if 0 == self.last_blade_changed.value:
+            blade_changed_date_string = "N/A"
+
+        if self.cut_total_since_changed.value >= self.cut_threshold_for_warning:
+            warning_msg_time        = "Time"
+            warning_msg_threshold   = "have exceeded"
+            span_start              = "<span class=error--text>"
+            message_type            = "error"
+            if not self.threshold_error_sent: 
+                self.threshold_error_sent = send_message = True
+
+        elif self.cut_total_since_changed.value >= (self.cut_threshold_for_warning - 1000):
+            warning_msg_time        = "Almost time"
+            warning_msg_threshold   = "is about to exceeded"
+            span_start              = "<span class=warning--text>"
+            message_type            = "warning"
+            if not self.threshold_warning_sent: 
+                self.threshold_warning_sent = send_message = True
+        else:
+            return
+
+        warning_msg = f"{warning_msg_time} to change cutting blade as your blade has performed {self.cut_total_since_changed} cuts\n"
+        warning_msg += f"since changed on {blade_changed_date_string}. Number of cuts {warning_msg_threshold} set threshold of {self.cut_threshold_for_warning}.\n"
+        warning_msg +=  "Once blade is changed, execute AFC_CHANGE_BLADE macro to reset count and date changed.\n"
+        if send_message:
+            self.logger.raw( f"{span_start}{warning_msg}</span>")
+            self.logger.afc.message_queue.append((warning_msg, message_type))
+
+    def increase_cut_total(self):
+        """
+        Helper function for increasing all cut counts
+        """
+        self.cut_total.increase_count()
+        self.cut_total_since_changed.increase_count()
+        self.check_cut_threshold()
+
+    def increase_toolcount_change(self):
+        """
+        Helper function for increasing total toolchange count and number of toolchanges with
+        error count.
+        """
+        self.tc_total.increase_count()
+        self.tc_without_error.increase_count()
+
+    def reset_toolchange_wo_error(self):
+        """
+        Helper function for reseting number of toolchanges without errors and
+        sets last error date/time as current
+        """
+        self.tc_without_error.reset_count()
+        self.tc_last_load_error.set_current_time()
+
+    def print_stats(self, afc_obj, short:bool=False):
+        """
+        Prints all stat to console
+
+        :param afc_obj: AFC class that hold lane information so lanes stats can also be printed out
+        :param short: When set to True calls print_stats_skinny function.
+        """
+        MAX_WIDTH = 87
+
+        def end_string():
+            nonlocal print_str, temp_str
+            print_str += f"{temp_str:{' '}<{86}}|\n"
+            temp_str = ""
+
+        if short:
+            return self.print_stats_skinny(afc_obj)
+
+        avg_tool_load   = f"Avg Tool Load: {self.average_tool_load_time.value:4.2f}s"
+        avg_tool_unload = f"Avg Tool Unload: {self.average_tool_unload_time.value:4.2f}s"
+        avg_tool_change = f"Avg Tool Change: {self.average_toolchange_time.value:4.2f}s"
+
+        print_str  = f"{'':{'-'}<{MAX_WIDTH}}\n"
+        print_str += f"|{'Toolchanges':{' '}^42}|{'Cut':{' '}^42}|\n"
+        print_str += f"|{'':{'-'}<{MAX_WIDTH-2}}|\n"
+        print_str += f"|{'Total':{' '}>22} : {self.tc_total.value:{' '}<17}|{'Total':{' '}>22} : {self.cut_total.value:{''}<17}|\n"
+        print_str += f"|{'Tool Unload':{' '}>22} : {self.tc_tool_unload.value:{' '}<17}|{'Total since changed':{' '}>22} : {self.cut_total_since_changed.value:{''}<17}|\n"
+        print_str += f"|{'Tool Load':{' '}>22} : {self.tc_tool_load.value:{' '}<17}|{'Blade last changed':{' '}>22} : {self.last_blade_changed.value:{''}<17}|\n"
+        print_str += f"|{'Changes without error':{' '}>22} : {self.tc_without_error.value:{' '}<17}|{'':{''}<42}|\n"
+        print_str += f"|{'Last error date':{' '}>22} : {self.tc_last_load_error.value:{' '}<17}|{'':{''}<42}|\n"
+        print_str += f"{'':{'-'}<{MAX_WIDTH}}\n"
+        print_str += f"|{avg_tool_load:{' '}^28}|{avg_tool_unload:{' '}^27}|{avg_tool_change:{' '}^28}|\n"
+        print_str += f"{'':{'-'}<{MAX_WIDTH}}\n"
+
+        strings = []
+        for lane in afc_obj.lanes.values():
+            espooler_stats = lane.espooler.get_spooler_stats()
+            str = f"{lane.name:{' '}>7} : Lane change count: {lane.lane_load_count.value:{' '}>7}"
+            if len(espooler_stats) > 0:
+                str += f"    {espooler_stats}"
+            strings.append(str)
+
+        temp_str = ""
+        for i, s in enumerate(strings):
+            if len(temp_str) > 60:
+                end_string()
+
+            if len(s) > 60:
+                if len(temp_str) > 0:
+                    end_string()
+                print_str += f"|{s}{'|':{' '}>4}\n"
+            else:
+                temp_str += f"|{s:{' '}<42}"
+        if len(temp_str) > 0:
+            end_string()
+
+        print_str += f"{'':{'-'}<{MAX_WIDTH}}\n"
+        self.logger.raw(print_str)
+
+    def print_stats_skinny(self, afc_obj):
+        """
+        Prints all stats to console, this is different as its skinner so its easier to view on phones, Klipperscreen, etc.
+
+        :param afc_obj: AFC class that hold lane information so lanes stats can also be printed out
+        """
+        MAX_WIDTH = 42
+
+        avg_tool_load   = f"{'Avg Tool Load':{' '}>22} : {self.average_tool_load_time.value:4.2f}s"
+        avg_tool_unload = f"{'Avg Tool Unload':{' '}>22} : {self.average_tool_unload_time.value:4.2f}s"
+        avg_tool_change = f"{'Avg Tool Change':{' '}>22} : {self.average_toolchange_time.value:4.2f}s"
+
+        print_str  = f"{'':{'-'}<{MAX_WIDTH+2}}\n"
+        print_str += f"|{'Toolchanges':{' '}^42}|\n"
+        print_str += f"|{'':{'-'}<{MAX_WIDTH}}|\n"
+        print_str += f"|{'Total':{' '}>22} : {self.tc_total.value:{' '}<17}|\n"
+        print_str += f"|{'Tool Unload':{' '}>22} : {self.tc_tool_unload.value:{' '}<17}|\n"
+        print_str += f"|{'Tool Load':{' '}>22} : {self.tc_tool_load.value:{' '}<17}|\n"
+        print_str += f"|{'Changes without error':{' '}>22} : {self.tc_without_error.value:{' '}<17}|\n"
+        print_str += f"|{'Last error date':{' '}>22} : {self.tc_last_load_error.value:{' '}<17}|\n"
+        print_str += f"|{'':{'-'}<{MAX_WIDTH}}|\n"
+        print_str += f"|{'Cut':{' '}^42}|\n"
+        print_str += f"|{'':{'-'}<{MAX_WIDTH}}|\n"
+        print_str += f"|{'Total':{' '}>22} : {self.cut_total.value:{''}<17}|\n"
+        print_str += f"|{'Total since changed':{' '}>22} : {self.cut_total_since_changed.value:{''}<17}|\n"
+        print_str += f"|{'Blade last changed':{' '}>22} : {self.last_blade_changed.value:{''}<17}|\n"
+        print_str += f"|{'':{'-'}<{MAX_WIDTH}}|\n"
+        print_str += f"|{avg_tool_load:{' '}<42}|\n|{avg_tool_unload:{' '}<42}|\n|{avg_tool_change:{' '}<42}|\n"
+        print_str += f"|{'':{'-'}<{MAX_WIDTH}}|\n"
+
+        for lane in afc_obj.lanes.values():
+            espooler_stats = lane.espooler.get_spooler_stats(short=True)
+            str = f"{lane.name:{' '}>7} : Lane change count: {lane.lane_load_count.value:{' '}>7}"
+            str = f"|{str:{' '}^{MAX_WIDTH}}|\n"
+            if len(espooler_stats) > 0:
+                str += f"|{espooler_stats:{' '}^{MAX_WIDTH}}|\n"
+            print_str += str
+
+        print_str += f"{'':{'-'}<{MAX_WIDTH+2}}\n"
+        self.logger.raw(print_str)

--- a/extras/AFC_stats.py
+++ b/extras/AFC_stats.py
@@ -237,11 +237,13 @@ class AFCStats:
         avg_tool_unload = f"Avg Tool Unload: {self.average_tool_unload_time.value:4.2f}s"
         avg_tool_change = f"Avg Tool Change: {self.average_toolchange_time.value:4.2f}s"
 
+        cuts_since_change = f"{self.cut_total_since_changed.value}/{self.cut_threshold_for_warning}"
+
         print_str  = f"{'':{'-'}<{MAX_WIDTH}}\n"
         print_str += f"|{'Toolchanges':{' '}^42}|{'Cut':{' '}^42}|\n"
         print_str += f"|{'':{'-'}<{MAX_WIDTH-2}}|\n"
         print_str += f"|{'Total':{' '}>22} : {self.tc_total.value:{' '}<17}|{'Total':{' '}>22} : {self.cut_total.value:{''}<17}|\n"
-        print_str += f"|{'Tool Unload':{' '}>22} : {self.tc_tool_unload.value:{' '}<17}|{'Total since changed':{' '}>22} : {self.cut_total_since_changed.value:{''}<17}|\n"
+        print_str += f"|{'Tool Unload':{' '}>22} : {self.tc_tool_unload.value:{' '}<17}|{'Total since changed':{' '}>22} : {cuts_since_change:{''}<17}|\n"
         print_str += f"|{'Tool Load':{' '}>22} : {self.tc_tool_load.value:{' '}<17}|{'Blade last changed':{' '}>22} : {self.last_blade_changed.value:{''}<17}|\n"
         print_str += f"|{'Changes without error':{' '}>22} : {self.tc_without_error.value:{' '}<17}|{'':{''}<42}|\n"
         print_str += f"|{'Last error date':{' '}>22} : {self.tc_last_load_error.value:{' '}<17}|{'':{''}<42}|\n"
@@ -286,6 +288,8 @@ class AFCStats:
         avg_tool_unload = f"{'Avg Tool Unload':{' '}>22} : {self.average_tool_unload_time.value:4.2f}s"
         avg_tool_change = f"{'Avg Tool Change':{' '}>22} : {self.average_toolchange_time.value:4.2f}s"
 
+        cuts_since_change = f"{self.cut_total_since_changed.value}/{self.cut_threshold_for_warning}"
+
         print_str  = f"{'':{'-'}<{MAX_WIDTH+2}}\n"
         print_str += f"|{'Toolchanges':{' '}^42}|\n"
         print_str += f"|{'':{'-'}<{MAX_WIDTH}}|\n"
@@ -298,7 +302,7 @@ class AFCStats:
         print_str += f"|{'Cut':{' '}^42}|\n"
         print_str += f"|{'':{'-'}<{MAX_WIDTH}}|\n"
         print_str += f"|{'Total':{' '}>22} : {self.cut_total.value:{''}<17}|\n"
-        print_str += f"|{'Total since changed':{' '}>22} : {self.cut_total_since_changed.value:{''}<17}|\n"
+        print_str += f"|{'Total since changed':{' '}>22} : {cuts_since_change:{''}<17}|\n"
         print_str += f"|{'Blade last changed':{' '}>22} : {self.last_blade_changed.value:{''}<17}|\n"
         print_str += f"|{'':{'-'}<{MAX_WIDTH}}|\n"
         print_str += f"|{avg_tool_load:{' '}<42}|\n|{avg_tool_unload:{' '}<42}|\n|{avg_tool_change:{' '}<42}|\n"

--- a/extras/AFC_stats.py
+++ b/extras/AFC_stats.py
@@ -45,7 +45,7 @@ class AFCStats_var:
                 except:
                     self._value = value
         else:
-            self.moonraker.logger.error("No data in database for {}.{}:{} {}".format( self.parent_name, name, bool(data is not None), bool(self.parent_name in data)))
+            self.moonraker.logger.debug("No data in database for {}.{}:{}".format( self.parent_name, name, bool(data is not None)))
             self._value = 0
 
     def __str__(self):
@@ -136,9 +136,6 @@ class AFCStats:
         self.tc_without_error   = AFCStats_var("toolchange_count", "changes_without_error", values, self.moonraker)
         self.tc_last_load_error = AFCStats_var("toolchange_count", "last_load_error",       values, self.moonraker)
 
-        if self.tc_last_load_error.value == 0:
-            self.tc_last_load_error.set_current_time()
-
         self.cut_total                  = AFCStats_var("cut", "cut_total",                  values, self.moonraker)
         self.cut_total_since_changed    = AFCStats_var("cut", "cut_total_since_changed",    values, self.moonraker)
         self.last_blade_changed         = AFCStats_var("cut", "last_blade_changed",         values, self.moonraker)
@@ -149,6 +146,14 @@ class AFCStats:
         self.average_toolchange_time    = AFCStats_var("average_time", "tool_change", values, self.moonraker)
         self.average_tool_unload_time   = AFCStats_var("average_time", "tool_unload", values, self.moonraker)
         self.average_tool_load_time     = AFCStats_var("average_time", "tool_load",   values, self.moonraker)
+
+        if self.tc_last_load_error.value == 0:
+            self.tc_last_load_error.value = "N/A"
+            self.tc_last_load_error.update_database()
+
+        if self.last_blade_changed.value == 0:
+            self.last_blade_changed.value = "N/A"
+            self.last_blade_changed.update_database()
 
     def check_cut_threshold(self):
         """

--- a/extras/AFC_stats.py
+++ b/extras/AFC_stats.py
@@ -41,7 +41,7 @@ class AFCStats_var:
                 except:
                     self._value = value
         else:
-            self.moonraker.logger.error("Something happened data when getting data:{} {}".format( bool(data is not None), bool(self.parent_name in data)))
+            self.moonraker.logger.error("No data in database for {}.{}:{} {}".format( self.parent_name, name, bool(data is not None), bool(self.parent_name in data)))
             self._value = 0
 
     def __str__(self):

--- a/extras/AFC_stats.py
+++ b/extras/AFC_stats.py
@@ -247,10 +247,10 @@ class AFCStats:
         strings = []
         for lane in afc_obj.lanes.values():
             espooler_stats = lane.espooler.get_spooler_stats()
-            str = f"{lane.name:{' '}>7} : Lane change count: {lane.lane_load_count.value:{' '}>7}"
+            string = f"{lane.name:{' '}>7} : Lane change count: {lane.lane_load_count.value:{' '}>7}"
             if len(espooler_stats) > 0:
-                str += f"    {espooler_stats}"
-            strings.append(str)
+                string += f"    {espooler_stats}"
+            strings.append(string)
 
         temp_str = ""
         for i, s in enumerate(strings):

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -5,14 +5,16 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
 import chelper
+import traceback
+
 from kinematics import extruder
 from configfile import error
 from extras.force_move import calc_move_time
 
-try:
-	from extras.AFC_lane import AFCLane
-except:
-    raise error("Error trying to import AFC_lane, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper")
+from extras.AFC_utils import ERROR_STR
+
+try: from extras.AFC_lane import AFCLane
+except: raise error(ERROR_STR.format(import_lib="AFC_lane", trace=traceback.format_exc()))
 
 class AFCExtruderStepper(AFCLane):
     def __init__(self, config):

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -11,7 +11,8 @@ from kinematics import extruder
 from configfile import error
 from extras.force_move import calc_move_time
 
-from extras.AFC_utils import ERROR_STR
+try: from extras.AFC_utils import ERROR_STR
+except: raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".format(trace=traceback.format_exc()))
 
 try: from extras.AFC_lane import AFCLane
 except: raise error(ERROR_STR.format(import_lib="AFC_lane", trace=traceback.format_exc()))

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -7,7 +7,8 @@ import traceback
 
 from configfile import error
 
-from extras.AFC_utils import ERROR_STR
+try: from extras.AFC_utils import ERROR_STR
+except: raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".format(trace=traceback.format_exc()))
 
 try: from extras.AFC_respond import AFCprompt
 except: raise error(ERROR_STR.format(import_lib="AFC_respond", trace=traceback.format_exc()))

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -3,12 +3,14 @@
 # Copyright (C) 2024 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+import traceback
 
 from configfile import error
-try:
-    from extras.AFC_respond import AFCprompt
-except:
-    raise error("Error trying to import AFC_respond, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper")
+
+from extras.AFC_utils import ERROR_STR
+
+try: from extras.AFC_respond import AFCprompt
+except: raise error(ERROR_STR.format(import_lib="AFC_respond", trace=traceback.format_exc()))
 
 class afcUnit:
     def __init__(self, config):

--- a/extras/AFC_utils.py
+++ b/extras/AFC_utils.py
@@ -5,10 +5,10 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
 # File is used to hold common functions that can be called from anywhere and don't belong to a class
+import traceback
 import json
-from sys import settrace
 
-from urllib import request
+from datetime import datetime
 from urllib.request import (
     Request,
     urlopen
@@ -17,6 +17,8 @@ from urllib.parse import (
     urlencode,
     urljoin
 )
+
+ERROR_STR = "Error trying to import {import_lib}, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper\n\n{trace}"
 
 def add_filament_switch( switch_name, switch_pin, printer ):
     """
@@ -45,45 +47,136 @@ def add_filament_switch( switch_name, switch_pin, printer ):
 
     return fila
 
+def check_and_return( value_str:str, data_values:dict ) -> str:
+    """
+    Common function to check if value exists in dictionary and returns value if it does.
+
+    :param value_str: Key string to check if value exists in dictionary
+    :param data_values: Dictionary of values to check for key
+
+    :return: Returns string of value if found in dictionary
+    """
+    value = "0"
+    if value_str in data_values:
+        value = data_values[value_str]
+
+    return value
+
 class AFC_moonraker:
-    def __init__(self, port, logger):
-        self.port = port
-        self.logger = logger
-        self.local_host = 'http://localhost{port}'.format( port=port )
-        self.database_url = urljoin(self.local_host, "server/database/item")
-        self.data_array = {"namespace":"afc_stats", "key":"", "value":""}
+    """
+    This class is used to communicate with moonraker to look up information and post
+    data into moonrakers database
+
+    Parameters
+    ----------------
+    port: String
+        Port to connect to moonrakers localhost
+    logger: AFC_logger
+        AFC logger object to log and print to console
+    """
+    ERROR_STRING = "Error getting data from moonraker, check AFC.log for more information"
+    def __init__(self, port:str, logger:object):
+        self.port           = port
+        self.logger         = logger
+        self.local_host     = 'http://localhost{port}'.format( port=port )
+        self.database_url   = urljoin(self.local_host, "server/database/item")
+        self.data_array     = {"namespace":"afc_stats", "key":"", "value":""}
+        self.afc_stats      = None
+        self.last_stats_time= None
 
     def _get_results(self, url_string):
-        try:
-            resp = json.load(urlopen(url_string))
-        except:
-            resp = None
-        return resp        
+        """
+        Helper function to get results, check for errors and return data if successful
 
-    def get_spoolman_server(self):
+        :param url_string: URL encoded string to fetch/post data to moonraker
+
+        :returns: Returns result dictionary if data is valid , returns None if and error occurred
+        """
+        data = None
+        try:
+            resp = urlopen(url_string)
+            if resp.status >= 200 and resp.status <= 300:
+                data = json.load(resp)
+            else:
+                self.logger.error(self.ERROR_STRING)
+                self.logger.debug(f"Response: {resp.status} Reason: {resp.reason}")
+        except:
+            self.logger.error(f"{self.ERROR_STR}\n{traceback.format_exc()}")
+            data = None
+        return data['result']
+
+    def get_spoolman_server(self)->str:
+        """
+        Queries moonraker to see if spoolman is configured, returns True when
+        spoolman is configured
+
+        :returns: Returns string for spoolmans IP, returns None if its not configured
+        """
         resp = self._get_results(urljoin(self.local_host, 'server/config'))
-        if resp is not None:
-            return resp['result']['orig']['spoolman']['server']     # check for spoolman and grab url
+        # Check to make sure response is valid and spoolman exists in dictionary
+        if resp is not None and 'orig' in resp and 'spoolman' in resp['orig']:
+            return resp['orig']['spoolman']['server']     # check for spoolman and grab url
         else:
+            self.logger.debug("Spoolman server is not defined")
             return None
 
-    def get_file_filament_change_count(self, filename ):
+    def get_file_filament_change_count(self, filename:str ):
+        """
+        Queries moonraker for files metadata and returns filament change count
+
+        :param filename: Filename to query moonraker and pull metadata
+        :return: Returns number of filament change counts if `filament_change_count` is in metadata.
+                 Returns zero if not found in metadata.
+        """
         change_count = 0
         resp = self._get_results(urljoin(self.local_host, 'server/files/metadata?filename={}'.format(filename)))
-        if resp is not None and 'filament_change_count' in resp['result']:
-            change_count =  resp['result']['filament_change_count']
+        if resp is not None and 'filament_change_count' in resp:
+            change_count =  resp['filament_change_count']
+        else:
+            self.logger.debug(f"Metadata not found for file:{filename}")
         return change_count
-    
+
     def get_afc_stats(self):
+        """
+        Queries moonraker database for all `afc_stats` entries and returns results if afc_stats exist.
+        Function also caches results and refetches data if cache is older than 60s. This is done to help
+        cut down on how much data is fetched from moonraker.
+
+        :return: Dictionary of afc_stats entries, None if afc_stats entry does not exist
+        """
         resp = None
-        req = Request(self.database_url)
-        resp = self._get_results(urljoin(self.database_url, "?namespace=afc_stats"))
-        if resp is None:
-            self.logger.info("AFC_stats not in database")
-        
-        return resp
-    
+        # Initially set to True since first time data always needs to be fetched
+        refetch_data = True
+        current_time = datetime.now()
+
+        # Check to see if data is older than 60 seconds and refreshes
+        if self.last_stats_time is not None:
+            refetch_data = False
+            delta = current_time - self.last_stats_time
+            if delta.seconds > 60:
+                refetch_data = True
+                self.last_stats_time = current_time
+        else:
+            self.last_stats_time = datetime.now()
+
+        # Cache results to keep queries to moonraker down
+        if self.afc_stats is None or refetch_data:
+            resp = self._get_results(urljoin(self.database_url, "?namespace=afc_stats"))
+            if resp is not None:
+                self.afc_stats = resp
+            else:
+                self.logger.debug("AFC_stats not in database")
+
+        return self.afc_stats
+
     def update_afc_stats(self, key, value):
+        """
+        Updates afc_stats in moonrakers database with key, value pair
+
+        :param key: The key indicating the field where the value should be inserted
+        :param value: The value to insert into the database
+        """
+        resp = None
         post_payload = {
             "request_method": "POST",
             "namespace": "afc_stats",
@@ -91,130 +184,29 @@ class AFC_moonraker:
             "value": value
         }
         req = Request(self.database_url, urlencode(post_payload).encode())
-        resp = self._get_results(req)
-    
-    def get_spool(self, id):
 
+        resp = self._get_results(req)
+        if resp is None:
+            self.logger.error(f"Error when trying to update {key} in moonraker, see AFC.log for more info")
+
+    def get_spool(self, id:int):
+        """
+        Uses moonrakers proxy to query spoolID from spoolman
+
+        :param id: SpoolID to lookup and fetch data from spoolman
+        :return: Returns dictionary of spoolID, returns None if error occurred or ID does not exist
+        """
+        resp = None
         request_payload = {
             "request_method": "GET",
             "path": f"/v1/spool/{id}"
         }
-        spool_url = urljoin(self.local_host, f'server/spoolman/proxy')
+        spool_url = urljoin(self.local_host, 'server/spoolman/proxy')
         req = Request( spool_url, urlencode(request_payload).encode() )
+
         resp = self._get_results(req)
-        return resp['result']
-
-def check_and_return( value_str, data_values ):
-    value = 0
-    if value_str in data_values:
-        value = data_values[value_str]
-    
-    return value
-
-class AFCStats_var:
-    def __init__(self, parent_name, name, data, moonraker):
-        self.parent_name = parent_name
-        self.name        = name
-        self.moonraker   = moonraker
-
-        if data is not None and self.parent_name in data:
-            self._value = check_and_return( self.name, data[self.parent_name])
+        if resp is not None:
+            resp = resp
         else:
-            self._value = 0
-            self.update_database()
-    @property
-    def value(self):
-        return self._value
-    @value.setter
-    def value(self, value):
-        self._value = value
-        self.update_database()
-    
-    def increase_count(self):
-        self.value += 1
-        self.update_database()
-    
-    def reset_count(self):
-        self.value = 0
-        self.update_database()
-    
-    def update_database(self):
-        self.moonraker.update_afc_stats(f"{self.parent_name}.{self.name}", self.value)
-        return
-    
-    def set_current_time(self):
-        from datetime import datetime
-        time = datetime.now()
-        self._value = time.strftime("%Y-%m-%d %H:%M")
-        self.update_database()
-
-class AFCStats:
-    def __init__(self, moonraker):
-        
-        self.moonraker = moonraker
-        afc_stats = self.moonraker.get_afc_stats()
-        
-        if afc_stats is not None:
-            values = ["values"]
-        else:
-            values = None
-
-        self.tc_total           = AFCStats_var("toolchange_count", "total", values, self.moonraker)
-        self.tc_tool_unload     = AFCStats_var("toolchange_count", "tool_unload", values, self.moonraker)
-        self.tc_tool_load       = AFCStats_var("toolchange_count", "tool_load", values, self.moonraker)
-        self.tc_without_error   = AFCStats_var("toolchange_count", "changes_without_error", values, self.moonraker)
-        self.tc_last_load_error = AFCStats_var("toolchange_count", "last_load_error", values, self.moonraker) # TimeDateValue
-        
-        if self.tc_last_load_error.value == 0:
-            self.tc_last_load_error.set_current_time()
-
-        self.cut_total                  = AFCStats_var("cut", "cut_total", values, self.moonraker)
-        self.cut_total_since_changed    = AFCStats_var("cut", "cut_total_since_changed", values, self.moonraker)
-        self.last_blade_changed         = AFCStats_var("cut", "last_blade_changed", values, self.moonraker)
-        # self.cut_threshold_for_warning  = AFCStats_var("cut", "cut_total", values, self.moonraker)
-
-        self.average_toolchange_time    = AFCStats_var("average_time", "tool_change", values, self.moonraker)
-        self.average_tool_unload_time   = AFCStats_var("average_time", "tool_unload", values, self.moonraker)
-        self.average_tool_load_time     = AFCStats_var("average_time", "tool_load",   values, self.moonraker)
-
-    def print_stats(self, afc_obj):
-        
-        print_str  = f"{'':{'-'}<87}\n"
-        print_str += f"|{'Toolchanges':{' '}^42}|{'Cut':{' '}^42}|\n"
-        print_str += f"|{'':{'-'}<85}|\n"
-        print_str += f"|{'Total':{' '}>22} : {self.tc_total.value:{' '}<17}|{'Total':{' '}>22} : {self.cut_total.value:{''}<17}|\n"
-        print_str += f"|{'Tool Unload':{' '}>22} : {self.tc_tool_unload.value:{' '}<17}|{'Total since changed':{' '}>22} : {self.cut_total_since_changed.value:{''}<17}|\n"
-        print_str += f"|{'Tool Load':{' '}>22} : {self.tc_tool_load.value:{' '}<17}|{'Blade last changed':{' '}>22} : {self.last_blade_changed.value:{''}<17}|\n"
-        print_str += f"|{'Changes without error':{' '}>22} : {self.tc_without_error.value:{' '}<17}|{'':{''}<42}|\n"
-        print_str += f"|{'Last error date':{' '}>22} : {self.tc_last_load_error.value:{' '}<17}|{'':{''}<42}|\n"
-        print_str += f"{'':{'-'}<87}\n"
-
-        for lane in afc_obj.lanes.values():
-            print_str += f"| {lane.name:{' '}>7} : N20 runtime: {lane.lane_stats.n20_runtime.value:{' '}>6}                Lane change count: {lane.lane_stats.lane_change_count.value:{' '}>6}\n"
-        afc_obj.logger.raw(print_str)
-
-
-# toolchange_count
-#   total
-#   tool_load
-#   tool_unload
-#   without_error
-#   last_load_error
-# cut_count
-#   total
-#   cut_count_since_changed
-#   last_blade_changed
-#   number_cut_for_warning - warn user when they are 1000 cuts away
-# average_toolchange_time
-#   tool_load
-#   tool_unload
-
-# Lane specific
-#   n20_runtime_per_lane
-#     lane1
-#     lane2
-#     etc....
-#   change_count_per_lane
-#     lane1
-#     lane2
-#     etc....
+            self.logger.info(f"SpoolID: {id} not found")
+        return resp

--- a/extras/AFC_utils.py
+++ b/extras/AFC_utils.py
@@ -6,15 +6,17 @@
 
 # File is used to hold common functions that can be called from anywhere and don't belong to a class
 import json
-try:
-    from urllib.request import urlopen
-    import urllib.request as request
-    import urllib.parse as urlparse
-except:
-    # Python 2.7 support
-    from urllib2 import urlopen
-    import urlparse
+from sys import settrace
 
+from urllib import request
+from urllib.request import (
+    Request,
+    urlopen
+)
+from urllib.parse import (
+    urlencode,
+    urljoin
+)
 
 def add_filament_switch( switch_name, switch_pin, printer ):
     """
@@ -48,7 +50,7 @@ class AFC_moonraker:
         self.port = port
         self.logger = logger
         self.local_host = 'http://localhost{port}'.format( port=port )
-        self.database_url = urlparse.urljoin(self.local_host, "server/database/item")
+        self.database_url = urljoin(self.local_host, "server/database/item")
         self.data_array = {"namespace":"afc_stats", "key":"", "value":""}
 
     def _get_results(self, url_string):
@@ -59,7 +61,7 @@ class AFC_moonraker:
         return resp        
 
     def get_spoolman_server(self):
-        resp = self._get_results(urlparse.urljoin(self.local_host, 'server/config'))
+        resp = self._get_results(urljoin(self.local_host, 'server/config'))
         if resp is not None:
             return resp['result']['orig']['spoolman']['server']     # check for spoolman and grab url
         else:
@@ -67,34 +69,152 @@ class AFC_moonraker:
 
     def get_file_filament_change_count(self, filename ):
         change_count = 0
-        resp = self._get_results(urlparse.urljoin(self.local_host, 'server/files/metadata?filename={}'.format(filename)))
+        resp = self._get_results(urljoin(self.local_host, 'server/files/metadata?filename={}'.format(filename)))
         if resp is not None and 'filament_change_count' in resp['result']:
             change_count =  resp['result']['filament_change_count']
         return change_count
     
     def get_afc_stats(self):
-
-        req = request.Request(self.database_url)
-        resp = self._get_results(urlparse.urljoin(self.database_url, "?namespace=afc_stats"))
+        resp = None
+        req = Request(self.database_url)
+        resp = self._get_results(urljoin(self.database_url, "?namespace=afc_stats"))
         if resp is None:
             self.logger.info("AFC_stats not in database")
+        
+        return resp
+    
+    def update_afc_stats(self, key, value):
+        post_payload = {
+            "request_method": "POST",
+            "namespace": "afc_stats",
+            "key": key,
+            "value": value
+        }
+        req = Request(self.database_url, urlencode(post_payload).encode())
+        resp = self._get_results(req)
+    
+    def get_spool(self, id):
+
+        request_payload = {
+            "request_method": "GET",
+            "path": f"/v1/spool/{id}"
+        }
+        spool_url = urljoin(self.local_host, f'server/spoolman/proxy')
+        req = Request( spool_url, urlencode(request_payload).encode() )
+        resp = self._get_results(req)
+        return resp['result']
+
+def check_and_return( value_str, data_values ):
+    value = 0
+    if value_str in data_values:
+        value = data_values[value_str]
+    
+    return value
+
+class AFCStats_var:
+    def __init__(self, parent_name, name, data, moonraker):
+        self.parent_name = parent_name
+        self.name        = name
+        self.moonraker   = moonraker
+
+        if data is not None and self.parent_name in data:
+            self._value = check_and_return( self.name, data[self.parent_name])
+        else:
+            self._value = 0
+            self.update_database()
+    @property
+    def value(self):
+        return self._value
+    @value.setter
+    def value(self, value):
+        self._value = value
+        self.update_database()
+    
+    def increase_count(self):
+        self.value += 1
+        self.update_database()
+    
+    def reset_count(self):
+        self.value = 0
+        self.update_database()
+    
+    def update_database(self):
+        self.moonraker.update_afc_stats(f"{self.parent_name}.{self.name}", self.value)
+        return
+    
+    def set_current_time(self):
+        from datetime import datetime
+        time = datetime.now()
+        self._value = time.strftime("%Y-%m-%d %H:%M")
+        self.update_database()
+
+class AFCStats:
+    def __init__(self, moonraker):
+        
+        self.moonraker = moonraker
+        afc_stats = self.moonraker.get_afc_stats()
+        
+        if afc_stats is not None:
+            values = ["values"]
+        else:
+            values = None
+
+        self.tc_total           = AFCStats_var("toolchange_count", "total", values, self.moonraker)
+        self.tc_tool_unload     = AFCStats_var("toolchange_count", "tool_unload", values, self.moonraker)
+        self.tc_tool_load       = AFCStats_var("toolchange_count", "tool_load", values, self.moonraker)
+        self.tc_without_error   = AFCStats_var("toolchange_count", "changes_without_error", values, self.moonraker)
+        self.tc_last_load_error = AFCStats_var("toolchange_count", "last_load_error", values, self.moonraker) # TimeDateValue
+        
+        if self.tc_last_load_error.value == 0:
+            self.tc_last_load_error.set_current_time()
+
+        self.cut_total                  = AFCStats_var("cut", "cut_total", values, self.moonraker)
+        self.cut_total_since_changed    = AFCStats_var("cut", "cut_total_since_changed", values, self.moonraker)
+        self.last_blade_changed         = AFCStats_var("cut", "last_blade_changed", values, self.moonraker)
+        # self.cut_threshold_for_warning  = AFCStats_var("cut", "cut_total", values, self.moonraker)
+
+        self.average_toolchange_time    = AFCStats_var("average_time", "tool_change", values, self.moonraker)
+        self.average_tool_unload_time   = AFCStats_var("average_time", "tool_unload", values, self.moonraker)
+        self.average_tool_load_time     = AFCStats_var("average_time", "tool_load",   values, self.moonraker)
+
+    def print_stats(self, afc_obj):
+        
+        print_str  = f"{'':{'-'}<87}\n"
+        print_str += f"|{'Toolchanges':{' '}^42}|{'Cut':{' '}^42}|\n"
+        print_str += f"|{'':{'-'}<85}|\n"
+        print_str += f"|{'Total':{' '}>22} : {self.tc_total.value:{' '}<17}|{'Total':{' '}>22} : {self.cut_total.value:{''}<17}|\n"
+        print_str += f"|{'Tool Unload':{' '}>22} : {self.tc_tool_unload.value:{' '}<17}|{'Total since changed':{' '}>22} : {self.cut_total_since_changed.value:{''}<17}|\n"
+        print_str += f"|{'Tool Load':{' '}>22} : {self.tc_tool_load.value:{' '}<17}|{'Blade last changed':{' '}>22} : {self.last_blade_changed.value:{''}<17}|\n"
+        print_str += f"|{'Changes without error':{' '}>22} : {self.tc_without_error.value:{' '}<17}|{'':{''}<42}|\n"
+        print_str += f"|{'Last error date':{' '}>22} : {self.tc_last_load_error.value:{' '}<17}|{'':{''}<42}|\n"
+        print_str += f"{'':{'-'}<87}\n"
+
+        for lane in afc_obj.lanes.values():
+            print_str += f"| {lane.name:{' '}>7} : N20 runtime: {lane.lane_stats.n20_runtime.value:{' '}>6}                Lane change count: {lane.lane_stats.lane_change_count.value:{' '}>6}\n"
+        afc_obj.logger.raw(print_str)
+
 
 # toolchange_count
 #   total
 #   tool_load
 #   tool_unload
+#   without_error
+#   last_load_error
 # cut_count
 #   total
 #   cut_count_since_changed
-# last_blade_changed
-# n20_runtime_per_lane
-#   lane1
-#   lane2
-#   etc....
+#   last_blade_changed
+#   number_cut_for_warning - warn user when they are 1000 cuts away
 # average_toolchange_time
 #   tool_load
 #   tool_unload
-# change_count_per_lane
-#   lane1
-#   lane2
-#   etc....
+
+# Lane specific
+#   n20_runtime_per_lane
+#     lane1
+#     lane2
+#     etc....
+#   change_count_per_lane
+#     lane1
+#     lane2
+#     etc....

--- a/extras/AFC_utils.py
+++ b/extras/AFC_utils.py
@@ -5,6 +5,16 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
 # File is used to hold common functions that can be called from anywhere and don't belong to a class
+import json
+try:
+    from urllib.request import urlopen
+    import urllib.request as request
+    import urllib.parse as urlparse
+except:
+    # Python 2.7 support
+    from urllib2 import urlopen
+    import urlparse
+
 
 def add_filament_switch( switch_name, switch_pin, printer ):
     """
@@ -32,3 +42,59 @@ def add_filament_switch( switch_name, switch_pin, printer ):
     fila.runout_helper.runout_pause = False
 
     return fila
+
+class AFC_moonraker:
+    def __init__(self, port, logger):
+        self.port = port
+        self.logger = logger
+        self.local_host = 'http://localhost{port}'.format( port=port )
+        self.database_url = urlparse.urljoin(self.local_host, "server/database/item")
+        self.data_array = {"namespace":"afc_stats", "key":"", "value":""}
+
+    def _get_results(self, url_string):
+        try:
+            resp = json.load(urlopen(url_string))
+        except:
+            resp = None
+        return resp        
+
+    def get_spoolman_server(self):
+        resp = self._get_results(urlparse.urljoin(self.local_host, 'server/config'))
+        if resp is not None:
+            return resp['result']['orig']['spoolman']['server']     # check for spoolman and grab url
+        else:
+            return None
+
+    def get_file_filament_change_count(self, filename ):
+        change_count = 0
+        resp = self._get_results(urlparse.urljoin(self.local_host, 'server/files/metadata?filename={}'.format(filename)))
+        if resp is not None and 'filament_change_count' in resp['result']:
+            change_count =  resp['result']['filament_change_count']
+        return change_count
+    
+    def get_afc_stats(self):
+
+        req = request.Request(self.database_url)
+        resp = self._get_results(urlparse.urljoin(self.database_url, "?namespace=afc_stats"))
+        if resp is None:
+            self.logger.info("AFC_stats not in database")
+
+# toolchange_count
+#   total
+#   tool_load
+#   tool_unload
+# cut_count
+#   total
+#   cut_count_since_changed
+# last_blade_changed
+# n20_runtime_per_lane
+#   lane1
+#   lane2
+#   etc....
+# average_toolchange_time
+#   tool_load
+#   tool_unload
+# change_count_per_lane
+#   lane1
+#   lane2
+#   etc....

--- a/extras/AFC_utils.py
+++ b/extras/AFC_utils.py
@@ -101,7 +101,7 @@ class AFC_moonraker:
                 self.logger.error(self.ERROR_STRING)
                 self.logger.debug(f"Response: {resp.status} Reason: {resp.reason}")
         except:
-            self.logger.error(f"{self.ERROR_STR}\n{traceback.format_exc()}")
+            self.logger.error(f"{self.ERROR_STRING}\n{traceback.format_exc()}")
             data = None
         return data['result']
 

--- a/extras/AFC_utils.py
+++ b/extras/AFC_utils.py
@@ -80,7 +80,7 @@ class AFC_moonraker:
         self.logger         = logger
         self.local_host     = 'http://localhost{port}'.format( port=port )
         self.database_url   = urljoin(self.local_host, "server/database/item")
-        self.data_array     = {"namespace":"afc_stats", "key":"", "value":""}
+        self.afc_stats_key  = "afc_stats"
         self.afc_stats      = None
         self.last_stats_time= None
 
@@ -103,7 +103,7 @@ class AFC_moonraker:
         except:
             self.logger.error(f"{self.ERROR_STRING}\n{traceback.format_exc()}")
             data = None
-        return data['result']
+        return data['result'] if data is not None else data
 
     def get_spoolman_server(self)->str:
         """
@@ -161,7 +161,7 @@ class AFC_moonraker:
 
         # Cache results to keep queries to moonraker down
         if self.afc_stats is None or refetch_data:
-            resp = self._get_results(urljoin(self.database_url, "?namespace=afc_stats"))
+            resp = self._get_results(urljoin(self.database_url, f"?namespace={self.afc_stats_key}"))
             if resp is not None:
                 self.afc_stats = resp
             else:
@@ -179,7 +179,7 @@ class AFC_moonraker:
         resp = None
         post_payload = {
             "request_method": "POST",
-            "namespace": "afc_stats",
+            "namespace": self.afc_stats_key,
             "key": key,
             "value": value
         }

--- a/extras/AFC_utils.py
+++ b/extras/AFC_utils.py
@@ -101,7 +101,7 @@ class AFC_moonraker:
                 self.logger.error(self.ERROR_STRING)
                 self.logger.debug(f"Response: {resp.status} Reason: {resp.reason}")
         except:
-            self.logger.error(f"{self.ERROR_STRING}\n{traceback.format_exc()}")
+            self.logger.error(self.ERROR_STRING, traceback=traceback.format_exc())
             data = None
         return data['result'] if data is not None else data
 


### PR DESCRIPTION
## Major Changes in this PR
- Added statistics tracking for tool load/unload/total change, n20 runtime, number of cuts
- Added ability to track when last blade was changed and how many cuts since last changed
- Added ability to track when last load error occurred and how many successful changes since last failure
- Statistics are stored in moonrakers database
- Added AFC_STATS macro to print statistics out
- Added AFC_CHANGE_BLADE macro for when users change blade as this reset count and date changed
- Added AFC_RESET_MOTOR_TIME macro added to allow users to reset N20 active time if motor was replaced in a lane
- Added common class for easily interacting with moonraker api
- Updated to use moonrakers proxy when fetching spoolmans data
- Added getting toolchange count from moonrakers file metadata, SET_AFC_TOOLCHANGES will be deprecated
- Updated import error message to pull from a common error string in AFC_utils.py file
- Added clearing pause in klipper when starting a print
- Added warning message when number of cuts is within 1K of `tool_cut_threshold` value
- Added error message when number of cuts is over `tool_cut_threshold`
- Fixed issue where virtual bypass was being set for newly installed instances of AFC

This closes #390, closes #384, closes #347

## Notes to Code Reviewers
Major changes are in the following files:
AFC_stats.py(new file), AFC_utils.py, AFC.py, and AFC_assist.py

## How the changes in this PR are tested
Ran through toolchanges to verify that values updated and were pushed to moonrakers database

`AFC_STAT` printout
![image](https://github.com/user-attachments/assets/cc940c13-4666-40e1-b2ba-1d54589b89d0)

`AFT_STAT SHORT=1` printout
![image](https://github.com/user-attachments/assets/d80edc07-f44a-4ca6-a670-400f08a32aeb)

Warning to user for blade cut count almost to their set threshold
![image](https://github.com/user-attachments/assets/9e0b4c40-d906-4437-9e33-23621605a452)

Error to user letting them know that blade cut count is more than their set threshold
![image](https://github.com/user-attachments/assets/f95a523c-9a9d-494f-965b-e58220d490ba)

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design channel requesting review
