### PR TITLE
Fixing issue where moves were going way to fast

### DIFF
--- a/config/macros/Brush.cfg
+++ b/config/macros/Brush.cfg
@@ -2,19 +2,19 @@
 description: Wipe the nozzle on the brush
 gcode:
     {% set gVars             = printer['gcode_macro _AFC_GLOBAL_VARS'] %}
-    {% set accel             = gVars['accel']|default(2000)|float %}
-    {% set travel_speed      = gVars['travel_speed'] * 60|default(120)*60|float %}
-    {% set z_travel_speed    = gVars['z_travel_speed'] * 60|default(30)*60|float %}
-    {% set verbose           = gVars['verbose']|default(1)|int %}
+    {% set accel             = gVars['accel']           | default(2000)  | float %}
+    {% set travel_speed      = gVars['travel_speed']    | default(120)*60| float %}
+    {% set z_travel_speed    = gVars['z_travel_speed']  | default(30)*60 | float %}
+    {% set verbose           = gVars['verbose']         | default(1)     | int %}
     {% set vars              = printer['gcode_macro _AFC_BRUSH_VARS'] %}
-    {% set Bx, By, Bz        = vars.brush_loc|default([-1,-1,-1])|map('float') %}
-    {% set brush_clean_accel = vars['brush_clean_accel']|default(0)|float %}
-    {% set y_brush           = vars['y_brush']|default(false)|lower == 'true' %}
-    {% set brush_clean_speed = vars['brush_clean_speed'] * 60|default(150)*60|float %}
-    {% set brush_width       = vars['brush_width']|default(30)|float %}
-    {% set brush_depth       = vars['brush_depth']|default(10)|float %}
-    {% set brush_count       = vars['brush_count']|default(4)|int %}
-    {% set z_move            = vars['z_move']     |default(-1)|float %}
+    {% set Bx, By, Bz        = vars.brush_loc           | default([-1,-1,-1])| map('float') %}
+    {% set brush_clean_accel = vars['brush_clean_accel']| default(0)         | float %}
+    {% set y_brush           = vars['y_brush']          | default(false)     | lower == 'true' %}
+    {% set brush_clean_speed = vars['brush_clean_speed']| default(150)*60    | float %}
+    {% set brush_width       = vars['brush_width']      | default(30)        | float %}
+    {% set brush_depth       = vars['brush_depth']      | default(10)        | float %}
+    {% set brush_count       = vars['brush_count']      | default(4)         | int %}
+    {% set z_move            = vars['z_move']           | default(-1)        | float %}
 
     # Get printer bounds to make sure none of our cleaning moves fall outside of them
     # Check for IDEX

--- a/config/macros/Cut.cfg
+++ b/config/macros/Cut.cfg
@@ -1,31 +1,31 @@
 [gcode_macro AFC_CUT]
 description: Cut filament by pressing the cutter on a pin
 gcode:
