### PR TITLE
Add AFC macros and improve command registration in AFC functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-05-27]
+### Added
+- Some AFC macros are now exposed in Mainsail/Fluidd. 
+
 ## [2025-05-25]
 ### Fixed
 - Exclude object bug where klipper would error out with max extrude error after excluding an object and 

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -4,7 +4,6 @@
 #
 
 import json
-import os
 import re
 import traceback
 from configfile import error

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -738,7 +738,7 @@ class afc:
         self.current_state = State.RESTORING_POS
         newpos = self.gcode_move.last_position
 
-        # Move toolhead to previous z location with zhop added
+        # Move toolhead to previous z location with z-hop added
         if move_z_first:
             newpos[2] = self.move_z_pos(self.last_gcode_position[2] + self.z_hop)
 
@@ -776,7 +776,7 @@ class afc:
                   make it more readable for users
         """
 
-        # Return early if prep is not done so that file is not overridden until prep is atleast done
+        # Return early if prep is not done so that file is not overridden until prep is at least done
         if not self.prep_done: return
         str = {}
         for UNIT in self.units.keys():
@@ -1071,7 +1071,7 @@ class afc:
 
             self.afcDeltaTime.log_with_time("Filament loaded to nozzle")
 
-            # Check if ramming is enabled, if it is go through ram load sequence.
+            # Check if ramming is enabled, if it is, go through ram load sequence.
             # Lane will load until Advance sensor is True
             # After the tool_stn distance the lane will retract off the sensor to confirm load and reset buffer
             if cur_extruder.tool_start == "buffer":
@@ -1605,7 +1605,6 @@ class afc:
         web_request.send( {"status:" : {"AFC": str}})
 
     cmd_AFC_STATUS_help = "Return current status of AFC"
-    cmd_AFC_STATUS_options = {"": {}}
     def cmd_AFC_STATUS(self, gcmd):
         """
         This function generates a status message for each unit and lane, indicating the preparation,
@@ -1679,7 +1678,8 @@ class afc:
     cmd_TURN_OFF_AFC_LED_help = "Turns off all LEDs for AFC_led configurations"
     def cmd_TURN_OFF_AFC_LED(self, gcmd: Any) -> None:
         """
-        This macro handles turning off all LEDs for AFC_led configurations. Color for LEDs are saved if colors are changed while they are turned off.
+        This macro handles turning off all LEDs for AFC_led configurations. Color for LEDs are saved if colors
+        are changed while they are turned off.
 
         Usage
         -----
@@ -1720,8 +1720,8 @@ class afc:
 
         Optional Values
         ----
-        Set SHORT=1 to have a smaller print that fits better on smaller screens. Setting `print_short_stats` variable in `[AFC]` section
-        in AFC.cfg file to True will always print statistics in short form
+        Set SHORT=1 to have a smaller print that fits better on smaller screens. Setting `print_short_stats`
+        variable in `[AFC]` section in the AFC.cfg file to True will always print statistics in short form.
 
         Usage
         -----
@@ -1741,7 +1741,7 @@ class afc:
     def cmd_AFC_CHANGE_BLADE(self, gcmd):
         """
         This macro handles resetting cut total since blade was last changed and updates the data
-        the blade was last changed to current date time when this macro was ran.
+        the blade was last changed to current date time when this macro was run.
 
         Usage
         -----

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -4,7 +4,14 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
+# This file includes code modified from the Shaketune Project. https://github.com/Frix-x/klippain-shaketune
+# Originally authored by Félix Boisselier and licensed under the GNU General Public License v3.0.
+#
+# Full license text available at: https://www.gnu.org/licenses/gpl-3.0.html
+
+
 import json
+import os
 import re
 import traceback
 from configfile import error
@@ -46,6 +53,7 @@ def load_config(config):
 
 class afc:
     def __init__(self, config):
+        self.config  = config
         self.printer = config.get_printer()
         self.reactor = self.printer.get_reactor()
         self.webhooks = self.printer.lookup_object('webhooks')
@@ -55,6 +63,7 @@ class afc:
         self.spool      = self.printer.load_object(config, 'AFC_spool')
         self.error      = self.printer.load_object(config, 'AFC_error')
         self.function   = self.printer.load_object(config, 'AFC_functions')
+        self.function.afc = self
         self.gcode      = self.printer.lookup_object('gcode')
 
         # Registering stepper callback so that mux macro can be set properly with valid lane names
