### PR TITLE
Update copyright years and add AFC macro commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-05-26]
+### Added
+
+- Added `show_macros` configuration option to the `AFC.cfg` file. This option allows a limited set of internal macros 
+to be displayed in mainsail/fluidd. 
+
 ## [2025-05-25]
 ### Fixed
 - Exclude object bug where klipper would error out with max extrude error after excluding an object and 

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -1,6 +1,6 @@
 # Armored Turtle Automated Filament Control
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import traceback

--- a/extras/AFC_HTLF.py
+++ b/extras/AFC_HTLF.py
@@ -1,6 +1,6 @@
 # Armored Turtle Automated Filament Changer
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import traceback

--- a/extras/AFC_NightOwl.py
+++ b/extras/AFC_NightOwl.py
@@ -1,6 +1,6 @@
 # Armored Turtle Automated Filament Changer
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import traceback

--- a/extras/AFC_assist.py
+++ b/extras/AFC_assist.py
@@ -1,6 +1,6 @@
 # Armored Turtle Automated Filament Changer
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math

--- a/extras/AFC_buffer.py
+++ b/extras/AFC_buffer.py
@@ -1,6 +1,6 @@
 # Armored Turtle Automated Filament Changer
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import traceback

--- a/extras/AFC_dummy_macros.cfg
+++ b/extras/AFC_dummy_macros.cfg
@@ -1,0 +1,51 @@
+[gcode_macro AFC_STATS]
+description: dummy
+gcode:
+    {% set dummy = params.SHORT|default(1) %}
+
+    _AFC_STATS {rawparams}
+
+[gcode_macro AFC_QUIET_MODE]
+description: dummy
+gcode:
+    {% set dummy = params.ENABLE|default(1) %}
+    {% set dummy = params.SPEED|default(50) %}
+
+    _AFC_QUIET_MODE {rawparams}
+
+[gcode_macro AFC_STATUS]
+description: dummy
+gcode:
+    _AFC_STATUS
+
+[gcode_macro TURN_OFF_AFC_LED]
+description: dummy
+gcode:
+    _TURN_OFF_AFC_LED
+
+[gcode_macro TURN_ON_AFC_LED]
+description: dummy
+gcode:
+    _TURN_ON_AFC_LED
+
+[gcode_macro AFC_CHANGE_BLADE]
+description: dummy
+gcode:
+    _AFC_CHANGE_BLADE
+
+[gcode_macro AFC_TOGGLE_MACRO]
+description: dummy
+gcode:
+    {% set dummy = params.TOOL_CUT|default(0)|int %}
+    {% set dummy = params.PARK|default(0)|int %}
+    {% set dummy = params.KICK|default(0)|int %}
+    {% set dummy = params.POOP|default(0)|int %}
+    {% set dummy = params.WIPE|default(0)|int %}
+    {% set dummy = params.FORM_TIP|default(0)|int %}
+
+    _AFC_TOGGLE_MACRO {rawparams}
+
+[gcode_macro UNSET_LANE_LOADED]
+description: dummy
+gcode:
+    _UNSET_LANE_LOADED

--- a/extras/AFC_dummy_macros.cfg
+++ b/extras/AFC_dummy_macros.cfg
@@ -49,3 +49,8 @@ gcode:
 description: dummy
 gcode:
     _UNSET_LANE_LOADED
+
+[gcode_macro AFC_CALIBRATION]
+description: dummy
+gcode:
+    _AFC_CALIBRATION

--- a/extras/AFC_dummy_macros.cfg
+++ b/extras/AFC_dummy_macros.cfg
@@ -1,7 +1,7 @@
 [gcode_macro AFC_STATS]
 description: dummy
 gcode:
-    {% set dummy = params.SHORT|default(1) %}
+    {% set short = params.SHORT|default(1) %}
 
     _AFC_STATS {rawparams}
 

--- a/extras/AFC_dummy_macros.cfg
+++ b/extras/AFC_dummy_macros.cfg
@@ -50,7 +50,3 @@ description: dummy
 gcode:
     _UNSET_LANE_LOADED
 
-[gcode_macro AFC_CALIBRATION]
-description: dummy
-gcode:
-    _AFC_CALIBRATION

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -1,6 +1,6 @@
 # Armored Turtle Automated Filament Changer
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import traceback

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -1,6 +1,6 @@
 # Armored Turtle Automated Filament Changer
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import traceback

