### PR TITLE
Adding filament density to SET_MATERIAL macro/pulling density from spoolman data

### DIFF
--- a/config/AFC.cfg
+++ b/config/AFC.cfg
@@ -17,6 +17,7 @@ enable_sensors_in_gui: True     # Uncomment to show all sensor switches as filam
 default_material_temps: default: 235, PLA:210, PETG:235, ABS:235, ASA:235 # Default temperature to set extruder when loading/unloading lanes.
                                                   # Material needs to be either manually set or uses material from spoolman if extruder temp is not
                                                   # set in spoolman. Follow current format to add more
+common_density_values: PLA:1.24, PETG:1.23, ABS:1.04, ASA:1.07 # Generic default density values.  Follow current format to add more
 #default_material_type: PLA      # Default material type to assign to a spool once loaded into a lane
 
 load_to_hub: True               # Fast loads filament to hub when inserted, set to False to disable. This is a global setting and can be overridden at AFC_stepper

--- a/config/AFC.cfg
+++ b/config/AFC.cfg
@@ -14,7 +14,7 @@ short_move_dis: 10              # Move distance for failsafe moves. Default is 1
                                 # This value can also be set per stepper with print_current: 0.6
 enable_sensors_in_gui: True     # Uncomment to show all sensor switches as filament sensors in mainsail/fluidd gui
                                 # this can also be set at individual levels in your config file
-default_material_temps: default: 235, PLA:210, ABS:235, ASA:235 # Default temperature to set extruder when loading/unloading lanes.
+default_material_temps: default: 235, PLA:210, PETG:235, ABS:235, ASA:235 # Default temperature to set extruder when loading/unloading lanes.
                                                   # Material needs to be either manually set or uses material from spoolman if extruder temp is not
                                                   # set in spoolman. Follow current format to add more
 #default_material_type: PLA      # Default material type to assign to a spool once loaded into a lane

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -796,7 +796,7 @@ class afc:
             name=[]
             for NAME in cur_unit.lanes:
                 cur_lane=self.lanes[NAME]
-                str[cur_unit.name][cur_lane.name]=cur_lane.get_status()
+                str[cur_unit.name][cur_lane.name]=cur_lane.get_status(save_to_file=True)
                 name.append(cur_lane.name)
 
         str["system"]={}

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -111,9 +111,13 @@ class afc:
         self.unit_order_list        = config.get('unit_order_list','')
         self.VarFile                = config.get('VarFile','../printer_data/config/AFC/AFC.var')# Path to the variables file for AFC configuration.
         self.cfgloc                 = self._remove_after_last(self.VarFile,"/")
-        self.default_material_temps = config.getlists("default_material_temps", None)# Default temperature to set extruder when loading/unloading lanes. Material needs to be either manually set or uses material from spoolman if extruder temp is not set in spoolman.
+        self.default_material_temps = config.getlists("default_material_temps",
+                                                      ("default: 235", "PLA:210", "PETG:235", "ABS:235", "ASA:235"))# Default temperature to set extruder when loading/unloading lanes. Material needs to be either manually set or uses material from spoolman if extruder temp is not set in spoolman.
         self.default_material_temps = list(self.default_material_temps) if self.default_material_temps is not None else None
         self.default_material_type  = config.get("default_material_type", None)     # Default material type to assign to a spool once loaded into a lane
+        self.common_density_values  = config.getlists("common_density_values",
+                                                      ("PLA:1.24", "PETG:1.23", "ABS:1.04", "ASA:1.07"))
+        self.common_density_values  = list(self.common_density_values)
 
         #LED SETTINGS
         self.ind_lights = None

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -27,7 +27,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 try: from extras.AFC_stats import AFCStats
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
 
-AFC_VERSION="1.0.18"
+AFC_VERSION="1.0.20"
 
 # Class for holding different states so its clear what all valid states are
 class State:

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -130,7 +130,7 @@ class AFCExtruder:
         else:
             self.logger.error("tool_sensor_after_extruder length should be greater than zero")
 
