### PR TITLE
Fixing minor calibration issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2025-006-06]
+## [2025-06-07]
+### Fixed
+- `unknown command: Prompt_end` error will no longer show when users try to exit out of Happy Printing popup after AFC_CALIBRATION is done
+- Lanes are now marked a loaded_to_hub when bowden calibration happens
+- Fixed issue where HTLF might error out when first homing during PREP
 
+## [2025-06-06]
 ### Added
 - There is now a configurable option `error_timeout` in the `[AFC]` section of the `AFC.cfg` file. This option allows 
 users to set a timeout for how long the printer will stay in a paused state when an error occurs. The default value is 
@@ -14,9 +19,12 @@ users to set a timeout for how long the printer will stay in a paused state when
 the `idle_timeout` value (if defined) and choose the larger of the two values. 
 
 ## [2025-05-30]
-
 ### Added
 - Updated park to allow moving to an absolute z height after the x,y move. This is intended to reduce oozing during unload and load prior to using the poop command.
+
+## [2025-05-29]
+### Fixed
+- HTLF infinite runout now works correctly
 
 ## [2025-05-27]
 ### Added
@@ -30,7 +38,6 @@ the `idle_timeout` value (if defined) and choose the larger of the two values.
 
 ## [2025-05-24]
 ### Fixed
-
 - The calibration routines will now not allow a negative bowden length value to be set. If a negative value is detected, 
 an error message will be displayed and the value will not be set.
 
@@ -81,7 +88,6 @@ an error message will be displayed and the value will not be set.
 
 ## [2025-05-11]
 ### Changed
-
 - The `install-afc.sh` script will remove any `velocity` settings present in the `[AFC_buffer <buffer_name>]` 
   section of the configuration files as they are no longer needed.
 

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -172,7 +172,7 @@ class afcBoxTurtle(afcUnit):
             # Checking if user has set a custom unload length and adding the delta to the new
             # calibrated bowden distance
             if cur_lane.hub_obj.afc_unload_bowden_length != cur_lane.hub_obj.afc_bowden_length:
-                unload_delta = ( cur_lane.hub_obj.afc_bowden_length - cur_lane.hub_obj.afc_unload_bowden_length ) * -1
+                unload_delta = cur_lane.hub_obj.afc_unload_bowden_length - cur_lane.hub_obj.afc_bowden_length
                 unload_new = bowden_dist + unload_delta
             else:
                 unload_new = bowden_dist

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -169,8 +169,18 @@ class afcBoxTurtle(afcUnit):
             else:
                 bowden_dist = bow_pos - cur_lane.short_move_dis
 
+            # Checking if user has set a custom unload length and adding the delta to the new 
+            # calibrated bowden distance
+            if cur_lane.hub_obj.afc_unload_bowden_length != cur_lane.hub_obj.afc_bowden_length:
+                unload_delta = ( cur_lane.hub_obj.afc_bowden_length - cur_lane.hub_obj.afc_unload_bowden_length ) * -1
+                unload_new = bowden_dist + unload_delta
+            else:
+                unload_new = bowden_dist
+
             cal_msg = '\n afc_bowden_length: New: {} Old: {}'.format(bowden_dist, cur_lane.hub_obj.afc_bowden_length)
+            unload_cal_msg = '\n afc_unload_bowden_length: New: {} Old: {}'.format(unload_new, cur_lane.hub_obj.afc_unload_bowden_length)
             cur_lane.hub_obj.afc_bowden_length = bowden_dist
+            cur_lane.hub_obj.afc_unload_bowden_length = unload_new
 
             if bowden_dist < 0:
                 self.afc.error.AFC_error(
@@ -178,6 +188,8 @@ class afcBoxTurtle(afcUnit):
                     pause=False)
                 return False, "Invalid bowden length", bowden_dist
             self.afc.function.ConfigRewrite(cur_hub.fullname, "afc_bowden_length", bowden_dist, cal_msg)
+            self.afc.function.ConfigRewrite(cur_hub.fullname, "afc_unload_bowden_length", unload_new, unload_cal_msg)
+            cur_lane.loaded_to_hub  = True
             cur_lane.do_enable(False)
             self.afc.save_vars()
             return True, "afc_bowden_length successful", bowden_dist

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -169,7 +169,7 @@ class afcBoxTurtle(afcUnit):
             else:
                 bowden_dist = bow_pos - cur_lane.short_move_dis
 
