### PR TITLE
Macro fix: Fixing default values for xy and z coordinate values

### DIFF
--- a/config/macros/Brush.cfg
+++ b/config/macros/Brush.cfg
@@ -7,7 +7,7 @@ gcode:
     {% set z_travel_speed    = gVars['z_travel_speed'] * 60|default(30)*60|float %}
     {% set verbose           = gVars['verbose']|default(1)|int %}
     {% set vars              = printer['gcode_macro _AFC_BRUSH_VARS'] %}
-    {% set Bx, By, Bz        = vars.brush_loc|default(-1,-1,-1)|map('float') %}
+    {% set Bx, By, Bz        = vars.brush_loc|default([-1,-1,-1])|map('float') %}
     {% set brush_clean_accel = vars['brush_clean_accel']|default(0)|float %}
     {% set y_brush           = vars['y_brush']|default(false)|lower == 'true' %}
     {% set brush_clean_speed = vars['brush_clean_speed'] * 60|default(150)*60|float %}

--- a/config/macros/Cut.cfg
+++ b/config/macros/Cut.cfg
@@ -6,7 +6,7 @@ gcode:
     {% set travel_speed = gVars['travel_speed'] * 60|default(120)*60|float %}
     {% set verbose = gVars['verbose']|default(1)|int %}
     {% set vars = printer['gcode_macro _AFC_CUT_TIP_VARS'] %}
-    {% set pin_loc_x, pin_loc_y = vars.pin_loc_xy|default(-1, -1)|map('float') %}
+    {% set pin_loc_x, pin_loc_y = vars.pin_loc_xy|default([-1, -1])|map('float') %}
     {% set pin_park_dist = vars['pin_park_dist']|default(6.0)|float %}
     {% set retract_length = vars['retract_length']|default(8.5)|float %}
     {% set quick_tip_forming = vars['quick_tip_forming']|default(true)|lower == 'true' %}

--- a/config/macros/Kick.cfg
+++ b/config/macros/Kick.cfg
@@ -6,7 +6,7 @@ gcode:
   {% set z_travel_speed = gVars['z_travel_speed'] * 60|default(30)*60|float %}
   {% set verbose = gVars['verbose']|default(1)|int %}
   {% set vars = printer['gcode_macro _AFC_KICK_VARS'] %}
-  {% set kick_start_x, kick_start_y, kick_start_z = vars.kick_start_loc|default(-1,-1,5)|map('float') %}
+  {% set kick_start_x, kick_start_y, kick_start_z = vars.kick_start_loc|default([-1,-1,5])|map('float') %}
   {% set kick_z = vars['kick_z']|default(1.5)|float %}
   {% set kick_direction = vars['kick_direction']|default('')|lower %}
   {% set kick_move_dist = vars['kick_move_dist']|default(45)|float %}

--- a/config/macros/Park.cfg
+++ b/config/macros/Park.cfg
@@ -5,7 +5,7 @@ gcode:
   {% set verbose = gVars['verbose']|default(1)|int %}
   {% set z_travel_speed = gVars['z_travel_speed'] * 60|default(30)*60|float %}
   {% set vars = printer['gcode_macro _AFC_PARK_VARS'] %}
-  {% set Px, Py = vars.park_loc_xy|default(-1,-1)|map('float') %}
+  {% set Px, Py = vars.park_loc_xy|default([-1,-1])|map('float') %}
   {% set Px = params.X|default(Px)|float %}
   {% set Py = params.Y|default(Py)|float %}
 

--- a/config/macros/Poop.cfg
+++ b/config/macros/Poop.cfg
@@ -13,7 +13,7 @@ gcode:
   {% set z_travel_speed         = gVars['z_travel_speed'] * 60|default(30)*60|float %}
   {% set verbose                = gVars['verbose']|default(1)|int %}
   {% set vars                   = printer['gcode_macro _AFC_POOP_VARS'] %}
-  {% set purge_x, purge_y       = vars.purge_loc_xy|default(-1,-1)|map('float') %}
+  {% set purge_x, purge_y       = vars.purge_loc_xy|default([-1,-1])|map('float') %}
   {% set purge_spd              = vars['purge_spd'] * 60|default(6.5)*60|float %}
   {% set z_poop                 = vars['z_purge_move']|default(true)|lower == 'true' %}
   {% set fast_z                 = vars['fast_z'] * 60|default(200)*60|float %}


### PR DESCRIPTION
## Major Changes in this PR
Previous PR defaults were added to macro variables, xy and z coordinate values were being passed in wrong. This PR corrects that and passes the values in as a list.

## How the changes in this PR are tested
Created test macros with all the variables to verify that the defaults would not error out jinja when running the macros. Ran the macros successfully without errors
![image](https://github.com/user-attachments/assets/7c423820-18b7-4fd9-a9b1-581374ae0e5b)

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [ ] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design channel requesting review
