### PR TITLE
Add AFCButton class for enhanced filament changer button handling

### DIFF
--- a/extras/AFC_button.py
+++ b/extras/AFC_button.py
@@ -29,10 +29,10 @@ class AFCButton:
         buttons.register_buttons([pin_name], self._button_callback)
 
         self.afc.logger.info(f"AFC_button for {self.lane_id} initialized on pin: {pin_name}")
-    
+
     def _handle_ready(self):
         """
-        Handle ready callback check to make sure lane is found within AFC lanes, if lanes 
+        Handle ready callback check to make sure lane is found within AFC lanes, if lanes
         is not found and error is raised.
         """
         self.lane_obj = self.afc.lanes.get(self.lane_id)

--- a/extras/AFC_button.py
+++ b/extras/AFC_button.py
@@ -5,9 +5,9 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
 
-class AFCExtras:
+class AFCButton:
     """
-    This class is used for extra functionality that doesn't fit into the main AFC logic.
+    This class is used for lane based button controls.
     """
     def __init__(self, config):
         self.printer = config.get_printer()
@@ -28,7 +28,7 @@ class AFCExtras:
         buttons = self.printer.load_object(config, 'buttons')
         buttons.register_buttons([pin_name], self._button_callback)
 
-        self.afc.logger.info(f"AFC_extras for {self.lane_id} initialized on pin: {pin_name}")
+        self.afc.logger.info(f"AFC_button for {self.lane_id} initialized on pin: {pin_name}")
 
     def _button_callback(self, eventtime, state):
         """
@@ -83,4 +83,4 @@ class AFCExtras:
 
 
 def load_config_prefix(config):
-    return AFCExtras(config)
+    return AFCButton(config)

--- a/extras/AFC_extras.py
+++ b/extras/AFC_extras.py
@@ -1,11 +1,14 @@
 # Armored Turtle Automated Filament Changer
 #
-# Copyright (C) 2024 Armored Turtle
+# Copyright (C) 2025 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
 
 class AFCExtras:
+    """
+    This class is used for extra functionality that doesn't fit into the main AFC logic.
+    """
     def __init__(self, config):
         self.printer = config.get_printer()
         self.gcode = self.printer.lookup_object('gcode')
@@ -28,6 +31,17 @@ class AFCExtras:
         self.afc.logger.info(f"AFC_extras for {self.lane_id} initialized on pin: {pin_name}")
 
     def _button_callback(self, eventtime, state):
+        """
+        Callback function for button press events.
+
+        Args:
+            eventtime: The time of the event.
+            state: The state of the button (True for press, False for release).
+
+        Behavior:
+            - Tracks press duration.
+            - Executes short or long press actions based on the duration.
+        """
         if state:
             self._press_time = eventtime
             return

--- a/extras/AFC_extras.py
+++ b/extras/AFC_extras.py
@@ -66,7 +66,7 @@ class AFCExtras:
             if cur_lane == self.lane_id:
                 self.afc.logger.info(f"Unloading {self.lane_id} before ejecting.")
                 if self.afc.TOOL_UNLOAD():
-                    self.afc.LANE_UNLOAD(cur_lane)
+                    self.gcode.run_script_from_command("LANE_UNLOAD LANE={}".format(self.lane_id))
             else:
                 # If another lane is active, just eject this one
                 self.afc.logger.info(f"Ejecting {self.lane_id}.")

--- a/extras/AFC_extras.py
+++ b/extras/AFC_extras.py
@@ -79,7 +79,7 @@ class AFCExtras:
                 self.afc.TOOL_UNLOAD(self)
             else:
                 self.afc.logger.info(f"Loading tool to {self.lane_id}.")
-                self.gcode.run_script_from_command(f"BT_CHANGE_TOOL LANE={self.lane_number}")
+                self.afc.CHANGE_TOOL(self, self.lane_number)
 
 
 def load_config_prefix(config):

--- a/extras/AFC_extras.py
+++ b/extras/AFC_extras.py
@@ -62,22 +62,21 @@ class AFCExtras:
 
         # Long Press
         if held_time >= self.long_press_duration:
-            # --- LONG PRESS ACTION ---
             self.afc.logger.info(f"{self.lane_id}: Long press detected.")
             if cur_lane == self.lane_id:
                 self.afc.logger.info(f"Unloading {self.lane_id} before ejecting.")
-                script = f"BT_TOOL_UNLOAD\nG4 P500\nBT_LANE_EJECT LANE={self.lane_number}"
-                self.gcode.run_script_from_command(script)
+                if self.afc.TOOL_UNLOAD(self):
+                    self.afc.LANE_UNLOAD(self, cur_lane)
             else:
                 # If another lane is active, just eject this one
-                self.afc.logger.info(f"Ejecting {self.lane_id}.")
-                self.gcode.run_script_from_command(f"BT_LANE_EJECT LANE={self.lane_number}")
+                self.afc.logger.info(f"Ejecting {self.lane_number}.")
+                self.afc.LANE_UNLOAD(self, self.lane_number)
         # Short Press
         else:
             self.afc.logger.info(f"{self.lane_id}: Short press detected.")
             if cur_lane == self.lane_id:
                 self.afc.logger.info(f"Unloading tool from {self.lane_id}.")
-                self.gcode.run_script_from_command("BT_TOOL_UNLOAD")
+                self.afc.TOOL_UNLOAD(self)
             else:
                 self.afc.logger.info(f"Loading tool to {self.lane_id}.")
                 self.gcode.run_script_from_command(f"BT_CHANGE_TOOL LANE={self.lane_number}")

--- a/extras/AFC_extras.py
+++ b/extras/AFC_extras.py
@@ -69,8 +69,8 @@ class AFCExtras:
                     self.afc.LANE_UNLOAD(cur_lane)
             else:
                 # If another lane is active, just eject this one
-                self.afc.logger.info(f"Ejecting {self.lane_number}.")
-                self.afc.LANE_UNLOAD(self.lane_number)
+                self.afc.logger.info(f"Ejecting {self.lane_id}.")
+                self.gcode.run_script_from_command("LANE_UNLOAD LANE={}".format(self.lane_id))
         # Short Press
         else:
             self.afc.logger.info(f"{self.lane_id}: Short press detected.")
@@ -79,7 +79,7 @@ class AFCExtras:
                 self.afc.TOOL_UNLOAD()
             else:
                 self.afc.logger.info(f"Loading tool to {self.lane_id}.")
-                self.afc.CHANGE_TOOL(self.lane_id)
+                self.gcode.run_script_from_command("CHANGE_TOOL LANE={}".format(self.lane_id))
 
 
 def load_config_prefix(config):

--- a/extras/AFC_extras.py
+++ b/extras/AFC_extras.py
@@ -65,21 +65,21 @@ class AFCExtras:
             self.afc.logger.info(f"{self.lane_id}: Long press detected.")
             if cur_lane == self.lane_id:
                 self.afc.logger.info(f"Unloading {self.lane_id} before ejecting.")
-                if self.afc.TOOL_UNLOAD(self):
-                    self.afc.LANE_UNLOAD(self, cur_lane)
+                if self.afc.TOOL_UNLOAD():
+                    self.afc.LANE_UNLOAD(cur_lane)
             else:
                 # If another lane is active, just eject this one
                 self.afc.logger.info(f"Ejecting {self.lane_number}.")
-                self.afc.LANE_UNLOAD(self, self.lane_number)
+                self.afc.LANE_UNLOAD(self.lane_number)
         # Short Press
         else:
             self.afc.logger.info(f"{self.lane_id}: Short press detected.")
             if cur_lane == self.lane_id:
                 self.afc.logger.info(f"Unloading tool from {self.lane_id}.")
-                self.afc.TOOL_UNLOAD(self)
+                self.afc.TOOL_UNLOAD()
             else:
                 self.afc.logger.info(f"Loading tool to {self.lane_id}.")
-                self.afc.CHANGE_TOOL(self, self.lane_number)
+                self.afc.CHANGE_TOOL(self.lane_id)
 
 
 def load_config_prefix(config):


### PR DESCRIPTION
## Major Changes in this PR

This pull request introduces a new class, `AFCButton`, in the `extras/AFC_button.py` file to handle lane-based button controls for the Armored Turtle Automated Filament Changer (AFC). The implementation includes button press detection, press duration tracking, and actions for both short and long presses. Below is a summary of the key changes:

### New Feature: Lane-Based Button Control
* **Class `AFCButton`**:
  - Implements button press handling with configurable lane-specific settings such as `lane_number`, `long_press_duration`, and `pin`.
  - Tracks press duration and differentiates between short and long presses to trigger appropriate AFC actions, such as tool loading, unloading, or ejecting.
  - Integrates with the AFC system to ensure button actions are only executed when the printer is not actively moving or homing.
  - Logs detailed information about button events and actions for better traceability.

* **Callback Registration**:
  - Registers the button callback function `_button_callback` with the printer's button system during initialization.

### Configuration Loader
* **Function `load_config_prefix`**:
  - Provides a mechanism to load the `AFCButton` configuration using a prefix.

## Notes to Code Reviewers

## How the changes in this PR are tested

Add something like 
```
[AFC_button lane1]
pin: ^!Turtle_1:SW6  # Pin from your old macro, including pull-up(^) and invert(!)
lane_number: 1         # The integer number for this lane, used in G-code commands
long_press_duration: 1.2
```
to your config to test with a switch/button

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [ ] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design channel requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.