@@ -189,13 +198,34 @@ class afc:
         self.printer.lookup_object("pins").register_chip("afc_virtual_bypass", self)
         self.printer.lookup_object("pins").register_chip("afc_quiet_mode", self)
 
-        # Printing here will not display in console but it will go to klippy.log
+        # Printing here will not display in console, but it will go to klippy.log
         self.print_version()
 
         self.BASE_UNLOAD_FILAMENT    = 'UNLOAD_FILAMENT'
         self.RENAMED_UNLOAD_FILAMENT = '_AFC_RENAMED_{}_'.format(self.BASE_UNLOAD_FILAMENT)
 
         self.afcDeltaTime = afcDeltaTime(self)
+
+        # Register AFC macros
+        self.show_macros = config.getboolean('show_macros',
+                                             True)  # Show internal python AFC_ macros in the web interfaces (Mainsail/Fluidd)
+
+        self.function.register_commands(self.show_macros, 'AFC_STATS', self.cmd_AFC_STATS, self.cmd_AFC_STATS_help,
+                                        self.cmd_AFC_STATS_options)
+        self.function.register_commands(self.show_macros, 'AFC_QUIET_MODE', self.cmd_AFC_QUIET_MODE,
+                                        self.cmd_AFC_QUIET_MODE_help, self.cmd_AFC_QUIET_MODE_options)
+        self.function.register_commands(self.show_macros, 'AFC_STATUS', self.cmd_AFC_STATUS,
+                                        self.cmd_AFC_STATUS_help)
+        self.function.register_commands(self.show_macros, 'TURN_ON_AFC_LED', self.cmd_TURN_ON_AFC_LED,
+                                        self.cmd_TURN_ON_AFC_LED_help)
+        self.function.register_commands(self.show_macros, 'TURN_OFF_AFC_LED', self.cmd_TURN_OFF_AFC_LED,
+                                        self.cmd_TURN_OFF_AFC_LED_help)
+        self.function.register_commands(self.show_macros, 'AFC_CHANGE_BLADE', self.cmd_AFC_CHANGE_BLADE,
+                                        self.cmd_AFC_CHANGE_BLADE_help)
+        self.function.register_commands(self.show_macros, 'AFC_TOGGLE_MACRO', self.cmd_AFC_TOGGLE_MACRO,
+                                        self.cmd_AFC_TOGGLE_MACRO_help, self.cmd_AFC_TOGGLE_MACRO_options)
+        self.function.register_commands(self.show_macros, 'UNSET_LANE_LOADED', self.cmd_UNSET_LANE_LOADED,
+                                        self.cmd_UNSET_LANE_LOADED_help)
 
     def _remove_after_last(self, string, char):
         last_index = string.rfind(char)
@@ -269,18 +299,10 @@ class afc:
         if self.show_quiet_mode:
             self.quiet_switch = add_filament_switch("filament_switch_sensor quiet_mode", "afc_quiet_mode:afc_quiet_mode", self.printer ).runout_helper
 
-        # GCODE REGISTERS
-        self.gcode.register_command('AFC_TOGGLE_MACRO',     self.cmd_AFC_TOGGLE_MACRO,      desc=self.cmd_AFC_TOGGLE_MACRO_help)
-        self.gcode.register_command('AFC_QUIET_MODE',       self.cmd_AFC_QUIET_MODE,        desc=self.cmd_AFC_QUIET_MODE_help)
+        # Register G-Code commands for macros we don't want to show up in mainsail/fluidd
         self.gcode.register_command('TOOL_UNLOAD',          self.cmd_TOOL_UNLOAD,           desc=self.cmd_TOOL_UNLOAD_help)
         self.gcode.register_command('CHANGE_TOOL',          self.cmd_CHANGE_TOOL,           desc=self.cmd_CHANGE_TOOL_help)
-        self.gcode.register_command('AFC_STATUS',           self.cmd_AFC_STATUS,            desc=self.cmd_AFC_STATUS_help)
         self.gcode.register_command('SET_AFC_TOOLCHANGES',  self.cmd_SET_AFC_TOOLCHANGES,   desc=self.cmd_SET_AFC_TOOLCHANGES_help)
