### PR TITLE
[Enhancement] macro to toggle other macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2025-05-21]
 ### Added
-- new macro `TOGGLE_MACRO` to enable disable other macros.
+- new macro `AFC_TOGGLE_MACRO` to enable disable other macros.
 
 
 ## [2025-05-15]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-05-21]
+### Added
+- new macro `TOGGLE_MACRO` to enable disable other macros.
+
+
 ## [2025-05-15]
 ### Added
 - added quiet mode support. `quiet_moves_speed` on `AFC.cfg` dictates the max speed when quiet mode is enabled.

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -264,7 +264,7 @@ class afc:
             self.quiet_switch = add_filament_switch("filament_switch_sensor quiet_mode", "afc_quiet_mode:afc_quiet_mode", self.printer ).runout_helper
 
         # GCODE REGISTERS
-        self.gcode.register_command('AFC_TOGGLE_MACRO',     self.cmd_AFC_TOGGLE_MACRO,      desc=self.cmd_TOGGLE_MACRO_help)
+        self.gcode.register_command('AFC_TOGGLE_MACRO',     self.cmd_AFC_TOGGLE_MACRO,      desc=self.cmd_AFC_TOGGLE_MACRO_help)
         self.gcode.register_command('AFC_QUIET_MODE',       self.cmd_AFC_QUIET_MODE,        desc=self.cmd_AFC_QUIET_MODE_help)
         self.gcode.register_command('TOOL_UNLOAD',          self.cmd_TOOL_UNLOAD,           desc=self.cmd_TOOL_UNLOAD_help)
         self.gcode.register_command('CHANGE_TOOL',          self.cmd_CHANGE_TOOL,           desc=self.cmd_CHANGE_TOOL_help)

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -264,7 +264,7 @@ class afc:
             self.quiet_switch = add_filament_switch("filament_switch_sensor quiet_mode", "afc_quiet_mode:afc_quiet_mode", self.printer ).runout_helper
 
         # GCODE REGISTERS
-        self.gcode.register_command('TOGGLE_MACRO',         self.cmd_TOGGLE_MACRO,          desc=self.cmd_TOGGLE_MACRO_help)
+        self.gcode.register_command('AFC_TOGGLE_MACRO',     self.cmd_AFC_TOGGLE_MACRO,      desc=self.cmd_TOGGLE_MACRO_help)
         self.gcode.register_command('AFC_QUIET_MODE',       self.cmd_AFC_QUIET_MODE,        desc=self.cmd_AFC_QUIET_MODE_help)
         self.gcode.register_command('TOOL_UNLOAD',          self.cmd_TOOL_UNLOAD,           desc=self.cmd_TOOL_UNLOAD_help)
         self.gcode.register_command('CHANGE_TOOL',          self.cmd_CHANGE_TOOL,           desc=self.cmd_CHANGE_TOOL_help)
@@ -429,19 +429,19 @@ class afc:
             pass
         return False
 
-    cmd_TOGGLE_MACRO_help = "Enable/disable TOOL_CUT/PARK/POOP/KICK/WIPE/FORM_TIP macros"
-    def cmd_TOGGLE_MACRO(self, gcmd):
+    cmd_AFC_TOGGLE_MACRO_help = "Enable/disable TOOL_CUT/PARK/POOP/KICK/WIPE/FORM_TIP macros"
+    def cmd_AFC_TOGGLE_MACRO(self, gcmd):
         """
         Enable/disable TOOL_CUT/PARK/POOP/KICK/WIPE/FORM_TIP macros.
 
         Usage
         -------
-        `TOGGLE_MACRO TOOL_CUT=<0 or 1> PARK=<> POOP=<> KICK=<> WIPE=<0 or 1> FORM_TIP=<0 or 1> `
+        `AFC_TOGGLE_MACRO TOOL_CUT=<0/1> PARK=<> POOP=<0/1> KICK=<0/1> WIPE=<0/1> FORM_TIP=<0/1> `
 
         Example
         -------
         ```
-        TOGGLE_MACRO TOOL_CUT=0
+        AFC_TOGGLE_MACRO TOOL_CUT=0
         ```
         """
         self.tool_cut = bool(gcmd.get_int("TOOL_CUT", self.tool_cut, minval=0, maxval=1))

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -264,7 +264,8 @@ class afc:
             self.quiet_switch = add_filament_switch("filament_switch_sensor quiet_mode", "afc_quiet_mode:afc_quiet_mode", self.printer ).runout_helper
 
         # GCODE REGISTERS