--- a/extras/AFC_form_tip.py
+++ b/extras/AFC_form_tip.py
@@ -1,6 +1,6 @@
 # Armored Turtle Automated Filament Changer
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -17,11 +17,18 @@ except: raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".f
 try: from extras.AFC_respond import AFCprompt
 except: raise error(ERROR_STR.format(import_lib="AFC_respond", trace=traceback.format_exc()))
 
+AFC_COMMANDS = {
+    'AFC_CALIBRATION': (
+        'Opens a guided prompt to calibrate AFC lanes and Bowden length.',
+    )
+}
+
 def load_config(config):
     return afcFunction(config)
 
 class afcFunction:
     def __init__(self, config):
+        self.config = config
         self.printer = config.get_printer()
         self.printer.register_event_handler("klippy:connect", self.handle_connect)
         self.printer.register_event_handler("afc_stepper:register_macros",self.register_lane_macros)
@@ -31,6 +38,55 @@ class afcFunction:
         self.afc      = None
         self.logger   = None
         self.mcu      = None
+
+        self._show_macros = True
+        self._register_commands()
+
+    # The below code is modified from the Shaketune project. See attributions at the top of this file.
+    def _register_commands(self):
+        gcode = self.printer.lookup_object('gcode')
+        afc_commands = [
+            ('AFC_CALIBRATION', self.cmd_AFC_CALIBRATION, AFC_COMMANDS['AFC_CALIBRATION']),
+        ]
+
+        # Register AFC macro commands using the official Klipper API (gcode.register_command)
+        # Doing this makes the commands available in Klipper, but they are not shown in the web interfaces
+        # and are only available by typing the full name in the console (like all the other Klipper commands)
+        for name, command, description in afc_commands:
+            gcode.register_command(f'_{name}' if self._show_macros else name, command, desc=description)
+
+        # Then, a hack to inject the macros into Klipper's config system in order to show them in the web
+        # interfaces. This is not a good way to do it, but it's the only way to do it for now to get
+        # a good user experience while using AFC (it's indeed easier to just click a macro button)
+        if self._show_macros:
+            configfile = self.printer.lookup_object('configfile')
+            dirname = os.path.dirname(os.path.realpath(__file__))
+            filename = os.path.join(dirname, 'AFC_dummy_macros.cfg')
+            try:
+                dummy_macros_cfg = configfile.read_config(filename)
+            except Exception as err:
+                raise self.config.error(f'Cannot load AFC dummy macro {filename}') from err
+
+            for gcode_macro in dummy_macros_cfg.get_prefix_sections('gcode_macro '):
+                gcode_macro_name = gcode_macro.get_name()
+
+                # Replace the dummy description by the one from AFC_COMMANDS (to avoid code duplication and define it
+                # in only one place)
+                command = gcode_macro_name.split(' ', 1)[1]
+                description = AFC_COMMANDS.get(command, 'AFC macro')
+                gcode_macro.fileconfig.set(gcode_macro_name, 'description', description)
+
+                # Add the section to the Klipper configuration object with all its options
+                if not self.config.fileconfig.has_section(gcode_macro_name.lower()):
+                    self.config.fileconfig.add_section(gcode_macro_name.lower())
+                for option in gcode_macro.fileconfig.options(gcode_macro_name):
+                    value = gcode_macro.fileconfig.get(gcode_macro_name, option)
+                    self.config.fileconfig.set(gcode_macro_name.lower(), option, value)
+                    # Small trick to ensure the new injected sections are considered valid by Klipper config system
+                    self.config.access_tracking[(gcode_macro_name.lower(), option.lower())] = 1
+
+                # Finally, load the section within the printer objects
+                self.printer.load_object(self.config, gcode_macro_name.lower())
 
     def register_lane_macros(self, lane_obj):
         """
@@ -61,7 +117,6 @@ class afcFunction:
         self.logger = self.afc.logger
         self.mcu = self.printer.lookup_object('mcu')
         self.afc.gcode.register_command('CALIBRATE_AFC',   self.cmd_CALIBRATE_AFC,   desc=self.cmd_CALIBRATE_AFC_help)
-        self.afc.gcode.register_command('AFC_CALIBRATION', self.cmd_AFC_CALIBRATION, desc=self.cmd_AFC_CALIBRATION_help)
         self.afc.gcode.register_command('ALL_CALIBRATION', self.cmd_ALL_CALIBRATION, desc=self.cmd_ALL_CALIBRATION_help)
         self.afc.gcode.register_command('AFC_CALI_COMP',   self.cmd_AFC_CALI_COMP,   desc=self.cmd_AFC_CALI_COMP_help)
         self.afc.gcode.register_command('AFC_CALI_FAIL',   self.cmd_AFC_CALI_FAIL,   desc=self.cmd_AFC_CALI_FAIL_help)

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -1,6 +1,6 @@
 # Armored Turtle Automated Filament Control
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 

--- a/extras/AFC_hub.py
+++ b/extras/AFC_hub.py
@@ -1,6 +1,6 @@
 # Armored Turtle Automated Filament Changer
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import traceback

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -1,6 +1,6 @@
 # Armored Turtle Automated Filament Changer
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math
@@ -25,6 +25,7 @@ class AssistActive(Enum):
     YES = 1
     NO = 2
     DYNAMIC = 3
+
 class SpeedMode(Enum):
     LONG = 1
     SHORT = 2

--- a/extras/AFC_logger.py
+++ b/extras/AFC_logger.py
@@ -1,6 +1,6 @@
 # Armored Turtle Automated Filament Control
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 

--- a/extras/AFC_poop.py
+++ b/extras/AFC_poop.py
@@ -1,6 +1,6 @@
 # Armored Turtle Automated Filament Changer
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -1,6 +1,6 @@
 # Armored Turtle Automated Filament Changer
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 

--- a/extras/AFC_respond.py
+++ b/extras/AFC_respond.py
@@ -1,6 +1,6 @@
 # Armored Turtle Automated Filament Control
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -1,6 +1,6 @@
 # Armored Turtle Automated Filament Changer
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 

--- a/extras/AFC_stats.py
+++ b/extras/AFC_stats.py
@@ -1,6 +1,6 @@
 # Armored Turtle Automated Filament Changer
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import traceback

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -1,6 +1,6 @@
 # Armored Turtle Automated Filament Changer
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -1,6 +1,6 @@
 # Armored Turtle Automated Filament Control
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import traceback

--- a/extras/AFC_utils.py
+++ b/extras/AFC_utils.py
@@ -1,6 +1,6 @@
 # Armored Turtle Automated Filament Changer
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 

--- a/include/buffer_configurations.sh
+++ b/include/buffer_configurations.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Armored Turtle Automated Filament Changer
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 

--- a/include/check_commands.sh
+++ b/include/check_commands.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Armored Turtle Automated Filament Changer
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 

--- a/include/colors.sh
+++ b/include/colors.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Armored Turtle Automated Filament Changer
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 

--- a/include/constants.sh
+++ b/include/constants.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Armored Turtle Automated Filament Changer
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 

--- a/include/install_functions.sh
+++ b/include/install_functions.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Armored Turtle Automated Filament Changer
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
@@ -29,6 +29,9 @@ link_extensions() {
   if [ -d "${klipper_dir}/klippy/extras" ]; then
     for extension in "${afc_path}"/extras/*.py; do
       ln -sf "${afc_path}/extras/$(basename "${extension}")" "${klipper_dir}/klippy/extras/$(basename "${extension}")"
+    done
+    for macro in "${afc_path}"/extras/*.cfg; do
+      ln -sf "${afc_path}/extras/$(basename "${macro}")" "${klipper_dir}/klippy/extras/$(basename "${macro}")"
     done
   else
     export message="AFC Klipper extensions not installed; Klipper extras directory not found."

--- a/include/menus/additional_system_menu.sh
+++ b/include/menus/additional_system_menu.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Armored Turtle Automated Filament Changer
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 

--- a/include/menus/install_menu.sh
+++ b/include/menus/install_menu.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Armored Turtle Automated Filament Changer
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 

--- a/include/menus/main_menu.sh
+++ b/include/menus/main_menu.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Armored Turtle Automated Filament Changer
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 

--- a/include/menus/update_menu.sh
+++ b/include/menus/update_menu.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Armored Turtle Automated Filament Changer
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 

--- a/include/menus/utilities_menu.sh
+++ b/include/menus/utilities_menu.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Armored Turtle Automated Filament Changer
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 

--- a/include/merge_files.sh
+++ b/include/merge_files.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Armored Turtle Automated Filament Changer
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 

--- a/include/uninstall.sh
+++ b/include/uninstall.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Armored Turtle Automated Filament Changer
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 

--- a/include/unit_functions.sh
+++ b/include/unit_functions.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Armored Turtle Automated Filament Changer
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 

--- a/include/update_commands.sh
+++ b/include/update_commands.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Armored Turtle Automated Filament Changer
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 

--- a/include/update_functions.sh
+++ b/include/update_functions.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Armored Turtle Automated Filament Changer
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 

--- a/include/utils.sh
+++ b/include/utils.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Armored Turtle Automated Filament Changer
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 

--- a/install-afc.sh
+++ b/install-afc.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Armored Turtle Automated Filament Changer
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 ruff==0.6.9
+
+pip~=24.3.1
+configfile~=1.2.4

--- a/troubleshooting/afc-debug.sh
+++ b/troubleshooting/afc-debug.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Armored Turtle Automated Filament Changer - Debug Script
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2024-2025 Armored Turtle
 # Licensed under GNU GPLv3
 # Thanks to @Esoterical, @bolliostu, and @dormouse for contributions to the original source / inspiration for this script
 # at https://github.com/Esoterical/voron_canbus/blob/main/troubleshooting/debugging/can_debug.sh


### PR DESCRIPTION
## Major Changes in this PR

This pull request introduces significant enhancements to the Armored Turtle Automated Filament Control (AFC) system, including new functionality, code attribution updates, and copyright adjustments. The most important changes are grouped into functionality improvements, licensing updates, and configuration enhancements.

### Functionality Improvements:
* Introduced a new `show_macros` configuration option in the `AFC.cfg` file, allowing internal macros to be displayed in web interfaces like Mainsail and Fluidd. This includes registering and exposing AFC commands such as `AFC_STATS`, `AFC_QUIET_MODE`, and `AFC_TOGGLE_MACRO` through a combination of Klipper API and configuration file hacks. (`extras/AFC.py`, `extras/AFC_dummy_macros.cfg`, [[1]](diffhunk://#diff-749740ba904c224003143ed84a943eb5885a486b4ec55cd658a5beeea1cd1ff4R37-R66) [[2]](diffhunk://#diff-749740ba904c224003143ed84a943eb5885a486b4ec55cd658a5beeea1cd1ff4L192-R293) [[3]](diffhunk://#diff-dccd47ab37bb2cfc6dc421f0ae1474cc1ed8ebea169814fd96afc57ed00654f2R1-R51)
* Added a dictionary `AFC_COMMANDS` to centralize command descriptions and streamline their registration. (`extras/AFC.py`, [extras/AFC.pyR37-R66](diffhunk://#diff-749740ba904c224003143ed84a943eb5885a486b4ec55cd658a5beeea1cd1ff4R37-R66))
* Enhanced the AFC initialization process to include macro registration and improved configuration handling. (`extras/AFC.py`, [extras/AFC.pyL192-R293](diffhunk://#diff-749740ba904c224003143ed84a943eb5885a486b4ec55cd658a5beeea1cd1ff4L192-R293))

### Licensing Updates:
* Updated copyright headers across multiple files to include the year 2025 and added attribution for code derived from the Shaketune Project, ensuring proper acknowledgment of external contributions. (`extras/AFC.py`, `extras/AFC_BoxTurtle.py`, `extras/AFC_HTLF.py`, `extras/AFC_NightOwl.py`, `extras/AFC_assist.py`, and others)

### Configuration Enhancements:
* Added a new section to the `CHANGELOG.md` documenting the `show_macros` configuration option and its purpose. (`CHANGELOG.md`, [CHANGELOG.mdR8-R13](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R13))

These updates improve the user experience, maintain compliance with licensing requirements, and enhance the configurability of the AFC system.

## Notes to Code Reviewers

So this covers macros that are registered with `register_command`. Not sure how to deal with the ones that use mux.

## How the changes in this PR are tested

![image](https://github.com/user-attachments/assets/9e68fd24-d82f-472b-8fb4-1a5a1e720dd8)

Tested macros and ensured they showed desired info.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design channel requesting review