-    {% set gVars = printer['gcode_macro _AFC_GLOBAL_VARS'] %}
-    {% set accel = gVars['accel']|default(2000)|float %}
-    {% set travel_speed = gVars['travel_speed'] * 60|default(120)*60|float %}
-    {% set verbose = gVars['verbose']|default(1)|int %}
-    {% set vars = printer['gcode_macro _AFC_CUT_TIP_VARS'] %}
-    {% set pin_loc_x, pin_loc_y = vars.pin_loc_xy|default([-1, -1])|map('float') %}
-    {% set pin_park_dist = vars['pin_park_dist']|default(6.0)|float %}
-    {% set retract_length = vars['retract_length']|default(8.5)|float %}
-    {% set quick_tip_forming = vars['quick_tip_forming']|default(true)|lower == 'true' %}
-    {% set rip_length = vars['rip_length']|default(1.0)|float %}
-    {% set cut_direction = vars['cut_direction']|default('')|lower %}
-    {% set cut_accel = vars['cut_accel']|default(0)|float %}
-    {% set pushback_length = vars['pushback_length']|default(15)|float %}
-    {% set pushback_dwell_time = vars['pushback_dwell_time']|default(20)|int %}
-    {% set extruder_move_speed = vars['extruder_move_speed'] * 60|default(25)*60|float %}
-    {% set restore_position = vars['restore_position']|default(true)|lower == 'true' %}
-    {% set cut_count = vars['cut_count']|default(2)|int %}
-    {% set y_cut = vars['y_cut']|default(false)|lower == 'true' %}
-    {% set awd = vars['awd']|default(false)|lower == 'true' %}
-    {% set tool_servo_enable = vars['tool_servo_enable']|default(false)|lower == 'true' %}
+    {% set gVars                = printer['gcode_macro _AFC_GLOBAL_VARS'] %}
+    {% set accel                = gVars['accel']                |default(2000)  | float %}
+    {% set travel_speed         = gVars['travel_speed']         |default(120)*60| float %}
+    {% set verbose              = gVars['verbose']              |default(1)     | int %}
+    {% set vars                 = printer['gcode_macro _AFC_CUT_TIP_VARS'] %}
+    {% set pin_loc_x, pin_loc_y = vars.pin_loc_xy               |default([-1, -1])| map('float') %}
+    {% set pin_park_dist        = vars['pin_park_dist']         |default(6.0)   | float %}
+    {% set retract_length       = vars['retract_length']        |default(8.5)   | float %}
+    {% set quick_tip_forming    = vars['quick_tip_forming']     |default(true)  | lower == 'true' %}
+    {% set rip_length           = vars['rip_length']            |default(1.0)   | float %}
+    {% set cut_direction        = vars['cut_direction']         |default('')    | lower %}
+    {% set cut_accel            = vars['cut_accel']             |default(0)     | float %}
+    {% set pushback_length      = vars['pushback_length']       |default(15)    | float %}
+    {% set pushback_dwell_time  = vars['pushback_dwell_time']   |default(20)    | int %}
+    {% set extruder_move_speed  = vars['extruder_move_speed']   |default(25)*60 | float %}
+    {% set restore_position     = vars['restore_position']      |default(true)  | lower == 'true' %}
+    {% set cut_count            = vars['cut_count']             |default(2)     | int %}
+    {% set y_cut                = vars['y_cut']                 |default(false) | lower == 'true' %}
+    {% set awd                  = vars['awd']                   |default(false) | lower == 'true' %}
+    {% set tool_servo_enable    = vars['tool_servo_enable']     |default(false) | lower == 'true' %}
 
-    {% set cut_current_x = vars['cut_current_stepper_x']|default(0)|float %}
-    {% set cut_current_dc = vars['cut_current_dual_carriage']|default(0)|float %}
-    {% set cut_current_y = vars['cut_current_stepper_y']|default(0)|float %}
-    {% set cut_current_z = vars['cut_current_stepper_z']|default(0)|float %}
+    {% set cut_current_x        = vars['cut_current_stepper_x'] |default(0)     | float %}
+    {% set cut_current_dc       = vars['cut_current_dual_carriage']|default(0)  | float %}
+    {% set cut_current_y        = vars['cut_current_stepper_y'] |default(0)     | float %}
+    {% set cut_current_z        = vars['cut_current_stepper_z'] |default(0)     | float %}
 
     {% if verbose > 0 %}
       RESPOND TYPE=command MSG='AFC_Cut: Cut Filament'

--- a/config/macros/Kick.cfg
+++ b/config/macros/Kick.cfg
@@ -1,18 +1,18 @@
 [gcode_macro AFC_KICK]
 gcode:
-  {% set gVars = printer['gcode_macro _AFC_GLOBAL_VARS'] %}
-  {% set accel = gVars['accel']|default(2000)|float %}
-  {% set travel_speed = gVars['travel_speed'] * 60|default(120)*60|float %}
-  {% set z_travel_speed = gVars['z_travel_speed'] * 60|default(30)*60|float %}
-  {% set verbose = gVars['verbose']|default(1)|int %}
-  {% set vars = printer['gcode_macro _AFC_KICK_VARS'] %}
+  {% set gVars              = printer['gcode_macro _AFC_GLOBAL_VARS'] %}
+  {% set accel              = gVars['accel']            | default(2000)     | float %}
+  {% set travel_speed       = gVars['travel_speed']     | default(120)*60   | float %}
+  {% set z_travel_speed     = gVars['z_travel_speed']   | default(30)*60    | float %}
+  {% set verbose            = gVars['verbose']          | default(1)        | int %}
+  {% set vars               = printer['gcode_macro _AFC_KICK_VARS'] %}
   {% set kick_start_x, kick_start_y, kick_start_z = vars.kick_start_loc|default([-1,-1,5])|map('float') %}
