### PR TITLE
Enhance QuattroBox support with updated configuration and installatio…

### DIFF
--- a/include/install_functions.sh
+++ b/include/install_functions.sh
@@ -155,13 +155,6 @@ install_afc() {
       add_buffer_to_extruder "${afc_config_dir}/AFC_${boxturtle_name}.cfg" "${boxturtle_name}"
     fi
   fi
-  # Setup buffer for QuattroBox
-  if [ "$installation_type" == "QuattroBox" ]; then
-    print_msg WARNING "Ensure you enter the correct pins here for the TN. The default pins are NOT valid for the QuattroBox."
-    query_tn_pins "TN"
-    append_buffer_config "TurtleNeck" "$tn_advance_pin" "$tn_trailing_pin"
-    add_buffer_to_extruder "${afc_config_dir}/AFC_QuattroBox_1.cfg" "QuattroBox_1"
-  fi
   check_and_append_prep "${afc_config_dir}/AFC.cfg"
   replace_varfile_path "${afc_config_dir}/AFC.cfg"
   update_moonraker_config

--- a/templates/AFC_Hardware-QuattroBox.cfg
+++ b/templates/AFC_Hardware-QuattroBox.cfg
@@ -11,7 +11,7 @@ tool_unload_speed: 35           # Unload speed in mm/s. Default is 25mm/s.
 tool_load_speed: 25             # Load speed in mm/s. Default is 25mm/s.
 
 #[filament_switch_sensor bypass]
-#switch_pin: ^Nightowl:PB5
+#switch_pin: ^MCU:PB5
 #pause_on_runout: False
 
 [AFC_buffer TN]

--- a/templates/AFC_Hardware-QuattroBox.cfg
+++ b/templates/AFC_Hardware-QuattroBox.cfg
@@ -14,12 +14,6 @@ tool_load_speed: 25             # Load speed in mm/s. Default is 25mm/s.
 #switch_pin: ^MCU:PB5
 #pause_on_runout: False
 
-[AFC_buffer TN]
-advance_pin: <insert_advance_pin>     # set advance pin
-trailing_pin: <insert_trailing_pin>   # set trailing pin
-multiplier_high: 1.05   # default 1.05, factor to feed more filament
-multiplier_low:  0.95   # default 0.95, factor to feed less filament
-
 #--=================================================================================--#
 ######### Tip Cut Servo ###############################################################
 #--=================================================================================--#

--- a/templates/AFC_QuattroBox_14.cfg
+++ b/templates/AFC_QuattroBox_14.cfg
@@ -11,16 +11,21 @@
 # sensor_type: temperature_mcu
 # sensor_mcu: QuattroBox
 
+[AFC_buffer QuattroBox_1]
+advance_pin: <insert_advance_pin>     # set advance pin
+trailing_pin: <insert_trailing_pin>   # set trailing pin
+multiplier_high: 1.05   # default 1.05, factor to feed more filament
+multiplier_low:  0.95   # default 0.95, factor to feed less filament
+
 [AFC_QuattroBox QuattroBox_1]
 type: 'Quattro_Box'
 hub: QuattroBox_Hub
 extruder: extruder
-buffer: TN                  #Turtleneck as standard Buffer
+buffer: QuattroBox_1                  #Turtleneck as standard Buffer
 led_logo_index: AFC_Indicator: 9-36   # A comma seperated list, can be ranged list eg. 1-4, 6, 11, 16-18
 led_logo_color: 1,0.15,0.66,0                # Sets custom color to logo when no lane is loaded in toolhead, defaults off
 # led_logo_loading: 0,0,1,0           # Sets custom color to set logo when loading a lane to toolhead, defaults to blue
 # led_spool_illuminate: 1,1,1,1       # Sets custom color to illuminate spool when filament is loaded, defaults to white
-
 
 [AFC_stepper lane1]
 unit: QuattroBox_1:1
@@ -117,7 +122,6 @@ uart_address: 0
 run_current: 0.7
 hold_current: 0.2
 sense_resistor: 0.110
-
 
 [AFC_hub QuattroBox_Hub]
 afc_bowden_length: 1145.0

--- a/templates/AFC_QuattroBox_14.cfg
+++ b/templates/AFC_QuattroBox_14.cfg
@@ -1,0 +1,146 @@
+# When using different hardware use config below as template
+# Adapt pins in config file
+[include mcu/MMB_QB.cfg]
+
+[mcu QuattroBox_1]
+#comment one out and add serial or uuid of the board QuattroBox
+#serial:
+#canbus_uuid: 
+
+# [temperature_sensor QuattroBox-ERB]
+# sensor_type: temperature_mcu
+# sensor_mcu: QuattroBox
+
+[AFC_QuattroBox QuattroBox_1]
+type: 'Quattro_Box'
+hub: QuattroBox_Hub
+extruder: extruder
+buffer: TN                  #Turtleneck as standard Buffer
+led_logo_index: AFC_Indicator: 9-36   # A comma seperated list, can be ranged list eg. 1-4, 6, 11, 16-18
+led_logo_color: 1,0.15,0.66,0                # Sets custom color to logo when no lane is loaded in toolhead, defaults off
+# led_logo_loading: 0,0,1,0           # Sets custom color to set logo when loading a lane to toolhead, defaults to blue
+# led_spool_illuminate: 1,1,1,1       # Sets custom color to illuminate spool when filament is loaded, defaults to white
+
+
+[AFC_stepper lane1]
+unit: QuattroBox_1:1
+extruder: extruder
+step_pin: QuattroBox_1:M1_STEP
+dir_pin: QuattroBox_1:M1_DIR
+enable_pin: !QuattroBox_1:M1_EN
+microsteps: 16
+gear_ratio: 50:10
+rotation_distance: 22.7316868
+dist_hub: 95.0
+park_dist: 10
+load: ^QuattroBox_1:EXT1
+prep: ^QuattroBox_1:TRG1
+led_index: AFC_Indicator:1
+led_spool_index: AFC_Indicator:2
+print_current: 0.4
+
+[tmc2209 AFC_stepper lane1]
+uart_pin: QuattroBox_1:M1_UART
+uart_address: 0
+run_current: 0.7
+hold_current: 0.2
+sense_resistor: 0.110
+
+[AFC_stepper lane2]
+unit: QuattroBox_1:2
+extruder: extruder
+step_pin: QuattroBox_1:M2_STEP
+dir_pin: QuattroBox_1:M2_DIR
+enable_pin: !QuattroBox_1:M2_EN
+microsteps: 16
+gear_ratio: 50:10
+rotation_distance: 22.7316868
+dist_hub: 45.0
+park_dist: 10
+load: ^QuattroBox_1:EXT2
+prep: ^QuattroBox_1:TRG2
+led_index: AFC_Indicator:3
+led_spool_index: AFC_Indicator:4
+print_current: 0.4
+
+[tmc2209 AFC_stepper lane2]
+uart_pin: QuattroBox_1:M2_UART
+uart_address: 0
+run_current: 0.7
+hold_current: 0.2
+sense_resistor: 0.110
+
+[AFC_stepper lane3]
+unit: QuattroBox_1:3
+extruder: extruder
+step_pin: QuattroBox_1:M3_STEP
+dir_pin: !QuattroBox_1:M3_DIR
+enable_pin: !QuattroBox_1:M3_EN
+microsteps: 16
+gear_ratio: 50:10
+rotation_distance: 22.7316868
+dist_hub: 40.0
+park_dist: 10
+load: ^QuattroBox_1:EXT3
+prep: ^QuattroBox_1:TRG3
+led_index: AFC_Indicator:5
+led_spool_index: AFC_Indicator:6
+print_current: 0.4
+
+[tmc2209 AFC_stepper lane3]
+uart_pin: QuattroBox_1:M3_UART
+uart_address: 0
+run_current: 0.7
+hold_current: 0.2
+sense_resistor: 0.110
+
+[AFC_stepper lane4]
+unit: QuattroBox_1:4
+extruder: extruder
+step_pin: QuattroBox_1:M4_STEP
+dir_pin: !QuattroBox_1:M4_DIR
+enable_pin: !QuattroBox_1:M4_EN
+microsteps: 16
+gear_ratio: 50:10
+rotation_distance: 22.7316868
+dist_hub: 90.0
+park_dist: 10
+load: ^QuattroBox_1:EXT4
+prep: ^QuattroBox_1:TRG4
+led_index: AFC_Indicator:7
+led_spool_index: AFC_Indicator:8
+print_current: 0.4
+
+[tmc2209 AFC_stepper lane4]
+uart_pin: QuattroBox_1:M4_UART
+uart_address: 0
+run_current: 0.7
+hold_current: 0.2
+sense_resistor: 0.110
+
+
+[AFC_hub QuattroBox_Hub]
+afc_bowden_length: 1145.0
+move_dis: 50                # Distance to move the filament within the hub in mm.
+cut: False                  # Hub has Cutter
+hub_clear_move_dis: 55
+
+#--=================================================================================--#
+######### Hub Cut #####################################################################
+#--=================================================================================--#
+cut_cmd: AFC                #CMD to use
+cut_dist: 200               # How much filament to cut off (in mm).
+cut_clear: 120              # How far the filament should retract back from the hub (in mm).
+cut_min_length: 300.0
+cut_servo_pass_angle: 10    # Servo angle to align the Bowden tube with the hole for loading the toolhead.
+cut_servo_clip_angle: 180   # Servo angle for cutting the filament.
+cut_servo_prep_angle: 80    # Servo angle to prepare the filament for cutting (aligning the exit hole).
+switch_pin: ^QuattroBox_1:HUB
+
+
+[AFC_led AFC_Indicator]
+pin: QuattroBox_1:RGB
+#    MCU pin definition for LED indicator.
+chain_count: 36
+#    Number of LEDs in the chain.
+color_order: GRBW,GRBW,GRBW,GRBW,GRBW,GRBW,GRBW,GRBW,GRB,GRB,GRB,GRB,GRB,GRB,GRB,GRB,GRB,GRB,GRB,GRB,GRB,GRB,GRB,GRB,GRB,GRB,GRB,GRB,GRB,GRB,GRB,GRB,GRB,GRB,GRB,GRB		# Set based on your particular neopixel specification (can be comma separated list)

--- a/templates/AFC_QuattroBox_17.cfg
+++ b/templates/AFC_QuattroBox_17.cfg
@@ -22,7 +22,7 @@ type: 'Quattro_Box'
 hub: QuattroBox_Hub
 extruder: extruder
 buffer: QuattroBox_1                  #Turtleneck as standard Buffer
-led_logo_index: AFC_Indicator: 9-36   # A comma seperated list, can be ranged list eg. 1-4, 6, 11, 16-18
+led_logo_index: AFC_Indicator: 9-36   # A comma separated list, can be ranged list eg. 1-4, 6, 11, 16-18
 led_logo_color: 1,0.15,0.66,0                # Sets custom color to logo when no lane is loaded in toolhead, defaults off
 # led_logoEXTing: 0,0,1,0              # Sets custom color to set logo when loading a lane to toolhead, defautls to blue
 # led_spool_illuminate: 1,1,1,1          # Sets custom color to illuminate spool when filament is loaded, defaults to white

--- a/templates/AFC_QuattroBox_17.cfg
+++ b/templates/AFC_QuattroBox_17.cfg
@@ -11,16 +11,21 @@
 sensor_type: temperature_mcu
 sensor_mcu: QuattroBox
 
+[AFC_buffer QuattroBox_1]
+advance_pin: <insert_advance_pin>     # set advance pin
+trailing_pin: <insert_trailing_pin>   # set trailing pin
+multiplier_high: 1.05   # default 1.05, factor to feed more filament
+multiplier_low:  0.95   # default 0.95, factor to feed less filament
+
 [AFC_QuattroBox QuattroBox_1]
 type: 'Quattro_Box'
 hub: QuattroBox_Hub
 extruder: extruder
-buffer: TN                  #Turtleneck as standard Buffer
+buffer: QuattroBox_1                  #Turtleneck as standard Buffer
 led_logo_index: AFC_Indicator: 9-36   # A comma seperated list, can be ranged list eg. 1-4, 6, 11, 16-18
 led_logo_color: 1,0.15,0.66,0                # Sets custom color to logo when no lane is loaded in toolhead, defaults off
 # led_logoEXTing: 0,0,1,0              # Sets custom color to set logo when loading a lane to toolhead, defautls to blue
 # led_spool_illuminate: 1,1,1,1          # Sets custom color to illuminate spool when filament is loaded, defaults to white
-
 
 [AFC_stepper lane1]
 unit: QuattroBox_1:1
@@ -37,7 +42,6 @@ prep: ^QuattroBox_1:TRG1
 led_index: AFC_Indicator:1
 led_spool_index: AFC_Indicator:2
 print_current: 0.4
-
 
 [tmc2209 AFC_stepper lane1]
 uart_pin: QuattroBox_1:M1_UART
@@ -61,7 +65,6 @@ prep: ^QuattroBox_1:TRG2
 led_index: AFC_Indicator:3
 led_spool_index: AFC_Indicator:4
 print_current: 0.4
-
 
 [tmc2209 AFC_stepper lane2]
 uart_pin: QuattroBox_1:M2_UART
@@ -116,7 +119,6 @@ run_current: 1.0
 hold_current: 0.2
 sense_resistor: 0.110
 
-
 [AFC_hub QuattroBox_Hub]
 afc_bowden_length: 1110.0 
 move_dis: 50                # Distance to move the filament within the hub in mm.
@@ -134,7 +136,6 @@ cut_servo_pass_angle: 10    # Servo angle to align the Bowden tube with the hole
 cut_servo_clip_angle: 180   # Servo angle for cutting the filament.
 cut_servo_prep_angle: 80    # Servo angle to prepare the filament for cutting (aligning the exit hole).
 switch_pin: ^QuattroBox_1:HUB
-
 
 [AFC_led AFC_Indicator]
 pin: QuattroBox_1:RGB

--- a/templates/AFC_QuattroBox_17.cfg
+++ b/templates/AFC_QuattroBox_17.cfg
@@ -1,15 +1,15 @@
 # When using different hardware use config below as template
 # Adapt pins in config file
-[include mcu/MMB_1.0_QB.cfg]
+[include mcu/MMB_QB.cfg]
 
 [mcu QuattroBox_1]
 #comment one out and add serial or uuid of the board QuattroBox
 #serial:
-#canbus_uuid: 
+#canbus_uuid:
 
-# [temperature_sensor QuattroBox-ERB]
-# sensor_type: temperature_mcu
-# sensor_mcu: QuattroBox
+[temperature_sensor QuattroBox_1]
+sensor_type: temperature_mcu
+sensor_mcu: QuattroBox
 
 [AFC_QuattroBox QuattroBox_1]
 type: 'Quattro_Box'
@@ -18,20 +18,19 @@ extruder: extruder
 buffer: TN                  #Turtleneck as standard Buffer
 led_logo_index: AFC_Indicator: 9-36   # A comma seperated list, can be ranged list eg. 1-4, 6, 11, 16-18
 led_logo_color: 1,0.15,0.66,0                # Sets custom color to logo when no lane is loaded in toolhead, defaults off
-# led_logo_loading: 0,0,1,0           # Sets custom color to set logo when loading a lane to toolhead, defaults to blue
-# led_spool_illuminate: 1,1,1,1       # Sets custom color to illuminate spool when filament is loaded, defaults to white
+# led_logoEXTing: 0,0,1,0              # Sets custom color to set logo when loading a lane to toolhead, defautls to blue
+# led_spool_illuminate: 1,1,1,1          # Sets custom color to illuminate spool when filament is loaded, defaults to white
 
 
 [AFC_stepper lane1]
 unit: QuattroBox_1:1
 extruder: extruder
 step_pin: QuattroBox_1:M1_STEP
-dir_pin: QuattroBox_1:M1_DIR
+dir_pin: !QuattroBox_1:M1_DIR
 enable_pin: !QuattroBox_1:M1_EN
 microsteps: 16
-gear_ratio: 50:10
 rotation_distance: 22.7316868
-dist_hub: 95.0
+dist_hub: 130.0 
 park_dist: 10
 load: ^QuattroBox_1:EXT1
 prep: ^QuattroBox_1:TRG1
@@ -39,10 +38,11 @@ led_index: AFC_Indicator:1
 led_spool_index: AFC_Indicator:2
 print_current: 0.4
 
+
 [tmc2209 AFC_stepper lane1]
 uart_pin: QuattroBox_1:M1_UART
 uart_address: 0
-run_current: 0.7
+run_current: 1.0
 hold_current: 0.2
 sense_resistor: 0.110
 
@@ -50,12 +50,11 @@ sense_resistor: 0.110
 unit: QuattroBox_1:2
 extruder: extruder
 step_pin: QuattroBox_1:M2_STEP
-dir_pin: QuattroBox_1:M2_DIR
+dir_pin: !QuattroBox_1:M2_DIR
 enable_pin: !QuattroBox_1:M2_EN
 microsteps: 16
-gear_ratio: 50:10
 rotation_distance: 22.7316868
-dist_hub: 45.0
+dist_hub: 80.0 
 park_dist: 10
 load: ^QuattroBox_1:EXT2
 prep: ^QuattroBox_1:TRG2
@@ -63,10 +62,11 @@ led_index: AFC_Indicator:3
 led_spool_index: AFC_Indicator:4
 print_current: 0.4
 
+
 [tmc2209 AFC_stepper lane2]
 uart_pin: QuattroBox_1:M2_UART
 uart_address: 0
-run_current: 0.7
+run_current: 1.0
 hold_current: 0.2
 sense_resistor: 0.110
 
@@ -77,9 +77,8 @@ step_pin: QuattroBox_1:M3_STEP
 dir_pin: !QuattroBox_1:M3_DIR
 enable_pin: !QuattroBox_1:M3_EN
 microsteps: 16
-gear_ratio: 50:10
 rotation_distance: 22.7316868
-dist_hub: 40.0
+dist_hub: 85.0 
 park_dist: 10
 load: ^QuattroBox_1:EXT3
 prep: ^QuattroBox_1:TRG3
@@ -90,7 +89,7 @@ print_current: 0.4
 [tmc2209 AFC_stepper lane3]
 uart_pin: QuattroBox_1:M3_UART
 uart_address: 0
-run_current: 0.7
+run_current: 1.0
 hold_current: 0.2
 sense_resistor: 0.110
 
@@ -101,9 +100,8 @@ step_pin: QuattroBox_1:M4_STEP
 dir_pin: !QuattroBox_1:M4_DIR
 enable_pin: !QuattroBox_1:M4_EN
 microsteps: 16
-gear_ratio: 50:10
 rotation_distance: 22.7316868
-dist_hub: 90.0
+dist_hub: 130.0 
 park_dist: 10
 load: ^QuattroBox_1:EXT4
 prep: ^QuattroBox_1:TRG4
@@ -114,16 +112,16 @@ print_current: 0.4
 [tmc2209 AFC_stepper lane4]
 uart_pin: QuattroBox_1:M4_UART
 uart_address: 0
-run_current: 0.7
+run_current: 1.0
 hold_current: 0.2
 sense_resistor: 0.110
 
 
 [AFC_hub QuattroBox_Hub]
-afc_bowden_length: 1145.0
+afc_bowden_length: 1110.0 
 move_dis: 50                # Distance to move the filament within the hub in mm.
 cut: False                  # Hub has Cutter
-hub_clear_move_dis: 55
+hub_clear_move_dis: 30
 
 #--=================================================================================--#
 ######### Hub Cut #####################################################################


### PR DESCRIPTION
…n scripts

## Major Changes in this PR

This pull request introduces significant updates to the QuattroBox configuration system, improving flexibility for different hardware setups and ensuring better compatibility with motor and board types. The changes include updates to the installation script, new configuration templates, and adjustments to existing templates for better hardware support.

### Installation Script Updates:
* Enhanced the `copy_unit_files()` function to handle different motor types (`NEMA_14` and `NEMA_17`) and board versions (`MMB_1.0`, `MMB_1.1`, `MMB_2.0`) with conditional logic for configuration file adjustments.
* Added a conditional check in `install_afc()` to skip excluding files from the Klipper `.gitignore` in test mode.
* Improved handling of `test_mode` by quoting variables in conditional checks for better scripting practices.

### Configuration Template Updates:
* Renamed `AFC_QuattroBox.cfg` to `AFC_QuattroBox_14.cfg` and introduced `AFC_QuattroBox_17.cfg` to support specific hardware configurations for `NEMA_14` and `NEMA_17` motors. [[1]](diffhunk://#diff-482bd007d8ee1188d561f50ed48fbfdc050a2e4f9c449b077d429fa28870193aL3-R3) [[2]](diffhunk://#diff-b23413d950f875f537272b4c8a082bc1fcc89acc01aec31664f4673848b73f08R1-R145)
* Updated `AFC_Hardware-QuattroBox.cfg` to replace outdated pin definitions and remove unused buffer settings.

### New Features and Documentation:
* Added a new message prompt for QuattroBox installation, instructing users to update buffer configurations and CAN bus or serial information.
* Introduced detailed configuration options in `AFC_QuattroBox_17.cfg` to define stepper motor settings, LED configurations, and hub parameters.

## Notes to Code Reviewers

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design channel requesting review
