### PR TITLE
Updating mapping auto assignment and mapping in RESET_AFC_MAPPING macro Fixes #343

### DIFF
--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -88,7 +88,10 @@ class AFCLane:
             pass
 
         self.extruder_name      = config.get('extruder', None)                          # Extruder name(AFC_extruder) that belongs to this stepper, overrides extruder that is set in unit(AFC_BoxTurtle/NightOwl/etc) section.
-        self.map                = config.get('cmd','NONE')
+        self.map                = config.get('cmd', None)								# Keeping this in so it does not break others config that may have used this, use map instead
+        # Saving to self._map so that if a user has it defined it will be reset back to this when
+        # the calling RESET_AFC_MAPPING macro.
+        self._map = self.map    = config.get('map', self.map)
         self.led_index          = config.get('led_index', None)                         # LED index of lane in chain of lane LEDs
         self.led_fault          = config.get('led_fault',None)                          # LED color to set when faults occur in lane        (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
         self.led_ready          = config.get('led_ready',None)                          # LED color to set when lane is ready               (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -121,7 +121,7 @@ class afcPrep:
                     if 'runout_lane' in units[cur_lane.unit][cur_lane.name]: cur_lane.runout_lane = units[cur_lane.unit][cur_lane.name]['runout_lane']
                     if cur_lane.runout_lane == '': cur_lane.runout_lane='NONE'
                     if 'map' in units[cur_lane.unit][cur_lane.name]: cur_lane.map = units[cur_lane.unit][cur_lane.name]['map']
-                    if cur_lane.map != 'NONE':
+                    if cur_lane.map != None:
                         self.afc.tool_cmds[cur_lane.map] = cur_lane.name
                     # Check first for hub_loaded as this was the old name in software with version <= 1030
                     if 'hub_loaded' in units[cur_lane.unit][cur_lane.name]: lane.loaded_to_hub = units[cur_lane.unit][cur_lane.name]['hub_loaded']


### PR DESCRIPTION
## Major Changes in this PR
- Added check to TcmdAssign function to check if generated T command already exists and check to make sure a user has not already manually assigned the same mapping to another lane in their config file.
- Added map variable, use this now instead of cmd variable
- Updated mapping reset in RESET_AFC_MAPPING macro to take into consideration lanes that were manually mapped so when resetting. Now the manually mapped lanes will be reset to the correct lane.

## How the changes in this PR are tested
- Manually created T6 macro in gcode
- Manually set lane8 mapping to T2
- Cleared out mapping in AFC.vars.unit file and restarted klipper
- Moved mappings around and reset with `RESET_AFC_MAPPING` macro



## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [ ] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design channel requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.