### PR TITLE
Validate length input in AFC functions and add dependencies to requir…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-05-24]
+### Fixed
+
+- The calibration routines will now not allow a negative bowden length value to be set. If a negative value is detected, 
+an error message will be displayed and the value will not be set.
+
 ## [2025-05-23]
 ### Updated
 - The `PREP` sequence will now check to ensure the trailing and advance buffer switches are not both triggered. If 

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -817,7 +817,7 @@ class afcFunction:
         """
         Common function to calculate length for afc_bowden_length, afc_unload_bowden_length, and hub_dist
 
-        :param config_length: Current configuration length thats in config file
+        :param config_length: Current configuration length that's in config file
         :param current_length: Current length for bowden or hub_dist
         :param new_length: New length to set, increase(+), decrease(-), or reset to config value
 
@@ -838,6 +838,10 @@ class afcFunction:
             else:
                 length = float(new_length)
 
+        if length < 0:
+            self.afc.error.AFC_error("'{}' is not a valid length. Please check your setup and re-run calibration.".format(length), pause=False)
+            # If length is negative, reset to config value
+            return config_length
         return length
 
     cmd_SET_BOWDEN_LENGTH_help = "Helper to dynamically set length of bowden between hub and toolhead. Pass in HUB if using multiple box turtles"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 ruff==0.6.9
+configfile
+pip~=24.3.1


### PR DESCRIPTION
Closes #354 

## Major Changes in this PR

This pull request introduces a minor fix and an enhancement to the `_calc_length` method in the `extras/AFC_functions.py` file. The changes improve error handling and correct a grammatical error in the method's documentation.

### Documentation Fix:
* Corrected a grammatical error in the docstring for the `_calc_length` method by fixing the contraction "thats" to "that's."

### Error Handling Enhancement:
* Added a check to ensure the calculated `length` is not negative. If it is, an error message is logged using the `AFC_error` method, and the length is reset to the `config_length` value. This prevents invalid lengths from being used.

## Notes to Code Reviewers

Think this is right?

## How the changes in this PR are tested

Not tested :(

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design channel requesting review
