### PR TITLE
[Fix] Moving skew_correction inside if statement

### DIFF
--- a/config/macros/AFC_macros.cfg
+++ b/config/macros/AFC_macros.cfg
@@ -65,10 +65,10 @@ gcode:
   {% set gVars = printer['gcode_macro _AFC_GLOBAL_VARS'] %}
   {% set verbose = gVars['verbose']|int %}
   {% set disable_skew = gVars['disable_skew_correction']|default(false)|lower == 'true' %}
-  SET_GCODE_VARIABLE MACRO=AFC_ENABLE_SKEW VARIABLE=skew_profile VALUE='"{printer.skew_correction.current_profile_name}"'
 
   # Disable skew correction if defined
   {% if disable_skew %}
+    SET_GCODE_VARIABLE MACRO=AFC_ENABLE_SKEW VARIABLE=skew_profile VALUE='"{printer.skew_correction.current_profile_name}"'
     {% if verbose > 1 %}
       RESPOND TYPE=command MSG='AFC: Disabling skew correction'
     {% endif %}


### PR DESCRIPTION
## Major Changes in this PR
- Found error with skew_correction from dev_testing, moving skew_correction inside if statement as this could error out for users that do not have skew_correction enabled.

## How the changes in this PR are tested
- Disabled skew_correction, and verified that fix didnt cause an error
- Re-enabled skew_correction and verified that enable/disable skew still worked

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design channel requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.