### PR TITLE
Fix crashes into depressor arm for filament cutter with fwd/rwd motion

### DIFF
--- a/config/macros/Cut.cfg
+++ b/config/macros/Cut.cfg
@@ -240,12 +240,20 @@ gcode:
     {% set gVars = printer['gcode_macro _AFC_GLOBAL_VARS'] %}
     {% set travel_speed = gVars['travel_speed'] * 60|float %}
     {% set vars = printer['gcode_macro _AFC_CUT_TIP_VARS'] %}
+    {% set cut_direction = vars['cut_direction']|default('')|lower %}
     {% set safe_margin_x, safe_margin_y = vars.safe_margin_xy|map('float') %}
 
     {% if ((printer.gcode_move.gcode_position.x - pin_park_x_loc)|abs < safe_margin_x) or ((printer.gcode_move.gcode_position.y - pin_park_y_loc)|abs < safe_margin_y) %}
         # Make a safe but slower travel move
-        G1 X{pin_park_x_loc} F{travel_speed}
-        G1 Y{pin_park_y_loc} F{travel_speed}
+        {% if cut_direction == "left" or cut_direction == "right" %}
+            G1 X{pin_park_x_loc} F{travel_speed}
+            G1 Y{pin_park_y_loc} F{travel_speed}
+        {% elif cut_direction == "front" or cut_direction == "back" %}
+            G1 Y{pin_park_y_loc} F{travel_speed}
+            G1 X{pin_park_x_loc} F{travel_speed}
+        {% else %}
+            { action_raise_error("Invalid cut direction. Check the cut_direction in your AFC_Macro_Vars.cfg file!") }
+        {% endif %}
     {% else %}
         G1 X{pin_park_x_loc} Y{pin_park_y_loc} F{travel_speed}
     {% endif %}


### PR DESCRIPTION
The current macro worked for left to right cutting action. But for forwards/backwards motion it resulted in a crash as it got on the wrong side of the depressor pin. This fixes that.

## Major Changes in this PR

## Notes to Code Reviewers

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [X] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design channel requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.