### PR TITLE
Add moonraker configuration file inclusion to afc-debug.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-06-19]
+## Updated
+- The `afc-debug.sh` script will now also include the `moonraker.conf` file if it is present.
+
 ## [2025-06-18]
 ## Updated
 - RESET_AFC_MAPPING function to reset manually set lane mapping in config to correct lane

--- a/troubleshooting/afc-debug.sh
+++ b/troubleshooting/afc-debug.sh
@@ -15,6 +15,7 @@ afc_path="$HOME/AFC-Klipper-Add-On"
 afc_config_dir="$printer_config_dir/AFC"
 afc_file="$afc_config_dir/AFC.cfg"
 klipper_venv="$HOME/klippy-env/bin"
+moonraker_config="$HOME/printer_data/config/moonraker.conf"
 
 # Global vars
 temp_log=""
@@ -270,6 +271,12 @@ find "$afc_config_dir" -type f | while read -r file; do
     append_file_to_log "$file_name" "$file"
 done
 
+# Add the moonraker config if it exists
+if [ -f "$moonraker_config" ]; then
+    append_file_to_log "$moonraker_config" "$moonraker_config"
+else
+    echo "Moonraker configuration file not found." >> "$temp_log"
+fi
 
 uploaded_files=()
 


### PR DESCRIPTION
## Major Changes in this PR

This pull request updates the `afc-debug.sh` script to include the `moonraker.conf` file in its logs if the file is present. Additionally, it updates the changelog to reflect this new functionality.

### Script enhancement:
* [`troubleshooting/afc-debug.sh`](diffhunk://#diff-f90bf2ef443900b47139a1df1cf4fed2ee7afaea3274ba701e86d8905f704d54R18): Added a new variable, `moonraker_config`, to reference the Moonraker configuration file. The script now checks for the existence of this file and appends it to the log if found, or logs a message if it is missing. [[1]](diffhunk://#diff-f90bf2ef443900b47139a1df1cf4fed2ee7afaea3274ba701e86d8905f704d54R18) [[2]](diffhunk://#diff-f90bf2ef443900b47139a1df1cf4fed2ee7afaea3274ba701e86d8905f704d54R274-R279)

### Documentation update:
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R11): Added an entry under the date `2025-06-19` to document the inclusion of the `moonraker.conf` file in the `afc-debug.sh` script logs.

## Notes to Code Reviewers

## How the changes in this PR are tested

https://termbin.com/owma

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design channel requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.