### PR TITLE
Merge main install scripts

### DIFF
--- a/include/constants.sh
+++ b/include/constants.sh
@@ -10,7 +10,7 @@
 printer_config_dir="$HOME/printer_data/config"
 klipper_dir="$HOME/klipper"
 afc_path="$HOME/AFC-Klipper-Add-On"
-afc_config_dir="$printer_config_dir/AFC"
+afc_config_dir="${printer_config_dir}/AFC"
 afc_file="$afc_config_dir/AFC.cfg"
 moonraker_config_file="$printer_config_dir/moonraker.conf"
 klipper_venv="$HOME/klippy-env/bin"

--- a/include/utils.sh
+++ b/include/utils.sh
@@ -32,10 +32,8 @@ function show_help() {
 }
 
 function copy_config() {
-  if [ -d "${afc_config_dir}" ]; then
-    mkdir -p "${afc_config_dir}"
-  fi
-  cp -R "${afc_path}/config" "${afc_config_dir}"
+  mkdir -p "${afc_config_dir}"
+  cp -R ${afc_path}/config/* "${afc_config_dir}"
 }
 
 clone_and_maybe_restart() {

--- a/install-afc.sh
+++ b/install-afc.sh
@@ -10,6 +10,8 @@ export LC_ALL=C
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+source include/constants.sh
+
 # Menu functions
 source include/menus/main_menu.sh
 source include/menus/install_menu.sh
@@ -17,11 +19,36 @@ source include/menus/update_menu.sh
 source include/menus/utilities_menu.sh
 source include/menus/additional_system_menu.sh
 
+
+###################### Main script logic below ######################
+
+while getopts "a:k:s:m:n:b:p:y:u:th" arg; do
+  case ${arg} in
+  a) export moonraker_address=${OPTARG} ;;
+  k) export klipper_dir=${OPTARG} ;;
+  m) export moonraker_config_file=${OPTARG} ;;
+  n) export moonraker_port=${OPTARG} ;;
+  s) export klipper_service=${OPTARG} ;;
+  b) export branch=${OPTARG} ;;
+  p) export printer_config_dir=${OPTARG} ;;
+  y) export klipper_venv=${OPTARG} ;;
+  t) export test_mode=True ;;
+  h) show_help
+    exit 0 ;;
+  *) exit 1 ;;
+  esac
+done
+
+moonraker="${moonraker_address}:${moonraker_port}"
+afc_config_dir="${printer_config_dir}/AFC"
+afc_file="${afc_config_dir}/AFC.cfg"
+moonraker_config_file="${printer_config_dir}/moonraker.conf"
+afc_path="$HOME/AFC-Klipper-Add-On"
+
 # Install / Update functions
 source include/buffer_configurations.sh
 source include/check_commands.sh
 source include/colors.sh
-source include/constants.sh
 source include/install_functions.sh
 source include/uninstall.sh
 source include/update_commands.sh

--- a/install-afc.sh
+++ b/install-afc.sh
@@ -18,7 +18,7 @@ source include/menus/install_menu.sh
 source include/menus/update_menu.sh
 source include/menus/utilities_menu.sh
 source include/menus/additional_system_menu.sh
-
+source include/utils.sh
 
 ###################### Main script logic below ######################
 
@@ -53,7 +53,6 @@ source include/install_functions.sh
 source include/uninstall.sh
 source include/update_commands.sh
 source include/update_functions.sh
-source include/utils.sh
 source include/unit_functions.sh
 
 original_args=("$@")


### PR DESCRIPTION
## Major Changes in this PR

This pull request introduces changes to improve the consistency of variable usage, enhance the `copy_config` function, and update the main script logic in `install-afc.sh`. The most notable changes involve refining path definitions, fixing potential issues with directory copying, and restructuring the script to better handle command-line arguments.

### Consistency and Path Handling:
* Updated the `afc_config_dir` variable in `include/constants.sh` to use consistent brace-enclosed variable syntax for better readability and to prevent potential parsing issues. (`[include/constants.shL13-R13](diffhunk://#diff-136fe1bcdb8818f9c4dbd399c55de34fc1c3426774f0135576365b3152460627L13-R13)`)

### Function Improvements:
* Modified the `copy_config` function in `include/utils.sh` to ensure that only the contents of the source directory are copied, avoiding nesting issues. (`[include/utils.shL35-R36](diffhunk://#diff-9e64712e624ee22bf3a68f5ecd584c7f805f610eb1fb10ce184a3d3beb0b8352L35-R36)`)

### Main Script Enhancements:
* Restructured `install-afc.sh` to:
  - Source `constants.sh` and `utils.sh` earlier for better modularity and maintainability. (`[install-afc.shR13-L29](diffhunk://#diff-808409cb3827534e4d3012fedbf1671577db5a220159b4b5d7b253bff3d890caR13-L29)`)
  - Added a `getopts` block to handle command-line arguments, allowing for dynamic configuration of key variables such as `moonraker_address`, `klipper_dir`, and others. (`[install-afc.shR13-L29](diffhunk://#diff-808409cb3827534e4d3012fedbf1671577db5a220159b4b5d7b253bff3d890caR13-L29)`)
  - Defined key variables (`afc_config_dir`, `afc_file`, `moonraker_config_file`, etc.) dynamically within the script to ensure they reflect user-provided inputs or defaults. (`[install-afc.shR13-L29](diffhunk://#diff-808409cb3827534e4d3012fedbf1671577db5a220159b4b5d7b253bff3d890caR13-L29)`)

## Notes to Code Reviewers

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design channel requesting review
