### PR TITLE
Add park macro option to lower z height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-05-30]
+
+### Added
+- Updated park to allow moving to an absolute z height after the x,y move. This is intended to reduce oozing during unload and load prior to using the poop command.
+
 ## [2025-05-27]
 ### Added
 - Some AFC macros are now exposed in Mainsail/Fluidd. 

--- a/config/AFC_Macro_Vars.cfg
+++ b/config/AFC_Macro_Vars.cfg
@@ -218,3 +218,6 @@ gcode: # Leave empty
 variable_park_loc_xy              : -1, -1    # Position to park the toolhead
 # If you want z_hop during toolchanges please set the value in the AFC.cfg
 variable_z_hop                    : 0         # Height to raise Z when moving to park. Leave 0 to disable
+variable_park_z                   : 0         # Absolute height to lower to after park move.  Leave 0 to disable
+                                              # This is intended to be used to reduce oozing during loading / unload right before a poop.
+                                              # Typically this would be set at the variable_purge_start value when needed.

--- a/config/macros/Park.cfg
+++ b/config/macros/Park.cfg
@@ -12,6 +12,8 @@ gcode:
   {% set z_hop = vars['z_hop']|float %}
   {% set z_hop = params.Z_HOP|default(z_hop)|float %}
 
+  {% set park_z = vars['park_z']|default(0.0)|float %}
+
   {% set max_z = printer.toolhead.axis_maximum.z - printer.gcode_move.homing_origin.z |float %}
   {% set cur_z = printer.toolhead.position.z|float %}
 
@@ -28,3 +30,8 @@ gcode:
 
   G1 Z{z_safe} F{z_travel_speed}
   G1 X{Px} Y{Py} F{travel_speed}
+
+  # Reduce likeliness of unwanted oozing during filament unload / load prior to a poop
+  {% if park_z > 0 and park_z < z_safe %}
+  G1 Z{park_z} F{z_travel_speed}
+  {% endif %}


### PR DESCRIPTION
This is intended to reduce oozing during filament unloading and loading prior to using the poop macro.

Adds a park_z macro variable to set the z height to move to after the move to the park x,y location.
This is default disabled and can only be used to move closer to the bed.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design channel requesting review
