### PR TITLE
[Fixes] Fixing infinite runout, adding default values to macro parameters

### DIFF
--- a/config/macros/Brush.cfg
+++ b/config/macros/Brush.cfg
@@ -2,19 +2,19 @@
 description: Wipe the nozzle on the brush
 gcode:
     {% set gVars             = printer['gcode_macro _AFC_GLOBAL_VARS'] %}
-    {% set accel             = gVars['accel']|float %}
-    {% set travel_speed      = gVars['travel_speed'] * 60|float %}
-    {% set z_travel_speed    = gVars['z_travel_speed'] * 60|float %}
-    {% set verbose           = gVars['verbose']|int %}
+    {% set accel             = gVars['accel']|default(2000)|float %}
+    {% set travel_speed      = gVars['travel_speed'] * 60|default(120)*60|float %}
+    {% set z_travel_speed    = gVars['z_travel_speed'] * 60|default(30)*60|float %}
+    {% set verbose           = gVars['verbose']|default(1)|int %}
     {% set vars              = printer['gcode_macro _AFC_BRUSH_VARS'] %}
-    {% set Bx, By, Bz        = vars.brush_loc|map('float') %}
-    {% set brush_clean_accel = vars['brush_clean_accel']|float %}
+    {% set Bx, By, Bz        = vars.brush_loc|default(-1,-1,-1)|map('float') %}
+    {% set brush_clean_accel = vars['brush_clean_accel']|default(0)|float %}
     {% set y_brush           = vars['y_brush']|default(false)|lower == 'true' %}