-        self.gcode.register_command('UNSET_LANE_LOADED',    self.cmd_UNSET_LANE_LOADED,     desc=self.cmd_UNSET_LANE_LOADED_help)
-        self.gcode.register_command('TURN_OFF_AFC_LED',     self.cmd_TURN_OFF_AFC_LED,      desc=self.cmd_TURN_OFF_AFC_LED_help)
-        self.gcode.register_command('TURN_ON_AFC_LED',      self.cmd_TURN_ON_AFC_LED,       desc=self.cmd_TURN_ON_AFC_LED_help)
-        self.gcode.register_command("AFC_STATS",            self.cmd_AFC_STATS,             desc=self.cmd_AFC_STATS_help)
-        self.gcode.register_command("AFC_CHANGE_BLADE",     self.cmd_AFC_CHANGE_BLADE,      desc=self.cmd_AFC_CHANGE_BLADE_help)
         self.current_state = State.IDLE
 
     def print_version(self, console_only=False):
@@ -471,6 +493,12 @@ class afc:
         return False
 
     cmd_AFC_TOGGLE_MACRO_help = "Enable/disable TOOL_CUT/PARK/POOP/KICK/WIPE/FORM_TIP macros"
+    cmd_AFC_TOGGLE_MACRO_options = {"TOOL_CUT": {"type": "int", "default": 0},
+                                    "PARK": {"type": "int", "default": 0},
+                                    "POOP": {"type": "int", "default": 0},
+                                    "KICK": {"type": "int", "default": 0},
+                                    "WIPE": {"type": "int", "default": 0},
+                                    "FORM_TIP": {"type": "int", "default": 0}}
     def cmd_AFC_TOGGLE_MACRO(self, gcmd):
         """
         Enable/disable TOOL_CUT/PARK/POOP/KICK/WIPE/FORM_TIP macros.
@@ -497,6 +525,8 @@ class afc:
         self.logger.info("Wipe {}, Form tip {}".format(self.tool_cut, self.form_tip))
 
     cmd_AFC_QUIET_MODE_help = "Set quiet mode speed and enable/disable quiet mode"
+    cmd_AFC_QUIET_MODE_options = {"SPEED": {"type": "float", "default": 50},
+                                  "ENABLE": {"type": "int", "default": 0}}
     def cmd_AFC_QUIET_MODE(self, gcmd):
         """
         Set lower speed on any filament moves.
@@ -573,6 +603,7 @@ class afc:
             self.message_queue.append((warning_text, "warning"))
 
     cmd_LANE_MOVE_help = "Lane Manual Movements"
+    cmd_LANE_MOVE_options = {"LANE": {"type": "string", "default": "lane1"}, "DISTANCE": {"type": "int", "default": 20}}
     def cmd_LANE_MOVE(self, gcmd):
         """
         This function handles the manual movement of a specified lane. It retrieves the lane
@@ -1582,6 +1613,7 @@ class afc:
         web_request.send( {"status:" : {"AFC": str}})
 
     cmd_AFC_STATUS_help = "Return current status of AFC"
+    cmd_AFC_STATUS_options = {"": {}}
     def cmd_AFC_STATUS(self, gcmd):
         """
         This function generates a status message for each unit and lane, indicating the preparation,
@@ -1689,6 +1721,7 @@ class afc:
             led.turn_on_leds()
 
     cmd_AFC_STATS_help ="Prints AFC toolchange statistics to console"
