### PR TITLE
Add configuration files and macros for QuattroBox support

### DIFF
--- a/include/install_functions.sh
+++ b/include/install_functions.sh
@@ -87,6 +87,7 @@ copy_unit_files() {
 
   "QuattroBox")
     cp "${afc_path}/templates/AFC_Hardware-QuattroBox.cfg" "${afc_config_dir}/AFC_Hardware.cfg"
+    cp "${afc_path}/templates/qb_macros/Eject_buttons.cfg" "${afc_config_dir}/macros/Eject_buttons.cfg"
     if [ "${qb_motor_type}" == "NEMA_14" ]; then
       cp "${afc_path}/templates/AFC_QuattroBox_14.cfg" "${afc_config_dir}/AFC_QuattroBox_1.cfg"
       if [ "${qb_board_type}" == "MMB_1.0" ]; then

--- a/templates/AFC_QuattroBox_14.cfg
+++ b/templates/AFC_QuattroBox_14.cfg
@@ -7,9 +7,9 @@
 #serial:
 #canbus_uuid: 
 
-# [temperature_sensor QuattroBox-ERB]
-# sensor_type: temperature_mcu
-# sensor_mcu: QuattroBox
+[temperature_sensor QuattroBox_1]
+sensor_type: temperature_mcu
+sensor_mcu: QuattroBox_1
 
 [AFC_buffer QuattroBox_1]
 advance_pin: <insert_advance_pin>     # set advance pin

--- a/templates/AFC_QuattroBox_17.cfg
+++ b/templates/AFC_QuattroBox_17.cfg
@@ -9,7 +9,7 @@
 
 [temperature_sensor QuattroBox_1]
 sensor_type: temperature_mcu
-sensor_mcu: QuattroBox
+sensor_mcu: QuattroBox_1
 
 [AFC_buffer QuattroBox_1]
 advance_pin: <insert_advance_pin>     # set advance pin


### PR DESCRIPTION
## Major Changes in this PR

This pull request introduces updates to configuration files and installation scripts for the QuattroBox hardware. The changes primarily ensure consistency in sensor naming conventions and add a new macro configuration file to the installation process.

### Updates to installation scripts:

* [`include/install_functions.sh`](diffhunk://#diff-cf22d03e9fcc2eda523c8a6f6005097e735a940a77248d9251bdd84219106e77R90): Added a new step to copy the `Eject_buttons.cfg` macro configuration file into the appropriate directory during the installation process for QuattroBox.

### Updates to configuration files:

* [`templates/AFC_QuattroBox_14.cfg`](diffhunk://#diff-482bd007d8ee1188d561f50ed48fbfdc050a2e4f9c449b077d429fa28870193aL10-R12): Updated the `[temperature_sensor]` section to use `QuattroBox_1` as the `sensor_mcu` name, ensuring consistency with the hardware naming conventions.
* [`templates/AFC_QuattroBox_17.cfg`](diffhunk://#diff-b23413d950f875f537272b4c8a082bc1fcc89acc01aec31664f4673848b73f08L12-R12): Similarly updated the `sensor_mcu` field in the `[temperature_sensor]` section to `QuattroBox_1` for consistency.

## Notes to Code Reviewers

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [ ] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design channel requesting review
