### PR TITLE
Updating default values to print assist is less aggressive and only activates when spool weight is below 500g

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-06-17]
+### Fixed
+- Updated `cycles_per_rotation` value to be less aggressive at 800 for print assist
+- Updated `enable_assist_weight` value to be 500 so print assist start once weight gets below 500 grams
+
 ## [2025-06-16]
 ### Removed
 - Removed the version checking functionality for force updates from the `install-afc.sh` script. 

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -27,7 +27,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 try: from extras.AFC_stats import AFCStats
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
 
-AFC_VERSION="1.0.20"
+AFC_VERSION="1.0.22"
 
 # Class for holding different states so its clear what all valid states are
 class State:

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -192,7 +192,7 @@ class afc:
         # Setting to True enables espooler assist while printing
         self.enable_assist          = config.getboolean("enable_assist",        True)
         # Weight spool has to be below to activate print assist
-        self.enable_assist_weight   = config.getfloat("enable_assist_weight",   5000.0)
+        self.enable_assist_weight   = config.getfloat("enable_assist_weight",   500.0)
 
         self.debug                  = config.getboolean('debug', False)             # Setting to True turns on more debugging to show on console
         # Get debug and cast to boolean

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -71,7 +71,7 @@ class afcUnit:
         # Time in seconds to enable spooler at full speed to help with getting the spool to spin
         self.kick_start_time        = config.getfloat("kick_start_time",        0.070)
         # Cycles per rotation in milliseconds
-        self.cycles_per_rotation    = config.getfloat("cycles_per_rotation",    1275)
+        self.cycles_per_rotation    = config.getfloat("cycles_per_rotation",    800)
         # PWM cycle time
         self.pwm_value              = config.getfloat("pwm_value",              0.6706)
         # Delta amount in mm from last move to trigger assist


### PR DESCRIPTION
## Major Changes in this PR
- Updated cycles_per_rotation value to be less aggressive at 800 for print assist
- Updated enable_assist_weight value to be 500 so print assist start once weight gets below 500 grams

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design channel requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.