### PR TITLE
[Bug fix] Fixing exclude object bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-05-25]
+### Fixed
+- Exclude object bug where klipper would error out with max extrude error after excluding an object and 
+  trying to do a lane swap or doing TOOL_UNLOAD in PRINT_END function.
+
 ## [2025-05-23]
 ### Updated
 - The `PREP` sequence will now check to ensure the trailing and advance buffer switches are not both triggered. If 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2025-05-25]
 ### Fixed
 - Exclude object bug where klipper would error out with max extrude error after excluding an object and 
-  trying to do a lane swap or doing TOOL_UNLOAD in PRINT_END function.
+  trying to do a lane swap or doing TOOL_UNLOAD in PRINT_END function. Fixes issue [#364](https://github.com/ArmoredTurtle/AFC-Klipper-Add-On/issues/364)
+- Fixing issue [#348](https://github.com/ArmoredTurtle/AFC-Klipper-Add-On/issues/348)
 
 ## [2025-05-23]
 ### Updated

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -566,7 +566,7 @@ class afc:
         :return newpos: Position list with updated z position
         """
         max_z = self.toolhead.get_status(0)['axis_maximum'][2]
-        newpos = self.toolhead.get_position()
+        newpos = self.gcode_move.position_with_transform()
 
         # Determine z movement, get the min value to not exceed max z movement
         newpos[2] = min(max_z - 1, z_amount)
@@ -630,7 +630,7 @@ class afc:
         self.function.log_toolhead_pos("Resume initial pos: ")
 
         self.current_state = State.RESTORING_POS
-        newpos = self.toolhead.get_position()
+        newpos = self.gcode_move.position_with_transform()
 
         # Move toolhead to previous z location with zhop added
         if move_z_first:
@@ -947,7 +947,7 @@ class afc:
             cur_lane.sync_to_extruder()
 
             if cur_extruder.tool_end:
-                pos = self.toolhead.get_position()
+                pos = self.gcode_move.position_with_transform()
                 while not cur_extruder.tool_end_state:
                     tool_attempts += 1
                     pos[3] += cur_lane.short_move_dis
@@ -965,7 +965,7 @@ class afc:
                 self.afcDeltaTime.log_with_time("Filament loaded to post-sensor")
 
             # Adjust tool position for loading.
-            pos = self.toolhead.get_position()
+            pos = self.gcode_move.position_with_transform()
             pos[3] += cur_extruder.tool_stn
             self.toolhead.manual_move(pos, cur_extruder.tool_load_speed)
             self.toolhead.wait_moves()
@@ -1117,7 +1117,7 @@ class afc:
             self.afcDeltaTime.log_with_time("Done heating toolhead")
 
         # Quick pull to prevent oozing.
-        pos = self.toolhead.get_position()
+        pos = self.gcode_move.position_with_transform()
         pos[3] -= 2
         self.toolhead.manual_move(pos, cur_extruder.tool_unload_speed)
         self.toolhead.wait_moves()
@@ -1188,7 +1188,7 @@ class afc:
                     self.logger.info("<span class=warning--text>{}</span>".format(msg))
                     break
             cur_lane.sync_to_extruder(False)
-            pos = self.toolhead.get_position()
+            pos = self.gcode_move.position_with_transform()
             pos[3] -= cur_extruder.tool_stn_unload
             with cur_lane.assist_move(cur_extruder.tool_unload_speed, True, cur_lane.assisted_unload):
                 self.toolhead.manual_move(pos, cur_extruder.tool_unload_speed)
@@ -1210,7 +1210,7 @@ class afc:
                     self.error.handle_lane_failure(cur_lane, message)
                     return False
                 cur_lane.sync_to_extruder()
-                pos = self.toolhead.get_position()
+                pos = self.gcode_move.position_with_transform()
                 pos[3] -= cur_extruder.tool_stn_unload
                 with cur_lane.assist_move(cur_extruder.tool_unload_speed, True, cur_lane.assisted_unload):
                     self.toolhead.manual_move(pos, cur_extruder.tool_unload_speed)
@@ -1220,7 +1220,7 @@ class afc:
 
         # Move filament past the sensor after the extruder, if applicable.
         if cur_extruder.tool_sensor_after_extruder > 0:
-            pos = self.toolhead.get_position()
+            pos = self.gcode_move.position_with_transform()
             pos[3] -= cur_extruder.tool_sensor_after_extruder
             with cur_lane.assist_move(cur_extruder.tool_unload_speed, True, cur_lane.assisted_unload):
                 self.toolhead.manual_move(pos, cur_extruder.tool_unload_speed)

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -656,12 +656,8 @@ class afc:
         """
         newpos = self.gcode_move.last_position
         newpos[3] += e_amount
-        self.function.log_toolhead_pos(f"move_e_pos({log_string}) before: commanded_pos:{newpos} ")
 
         self.gcode_move.move_with_transform(newpos, speed)
-        if wait_tool: self.toolhead.wait_moves()
-
-        self.function.log_toolhead_pos(f"move_e_pos({log_string}) after: ")
 
     def save_pos(self):
         """
@@ -1208,7 +1204,6 @@ class afc:
         pos = self.gcode_move.last_position
         pos[2] += self.z_hop
         self.move_z_pos(pos[2])
-        # self.toolhead.wait_moves()
 
         # Disable the buffer if it's active.
         cur_lane.disable_buffer()

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -657,9 +657,9 @@ class afc:
         newpos = self.gcode_move.last_position
         newpos[3] += e_amount
 
-        if wait_tool: self.toolhead.wait_moves()
-
         self.gcode_move.move_with_transform(newpos, speed)
+
+        if wait_tool: self.toolhead.wait_moves()
 
     def save_pos(self):
         """

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1270,7 +1270,7 @@ class afc:
             with cur_lane.assist_move(cur_extruder.tool_unload_speed, True, cur_lane.assisted_unload):
                 self.move_e_pos( cur_extruder.tool_stn_unload * -1, cur_extruder.tool_unload_speed, "Buffer Move")
 
-            self.function.log_toolhead_pos(f"Buffer move after ")
+            self.function.log_toolhead_pos("Buffer move after ")
         else:
             while cur_lane.get_toolhead_pre_sensor_state() or cur_extruder.tool_end_state:
                 num_tries += 1
@@ -1292,7 +1292,7 @@ class afc:
                 with cur_lane.assist_move(cur_extruder.tool_unload_speed, True, cur_lane.assisted_unload):
                     self.move_e_pos( cur_extruder.tool_stn_unload * -1, cur_extruder.tool_unload_speed, "Sensor move", wait_tool=True)
 
-                self.function.log_toolhead_pos(f"Sensor move after ")
+                self.function.log_toolhead_pos("Sensor move after ")
 
         self.afcDeltaTime.log_with_time("Unloaded from toolhead")
 

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -652,7 +652,7 @@ class afc:
         :param e_amount: Amount to move extruder either positive(extruder) or negative(retract)
         :param speed: Speed to perform move at
         :param log_string: Additional string or name to log to logger when recording toolhead position in log
-        :param wait_tool: Set to False to not wait on toolhead moves
+        :param wait_tool: Set to True to wait on toolhead moves
         """
         newpos = self.gcode_move.last_position
         newpos[3] += e_amount
@@ -1068,6 +1068,7 @@ class afc:
             # Update tool and lane status.
             cur_lane.set_loaded()
             cur_lane.enable_buffer()
+            self.save_vars()
 
             # Activate the tool-loaded LED and handle filament operations if enabled.
             self.function.afc_led(cur_lane.led_tool_loaded, cur_lane.led_index)

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -556,27 +556,43 @@ class afc:
         """
         return self.resume_z_speed if self.resume_z_speed > 0 else self.speed
 
-    def _move_z_pos(self, z_amount):
+    def move_z_pos(self, z_amount):
         """
         Common function helper to move z, also does a check for max z so toolhead does not exceed max height
 
-        :param base_pos: position to apply z amount to
         :param z_amount: amount to add to the base position
 
         :return newpos: Position list with updated z position
         """
         max_z = self.toolhead.get_status(0)['axis_maximum'][2]
-        newpos = self.gcode_move.position_with_transform()
+        newpos = self.gcode_move.last_position
 
         # Determine z movement, get the min value to not exceed max z movement
         newpos[2] = min(max_z - 1, z_amount)
 
         self.gcode_move.move_with_transform(newpos, self._get_resume_speedz())
-        # Update gcode move last position to current position
-        self.gcode_move.reset_last_position()
-        self.function.log_toolhead_pos("_move_z_pos: ")
+
+        self.function.log_toolhead_pos("move_z_pos: ")
 
         return newpos[2]
+
+    def move_e_pos( self, e_amount, speed, log_string="", wait_tool=True):
+        """
+        Common function helper to move extruder position
+
+        :param e_amount: Amount to move extruder either positive(extruder) or negative(retract)
+        :param speed: Speed to perform move at
+        :param log_string: Additional string or name to log to logger when recording toolhead position in log
+        :param wait_tool: Set to False to not wait on toolhead moves
+        """
+        newpos = self.gcode_move.last_position
+        newpos[3] += e_amount
+        self.function.log_toolhead_pos(f"move_e_pos({log_string}) before: commanded_pos:{newpos} ")
+
+        self.gcode_move.move_with_transform(newpos, speed)
+        if wait_tool: self.toolhead.wait_moves()
+
+        self.function.log_toolhead_pos(f"move_e_pos({log_string}) after: ")
 
     def save_pos(self):
         """
@@ -630,11 +646,11 @@ class afc:
         self.function.log_toolhead_pos("Resume initial pos: ")
 
         self.current_state = State.RESTORING_POS
-        newpos = self.gcode_move.position_with_transform()
+        newpos = self.gcode_move.last_position
 
         # Move toolhead to previous z location with zhop added
         if move_z_first:
-            newpos[2] = self._move_z_pos(self.last_gcode_position[2] + self.z_hop)
+            newpos[2] = self.move_z_pos(self.last_gcode_position[2] + self.z_hop)
 
         # Move to previous x,y location
         newpos[:2] = self.last_gcode_position[:2]
@@ -947,12 +963,9 @@ class afc:
             cur_lane.sync_to_extruder()
 
             if cur_extruder.tool_end:
-                pos = self.gcode_move.position_with_transform()
                 while not cur_extruder.tool_end_state:
                     tool_attempts += 1
-                    pos[3] += cur_lane.short_move_dis
-                    self.toolhead.manual_move(pos, cur_extruder.tool_load_speed)
-                    self.toolhead.wait_moves()
+                    self.move_e_pos( cur_lane.short_move_dis, cur_extruder.tool_load_speed, "Tool end" )
                     if tool_attempts > 20:
                         message = 'filament failed to trigger post extruder gear toolhead sensor, CHECK FILAMENT PATH\n||=====||====||==>--||\nTRG   LOAD   HUB   TOOL'
                         message += '\nTo resolve set lane loaded with `SET_LANE_LOADED LANE={}` macro.'.format(cur_lane.name)
@@ -965,10 +978,7 @@ class afc:
                 self.afcDeltaTime.log_with_time("Filament loaded to post-sensor")
 
             # Adjust tool position for loading.
-            pos = self.gcode_move.position_with_transform()
-            pos[3] += cur_extruder.tool_stn
-            self.toolhead.manual_move(pos, cur_extruder.tool_load_speed)
-            self.toolhead.wait_moves()
+            self.move_e_pos( cur_extruder.tool_stn, cur_extruder.tool_load_speed, "tool stn" )
 
             self.afcDeltaTime.log_with_time("Filament loaded to nozzle")
 
@@ -1117,17 +1127,14 @@ class afc:
             self.afcDeltaTime.log_with_time("Done heating toolhead")
 
         # Quick pull to prevent oozing.
-        pos = self.gcode_move.position_with_transform()
-        pos[3] -= 2
-        self.toolhead.manual_move(pos, cur_extruder.tool_unload_speed)
-        self.toolhead.wait_moves()
-
+        self.move_e_pos( -2, cur_extruder.tool_unload_speed, "Quick Pull", wait_tool=False)
         self.function.log_toolhead_pos("TOOL_UNLOAD quick pull: ")
 
         # Perform Z-hop to avoid collisions during unloading.
+        pos = self.gcode_move.last_position
         pos[2] += self.z_hop
-        self._move_z_pos(pos[2])
-        self.toolhead.wait_moves()
+        self.move_z_pos(pos[2])
+        # self.toolhead.wait_moves()
 
         # Disable the buffer if it's active.
         cur_lane.disable_buffer()
@@ -1188,11 +1195,10 @@ class afc:
                     self.logger.info("<span class=warning--text>{}</span>".format(msg))
                     break
             cur_lane.sync_to_extruder(False)
-            pos = self.gcode_move.position_with_transform()
-            pos[3] -= cur_extruder.tool_stn_unload
             with cur_lane.assist_move(cur_extruder.tool_unload_speed, True, cur_lane.assisted_unload):
-                self.toolhead.manual_move(pos, cur_extruder.tool_unload_speed)
-                self.toolhead.wait_moves()
+                self.move_e_pos( cur_extruder.tool_stn_unload * -1, cur_extruder.tool_unload_speed, "Buffer Move")
+
+            self.function.log_toolhead_pos(f"Buffer move after ")
         else:
             while cur_lane.get_toolhead_pre_sensor_state() or cur_extruder.tool_end_state:
                 num_tries += 1
@@ -1210,21 +1216,18 @@ class afc:
                     self.error.handle_lane_failure(cur_lane, message)
                     return False
                 cur_lane.sync_to_extruder()
-                pos = self.gcode_move.position_with_transform()
-                pos[3] -= cur_extruder.tool_stn_unload
+
                 with cur_lane.assist_move(cur_extruder.tool_unload_speed, True, cur_lane.assisted_unload):
-                    self.toolhead.manual_move(pos, cur_extruder.tool_unload_speed)
-                    self.toolhead.wait_moves()
+                    self.move_e_pos( cur_extruder.tool_stn_unload * -1, cur_extruder.tool_unload_speed, "Sensor move")
+
+                self.function.log_toolhead_pos(f"Sensor move after ")
 
         self.afcDeltaTime.log_with_time("Unloaded from toolhead")
 
         # Move filament past the sensor after the extruder, if applicable.
         if cur_extruder.tool_sensor_after_extruder > 0:
-            pos = self.gcode_move.position_with_transform()
-            pos[3] -= cur_extruder.tool_sensor_after_extruder
             with cur_lane.assist_move(cur_extruder.tool_unload_speed, True, cur_lane.assisted_unload):
-                self.toolhead.manual_move(pos, cur_extruder.tool_unload_speed)
-                self.toolhead.wait_moves()
+                self.move_e_pos(cur_extruder.tool_sensor_after_extruder * -1, cur_extruder.tool_unload_speed, "After extruder")
 
             self.afcDeltaTime.log_with_time("Tool sensor after extruder move done")
 

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -165,7 +165,8 @@ class afcError:
 
         # Save current pause state
         temp_is_paused = self.afc.function.is_paused()
-        curr_pos = self.afc.toolhead.get_position()
+        
+        curr_pos = self.afc.gcode_move.position_with_transform()
 
         # Verify that printer is in absolute mode
         self.afc.function.check_absolute_mode("AFC_RESUME")

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -165,8 +165,8 @@ class afcError:
 
         # Save current pause state
         temp_is_paused = self.afc.function.is_paused()
-        
-        curr_pos = self.afc.gcode_move.position_with_transform()
+
+        curr_pos = self.afc.gcode_move.last_position
 
         # Verify that printer is in absolute mode
         self.afc.function.check_absolute_mode("AFC_RESUME")
@@ -174,7 +174,7 @@ class afcError:
         # Check if current position is below saved gcode position, if its lower first raise z above last saved
         #   position so that toolhead does not crash into part
         if curr_pos[2] <= self.afc.last_gcode_position[2]:
-            self.afc._move_z_pos(self.afc.last_gcode_position[2] + self.afc.z_hop)
+            self.afc.move_z_pos(self.afc.last_gcode_position[2] + self.afc.z_hop)
 
         self.logger.debug("AFC_RESUME: Before User Restore")
         self.afc.function.log_toolhead_pos()
@@ -217,7 +217,7 @@ class afcError:
             # Verify that printer is in absolute mode
             self.afc.function.check_absolute_mode("AFC_PAUSE")
             # Move Z up by z-hop value
-            self.afc._move_z_pos(self.afc.last_gcode_position[2] + self.afc.z_hop)
+            self.afc.move_z_pos(self.afc.last_gcode_position[2] + self.afc.z_hop)
             # Call users PAUSE
             self.afc.gcode.run_script_from_command("{macro_name} {user_params}".format(macro_name=self.AFC_RENAME_PAUSE_NAME, user_params=gcmd.get_raw_command_parameters()))
             # Set Idle timeout to 10 hours

--- a/extras/AFC_form_tip.py
+++ b/extras/AFC_form_tip.py
@@ -34,10 +34,7 @@ class afc_tip_form:
 
 
     def afc_extrude(self, distance, speed):
-        pos = self.afc.gcode_move.position_with_transform()
-        pos[3] += distance
-        self.afc.toolhead.manual_move(pos, speed)
-        self.afc.toolhead.wait_moves()
+        self.afc.move_e_post( distance, speed, "form tip")
 
     cmd_TEST_AFC_TIP_FORMING_help = "Gives ability to test AFC tip forming without doing a tool change"
     def cmd_TEST_AFC_TIP_FORMING(self, gcmd):

--- a/extras/AFC_form_tip.py
+++ b/extras/AFC_form_tip.py
@@ -34,7 +34,7 @@ class afc_tip_form:
 
 
     def afc_extrude(self, distance, speed):
-        pos = self.afc.toolhead.get_position()
+        pos = self.afc.gcode_move.position_with_transform()
         pos[3] += distance
         self.afc.toolhead.manual_move(pos, speed)
         self.afc.toolhead.wait_moves()

--- a/extras/AFC_form_tip.py
+++ b/extras/AFC_form_tip.py
@@ -34,7 +34,7 @@ class afc_tip_form:
 
 
     def afc_extrude(self, distance, speed):
-        self.afc.move_e_post( distance, speed, "form tip")
+        self.afc.move_e_pos( distance, speed, "form tip")
 
     cmd_TEST_AFC_TIP_FORMING_help = "Gives ability to test AFC tip forming without doing a tool change"
     def cmd_TEST_AFC_TIP_FORMING(self, gcmd):

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -27,7 +27,7 @@ class afcFunction:
         self.afc      = None
         self.logger   = None
         self.mcu      = None
-
+ 
     def register_lane_macros(self, lane_obj):
         """
         Callback function to register macros with proper lane names so that klipper errors out correctly when users supply lanes names that
@@ -307,6 +307,7 @@ class afcFunction:
         :param move_pre: String that get appended before the position data
         """
         msg = "{}Position: {}".format(move_pre, self.afc.toolhead.get_position())
+        msg += f" position_with_transform {self.afc.gcode_move.position_with_transform()}"
         msg += " base_position: {}".format(self.afc.gcode_move.base_position)
         msg += " last_position: {}".format(self.afc.gcode_move.last_position)
         msg += " homing_position: {}".format(self.afc.gcode_move.homing_position)

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -31,7 +31,7 @@ class afcFunction:
         self.afc      = None
         self.logger   = None
         self.mcu      = None
- 
+
     def register_lane_macros(self, lane_obj):
         """
         Callback function to register macros with proper lane names so that klipper errors out correctly when users supply lanes names that

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -317,10 +317,8 @@ class afcFunction:
         :param move_pre: String that get appended before the position data
         """
         msg = "{}Position: {}".format(move_pre, self.afc.toolhead.get_position())
-        msg += f" position_with_transform {self.afc.gcode_move.position_with_transform()}"
         msg += " base_position: {}".format(self.afc.gcode_move.base_position)
         msg += " last_position: {}".format(self.afc.gcode_move.last_position)
-        msg += " homing_position: {}".format(self.afc.gcode_move.homing_position)
         msg += " speed: {}".format(self.afc.gcode_move.speed)
         msg += " speed_factor: {}".format(self.afc.gcode_move.speed_factor)
         msg += " extrude_factor: {}".format(self.afc.gcode_move.extrude_factor)
@@ -362,7 +360,7 @@ class afcFunction:
 
         if past_extruder_position is None or last_extruder_position > past_extruder_position:
             past_extruder_position = last_extruder_position
-            if last_extruder_position > 0: self.logger.debug("Extruder last position: {}".format(last_extruder_position))
+            # if last_extruder_position > 0: self.logger.debug("Extruder last position: {}".format(last_extruder_position))
             return last_extruder_position
         else:
             return past_extruder_position

--- a/extras/AFC_poop.py
+++ b/extras/AFC_poop.py
@@ -34,14 +34,13 @@ class afc_poop:
         step = 1
         if self.verbose:
             self.logger.info('AFC_Poop: {} Move To Purge Location'.format(step))
-        pooppos = self.afc.gcode_move.position_with_transform()
+        pooppos = self.afc.gcode_move.last_position
         pooppos[0] = float(self.purge_loc_xy.split(',')[0])
         pooppos[1] = float(self.purge_loc_xy.split(',')[1])
-        self.toolhead.manual_move(pooppos, 100)
-        self.toolhead.wait_moves()
+        self.afc.gcode_move.move_with_transform(pooppos, 100)
         pooppos[2] = self.purge_start
-        self.toolhead.manual_move(pooppos, 100)
-        self.toolhead.wait_moves()
+        self.afc.gcode_move.move_with_transform(pooppos, 100)
+
         step +=1
         if self.full_fan:
             if self.verbose:
@@ -61,19 +60,17 @@ class afc_poop:
             raise_z = (self.iteration_z_raise - z_raise_substract) * extrude_ratio
             duration = extrude_amount / self.purge_spd
             speed = raise_z / duration
-            pooppos = self.afc.gcode_move.position_with_transform()
+            pooppos = self.afc.gcode_move.last_position
             pooppos[2] += raise_z
             pooppos[3] += extrude_amount
-            self.toolhead.manual_move(pooppos, speed)
-            self.toolhead.wait_moves()
+            self.afc.gcode_move.move_with_transform(pooppos, speed)
             iteration += 1
         step += 1
         if self.verbose:
             self.logger.info('AFC_Poop: {} Fast Z Lift to keep poop from sticking'.format(step))
-        pooppos = self.afc.gcode_move.position_with_transform()
+        pooppos = self.afc.gcode_move.last_position
         pooppos[2] = self.z_lift
-        self.toolhead.manual_move(pooppos, self.fast_z)
-        self.toolhead.wait_moves()
+        self.afc.gcode_move.move_with_transform(pooppos, self.fast_z)
         step += 1
         if self.full_fan:
             if self.verbose:

--- a/extras/AFC_poop.py
+++ b/extras/AFC_poop.py
@@ -34,7 +34,7 @@ class afc_poop:
         step = 1
         if self.verbose:
             self.logger.info('AFC_Poop: {} Move To Purge Location'.format(step))
-        pooppos = self.toolhead.get_position()
+        pooppos = self.afc.gcode_move.position_with_transform()
         pooppos[0] = float(self.purge_loc_xy.split(',')[0])
         pooppos[1] = float(self.purge_loc_xy.split(',')[1])
         self.toolhead.manual_move(pooppos, 100)
@@ -61,7 +61,7 @@ class afc_poop:
             raise_z = (self.iteration_z_raise - z_raise_substract) * extrude_ratio
             duration = extrude_amount / self.purge_spd
             speed = raise_z / duration
-            pooppos = self.toolhead.get_position()
+            pooppos = self.afc.gcode_move.position_with_transform()
             pooppos[2] += raise_z
             pooppos[3] += extrude_amount
             self.toolhead.manual_move(pooppos, speed)
@@ -70,7 +70,7 @@ class afc_poop:
         step += 1
         if self.verbose:
             self.logger.info('AFC_Poop: {} Fast Z Lift to keep poop from sticking'.format(step))
-        pooppos = self.toolhead.get_position()
+        pooppos = self.afc.gcode_move.position_with_transform()
         pooppos[2] = self.z_lift
         self.toolhead.manual_move(pooppos, self.fast_z)
         self.toolhead.wait_moves()


### PR DESCRIPTION
## Major Changes in this PR
- Fixes exclude object bug, closes #364 
- Adding save before macros are called when loading a lane to toolhead, closes #348 

## Notes to Code Reviewers

## How the changes in this PR are tested
Performed test with two multi-color objects and excluded one and made sure print finished successfully

GUI showing print finished without error
![image](https://github.com/user-attachments/assets/93ee6591-9eda-435f-bee6-57bf3320902d)

Print done
![image](https://github.com/user-attachments/assets/1d3eb28c-55b6-425f-9bff-9068f2bc1143)

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design channel requesting review