-  {% set kick_z = vars['kick_z']|default(1.5)|float %}
-  {% set kick_direction = vars['kick_direction']|default('')|lower %}
-  {% set kick_move_dist = vars['kick_move_dist']|default(45)|float %}
-  {% set z_after_kick = vars['z_after_kick']|default(10)|float %}
-  {% set kick_speed = vars['kick_speed'] * 60|default(150)*60|float %}
-  {% set kick_accel = vars['kick_accel']|default(0)|float %}
+  {% set kick_z             = vars['kick_z']            | default(1.5)      | float %}
+  {% set kick_direction     = vars['kick_direction']    | default('')       | lower %}
+  {% set kick_move_dist     = vars['kick_move_dist']    | default(45)       | float %}
+  {% set z_after_kick       = vars['z_after_kick']      | default(10)       | float %}
+  {% set kick_speed         = vars['kick_speed']        | default(150)*60   | float %}
+  {% set kick_accel         = vars['kick_accel']        | default(0)        | float %}
 
   # Get printer bounds to make sure none of our kick moves fall outside of them
   # Check for IDEX

--- a/config/macros/Park.cfg
+++ b/config/macros/Park.cfg
@@ -1,21 +1,21 @@
 [gcode_macro AFC_PARK]
 gcode:
-  {% set gVars = printer['gcode_macro _AFC_GLOBAL_VARS'] %}
-  {% set travel_speed = gVars['travel_speed'] * 60|default(120)*60|float %}
-  {% set verbose = gVars['verbose']|default(1)|int %}
-  {% set z_travel_speed = gVars['z_travel_speed'] * 60|default(30)*60|float %}
-  {% set vars = printer['gcode_macro _AFC_PARK_VARS'] %}
-  {% set Px, Py = vars.park_loc_xy|default([-1,-1])|map('float') %}
-  {% set Px = params.X|default(Px)|float %}
-  {% set Py = params.Y|default(Py)|float %}
+  {% set gVars          = printer['gcode_macro _AFC_GLOBAL_VARS'] %}
+  {% set travel_speed   = gVars['travel_speed']     | default(120)*60   | float %}
+  {% set verbose        = gVars['verbose']          | default(1)        | int %}
+  {% set z_travel_speed = gVars['z_travel_speed']   | default(30)*60    | float %}
+  {% set vars           = printer['gcode_macro _AFC_PARK_VARS'] %}
+  {% set Px, Py         = vars.park_loc_xy          | default([-1,-1])  | map('float') %}
+  {% set Px             = params.X                  | default(Px)       | float %}
+  {% set Py             = params.Y                  | default(Py)       | float %}
 
-  {% set z_hop = vars['z_hop']|float %}
-  {% set z_hop = params.Z_HOP|default(z_hop)|float %}
+  {% set z_hop          = vars['z_hop']             | default(0)        | float %}
+  {% set z_hop          = params.Z_HOP              | default(z_hop)    | float %}
 
-  {% set park_z = vars['park_z']|default(0.0)|float %}
+  {% set park_z         = vars['park_z']            | default(0.0)      | float %}
 
-  {% set max_z = printer.toolhead.axis_maximum.z - printer.gcode_move.homing_origin.z |float %}
-  {% set cur_z = printer.toolhead.position.z|float %}
+  {% set max_z          = printer.toolhead.axis_maximum.z - printer.gcode_move.homing_origin.z |float %}
+  {% set cur_z          = printer.toolhead.position.z|float %}
 
   {% set z_safe = cur_z + z_hop %}
   {% if z_safe > max_z %}

--- a/config/macros/Poop.cfg
+++ b/config/macros/Poop.cfg
@@ -9,22 +9,22 @@ variable_purge_z: 0
 
 gcode:
   {% set gVars                  = printer['gcode_macro _AFC_GLOBAL_VARS'] %}
