### PR TITLE
[Fix] Fixes Issue 419 and a bug where rev_long_moves_speed_factor was not being pulled right from AFC object

### DIFF
--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -51,7 +51,7 @@ class afcUnit:
         self.short_move_dis              = config.getfloat("short_move_dis", self.afc.short_move_dis)       # Move distance in mm for failsafe moves. Setting value here overrides values set in AFC.cfg file
         self.max_move_dis                = config.getfloat("max_move_dis", self.afc.max_move_dis)            # Maximum distance to move filament. AFC breaks filament moves over this number into multiple moves. Useful to lower this number if running into timer too close errors when doing long filament moves. Setting value here overrides values set in AFC.cfg file
         self.debug                       = config.getboolean("debug",            False)                      # Turns on/off debug messages to console
-        self.rev_long_moves_speed_factor = config.getfloat("rev_long_moves_speed_factor", self.afc.short_moves_speed)
+        self.rev_long_moves_speed_factor = config.getfloat("rev_long_moves_speed_factor", self.afc.rev_long_moves_speed_factor)
 
         # Espooler defines
         # Time in seconds to wait between breaking n20 motors(nSleep/FWD/RWD all 1) and then releasing the break to allow coasting. Setting value here overrides values set in AFC.cfg file

--- a/extras/AFC_utils.py
+++ b/extras/AFC_utils.py
@@ -15,7 +15,8 @@ from urllib.request import (
 )
 from urllib.parse import (
     urlencode,
-    urljoin
+    urljoin,
+    quote
 )
 
 ERROR_STR = "Error trying to import {import_lib}, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper\n\n{trace}"
@@ -129,7 +130,8 @@ class AFC_moonraker:
                  Returns zero if not found in metadata.
         """
         change_count = 0
-        resp = self._get_results(urljoin(self.local_host, 'server/files/metadata?filename={}'.format(filename)))
+        resp = self._get_results(urljoin(self.local_host,
+                                    'server/files/metadata?filename={}'.format(quote(filename))))
         if resp is not None and 'filament_change_count' in resp:
             change_count =  resp['filament_change_count']
         else:

--- a/extras/AFC_utils.py
+++ b/extras/AFC_utils.py
@@ -135,7 +135,7 @@ class AFC_moonraker:
         if resp is not None and 'filament_change_count' in resp:
             change_count =  resp['filament_change_count']
         else:
-            self.logger.debug(f"Metadata not found for file:{filename}")
+            self.logger.debug(f"Filament change count metadata not found for file:{filename}")
         return change_count
 
     def get_afc_stats(self):


### PR DESCRIPTION
## Major Changes in this PR
- Fixes #419 issue where filename was not being encoded correctly, so filenames with spaces would throw an error
- Fixes issue found by discord user where rev_long_moves_speed_factor value was not being grabbed correctly from AFC object

## Notes to Code Reviewers

## How the changes in this PR are tested
Filename with spaces error before:
![image](https://github.com/user-attachments/assets/6316d7ad-8e2d-4fea-ad0f-59008041f426)

Same file after fix:
![image](https://github.com/user-attachments/assets/1d84cc01-5cd8-4787-ae33-b2fad2269ee0)

File with toolchanges and spaces in name:
![image](https://github.com/user-attachments/assets/36f57e9a-146d-4d9e-ba6c-ed0f05009bed)

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design channel requesting review