-        self.gcode.register_command('AFC_QUIET_MODE',           self.cmd_AFC_QUIET_MODE,        desc=self.cmd_AFC_QUIET_MODE_help)
+        self.gcode.register_command('TOGGLE_MACRO',         self.cmd_TOGGLE_MACRO,          desc=self.cmd_TOGGLE_MACRO_help)
+        self.gcode.register_command('AFC_QUIET_MODE',       self.cmd_AFC_QUIET_MODE,        desc=self.cmd_AFC_QUIET_MODE_help)
         self.gcode.register_command('TOOL_UNLOAD',          self.cmd_TOOL_UNLOAD,           desc=self.cmd_TOOL_UNLOAD_help)
         self.gcode.register_command('CHANGE_TOOL',          self.cmd_CHANGE_TOOL,           desc=self.cmd_CHANGE_TOOL_help)
         self.gcode.register_command('AFC_STATUS',           self.cmd_AFC_STATUS,            desc=self.cmd_AFC_STATUS_help)
@@ -427,6 +428,32 @@ class afc:
         except:
             pass
         return False
+
+    cmd_TOGGLE_MACRO_help = "Enable/disable TOOL_CUT/PARK/POOP/KICK/WIPE/FORM_TIP macros"
+    def cmd_TOGGLE_MACRO(self, gcmd):
+        """
+        Enable/disable TOOL_CUT/PARK/POOP/KICK/WIPE/FORM_TIP macros.
+
+        Usage
+        -------
+        `TOGGLE_MACRO TOOL_CUT=<0 or 1> PARK=<> POOP=<> KICK=<> WIPE=<0 or 1> FORM_TIP=<0 or 1> `
+
+        Example
+        -------
+        ```
+        TOGGLE_MACRO TOOL_CUT=0
+        ```
+        """
+        self.tool_cut = bool(gcmd.get_int("TOOL_CUT", self.tool_cut, minval=0, maxval=1))
+        self.park = bool(gcmd.get_int("PARK", self.park, minval=0, maxval=1))
+        self.kick = bool(gcmd.get_int("KICK", self.kick, minval=0, maxval=1))
+        self.poop = bool(gcmd.get_int("POOP", self.poop, minval=0, maxval=1))
+        self.wipe = bool(gcmd.get_int("WIPE", self.wipe, minval=0, maxval=1))
+        self.form_tip = bool(gcmd.get_int("FORM_TIP", self.form_tip, minval=0, maxval=1))
+
+        self.logger.info("Tool Cut {}, Park {}".format(self.tool_cut, self.park))
+        self.logger.info("Kick {}, Poop {}".format(self.kick, self.poop))
+        self.logger.info("Wipe {}, Form tip {}".format(self.tool_cut, self.form_tip))
 
 
     cmd_AFC_QUIET_MODE_help = "Set quiet mode speed and enable/disable quiet mode"


### PR DESCRIPTION
## Minor Changes in this PR
https://github.com/ArmoredTurtle/AFC-Klipper-Add-On/issues/403
Allow for the standard AFC macros (PARK, POOP, CUT, BRUSH, HUB_CUT, etc) to be dynamically enabled or disabled without requiring an edit to the file and a klipper restart.

## Notes to Code Reviewers

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design channel requesting review
