### PR TITLE
Reset infinite spool with afc reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2025-06-15]
 ### Added
-- Added support for the AFC-Pro board in the installer to install an 8-Lane Boxturtle. 
+- Added support for the AFC-Pro board in the installer to install an 8-Lane Boxturtle.
+- The `RESET_AFC_MAPPING` macro will now also reset any runout lane configurations.
 
 ## [2025-06-10]
 ### Added

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -340,6 +340,10 @@ class AFCSpool:
                 self.afc.lanes[lane].map = map_cmd
                 t_index += 1
 
+        # Resetting runout lanes to None
+        for lane in self.afc.lanes.values():
+            lane.runout_lane = None
+
         self.afc.save_vars()
         self.logger.info("Tool mappings reset")
 


### PR DESCRIPTION
## Major Changes in this PR

Closes #392 

This pull request introduces updates to the AFC mapping functionality, specifically enhancing the `RESET_AFC_MAPPING` macro to reset additional configurations. The changes include updates to the documentation and the implementation of the macro.

### Documentation Update:
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR11): Added a note that the `RESET_AFC_MAPPING` macro now resets runout lane configurations in addition to its existing functionality.

### Functional Enhancement:
* [`extras/AFC_spool.py`](diffhunk://#diff-13e9a07c4eadfbd5a3e17927b682551beac5c0ce7d2ccf5315cff8bdb139985fR343-R346): Updated the `cmd_RESET_AFC_MAPPING` method to reset the `runout_lane` attribute for all lanes to `None` during the reset process.

## Notes to Code Reviewers

## How the changes in this PR are tested

https://github.com/user-attachments/assets/bdb9fc52-e131-42b1-aa40-3ca01c1e0c2c

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design channel requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.