+    cmd_AFC_STATS_options = {"SHORT": {"type": "int", "default": 1}}
     def cmd_AFC_STATS(self, gcmd):
         """
         This macro handles printing toolchange statistics to console.

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -2,13 +2,6 @@
 #
 # Copyright (C) 2024 Armored Turtle
 #
-# This file may be distributed under the terms of the GNU GPLv3 license.
-
-# This file includes code modified from the Shaketune Project. https://github.com/Frix-x/klippain-shaketune
-# Originally authored by Félix Boisselier and licensed under the GNU General Public License v3.0.
-#
-# Full license text available at: https://www.gnu.org/licenses/gpl-3.0.html
-
 
 import json
 import os

--- a/extras/AFC_assist.py
+++ b/extras/AFC_assist.py
@@ -410,7 +410,6 @@ class Espooler:
         self.stats                  = None
 
         self.function = self.printer.load_object(config, 'AFC_functions')
-        self.function.afc = self
         self.show_macros = self.afc.show_macros
 
         if self.afc_motor_rwd is not None:

--- a/extras/AFC_assist.py
+++ b/extras/AFC_assist.py
@@ -409,6 +409,10 @@ class Espooler:
         self.espooler_values        = Espooler_values(config)
         self.stats                  = None
 
+        self.function = self.printer.load_object(config, 'AFC_functions')
+        self.function.afc = self
+        self.show_macros = self.afc.show_macros
+
         if self.afc_motor_rwd is not None:
             self.afc_motor_rwd = AFCassistMotor(config, "rwd")
         if self.afc_motor_fwd is not None:
@@ -423,7 +427,9 @@ class Espooler:
 
         # Only register macro if fwd or rwd pins are defined
         if self.afc_motor_fwd is not None or self.afc_motor_rwd is not None:
-            self.afc.gcode.register_mux_command("AFC_RESET_MOTOR_TIME"      , "LANE", self.name, self.cmd_AFC_RESET_MOTOR_TIME,     desc=self.cmd_AFC_RESET_MOTOR_TIME_help)
+            self.function.register_mux_command(self.show_macros, 'AFC_RESET_MOTOR_TIME', 'LANE', self.name,
+                                               self.cmd_AFC_RESET_MOTOR_TIME, self.cmd_AFC_RESET_MOTOR_TIME_help,
+                                               self.cmd_AFC_RESET_MOTOR_TIME_options)
 
 
     def handle_ready(self):
@@ -782,6 +788,7 @@ class Espooler:
         self.logger.info(f"Espooler values updated for {self.name}, please manually save values in config file.")
 
     cmd_AFC_RESET_MOTOR_TIME_help = "Resets N20 active time, useful for resetting time for N20 if one was replaced in a lane"
+    cmd_AFC_RESET_MOTOR_TIME_options = {"LANE": {"type": "string", "default": "lane1"}}
     def cmd_AFC_RESET_MOTOR_TIME(self, gcmd):
         """
         This macro handles resetting N20 fwd/rwd active time for specified lane. Useful to reset time if N20

--- a/extras/AFC_buffer.py
+++ b/extras/AFC_buffer.py
@@ -67,7 +67,6 @@ class AFCTrigger:
         self.printer.register_event_handler("klippy:ready", self._handle_ready)
 
         self.function = self.printer.load_object(config, 'AFC_functions')