-    {% set brush_clean_speed = vars['brush_clean_speed'] * 60|float %}
-    {% set brush_width       = vars['brush_width']|float %}
-    {% set brush_depth       = vars['brush_depth']|float %}
-    {% set brush_count       = vars['brush_count']|int %}
-    {% set z_move            = vars['z_move']     |float %}
+    {% set brush_clean_speed = vars['brush_clean_speed'] * 60|default(150)*60|float %}
+    {% set brush_width       = vars['brush_width']|default(30)|float %}
+    {% set brush_depth       = vars['brush_depth']|default(10)|float %}
+    {% set brush_count       = vars['brush_count']|default(4)|int %}
+    {% set z_move            = vars['z_move']     |(default(-1)|float %}
 
     # Get printer bounds to make sure none of our cleaning moves fall outside of them
     # Check for IDEX

--- a/config/macros/Brush.cfg
+++ b/config/macros/Brush.cfg
@@ -14,7 +14,7 @@ gcode:
     {% set brush_width       = vars['brush_width']|default(30)|float %}
     {% set brush_depth       = vars['brush_depth']|default(10)|float %}
     {% set brush_count       = vars['brush_count']|default(4)|int %}
-    {% set z_move            = vars['z_move']     |(default(-1)|float %}
+    {% set z_move            = vars['z_move']     |default(-1)|float %}
 
     # Get printer bounds to make sure none of our cleaning moves fall outside of them
     # Check for IDEX

--- a/config/macros/Cut.cfg
+++ b/config/macros/Cut.cfg
@@ -2,22 +2,22 @@
 description: Cut filament by pressing the cutter on a pin
 gcode:
     {% set gVars = printer['gcode_macro _AFC_GLOBAL_VARS'] %}
-    {% set accel = gVars['accel']|float %}
-    {% set travel_speed = gVars['travel_speed'] * 60|float %}
-    {% set verbose = gVars['verbose']|int %}
+    {% set accel = gVars['accel']|default(2000)|float %}
+    {% set travel_speed = gVars['travel_speed'] * 60|default(120)*60|float %}
+    {% set verbose = gVars['verbose']|default(1)|int %}
     {% set vars = printer['gcode_macro _AFC_CUT_TIP_VARS'] %}
-    {% set pin_loc_x, pin_loc_y = vars.pin_loc_xy|map('float') %}
-    {% set pin_park_dist = vars['pin_park_dist']|float %}
-    {% set retract_length = vars['retract_length']|float %}
+    {% set pin_loc_x, pin_loc_y = vars.pin_loc_xy|default(-1, -1)|map('float') %}
+    {% set pin_park_dist = vars['pin_park_dist']|default(6.0)|float %}
+    {% set retract_length = vars['retract_length']|default(8.5)|float %}
     {% set quick_tip_forming = vars['quick_tip_forming']|default(true)|lower == 'true' %}
-    {% set rip_length = vars['rip_length']|float %}
+    {% set rip_length = vars['rip_length']|default(1.0)|float %}
     {% set cut_direction = vars['cut_direction']|default('')|lower %}
-    {% set cut_accel = vars['cut_accel']|float %}
-    {% set pushback_length = vars['pushback_length']|float %}
-    {% set pushback_dwell_time = vars['pushback_dwell_time']|int %}
-    {% set extruder_move_speed = vars['extruder_move_speed'] * 60|float %}
+    {% set cut_accel = vars['cut_accel']|default(0)|float %}
+    {% set pushback_length = vars['pushback_length']|default(15)|float %}
+    {% set pushback_dwell_time = vars['pushback_dwell_time']|default(20)|int %}
+    {% set extruder_move_speed = vars['extruder_move_speed'] * 60|default(25)*60|float %}
     {% set restore_position = vars['restore_position']|default(true)|lower == 'true' %}
-    {% set cut_count = vars['cut_count']|int %}
+    {% set cut_count = vars['cut_count']|default(2)|int %}
     {% set y_cut = vars['y_cut']|default(false)|lower == 'true' %}
     {% set awd = vars['awd']|default(false)|lower == 'true' %}
     {% set tool_servo_enable = vars['tool_servo_enable']|default(false)|lower == 'true' %}

--- a/config/macros/Kick.cfg
+++ b/config/macros/Kick.cfg
@@ -1,18 +1,18 @@
 [gcode_macro AFC_KICK]
 gcode:
   {% set gVars = printer['gcode_macro _AFC_GLOBAL_VARS'] %}
-  {% set accel = gVars['accel']|float %}
-  {% set travel_speed = gVars['travel_speed'] * 60|float %}
-  {% set z_travel_speed = gVars['z_travel_speed'] * 60|float %}
-  {% set verbose = gVars['verbose']|int %}
+  {% set accel = gVars['accel']|default(2000)|float %}
+  {% set travel_speed = gVars['travel_speed'] * 60|default(120)*60|float %}
+  {% set z_travel_speed = gVars['z_travel_speed'] * 60|default(30)*60|float %}
+  {% set verbose = gVars['verbose']|default(1)|int %}
   {% set vars = printer['gcode_macro _AFC_KICK_VARS'] %}
-  {% set kick_start_x, kick_start_y, kick_start_z = vars.kick_start_loc|map('float') %}
-  {% set kick_z = vars['kick_z']|float %}
+  {% set kick_start_x, kick_start_y, kick_start_z = vars.kick_start_loc|default(-1,-1,5)|map('float') %}
+  {% set kick_z = vars['kick_z']|default(1.5)|float %}
   {% set kick_direction = vars['kick_direction']|default('')|lower %}
-  {% set kick_move_dist = vars['kick_move_dist']|float %}
-  {% set z_after_kick = vars['z_after_kick']|float %}
-  {% set kick_speed = vars['kick_speed'] * 60|float %}
-  {% set kick_accel = vars['kick_accel']|float %}
+  {% set kick_move_dist = vars['kick_move_dist']|default(45)|float %}
+  {% set z_after_kick = vars['z_after_kick']|default(10)|float %}
+  {% set kick_speed = vars['kick_speed'] * 60|default(150)*60|float %}
+  {% set kick_accel = vars['kick_accel']|default(0)|float %}
 
   # Get printer bounds to make sure none of our kick moves fall outside of them
   # Check for IDEX

--- a/config/macros/Park.cfg
+++ b/config/macros/Park.cfg
@@ -1,11 +1,11 @@
 [gcode_macro AFC_PARK]
 gcode:
   {% set gVars = printer['gcode_macro _AFC_GLOBAL_VARS'] %}
-  {% set travel_speed = gVars['travel_speed'] * 60|float %}
-  {% set verbose = gVars['verbose']|int %}
-  {% set z_travel_speed = gVars['z_travel_speed'] * 60|float %}
+  {% set travel_speed = gVars['travel_speed'] * 60|default(120)*60|float %}
+  {% set verbose = gVars['verbose']|default(1)|int %}
+  {% set z_travel_speed = gVars['z_travel_speed'] * 60|default(30)*60|float %}
   {% set vars = printer['gcode_macro _AFC_PARK_VARS'] %}
-  {% set Px, Py = vars.park_loc_xy|map('float') %}
+  {% set Px, Py = vars.park_loc_xy|default(-1,-1)|map('float') %}
   {% set Px = params.X|default(Px)|float %}
   {% set Py = params.Y|default(Py)|float %}
 

--- a/config/macros/Poop.cfg
+++ b/config/macros/Poop.cfg
@@ -9,21 +9,21 @@ variable_purge_z: 0
 
 gcode:
   {% set gVars                  = printer['gcode_macro _AFC_GLOBAL_VARS'] %}
-  {% set travel_speed           = gVars['travel_speed'] * 60|float %}
-  {% set z_travel_speed         = gVars['z_travel_speed'] * 60|float %}
-  {% set verbose                = gVars['verbose']|int %}
+  {% set travel_speed           = gVars['travel_speed'] * 60|default(120)*60|float %}
+  {% set z_travel_speed         = gVars['z_travel_speed'] * 60|default(30)*60|float %}
+  {% set verbose                = gVars['verbose']|default(1)|int %}
   {% set vars                   = printer['gcode_macro _AFC_POOP_VARS'] %}
-  {% set purge_x, purge_y       = vars.purge_loc_xy|map('float') %}
-  {% set purge_spd              = vars['purge_spd'] * 60|float %}
+  {% set purge_x, purge_y       = vars.purge_loc_xy|default(-1,-1)|map('float') %}
+  {% set purge_spd              = vars['purge_spd'] * 60|default(6.5)*60|float %}
   {% set z_poop                 = vars['z_purge_move']|default(true)|lower == 'true' %}
-  {% set fast_z                 = vars['fast_z'] * 60|float %}
-  {% set z_lift                 = vars['z_lift']|float %}
+  {% set fast_z                 = vars['fast_z'] * 60|default(200)*60|float %}
+  {% set z_lift                 = vars['z_lift']|default(10)|float %}
   {% set part_cooling_fan       = vars['part_cooling_fan']|default(true)|lower == 'true' %}
   {% set part_cooling_fan_speed = vars['part_cooling_fan_speed']|default(1.0)|float %}
-  {% set purge_cool_time        = vars['purge_cool_time'] * 1000|float %}
-  {% set purge_length           = vars['purge_length']|float %}
-  {% set purge_length_minimum   = vars['purge_length_minimum']|float %}
-  {% set purge_start            = vars['purge_start']|float %}
+  {% set purge_cool_time        = vars['purge_cool_time'] * 1000|default(2)*1000|float %}
+  {% set purge_length           = vars['purge_length']|default(72.111)|float %}
+  {% set purge_length_minimum   = vars['purge_length_minimum']|default(60.999)|float %}
+  {% set purge_start            = vars['purge_start']|default(0.6)|float %}
   {% set restore_position       = vars['restore_position']|default(true)|lower == 'true' %}
 
   {% if verbose > 0 %}

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -648,11 +648,12 @@ class afc:
         """
         return self.resume_z_speed if self.resume_z_speed > 0 else self.speed
 
-    def move_z_pos(self, z_amount):
+    def move_z_pos(self, z_amount, string=""):
         """
         Common function helper to move z, also does a check for max z so toolhead does not exceed max height
 
         :param z_amount: amount to add to the base position
+        :param string: String to write to log, this can be used
 
         :return newpos: Position list with updated z position
         """
@@ -664,7 +665,7 @@ class afc:
 
         self.gcode_move.move_with_transform(newpos, self._get_resume_speedz())
 
-        self.function.log_toolhead_pos("move_z_pos: ")
+        self.function.log_toolhead_pos(f"move_z_pos({string}): ")
 
         return newpos[2]
 
@@ -740,7 +741,7 @@ class afc:
 
         # Move toolhead to previous z location with z-hop added
         if move_z_first:
-            newpos[2] = self.move_z_pos(self.last_gcode_position[2] + self.z_hop)
+            newpos[2] = self.move_z_pos(self.last_gcode_position[2] + self.z_hop, "restore_pos")
 
         # Move to previous x,y location
         newpos[:2] = self.last_gcode_position[:2]
@@ -1229,7 +1230,7 @@ class afc:
         # Perform Z-hop to avoid collisions during unloading.
         pos = self.gcode_move.last_position
         pos[2] += self.z_hop
-        self.move_z_pos(pos[2])
+        self.move_z_pos(pos[2], "Tool_Unload quick pull")
 
         # Disable the buffer if it's active.
         cur_lane.disable_buffer()

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -182,7 +182,7 @@ class afcError:
         if self.afc.gcode_move.last_position[2] <= move_z_pos:
             self.afc.move_z_pos(move_z_pos, "AFC_RESUME")
         else:
-            self.logger.debug(f"AFC_RESUME: not moving in z cur_pos:{self.gcode.last_position} move_z_pos:{move_z_pos}")
+            self.logger.debug(f"AFC_RESUME: not moving in z cur_pos:{self.afc.gcode_move.last_position} move_z_pos:{move_z_pos}")
 
         self.logger.debug("AFC_RESUME: Before User Restore")
         self.afc.function.log_toolhead_pos()
@@ -230,7 +230,7 @@ class afcError:
                 # Move Z up by z-hop value
                 self.afc.move_z_pos(move_z_pos, "AFC_PAUSE")
             else:
-                self.logger.debug(f"AFC_PAUSE: not moving in z cur_pos:{self.gcode.last_position} move_z_pos:{move_z_pos}")
+                self.logger.debug(f"AFC_PAUSE: not moving in z cur_pos:{self.afc.gcode_move.last_position} move_z_pos:{move_z_pos}")
             # Call users PAUSE
             self.afc.gcode.run_script_from_command("{macro_name} {user_params}".format(macro_name=self.AFC_RENAME_PAUSE_NAME, user_params=gcmd.get_raw_command_parameters()))
             # Set Idle timeout to 10 hours

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -173,15 +173,16 @@ class afcError:
         # Save current pause state
         temp_is_paused = self.afc.function.is_paused()
 
-        curr_pos = self.afc.gcode_move.last_position
-
         # Verify that printer is in absolute mode
         self.afc.function.check_absolute_mode("AFC_RESUME")
 
+        move_z_pos = self.afc.last_gcode_position[2] + self.afc.z_hop
         # Check if current position is below saved gcode position, if its lower first raise z above last saved
         #   position so that toolhead does not crash into part
-        if curr_pos[2] <= self.afc.last_gcode_position[2]:
-            self.afc.move_z_pos(self.afc.last_gcode_position[2] + self.afc.z_hop)
+        if self.afc.gcode_move.last_position[2] <= move_z_pos:
+            self.afc.move_z_pos(move_z_pos, "AFC_RESUME")
+        else:
+            self.logger.debug(f"AFC_RESUME: not moving in z cur_pos:{self.gcode.last_position} move_z_pos:{move_z_pos}")
 
         self.logger.debug("AFC_RESUME: Before User Restore")
         self.afc.function.log_toolhead_pos()
@@ -223,8 +224,13 @@ class afcError:
             self.pause_resume.send_pause_command()
             # Verify that printer is in absolute mode
             self.afc.function.check_absolute_mode("AFC_PAUSE")
-            # Move Z up by z-hop value
-            self.afc.move_z_pos(self.afc.last_gcode_position[2] + self.afc.z_hop)
+            move_z_pos = self.afc.last_gcode_position[2] + self.afc.z_hop
+            # Check to see if current position is less than saved postion plus z-hop
+            if self.afc.gcode_move.last_position[2] <= move_z_pos:
+                # Move Z up by z-hop value
+                self.afc.move_z_pos(move_z_pos, "AFC_PAUSE")
+            else:
+                self.logger.debug(f"AFC_PAUSE: not moving in z cur_pos:{self.gcode.last_position} move_z_pos:{move_z_pos}")
             # Call users PAUSE
             self.afc.gcode.run_script_from_command("{macro_name} {user_params}".format(macro_name=self.AFC_RENAME_PAUSE_NAME, user_params=gcmd.get_raw_command_parameters()))
             # Set Idle timeout to 10 hours

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -481,7 +481,7 @@ class AFCLane:
                 if self.unit_obj.check_runout(self):
                     # Checking to make sure runout_lane is set and does not equal 'NONE'
                     if  self.runout_lane != 'NONE':
-                        self._perform_runout()
+                        self._perform_infinite_runout()
                     else:
                         self._perform_pause_runout()
                 elif self.status != "calibrating":
@@ -561,7 +561,7 @@ class AFCLane:
                 elif self.prep_state == False and self.name == self.afc.current and self.afc.function.is_printing() and self.load_state and self.status != AFCLaneState.EJECTING:
                     # Checking to make sure runout_lane is set and does not equal 'NONE'
                     if  self.runout_lane != 'NONE':
-                        self._perform_runout()
+                        self._perform_infinite_runout()
                     else:
                         self._perform_pause_runout()
 


### PR DESCRIPTION
## Major Changes in this PR
- Fixes infinite runout as it was calling a function that did not exist when AFC_stepper and AFC_lane files were consolidated.
- Added check to see if Z to move to in pause/resume function was already higher than last_position + z_hop
- Added default values to macros parameters
## Notes to Code Reviewers

## How the changes in this PR are tested
Tested infinite runout
![image](https://github.com/user-attachments/assets/1a9d70b7-7c74-490d-b70c-53985ed2804a)

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design channel requesting review
