### PR TITLE
Add configuration files and update afc-debug.sh for log archiving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ users to set a timeout for how long the printer will stay in a paused state when
 `36000` seconds (10 hours). When a `PAUSE` action is triggered, AFC will now compare the value of the `error_timeout` and
 the `idle_timeout` value (if defined) and choose the larger of the two values. 
 
+### Changed
+- The `afc-debug.sh` script will now create a zip file of the logs if the `nc` utility is not available. 
+
+
 ## [2025-05-30]
 
 ### Added


### PR DESCRIPTION
## Major Changes in this PR

This pull request enhances the `afc-debug.sh` script by introducing a fallback mechanism for handling logs when `NetCat` is unavailable. It also includes minor improvements for readability. Below are the most important changes:

### New fallback mechanism for log handling:
* Added a `NO_NC` variable to track the availability of `NetCat` and updated the `checknc` function to set this variable if `NetCat` installation fails. [[1]](diffhunk://#diff-f90bf2ef443900b47139a1df1cf4fed2ee7afaea3274ba701e86d8905f704d54R23-R29) [[2]](diffhunk://#diff-f90bf2ef443900b47139a1df1cf4fed2ee7afaea3274ba701e86d8905f704d54L102-R105)
* Implemented logic to create a zip archive of logs when `NetCat` is unavailable, ensuring logs can still be shared with the support team.

### Code readability improvements:
* Fixed a minor typo in a comment for better clarity (`Lets` → `Let's`).
* Added a missing `fi` to properly close the conditional block in the log handling section.

## Notes to Code Reviewers

## How the changes in this PR are tested

Use a bad `nc` package name 
```
This script will collect diagnostic information and upload it to Armored Turtle support.
Please review the script if you have concerns about its contents.
Klipper will be stopped during this process — do not run this while printing.

Do you wish to continue? [y/n]: y
Stopping Klipper using systemd...
NetCat not found, installing...
E: Unable to locate package 1netcat-openbsd
Using temporary log file: /tmp/tmp.wPfwmafbEF
Extracting Klipper logs...
Temporary directory created at /tmp/tmp.YrqiZmOz74
Gathering system information...
Querying CAN devices...
NetCat is unavailable. Creating a zip archive of logs instead.
Logs have been saved to /home/pi/afc_debug_logs_20250607_120105.zip
Please share this file with the Armored Turtle support team.
Starting Klipper using systemd...
```
Then run it with `nc` installed and verified it uploaded properly.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design channel requesting review
