### PR TITLE
[Fix]: Weight fix for determine spoolers speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-06-16]
+### Fixed
+- Issue where espoolers would move way faster than normal when weight was below empty spool weight.
+
 ## [2025-06-15]
 ### Added
 - Added support for the AFC-Pro board in the installer to install an 8-Lane Boxturtle.

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -676,11 +676,11 @@ class AFCLane:
         :param feed_rate: Filament feed rate in mm/s
         :return: Calculated RPM for the assist motor
         """
-        if self.weight <= self.empty_spool_weight:
-            return self.empty_spool_weight  # No filament left to assist
+        # Figure in weight of empty spool
+        weight = self.weight + self.empty_spool_weight
 
         # Calculate the effective diameter
-        effective_diameter = self.calculate_effective_diameter(self.weight)
+        effective_diameter = self.calculate_effective_diameter(weight)
 
         # Calculate RPM
         rpm = (feed_rate * 60) / (math.pi * effective_diameter)
@@ -757,8 +757,9 @@ class AFCLane:
         filament_weight_change = filament_volume_mm3 * self.filament_density / 1000  # Convert mm cubed to g
         self.weight -= filament_weight_change
 
-        if self.weight < self.empty_spool_weight:
-            self.weight = self.empty_spool_weight  # Ensure weight doesn't drop below empty spool weight
+        # Weight cannot be negative, force back to zero if its below zero
+        if self.weight < 0:
+            self.weight = 0
 
     def set_loaded(self):
         """

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -757,7 +757,7 @@ class AFCLane:
         filament_weight_change = filament_volume_mm3 * self.filament_density / 1000  # Convert mm cubed to g
         self.weight -= filament_weight_change
 
-        # Weight cannot be negative, force back to zero if its below zero
+        # Weight cannot be negative, force back to zero if it's below zero
         if self.weight < 0:
             self.weight = 0
 


### PR DESCRIPTION
## Major Changes in this PR
- Fix issue where spoolers would be super fast once weight fell below empty spool weight
- Added a check to make sure when updating weight during printing that weight does not fall below zero

Closes #453 

## How the changes in this PR are tested
- First tested to verify that lane moved super fast by setting weight to zero, then set weight to 500 to verify normal speed.
- After making changes, verified lane moves with weight at 0, 500, and 1000. Spooler moved at normal speed with these weights. 
## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design channel requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.