-            # Checking if user has set a custom unload length and adding the delta to the new 
+            # Checking if user has set a custom unload length and adding the delta to the new
             # calibrated bowden distance
             if cur_lane.hub_obj.afc_unload_bowden_length != cur_lane.hub_obj.afc_bowden_length:
                 unload_delta = ( cur_lane.hub_obj.afc_bowden_length - cur_lane.hub_obj.afc_unload_bowden_length ) * -1

--- a/extras/AFC_HTLF.py
+++ b/extras/AFC_HTLF.py
@@ -127,7 +127,7 @@ class AFC_HTLF(afcBoxTurtle):
         while not self.home_state and not self.failed_to_home:
             self.selector_stepper_obj.move(-1, 20, 20, False)
             total_moved += 1
-            if total_moved > (self.mm_move_per_rotation/360)*self.MAX_ANGLE_MOVEMENT:
+            if total_moved > (self.mm_move_per_rotation/360)*(self.MAX_ANGLE_MOVEMENT+self.cam_angle):
                 self.failed_to_home = True
                 self.afc.error.AFC_error("Failed to home {}".format(self.name), False)
                 return False

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -645,11 +645,10 @@ class afcFunction:
 
             # Setting tool start to buffer if only tool_end is set and user has buffer so calibration can run
             if cur_lane.extruder_obj.tool_start is None:
-                if cur_lane.extruder_obj.tool_end is not None and cur_lane.buffer_obj is None:
-                    self.logger.error("Cannot run calibration using post extruder sensor, using buffer to calibrate bowden length")
+                if cur_lane.extruder_obj.tool_end is not None and cur_lane.buffer_obj is not None:
+                    self.logger.info("Cannot run calibration using post extruder sensor, using buffer to calibrate bowden length")
                     cur_lane.extruder_obj.tool_start = "buffer"
                     set_tool_start_back_to_none = True
-                    return
                 else:
                     # Cannot calibrate
                     self.afc.error.AFC_error("Cannot calibrate with only post extruder sensor and no turtleneck buffer defined in config", pause=False)

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -645,7 +645,7 @@ class afcFunction:
 
             # Setting tool start to buffer if only tool_end is set and user has buffer so calibration can run
             if cur_lane.extruder_obj.tool_start is None:
-                if cur_lane.extruder_obj.tool_end is not None and cur_lane.buffer_obj is not None:
+                if cur_lane.extruder_obj.tool_end is not None and cur_lane.buffer_obj is None:
                     self.logger.info("Cannot run calibration using post extruder sensor, using buffer to calibrate bowden length")
                     cur_lane.extruder_obj.tool_start = "buffer"
                     set_tool_start_back_to_none = True

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -730,7 +730,6 @@ class afcFunction:
         footer = []
         title = '{} Completed'.format(step)
         text = 'Happy Printing!'
-        footer.append(('EXIT', 'prompt_end', 'info'))
         prompt.create_custom_p(title, text, buttons,
                                False, None, footer)
         self.afc.reactor.pause(self.afc.reactor.monotonic() + 3)

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -646,9 +646,10 @@ class afcFunction:
             # Setting tool start to buffer if only tool_end is set and user has buffer so calibration can run
             if cur_lane.extruder_obj.tool_start is None:
                 if cur_lane.extruder_obj.tool_end is not None and cur_lane.buffer_obj is None:
-                    self.logger.info("Cannot run calibration using post extruder sensor, using buffer to calibrate bowden length")
+                    self.logger.error("Cannot run calibration using post extruder sensor, using buffer to calibrate bowden length")
                     cur_lane.extruder_obj.tool_start = "buffer"
                     set_tool_start_back_to_none = True
+                    return
                 else:
                     # Cannot calibrate
                     self.afc.error.AFC_error("Cannot calibrate with only post extruder sensor and no turtleneck buffer defined in config", pause=False)


### PR DESCRIPTION
## Major Changes in this PR
- Updating afc_unload_bowden_length when running AFC_CALIBRATION, closes #346
- Added marking lane as loaded_to_hub when running bowden calibration, closes #346
- Adding extra tolerance when homing HTLF so it's less likely to error out when first homing
- Removed footer from `Happy Printing` popup when calibration was done so users don't get `unknown command: Prompt_end` error. Closes #341 
## Notes to Code Reviewers

## How the changes in this PR are tested
Tested `afc_unload_bowden_length` being greater and less than `afc_bowden_length` to verify that +/-5 delta is still kept after calibration.

afc_unload_bowden_length less:
![image](https://github.com/user-attachments/assets/4b3365bc-82da-4bbd-ab8e-ddeb1c5c3d02)

afc_unload_bowden_length greater:
![image](https://github.com/user-attachments/assets/07219a04-430c-4d13-be95-873f452d1475)

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design channel requesting review