-    cmd_UPDATE_TOOLHEAD_SENSORS_help = "Gives ability to update tool_stn\tool_stn_unload\tool_sensor_after_extruder values without restarting klipper"
+    cmd_UPDATE_TOOLHEAD_SENSORS_help = "Gives ability to update tool_stn, tool_stn_unload, tool_sensor_after_extruder values without restarting klipper"
     cmd_UPDATE_TOOLHEAD_SENSORS_options = {
         "EXTRUDER": {"type": "string", "default": "extruder"},
         "TOOL_STN": {"type": "float", "default": 0},

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -67,10 +67,9 @@ class AFCLane:
         self.tool_loaded        = False
         self.loaded_to_hub      = False
         self.spool_id           = None
-        self.material           = None
         self.color              = None
         self.weight             = 0
-        self.material           = None
+        self._material          = None
         self.extruder_temp      = None
         self.runout_lane        = 'NONE'
         self.status             = AFCLaneState.NONE
@@ -175,6 +174,30 @@ class AFCLane:
 
     def __str__(self):
         return self.name
+
+    @property
+    def material(self):
+        """
+        Returns lanes filament material type
+        """
+        return self._material
+
+    @material.setter
+    def material(self, value):
+        """
+        Sets filament material type and sets filament density based off material type.
+        To use custom density, set density after setting material
+        """
+        self._material = value
+        if not value:
+            self.filament_density = 1.24 # Setting to a default value
+            return
+
+        for density in self.afc.common_density_values:
+            v = density.split(":")
+            if v[0] in value:
+                self.filament_density = float(v[1])
+                break
 
     def _handle_ready(self):
         """

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -78,7 +78,7 @@ class AFCLane:
         self.drive_stepper      = None
         unit                    = config.get('unit')                                    # Unit name(AFC_BoxTurtle/NightOwl/etc) that belongs to this stepper.
         # Overrides buffers set at the unit level
-        self.hub 				= config.get('hub',None)                                # Hub name(AFC_hub) that belongs to this stepper, overrides hub that is set in unit(AFC_BoxTurtle/NightOwl/etc) section.
+        self.hub                = config.get('hub',None)                                # Hub name(AFC_hub) that belongs to this stepper, overrides hub that is set in unit(AFC_BoxTurtle/NightOwl/etc) section.
         # Overrides buffers set at the unit and extruder level
         self.buffer_name        = config.get("buffer", None)                            # Buffer name(AFC_buffer) that belongs to this stepper, overrides buffer that is set in extruder(AFC_extruder) or unit(AFC_BoxTurtle/NightOwl/etc) sections.
         self.unit               = unit.split(':')[0]
@@ -90,26 +90,26 @@ class AFCLane:
 
         self.extruder_name      = config.get('extruder', None)                          # Extruder name(AFC_extruder) that belongs to this stepper, overrides extruder that is set in unit(AFC_BoxTurtle/NightOwl/etc) section.
         self.map                = config.get('cmd','NONE')
-        self.led_index 			= config.get('led_index', None)                         # LED index of lane in chain of lane LEDs
-        self.led_fault 			= config.get('led_fault',None)                          # LED color to set when faults occur in lane        (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
-        self.led_ready 			= config.get('led_ready',None)                          # LED color to set when lane is ready               (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
-        self.led_not_ready 		= config.get('led_not_ready',None)                      # LED color to set when lane not ready              (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
-        self.led_loading 		= config.get('led_loading',None)                        # LED color to set when lane is loading             (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
-        self.led_prep_loaded 	= config.get('led_loading',None)                        # LED color to set when lane is loaded              (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
-        self.led_unloading 		= config.get('led_unloading',None)                      # LED color to set when lane is unloading           (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
-        self.led_tool_loaded 	= config.get('led_tool_loaded',None)                    # LED color to set when lane is loaded into tool    (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
+        self.led_index          = config.get('led_index', None)                         # LED index of lane in chain of lane LEDs
+        self.led_fault          = config.get('led_fault',None)                          # LED color to set when faults occur in lane        (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
+        self.led_ready          = config.get('led_ready',None)                          # LED color to set when lane is ready               (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
+        self.led_not_ready      = config.get('led_not_ready',None)                      # LED color to set when lane not ready              (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
+        self.led_loading        = config.get('led_loading',None)                        # LED color to set when lane is loading             (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
+        self.led_prep_loaded    = config.get('led_loading',None)                        # LED color to set when lane is loaded              (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
+        self.led_unloading      = config.get('led_unloading',None)                      # LED color to set when lane is unloading           (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
+        self.led_tool_loaded    = config.get('led_tool_loaded',None)                    # LED color to set when lane is loaded into tool    (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
         self.led_spool_index    = config.get('led_spool_index', None)                   # LED index to illuminate under spool
         self.led_spool_illum    = config.get('led_spool_illuminate', None)              # LED color to illuminate under spool
 
-        self.long_moves_speed 	= config.getfloat("long_moves_speed", None)             # Speed in mm/s to move filament when doing long moves. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
-        self.long_moves_accel 	= config.getfloat("long_moves_accel", None)             # Acceleration in mm/s squared when doing long moves. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
-        self.short_moves_speed 	= config.getfloat("short_moves_speed", None)            # Speed in mm/s to move filament when doing short moves. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
-        self.short_moves_accel	= config.getfloat("short_moves_accel", None)            # Acceleration in mm/s squared when doing short moves. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
-        self.short_move_dis 	= config.getfloat("short_move_dis", None)               # Move distance in mm for failsafe moves. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
+        self.long_moves_speed   = config.getfloat("long_moves_speed", None)             # Speed in mm/s to move filament when doing long moves. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
+        self.long_moves_accel   = config.getfloat("long_moves_accel", None)             # Acceleration in mm/s squared when doing long moves. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
+        self.short_moves_speed  = config.getfloat("short_moves_speed", None)            # Speed in mm/s to move filament when doing short moves. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
+        self.short_moves_accel  = config.getfloat("short_moves_accel", None)            # Acceleration in mm/s squared when doing short moves. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
+        self.short_move_dis     = config.getfloat("short_move_dis", None)               # Move distance in mm for failsafe moves. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
         self.max_move_dis       = config.getfloat("max_move_dis", None)                 # Maximum distance to move filament. AFC breaks filament moves over this number into multiple moves. Useful to lower this number if running into timer too close errors when doing long filament moves. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
         self.n20_break_delay_time= config.getfloat("n20_break_delay_time", None)        # Time to wait between breaking n20 motors(nSleep/FWD/RWD all 1) and then releasing the break to allow coasting. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
 
-        self.rev_long_moves_speed_factor 	= config.getfloat("rev_long_moves_speed_factor", None)     # scalar speed factor when reversing filamentalist
+        self.rev_long_moves_speed_factor = config.getfloat("rev_long_moves_speed_factor", None)     # scalar speed factor when reversing filamentalist
 
         self.dist_hub           = config.getfloat('dist_hub', 60)                       # Bowden distance between Box Turtle extruder and hub
         self.park_dist          = config.getfloat('park_dist', 10)                      # Currently unused
@@ -914,8 +914,8 @@ class AFCLane:
         old_fwd_value = self.fwd_speed_multi
         old_rwd_value = self.rwd_speed_multi
 
-        self.fwd_speed_multi = gcmd.get_float("FWD", self.fwd_speed_multi, minval=0.0, maxval=1.0)
-        self.rwd_speed_multi = gcmd.get_float("RWD", self.rwd_speed_multi, minval=0.0, maxval=1.0)
+        self.fwd_speed_multi = gcmd.get_float("FWD", self.fwd_speed_multi, minval=0.0)
+        self.rwd_speed_multi = gcmd.get_float("RWD", self.rwd_speed_multi, minval=0.0)
 
         if self.fwd_speed_multi != old_fwd_value:
             self.logger.info("{name} forward speed multiplier set, New: {new}, Old: {old}".format(name=self.name, new=self.fwd_speed_multi, old=old_fwd_value))
@@ -993,7 +993,7 @@ class AFCLane:
         """
         self.afc.function.ConfigRewrite(self.fullname, 'dist_hub', self.dist_hub, '')
 
-    def get_status(self, eventtime=None):
+    def get_status(self, eventtime=None, save_to_file=False):
         response = {}
         if not self.connect_done: return response
         response['name'] = self.name
@@ -1009,14 +1009,19 @@ class AFCLane:
         response["tool_loaded"] = self.tool_loaded
         response["loaded_to_hub"] = self.loaded_to_hub
         response["material"]=self.material
+        if save_to_file:
+            response["density"]=self.filament_density
+            response["diameter"]=self.filament_diameter
+            response["empty_spool_weight"]=self.empty_spool_weight
+
         response["spool_id"]= int(self.spool_id) if self.spool_id else None
         response["color"]=self.color
         response["weight"]=self.weight
         response["extruder_temp"] = self.extruder_temp
         response["runout_lane"]=self.runout_lane
-        filiment_stat=self.afc.function.get_filament_status(self).split(':')
-        response['filament_status'] = filiment_stat[0]
-        response['filament_status_led'] = filiment_stat[1]
+        filament_stat=self.afc.function.get_filament_status(self).split(':')
+        response['filament_status'] = filament_stat[0]
+        response['filament_status_led'] = filament_stat[1]
         response['status'] = self.status
         return response
 

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -894,7 +894,7 @@ class AFCLane:
     def cmd_SET_SPEED_MULTIPLIER(self, gcmd):
         """
         Macro call to update fwd_speed_multiplier or rwd_speed_multiplier values without having to set in config and restart klipper. This macro allows adjusting
-        these values while printing. Multiplier values must be between 0.0 - 1.0
+        these values while printing.
 
         Use `FWD` variable to set forward multiplier, use `RWD` to set reverse multiplier
 

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -99,9 +99,19 @@ class afcPrep:
                     if self.afc.spoolman is not None and cur_lane.spool_id:
                         self.afc.spool.set_spoolID(cur_lane, cur_lane.spool_id, save_vars=False)
                     else:
-                        if 'material' in units[cur_lane.unit][cur_lane.name]: cur_lane.material = units[cur_lane.unit][cur_lane.name]['material']
-                        if 'color' in units[cur_lane.unit][cur_lane.name]: cur_lane.color = units[cur_lane.unit][cur_lane.name]['color']
-                        if 'weight' in units[cur_lane.unit][cur_lane.name]: cur_lane.weight = units[cur_lane.unit][cur_lane.name]['weight']
+                        if 'material' in units[cur_lane.unit][cur_lane.name]:
+                            cur_lane.material = units[cur_lane.unit][cur_lane.name]['material']
+                        if 'color' in units[cur_lane.unit][cur_lane.name]:
+                            cur_lane.color = units[cur_lane.unit][cur_lane.name]['color']
+                        if 'weight' in units[cur_lane.unit][cur_lane.name]:
+                            cur_lane.weight = units[cur_lane.unit][cur_lane.name]['weight']
+                        if 'density' in units[cur_lane.unit][cur_lane.name]:
+                            cur_lane.filament_density= units[cur_lane.unit][cur_lane.name]["density"]
+                        if 'diameter' in units[cur_lane.unit][cur_lane.name]:
+                            cur_lane.filament_diameter= units[cur_lane.unit][cur_lane.name]["diameter"]
+                        if 'empty_spool_weight' in units[cur_lane.unit][cur_lane.name]:
+                            cur_lane.empty_spool_weight= units[cur_lane.unit][cur_lane.name]["empty_spool_weight"]
+
                         if not isinstance(cur_lane.weight, int):
                             if cur_lane.weight:
                                 cur_lane.weight = int(cur_lane.weight)

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -148,7 +148,7 @@ class AFCSpool:
 
         Optional Values
         ----
-        DENISITY - Density value to assign to lane. If this is not provided then a default value will be selected based
+        DENSITY - Density value to assign to lane. If this is not provided then a default value will be selected based
                    of material. Current default values: PLA: 1.24, PETG:1.23, ABS:1.04, ASA:1.07
         DIAMETER - Diameter of filament, defaults to 1.75
         EMPTY_SPOOL_WEIGHT - Weight of spool once its empty. Defaults to 190.


### PR DESCRIPTION
## Major Changes in this PR
- Added pulling density, diameter, and empty spool weight from spoolman data
- Added density, diameter, and empty spool weight optional values to SET_MATERIAL macro. If density is not supplied AFC tries to look up density from default values based on material passed in
- Removed upper bounds for fwd/rwd values when calling SET_SPEED_MULTIPLIER macro
- Removed slashes in macro help as this causes the character afterwards to be escaped leading to help being displayed weird in gui's

## How the changes in this PR are tested
Added spool form spoolman and manually set material to verify that defaults were selected properly based off material passed in.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design channel requesting review