-        self.function.afc = self
         self.show_macros = self.afc.show_macros
 
         self.function.register_mux_command(self.show_macros, "QUERY_BUFFER", "BUFFER", self.name,

--- a/extras/AFC_buffer.py
+++ b/extras/AFC_buffer.py
@@ -65,7 +65,14 @@ class AFCTrigger:
             self.fila_trail = add_filament_switch(self.trail_filament_switch_name, self.trailing_pin, self.printer )
 
         self.printer.register_event_handler("klippy:ready", self._handle_ready)
-        self.gcode.register_mux_command("QUERY_BUFFER",         "BUFFER", self.name, self.cmd_QUERY_BUFFER,         desc=self.cmd_QUERY_BUFFER_help)
+
+        self.function = self.printer.load_object(config, 'AFC_functions')
+        self.function.afc = self
+        self.show_macros = self.afc.show_macros
+
+        self.function.register_mux_command(self.show_macros, "QUERY_BUFFER", "BUFFER", self.name,
+                                            self.cmd_QUERY_BUFFER,
+                                        self.cmd_QUERY_BUFFER_help, self.cmd_QUERY_BUFFER_options)
         self.gcode.register_mux_command("ENABLE_BUFFER",        "BUFFER", self.name, self.cmd_ENABLE_BUFFER)
         self.gcode.register_mux_command("DISABLE_BUFFER",       "BUFFER", self.name, self.cmd_DISABLE_BUFFER)
 
@@ -256,6 +263,7 @@ class AFCTrigger:
             self.logger.info("BUFFER {} CAN'T CHANGE ROTATION DISTANCE".format(self.name))
 
     cmd_QUERY_BUFFER_help = "Report Buffer sensor state"
+    cmd_QUERY_BUFFER_options = {"BUFFER": {"type": "string", "default": "Turtle_1"}}
     def cmd_QUERY_BUFFER(self, gcmd):
         """
         Reports the current state of the buffer sensor and, if applicable, the rotation

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -57,6 +57,17 @@ class AFCExtruder:
 
         self.common_save_msg = "\nRun SAVE_EXTRUDER_VALUES EXTRUDER={} once done to update values in config".format(self.name)
 
+        self.show_macros = self.afc.show_macros
+        self.function = self.printer.load_object(config, 'AFC_functions')
+        self.function.afc = self
+
+        self.function.register_mux_command(self.show_macros, 'UPDATE_TOOLHEAD_SENSORS', "EXTRUDER", self.name,
+                                           self.cmd_UPDATE_TOOLHEAD_SENSORS, self.cmd_UPDATE_TOOLHEAD_SENSORS_help,
+                                           self.cmd_UPDATE_TOOLHEAD_SENSORS_options)
+        self.function.register_mux_command(self.show_macros, 'SAVE_EXTRUDER_VALUES', "EXTRUDER", self.name,
+                                           self.cmd_SAVE_EXTRUDER_VALUES, self.cmd_SAVE_EXTRUDER_VALUES_help,
+                                           self.cmd_SAVE_EXTRUDER_VALUES_options)
+
     def __str__(self):
         return self.name
 
@@ -68,9 +79,6 @@ class AFCExtruder:
         """
         self.reactor = self.afc.reactor
         self.afc.tools[self.name] = self
-
-        self.afc.gcode.register_mux_command('UPDATE_TOOLHEAD_SENSORS', "EXTRUDER", self.name, self.cmd_UPDATE_TOOLHEAD_SENSORS, desc=self.cmd_UPDATE_TOOLHEAD_SENSORS_help)
-        self.afc.gcode.register_mux_command('SAVE_EXTRUDER_VALUES', "EXTRUDER", self.name, self.cmd_SAVE_EXTRUDER_VALUES, desc=self.cmd_SAVE_EXTRUDER_VALUES_help)
 
     def tool_start_callback(self, eventtime, state):
         self.tool_start_state = state
@@ -124,6 +132,13 @@ class AFCExtruder:
             self.logger.error("tool_sensor_after_extruder length should be greater than zero")
 
     cmd_UPDATE_TOOLHEAD_SENSORS_help = "Gives ability to update tool_stn\tool_stn_unload\tool_sensor_after_extruder values without restarting klipper"
+    cmd_UPDATE_TOOLHEAD_SENSORS_options = {
+        "EXTRUDER": {"type": "string", "default": "extruder"},
+        "TOOL_STN": {"type": "float", "default": 0},
+        "TOOL_STN_UNLOAD": {"type": "float", "default": 0},
+        "TOOL_AFTER_EXTRUDER": {"type": "float", "default": 0}
+    }
+
     def cmd_UPDATE_TOOLHEAD_SENSORS(self, gcmd):
         """
         Macro call to adjust `tool_stn` `tool_stn_unload` `tool_sensor_after_extruder` lengths for specified extruder without having to
@@ -161,7 +176,9 @@ class AFCExtruder:
         if tool_sensor_after_extruder != self.tool_sensor_after_extruder:
             self._update_tool_after_extr( tool_sensor_after_extruder )
 
-    cmd_SAVE_EXTRUDER_VALUES_help = "Saves tool_stn, tool_stn_unload and tool_sensor_after_extruder values to config file "
+    cmd_SAVE_EXTRUDER_VALUES_help = ("Saves tool_stn, tool_stn_unload and tool_sensor_after_extruder values to config "
+                                     "file.")
+    cmd_SAVE_EXTRUDER_VALUES_options = {"EXTRUDER": {"type": "string", "default": "extruder"}}
     def cmd_SAVE_EXTRUDER_VALUES(self, gcmd):
         """
         Macro call to write tool_stn, tool_stn_unload and tool_sensor_after_extruder variables to config file for specified extruder.

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -59,7 +59,6 @@ class AFCExtruder:
 
         self.show_macros = self.afc.show_macros
         self.function = self.printer.load_object(config, 'AFC_functions')
-        self.function.afc = self
 
         self.function.register_mux_command(self.show_macros, 'UPDATE_TOOLHEAD_SENSORS', "EXTRUDER", self.name,
                                            self.cmd_UPDATE_TOOLHEAD_SENSORS, self.cmd_UPDATE_TOOLHEAD_SENSORS_help,

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -3,6 +3,11 @@
 # Copyright (C) 2024 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+#
+# This file includes code modified from the Shaketune Project. https://github.com/Frix-x/klippain-shaketune
+# Originally authored by Félix Boisselier and licensed under the GNU General Public License v3.0.
+#
+# Full license text available at: https://www.gnu.org/licenses/gpl-3.0.html
 
 import os
 import re
@@ -22,6 +27,7 @@ def load_config(config):
 
 class afcFunction:
     def __init__(self, config):
+        self.config = config
         self.printer = config.get_printer()
         self.printer.register_event_handler("klippy:connect", self.handle_connect)
         self.printer.register_event_handler("afc_stepper:register_macros",self.register_lane_macros)
@@ -31,6 +37,14 @@ class afcFunction:
         self.afc      = None
         self.logger   = None
         self.mcu      = None
+
+        self.show_macros = True
+        self.register_commands(self.show_macros, 'AFC_CALIBRATION', self.cmd_AFC_CALIBRATION, self.cmd_AFC_CALIBRATION_help)
+        self.register_commands(self.show_macros, 'AFC_RESET', self.cmd_AFC_RESET, self.cmd_AFC_RESET_help,
+                               self.cmd_AFC_RESET_options)
+        self.register_commands(self.show_macros, 'AFC_LANE_RESET', self.cmd_AFC_LANE_RESET,
+                               self.cmd_AFC_LANE_RESET_help, self.cmd_AFC_LANE_RESET_options)
+
 
     def register_lane_macros(self, lane_obj):
         """
@@ -61,13 +75,10 @@ class afcFunction:
         self.logger = self.afc.logger
         self.mcu = self.printer.lookup_object('mcu')
         self.afc.gcode.register_command('CALIBRATE_AFC',   self.cmd_CALIBRATE_AFC,   desc=self.cmd_CALIBRATE_AFC_help)
-        self.afc.gcode.register_command('AFC_CALIBRATION', self.cmd_AFC_CALIBRATION, desc=self.cmd_AFC_CALIBRATION_help)
         self.afc.gcode.register_command('ALL_CALIBRATION', self.cmd_ALL_CALIBRATION, desc=self.cmd_ALL_CALIBRATION_help)
         self.afc.gcode.register_command('AFC_CALI_COMP',   self.cmd_AFC_CALI_COMP,   desc=self.cmd_AFC_CALI_COMP_help)
         self.afc.gcode.register_command('AFC_CALI_FAIL',   self.cmd_AFC_CALI_FAIL,   desc=self.cmd_AFC_CALI_FAIL_help)
         self.afc.gcode.register_command('AFC_HAPPY_P',     self.cmd_AFC_HAPPY_P,     desc=self.cmd_AFC_HAPPY_P_help)
-        self.afc.gcode.register_command('AFC_RESET',       self.cmd_AFC_RESET,       desc=self.cmd_AFC_RESET_help)
-        self.afc.gcode.register_command('AFC_LANE_RESET',  self.cmd_AFC_LANE_RESET,  desc=self.cmd_AFC_LANE_RESET_help)
 
     def ConfigRewrite(self, rawsection, rawkey, rawvalue, msg=""):
         taskdone = False
@@ -382,6 +393,61 @@ class afcFunction:
 
         return '#{:02x}{:02x}{:02x}'.format(*led)
 
+    def _create_options(self, macro_name, options):
+        option_str = ""
+
+        for key, value in options.items():
+            option_str += f"{{%set dummy=params.{key}|default('{value['default']}')|{value['type']}%}}\n"
+
+        option_str += f"_{macro_name} {{rawparams}}"
+        return option_str
+
+    def _create_no_options(self, macro_name):
+        return f"_{macro_name}"
+
+    # Modified from the ShakeTune project
+    def register_mux_command(self, show_macros, macro_name, key, value, command, description, options=None):
+        gcode = self.printer.lookup_object('gcode')
+
+        # Register AFC macro commands using the official Klipper API (gcode.register_command)
+        # Doing this makes the commands available in Klipper, but they are not shown in the web interfaces
+        # and are only available by typing the full name in the console (like all the other Klipper commands)
+        # for name, command, description in afc_commands:
+        gcode.register_mux_command(f'_{macro_name}' if show_macros else macro_name, key, value, command,
+                                   desc=description)
+        self._register_klipper(show_macros, macro_name, command, description, options)
+
+    # Modified from the ShakeTune project
+    def register_commands(self, show_macros, macro_name, command, description, options=None):
+        gcode = self.printer.lookup_object('gcode')
+
+        # Register AFC macro commands using the official Klipper API (gcode.register_command)
+        # Doing this makes the commands available in Klipper, but they are not shown in the web interfaces
+        # and are only available by typing the full name in the console (like all the other Klipper commands)
+        # for name, command, description in afc_commands:
+        gcode.register_command(f'_{macro_name}' if show_macros else macro_name, command, desc=description)
+
+        self._register_klipper(show_macros, macro_name, command, description, options)
+
+    # Modified from the ShakeTune project
+    def _register_klipper(self, show_macros, macro_name, command, description, options=None):
+        # Then, a hack to inject the macros into Klipper's config system in order to show them in the web
+        # interfaces. This is not a good way to do it, but it's the only way to do it for now to get
+        # a good user experience while using AFC (it's indeed easier to just click a macro button)
+        if show_macros:
+            name = f'gcode_macro {macro_name}'
+            if not self.config.fileconfig.has_section(name):
+                self.config.fileconfig.add_section(name)
+                self.config.fileconfig.set(name, 'description', description)
+                if options is not None:
+                    self.config.fileconfig.set(name, 'gcode', self._create_options(macro_name, options))
+                else:
+                    self.config.fileconfig.set(name, 'gcode', self._create_no_options(macro_name))
+
+                for option in self.config.fileconfig.options(name):
+                    self.config.access_tracking[(name.lower(), option.lower())] = 1
+            self.printer.load_object(self.config, name)
+
     cmd_AFC_CALIBRATION_help = 'open prompt to begin calibration by selecting Unit to calibrate'
     def cmd_AFC_CALIBRATION(self, gcmd):
         """
@@ -691,6 +757,7 @@ class afcFunction:
                                True, None)
 
     cmd_AFC_RESET_help = 'Opens prompt to select lane to reset.'
+    cmd_AFC_RESET_options = {"DISTANCE": {"default": "30", "type": "float"}}
     def cmd_AFC_RESET(self, gcmd):
         """
         This function opens a prompt allowing the user to select a loaded lane for reset. It displays a list of loaded lanes
@@ -739,6 +806,8 @@ class afcFunction:
                         True, None)
 
     cmd_AFC_LANE_RESET_help = 'reset a loaded lane to hub'
+    cmd_AFC_LANE_RESET_options = {"DISTANCE": {"default": "50", "type": "float"},
+                                  "LANE": {"default": "lane1", "type": "string"}}
     def cmd_AFC_LANE_RESET(self, gcmd):
         """
         This function resets a specified lane to the hub position in the AFC system. It checks for various error conditions,

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -166,7 +166,6 @@ class AFCLane:
 
         self.show_macros = self.afc.show_macros
         self.function = self.printer.load_object(config, 'AFC_functions')
-        self.function.afc = self
         self.function.register_mux_command(self.show_macros, 'SET_LANE_LOADED', 'LANE', self.name,
                                            self.cmd_SET_LANE_LOADED, self.cmd_SET_LANE_LOADED_help,
                                            self.cmd_SET_LANE_LOAD_options )

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2024 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+
 import math
 import traceback
 
@@ -163,6 +164,13 @@ class AFCLane:
         self.prep_active = False
         self.last_prep_time = 0
 
+        self.show_macros = self.afc.show_macros
+        self.function = self.printer.load_object(config, 'AFC_functions')
+        self.function.afc = self
+        self.function.register_mux_command(self.show_macros, 'SET_LANE_LOADED', 'LANE', self.name,
+                                           self.cmd_SET_LANE_LOADED, self.cmd_SET_LANE_LOADED_help,
+                                           self.cmd_SET_LANE_LOAD_options )
+
     def __str__(self):
         return self.name
 
@@ -305,8 +313,6 @@ class AFCLane:
 
         # Register macros
         # TODO: add check so that HTLF stepper lanes do not get registered here
-        self.gcode.register_mux_command('SET_LANE_LOADED',    "LANE", self.name, self.cmd_SET_LANE_LOADED, desc=self.cmd_SET_LANE_LOADED_help)
-
         self.afc.gcode.register_mux_command('SET_LONG_MOVE_SPEED',   "LANE", self.name, self.cmd_SET_LONG_MOVE_SPEED, desc=self.cmd_SET_LONG_MOVE_SPEED_help)
         self.afc.gcode.register_mux_command('SET_SPEED_MULTIPLIER',  "LANE", self.name, self.cmd_SET_SPEED_MULTIPLIER, desc=self.cmd_SET_SPEED_MULTIPLIER_help)
         self.afc.gcode.register_mux_command('SAVE_SPEED_MULTIPLIER', "LANE", self.name, self.cmd_SAVE_SPEED_MULTIPLIER, desc=self.cmd_SAVE_SPEED_MULTIPLIER_help)
@@ -748,6 +754,7 @@ class AFCLane:
         else: return None
 
     cmd_SET_LANE_LOADED_help = "Sets current lane as loaded to toolhead, useful when manually loading lanes during prints if AFC detects an error when trying to unload/load a lane"
+    cmd_SET_LANE_LOAD_options = {"LANE": {"type": "string", "default": "lane1"}}
     def cmd_SET_LANE_LOADED(self, gcmd):
         """
         This macro handles manually setting a lane loaded into the toolhead. This is useful when manually loading lanes


### PR DESCRIPTION
## Major Changes in this PR

This pull request introduces several updates to the AFC (Automated Filament Control) system, focusing on adding macro registration options, improving configurability, and integrating functionality from the Shaketune Project. The changes enhance user experience by allowing macros to be shown or hidden in web interfaces, providing default options for macros, and improving modularity.

### Macro Registration and Configurability:
* Introduced `register_commands` and `register_mux_command` methods in `extras/AFC_functions.py` to allow dynamic registration of AFC macros, with options to show or hide them in web interfaces like Mainsail/Fluidd. These methods include support for default options and descriptions.
* Added macro options for commands such as `AFC_TOGGLE_MACRO`, `AFC_QUIET_MODE`, `AFC_STATS`, and others to improve configurability and provide default values for parameters. [[1]](diffhunk://#diff-749740ba904c224003143ed84a943eb5885a486b4ec55cd658a5beeea1cd1ff4R496-R501) [[2]](diffhunk://#diff-749740ba904c224003143ed84a943eb5885a486b4ec55cd658a5beeea1cd1ff4R528-R529) [[3]](diffhunk://#diff-749740ba904c224003143ed84a943eb5885a486b4ec55cd658a5beeea1cd1ff4R606) [[4]](diffhunk://#diff-749740ba904c224003143ed84a943eb5885a486b4ec55cd658a5beeea1cd1ff4R1724)
* Updated `extras/AFC_lane.py` and `extras/AFC_assist.py` to use the new `register_mux_command` method for macro registration, ensuring consistency across modules. [[1]](diffhunk://#diff-120880cf9386cf18b6cdd101a1352383e1aa13474d51b2d99255ff11f286a279R167-R173) [[2]](diffhunk://#diff-22dd59466baa12a91c9a52b0997ae89b75b13a897c47a21d8b63fc7c5f5be557L426-R432)

### Licensing and Attribution:
* Added attribution and licensing information for code adapted from the Shaketune Project in `extras/AFC.py` and `extras/AFC_functions.py`, ensuring compliance with the GNU GPLv3 license. [[1]](diffhunk://#diff-749740ba904c224003143ed84a943eb5885a486b4ec55cd658a5beeea1cd1ff4R7-R14) [[2]](diffhunk://#diff-a8ca611e32387e969fe3a6ed568f67798d442aa9e6a89dce97739fbf011a4bc3R6-R10)

### Codebase Enhancements:
* Added the `show_macros` configuration option to control the visibility of internal AFC macros in web interfaces, improving user customization. [[1]](diffhunk://#diff-749740ba904c224003143ed84a943eb5885a486b4ec55cd658a5beeea1cd1ff4L192-R229) [[2]](diffhunk://#diff-a8ca611e32387e969fe3a6ed568f67798d442aa9e6a89dce97739fbf011a4bc3R41-R48)
* Refactored macro registration logic to reduce redundancy and centralize functionality in `extras/AFC_functions.py`.

### Minor Fixes:
* Corrected a comment typo in `extras/AFC.py` for better clarity.
* Added minor adjustments to macro descriptions and options for better documentation and usability. [[1]](diffhunk://#diff-22dd59466baa12a91c9a52b0997ae89b75b13a897c47a21d8b63fc7c5f5be557R791) [[2]](diffhunk://#diff-120880cf9386cf18b6cdd101a1352383e1aa13474d51b2d99255ff11f286a279L308-L309)

## Notes to Code Reviewers

## How the changes in this PR are tested

![image](https://github.com/user-attachments/assets/d2e3794e-4189-4fc0-b48d-bd1d957aeee6)


## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design channel requesting review
