### PR TITLE
Add configurable error timeout in AFC configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-006-06]
+
+### Added
+- There is now a configurable option `error_timeout` in the `[AFC]` section of the `AFC.cfg` file. This option allows 
+users to set a timeout for how long the printer will stay in a paused state when an error occurs. The default value is 
+`36000` seconds (10 hours). 
+
 ## [2025-05-30]
 
 ### Added

--- a/config/AFC.cfg
+++ b/config/AFC.cfg
@@ -41,6 +41,7 @@ assisted_unload: True           # If True, the unload retract is assisted to pre
 z_hop: 5                        # Height to move up before and after a tool change completes
 resume_speed: 120               # Speed mm/s of resume move. Set to 0 to use gcode speed
 resume_z_speed: 30              # Speed mm/s of resume move in Z. Set to 0 to use gcode speed
+error_timeout: 36000            # Time in seconds to pause when an error is detected.
 
 
 #--=================================================================================-

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -170,6 +170,7 @@ class afc:
         self.z_hop                  = config.getfloat("z_hop", 0)                   # Height to move up before and after a tool change completes
         self.xy_resume              = config.getboolean("xy_resume", False)         # Need description or remove as this is currently an unused variable
         self.resume_speed           = config.getfloat("resume_speed", self.speed)   # Speed mm/s of resume move. Set to 0 to use gcode speed
+        self.error_timeout          = config.getfloat("error_timeout", 36000)      # Timeout in seconds to pause before erroring out when AFC is in error state
         self.resume_z_speed         = config.getfloat("resume_z_speed", self.speed) # Speed mm/s of resume move in Z. Set to 0 to use gcode speed
 
         self.global_print_current   = config.getfloat("global_print_current", None) # Global variable to set steppers current to a specified current when printing. Going lower than 0.6 may result in TurtleNeck buffer's not working correctly

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -35,7 +35,8 @@ class afcError:
         """
         self.afc            = self.printer.lookup_object('AFC')
         self.pause_resume   = self.printer.lookup_object("pause_resume")
-        self.logger = self.afc.logger
+        self.logger         = self.afc.logger
+        self.error_timeout  = self.afc.error_timeout
         # Constant variable for renaming RESUME macro
         self.BASE_RESUME_NAME       = 'RESUME'
         self.AFC_RENAME_RESUME_NAME = '_AFC_RENAMED_{}_'.format(self.BASE_RESUME_NAME)
@@ -234,7 +235,7 @@ class afcError:
             # Call users PAUSE
             self.afc.gcode.run_script_from_command("{macro_name} {user_params}".format(macro_name=self.AFC_RENAME_PAUSE_NAME, user_params=gcmd.get_raw_command_parameters()))
             # Set Idle timeout to 10 hours
-            self.afc.gcode.run_script_from_command("SET_IDLE_TIMEOUT TIMEOUT=36000")
+            self.afc.gcode.run_script_from_command("SET_IDLE_TIMEOUT TIMEOUT={error_timeout}".format(error_timeout=self.error_timeout))
         else:
             self.logger.debug("AFC_PAUSE: Not Pausing")
 


### PR DESCRIPTION
## Major Changes in this PR

This pull request introduces a new configurable option, `error_timeout`, to the `[AFC]` section of the `AFC.cfg` file, allowing users to set a timeout for how long the printer remains paused when an error occurs. The default value is 10 hours (36000 seconds). The changes include updates to the configuration file, relevant Python classes, and the changelog.

### Configuration Updates:
* Added `error_timeout` to the `[AFC]` section of the `AFC.cfg` file, with a default value of `36000` seconds. This option determines the timeout duration for the printer in a paused state during errors.

### Codebase Updates:
* Updated the `AFC` class in `extras/AFC.py` to initialize the `error_timeout` property from the configuration file, defaulting to 36000 seconds.
* Modified the `AFC_error` class in `extras/AFC_error.py` to retrieve the `error_timeout` value during initialization and use it dynamically in the `cmd_AFC_PAUSE` method when setting the idle timeout. [[1]](diffhunk://#diff-c91f8e448ecb59adbf9ca981102fddfd8b80642ef85128ace14b0f6663e056d6R39) [[2]](diffhunk://#diff-c91f8e448ecb59adbf9ca981102fddfd8b80642ef85128ace14b0f6663e056d6L237-R238)

### Documentation Updates:
* Updated the `CHANGELOG.md` file to document the addition of the `error_timeout` option.

## Notes to Code Reviewers

Closes #374

## How the changes in this PR are tested

Verify configuration loads, not sure how to manually trigger it.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design channel requesting review