-  {% set travel_speed           = gVars['travel_speed'] * 60|default(120)*60|float %}
-  {% set z_travel_speed         = gVars['z_travel_speed'] * 60|default(30)*60|float %}
-  {% set verbose                = gVars['verbose']|default(1)|int %}
+  {% set travel_speed           = gVars['travel_speed']     | default(120)*60   | float %}
+  {% set z_travel_speed         = gVars['z_travel_speed']   | default(30)*60    | float %}
+  {% set verbose                = gVars['verbose']          | default(1)        | int %}
   {% set vars                   = printer['gcode_macro _AFC_POOP_VARS'] %}
-  {% set purge_x, purge_y       = vars.purge_loc_xy|default([-1,-1])|map('float') %}
-  {% set purge_spd              = vars['purge_spd'] * 60|default(6.5)*60|float %}
-  {% set z_poop                 = vars['z_purge_move']|default(true)|lower == 'true' %}
-  {% set fast_z                 = vars['fast_z'] * 60|default(200)*60|float %}
-  {% set z_lift                 = vars['z_lift']|default(10)|float %}
-  {% set part_cooling_fan       = vars['part_cooling_fan']|default(true)|lower == 'true' %}
-  {% set part_cooling_fan_speed = vars['part_cooling_fan_speed']|default(1.0)|float %}
-  {% set purge_cool_time        = vars['purge_cool_time'] * 1000|default(2)*1000|float %}
-  {% set purge_length           = vars['purge_length']|default(72.111)|float %}
-  {% set purge_length_minimum   = vars['purge_length_minimum']|default(60.999)|float %}
-  {% set purge_start            = vars['purge_start']|default(0.6)|float %}
-  {% set restore_position       = vars['restore_position']|default(true)|lower == 'true' %}
+  {% set purge_x, purge_y       = vars.purge_loc_xy         | default([-1,-1])  | map('float') %}
+  {% set purge_spd              = vars['purge_spd']         | default(6.5)*60   | float %}
+  {% set z_poop                 = vars['z_purge_move']      | default(true)     | lower == 'true' %}
+  {% set fast_z                 = vars['fast_z']            | default(200)*60   | float %}
+  {% set z_lift                 = vars['z_lift']            | default(10)       | float %}
+  {% set part_cooling_fan       = vars['part_cooling_fan']  | default(true)     | lower == 'true' %}
+  {% set part_cooling_fan_speed = vars['part_cooling_fan_speed']| default(1.0)  | float %}
+  {% set purge_cool_time        = vars['purge_cool_time']   | default(2)*1000   | float %}
+  {% set purge_length           = vars['purge_length']      | default(72.111)   | float %}
+  {% set purge_length_minimum   = vars['purge_length_minimum']| default(60.999) | float %}
+  {% set purge_start            = vars['purge_start']       | default(0.6)      | float %}
+  {% set restore_position       = vars['restore_position']  | default(true)     | lower == 'true' %}
 
   {% if verbose > 0 %}
     RESPOND TYPE=command MSG='AFC_Poop: Starting poop'


### PR DESCRIPTION
## Major Changes in this PR
- Fixing issue where an extra 60 multiple was introduced when adding defaults
- Moved multiplicative number after default as klipper would error out if the variable did not exist and default value would not apply.

## Notes to Code Reviewers

## How the changes in this PR are tested
Manually created a test macro for each one and manually called each to make sure there were no errors in my updates. Before speed reported as 1,260,000, not speed reads correctly as 21,000 for 350mm/s
```
13:45:13 $ AFC_BRUSH_TEST
13:45:14 // Bx:120.0 By:120.0 Bz:-1.0 Z-move-1.0
13:45:18 $ AFC_CUT_TEST
13:45:18 // Bx:210.0 By:0.0
13:45:22 $ AFC_KICK_TEST
13:45:22 // Bx:170.0 By:220.0 Bz:5.0
13:45:28 $ AFC_PARK_TEST
13:45:28 // Bx:220.0 By:200.0
13:45:28 // Travel Speed 21000.0 350
13:45:59 $ AFC_POOP_TEST
13:46:00 // Bx:220.0 By:200.0
```
## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design channel requesting review
