### PR TITLE
Update pull request template to reflect new review notification channels

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@
 - [ ] I have performed a self-review of my code
 - [ ] CHANGELOG.md is updated (if end-user facing)
 - [ ] Documentation updated in AT-Documentation repository
-- [ ] Sent notification to software-design channel requesting review
+- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
 - [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description
 
 **NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 


### PR DESCRIPTION
## Major Changes in this PR

This pull request updates the pull request template to clarify the notification process for requesting reviews.

* [`.github/pull_request_template.md`](diffhunk://#diff-b2496e80299b8c3150b1944450bd81c622e04e13d15c411d291db0927d75fd6bL12-R12): Updated the notification checklist item to specify sending notifications to either the `software-design` or `software-discussions` channel, as appropriate.

## Notes to Code Reviewers

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design channel requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.