### PR TITLE
Hub and Toolhead runout detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-## [2025-06-22]
+## [2025-06-23]
 ### Added
-- Runout/break/jam detection for all sensors along the filament path (prep, load, hub, toolhead):
+- Runout/break/jam detection for hub and toolhead sensors:
 - If the toolhead or hub sensor detects runout but upstream sensors still detect filament, the print is paused and the user is notified of a possible break/jam (no eject or endless spool mode is attempted).
 - Runout/pause logic only triggers during normal printing states, preventing false positives during lane load/unload or filament swaps.
 - `handle_toolhead_runout` and `handle_hub_runout` methods added to `AFCLane` for special handling of break/jam scenarios at the toolhead and hub.
@@ -16,8 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enhanced runout logic in `AFC_lane.py`, `AFC_extruder.py`, and `AFC_hub.py` to support multi-sensor and break/jam detection.
 
 ### Fixed
-- Addresses issue [#389](https://github.com/ArmoredTurtle/AFC-Klipper-Add-On/issues/389) and [#387](https://github.com/ArmoredTurtle/AFC-Klipper-Add-On/issues/387):
-- Ensures robust detection of filament runout, break, or jam at any sensor location.
+- Addresses issue [#389](https://github.com/ArmoredTurtle/AFC-Klipper-Add-On/issues/389) and [#387](https://github.com/ArmoredTurtle/AFC-Klipper-Add-On/issues/387)
+
 
 ## [2025-06-21]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [2025-06-22]
+### Added
+- Robust runout/break/jam detection for all sensors along the filament path (prep, load, hub, toolhead):
+  - The printer now pauses if any sensor detects runout, not just the first sensor.
+  - If the toolhead or hub sensor detects runout but upstream sensors still detect filament, the print is paused and the user is notified of a possible break/jam (no eject or endless spool mode is attempted).
+  - Runout/pause logic only triggers during normal printing states, preventing false positives during lane load/unload or filament swaps.
+- `handle_toolhead_runout` and `handle_hub_runout` methods added to `AFCLane` for special handling of break/jam scenarios at the toolhead and hub.
+- Hub sensor callback now calls `handle_hub_runout` on all associated lanes when runout is detected.
+
+### Changed
+- Enhanced runout logic in `AFC_lane.py`, `AFC_extruder.py`, and `AFC_hub.py` to support multi-sensor and break/jam detection.
+
+### Fixed
+- Addresses issue [#389](https://github.com/ArmoredTurtle/AFC-Klipper-Add-On/issues/389) and [#387](https://github.com/ArmoredTurtle/AFC-Klipper-Add-On/issues/387):
+  - Prevents false positives and ensures robust detection of filament runout, break, or jam at any sensor location.
+
 ## [2025-06-21]
 ### Fixed
 - Ensure `default_material_temps` name matching in temperature selection logic is case-insensitive.
@@ -832,16 +848,6 @@ gcode:
 ### Fixed
 
   - Minor adjustments to the use of single sensor buffers, retaining functionality for Belay
-
-## [2024-08-28]
-
-### Added
-
-- Addition of two helper macros for the AFC system. 
-  - `BT_LANE_EJECT` - This macro will eject a specified box turtle lane.
-  - `BT_TOOL_UNLOAD` - This macro will unload a specified box turtle tool.
-
-- Sample configuration files for the most popular boards are located in the `Klipper_cfg_example/AFC` directory.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Ensure `default_material_temps` name matching in temperature selection logic is case-insensitive.
 
+## [2025-06-21]
+### Fixed
+- Ensure `default_material_temps` name matching in temperature selection logic is case-insensitive.
+
 ## [2025-06-17]
 ### Fixed
 - Updated `cycles_per_rotation` value to be less aggressive at 800 for print assist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,14 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 - Fixed function that auto assigns T(n) commands to check and verify that other T(n) commands are not already registered outside of AFC
 
-## [2025-06-21]
-### Fixed
-- Ensure `default_material_temps` name matching in temperature selection logic is case-insensitive.
-
-## [2025-06-21]
-### Fixed
-- Ensure `default_material_temps` name matching in temperature selection logic is case-insensitive.
-
 ## [2025-06-17]
 ### Fixed
 - Updated `cycles_per_rotation` value to be less aggressive at 800 for print assist
@@ -848,7 +840,15 @@ gcode:
 
   - Minor adjustments to the use of single sensor buffers, retaining functionality for Belay
 
+## [2024-08-28]
 
+### Added
+
+- Addition of two helper macros for the AFC system. 
+  - `BT_LANE_EJECT` - This macro will eject a specified box turtle lane.
+  - `BT_TOOL_UNLOAD` - This macro will unload a specified box turtle tool.
+
+- Sample configuration files for the most popular boards are located in the `Klipper_cfg_example/AFC` directory.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 - Fixed function that auto assigns T(n) commands to check and verify that other T(n) commands are not already registered outside of AFC
 
+## [2025-06-21]
+### Fixed
+- Ensure `default_material_temps` name matching in temperature selection logic is case-insensitive.
+
 ## [2025-06-17]
 ### Fixed
 - Updated `cycles_per_rotation` value to be less aggressive at 800 for print assist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [2025-06-22]
 ### Added
-- Robust runout/break/jam detection for all sensors along the filament path (prep, load, hub, toolhead):
-  - The printer now pauses if any sensor detects runout, not just the first sensor.
-  - If the toolhead or hub sensor detects runout but upstream sensors still detect filament, the print is paused and the user is notified of a possible break/jam (no eject or endless spool mode is attempted).
-  - Runout/pause logic only triggers during normal printing states, preventing false positives during lane load/unload or filament swaps.
+- Runout/break/jam detection for all sensors along the filament path (prep, load, hub, toolhead):
+- If the toolhead or hub sensor detects runout but upstream sensors still detect filament, the print is paused and the user is notified of a possible break/jam (no eject or endless spool mode is attempted).
+- Runout/pause logic only triggers during normal printing states, preventing false positives during lane load/unload or filament swaps.
 - `handle_toolhead_runout` and `handle_hub_runout` methods added to `AFCLane` for special handling of break/jam scenarios at the toolhead and hub.
 - Hub sensor callback now calls `handle_hub_runout` on all associated lanes when runout is detected.
 
@@ -18,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Addresses issue [#389](https://github.com/ArmoredTurtle/AFC-Klipper-Add-On/issues/389) and [#387](https://github.com/ArmoredTurtle/AFC-Klipper-Add-On/issues/387):
-  - Prevents false positives and ensures robust detection of filament runout, break, or jam at any sensor location.
+- Ensures robust detection of filament runout, break, or jam at any sensor location.
 
 ## [2025-06-21]
 ### Fixed

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -384,11 +384,12 @@ class afc:
             using_min_value = False
         elif self.default_material_temps is not None and cur_lane.material is not None:
             lane_material = str(cur_lane.material).strip().lower()
+            lane_material = str(cur_lane.material).strip().lower()
             for mat in self.default_material_temps:
                 m = mat.split(":")
                 mat_key = m[0].strip().lower()
                 # Use substring match for material name (case-insensitive, ignore whitespace)
-                if mat_key in lane_material:
+                if lane_material in mat_key:
                     temp_value = m[1]
                     using_min_value = False
                     break

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -389,7 +389,7 @@ class afc:
                 m = mat.split(":")
                 mat_key = m[0].strip().lower()
                 # Use substring match for material name (case-insensitive, ignore whitespace)
-                if lane_material in mat_key:
+                if mat_key in lane_material:
                     temp_value = m[1]
                     using_min_value = False
                     break

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -407,7 +407,6 @@ class afc:
         wait = False
 
         # If extruder can extrude and printing return and do not update temperature, don't want to modify extruder temperature during prints
-        # If extruder can extrude and printing return and do not update temperature, don't want to modify extruder temperature during prints
         if self.heater.can_extrude and self.function.is_printing():
             return
         target_temp, using_min_value = self._get_default_material_temps(cur_lane)

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -384,12 +384,11 @@ class afc:
             using_min_value = False
         elif self.default_material_temps is not None and cur_lane.material is not None:
             lane_material = str(cur_lane.material).strip().lower()
-            lane_material = str(cur_lane.material).strip().lower()
             for mat in self.default_material_temps:
                 m = mat.split(":")
                 mat_key = m[0].strip().lower()
                 # Use substring match for material name (case-insensitive, ignore whitespace)
-                if mat_key in lane_material:
+                if lane_material in mat_key:
                     temp_value = m[1]
                     using_min_value = False
                     break
@@ -407,6 +406,7 @@ class afc:
         pheaters = self.printer.lookup_object('heaters')
         wait = False
 
+        # If extruder can extrude and printing return and do not update temperature, don't want to modify extruder temperature during prints
         # If extruder can extrude and printing return and do not update temperature, don't want to modify extruder temperature during prints
         if self.heater.can_extrude and self.function.is_printing():
             return

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -388,7 +388,7 @@ class afc:
                 m = mat.split(":")
                 mat_key = m[0].strip().lower()
                 # Use substring match for material name (case-insensitive, ignore whitespace)
-                if lane_material in mat_key:
+                if mat_key in lane_material:
                     temp_value = m[1]
                     using_min_value = False
                     break

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -87,6 +87,9 @@ class AFCExtruder:
             if hasattr(lane, "handle_toolhead_runout"):
                 lane.handle_toolhead_runout(sensor="tool_start")
 
+    def buffer_trailing_callback(self, eventtime, state):
+        self.buffer_trailing = state
+
     def tool_end_callback(self, eventtime, state):
         self.tool_end_state = state
         # Notify the currently loaded lane if filament is missing at toolhead
@@ -94,9 +97,6 @@ class AFCExtruder:
             lane = self.lanes[self.lane_loaded]
             if hasattr(lane, "handle_toolhead_runout"):
                 lane.handle_toolhead_runout(sensor="tool_end")
-
-    def buffer_trailing_callback(self, eventtime, state):
-        self.buffer_trailing = state
 
     def _update_tool_stn(self, length):
         """

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -79,24 +79,23 @@ class AFCExtruder:
         self.reactor = self.afc.reactor
         self.afc.tools[self.name] = self
 
-    def tool_start_callback(self, eventtime, state):
-        self.tool_start_state = state
+    def _handle_toolhead_sensor_runout(self, state, sensor_name):
         # Notify the currently loaded lane if filament is missing at toolhead
         if not state and self.lane_loaded and self.lane_loaded in self.lanes:
             lane = self.lanes[self.lane_loaded]
             if hasattr(lane, "handle_toolhead_runout"):
-                lane.handle_toolhead_runout(sensor="tool_start")
+                lane.handle_toolhead_runout(sensor=sensor_name)
+
+    def tool_start_callback(self, eventtime, state):
+        self.tool_start_state = state
+        self._handle_toolhead_sensor_runout(state, "tool_start")
 
     def buffer_trailing_callback(self, eventtime, state):
         self.buffer_trailing = state
 
     def tool_end_callback(self, eventtime, state):
         self.tool_end_state = state
-        # Notify the currently loaded lane if filament is missing at toolhead
-        if not state and self.lane_loaded and self.lane_loaded in self.lanes:
-            lane = self.lanes[self.lane_loaded]
-            if hasattr(lane, "handle_toolhead_runout"):
-                lane.handle_toolhead_runout(sensor="tool_end")
+        self._handle_toolhead_sensor_runout(state, "tool_end")
 
     def _update_tool_stn(self, length):
         """

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -80,6 +80,12 @@ class AFCExtruder:
         self.afc.tools[self.name] = self
 
     def _handle_toolhead_sensor_runout(self, state, sensor_name):
+        """
+        Handles runout detection at the toolhead sensors (tool_start or tool_end).
+        Notifies the currently loaded lane if filament is missing at the toolhead sensor.
+        :param state: Boolean indicating sensor state (True = filament present, False = runout)
+        :param sensor_name: Name of the triggering sensor ("tool_start" or "tool_end")
+        """
         # Notify the currently loaded lane if filament is missing at toolhead
         if not state and self.lane_loaded and self.lane_loaded in self.lanes:
             lane = self.lanes[self.lane_loaded]
@@ -87,6 +93,12 @@ class AFCExtruder:
                 lane.handle_toolhead_runout(sensor=sensor_name)
 
     def tool_start_callback(self, eventtime, state):
+        """
+        Callback for the tool_start (pre-extruder) filament sensor.
+        Updates the sensor state and triggers runout handling if filament is missing.
+        :param eventtime: Event time from the button press
+        :param state: Boolean indicating sensor state (True = filament present, False = runout)
+        """
         self.tool_start_state = state
         self._handle_toolhead_sensor_runout(state, "tool_start")
 
@@ -94,6 +106,12 @@ class AFCExtruder:
         self.buffer_trailing = state
 
     def tool_end_callback(self, eventtime, state):
+        """
+        Callback for the tool_end (post-extruder) filament sensor.
+        Updates the sensor state and triggers runout handling if filament is missing.
+        :param eventtime: Event time from the button press
+        :param state: Boolean indicating sensor state (True = filament present, False = runout)
+        """
         self.tool_end_state = state
         self._handle_toolhead_sensor_runout(state, "tool_end")
 

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -81,12 +81,22 @@ class AFCExtruder:
 
     def tool_start_callback(self, eventtime, state):
         self.tool_start_state = state
-
-    def buffer_trailing_callback(self, eventtime, state):
-        self.buffer_trailing = state
+        # Notify the currently loaded lane if filament is missing at toolhead
+        if not state and self.lane_loaded and self.lane_loaded in self.lanes:
+            lane = self.lanes[self.lane_loaded]
+            if hasattr(lane, "handle_toolhead_runout"):
+                lane.handle_toolhead_runout(sensor="tool_start")
 
     def tool_end_callback(self, eventtime, state):
         self.tool_end_state = state
+        # Notify the currently loaded lane if filament is missing at toolhead
+        if not state and self.lane_loaded and self.lane_loaded in self.lanes:
+            lane = self.lanes[self.lane_loaded]
+            if hasattr(lane, "handle_toolhead_runout"):
+                lane.handle_toolhead_runout(sensor="tool_end")
+
+    def buffer_trailing_callback(self, eventtime, state):
+        self.buffer_trailing = state
 
     def _update_tool_stn(self, length):
         """

--- a/extras/AFC_hub.py
+++ b/extras/AFC_hub.py
@@ -78,6 +78,11 @@ class afc_hub:
 
     def switch_pin_callback(self, eventtime, state):
         self.state = state
+        # If hub sensor is triggered (runout), notify all associated lanes
+        if state is False:
+            for lane in self.lanes.values():
+                if hasattr(lane, 'handle_hub_runout'):
+                    lane.handle_hub_runout(sensor='hub')
 
     def hub_cut(self, cur_lane):
         servo_string = 'SET_SERVO SERVO={servo} ANGLE={{angle}}'.format(servo=self.cut_servo_name)

--- a/extras/AFC_hub.py
+++ b/extras/AFC_hub.py
@@ -78,11 +78,11 @@ class afc_hub:
 
     def switch_pin_callback(self, eventtime, state):
         self.state = state
-        # If hub sensor is triggered (runout), notify all associated lanes
-        if state is False:
-            for lane in self.lanes.values():
-                if hasattr(lane, 'handle_hub_runout'):
-                    lane.handle_hub_runout(sensor='hub')
+        # Only trigger runout for the currently loaded lane (in the toolhead) if it belongs to this hub
+        current_lane_name = getattr(self.afc, 'current', None)
+        if current_lane_name and current_lane_name in self.lanes:
+            lane = self.lanes[current_lane_name]
+            lane.handle_hub_runout()
 
     def hub_cut(self, cur_lane):
         servo_string = 'SET_SERVO SERVO={servo} ANGLE={{angle}}'.format(servo=self.cut_servo_name)

--- a/extras/AFC_hub.py
+++ b/extras/AFC_hub.py
@@ -82,7 +82,7 @@ class afc_hub:
         current_lane_name = getattr(self.afc, 'current', None)
         if current_lane_name and current_lane_name in self.lanes:
             lane = self.lanes[current_lane_name]
-            lane.handle_hub_runout()
+            lane.handle_hub_runout(sensor_name=self.name)
 
     def hub_cut(self, cur_lane):
         servo_string = 'SET_SERVO SERVO={servo} ANGLE={{angle}}'.format(servo=self.cut_servo_name)

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -871,13 +871,7 @@ class AFCLane:
             self.afc.error.pause_resume.send_pause_command()
             self.afc.save_pos()
             self.afc.error.AFC_error(msg)
-        else:
-            # Normal runout handling (fall back to existing logic)
-            if self.status != AFCLaneState.EJECTING:
-                if self.runout_lane != 'NONE':
-                    self._perform_infinite_runout()
-                else:
-                    self._perform_pause_runout()
+        # No else: do not trigger infinite runout or pause runout here
 
     def handle_hub_runout(self, sensor=None):
         """
@@ -904,13 +898,7 @@ class AFCLane:
             self.afc.error.pause_resume.send_pause_command()
             self.afc.save_pos()
             self.afc.error.AFC_error(msg)
-        else:
-            # Normal runout handling (fall back to existing logic)
-            if self.afc.function.is_printing() and self.status != AFCLaneState.EJECTING:
-                if self.runout_lane != 'NONE':
-                    self._perform_infinite_runout()
-                else:
-                    self._perform_pause_runout()
+        # No else: do not trigger infinite runout or pause runout here
 
 
     cmd_SET_LANE_LOADED_help = "Sets current lane as loaded to toolhead, useful when manually loading lanes during prints if AFC detects an error when trying to unload/load a lane"

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -1087,8 +1087,8 @@ class AFCLane:
                     self._perform_pause_runout()
 
     def handle_hub_runout(self, sensor=None):
-        # Only trigger runout logic if in a normal printing state
-        if not self._is_normal_printing_state():
+        # Only trigger runout logic if in a normal printing state AND printer is actively printing
+        if not (self._is_normal_printing_state() and self.afc.function.is_printing()):
             return
 
         # Check upstream sensors: prep, load

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -838,7 +838,7 @@ class AFCLane:
             return self.buffer_obj.trailing_state
         else: return None
 
-   
+
     def _is_normal_printing_state(self):
         """
         Returns True if the lane is in a normal printing state (TOOLED or LOADED).
@@ -1115,7 +1115,7 @@ class AFCLane:
         response['status'] = self.status
         return response
 
-    
+
 
 def load_config_prefix(config):
     return AFCLane(config)

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -1052,6 +1052,9 @@ class AFCLane:
         response['status'] = self.status
         return response
 
+    def load_config_prefix(config):
+        return AFCLane(config)
+
     def _is_normal_printing_state(self):
         """
         Returns True if the lane is in a normal printing state (TOOLED or LOADED).

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -1052,9 +1052,6 @@ class AFCLane:
         response['status'] = self.status
         return response
 
-    def load_config_prefix(config):
-        return AFCLane(config)
-
     def _is_normal_printing_state(self):
         """
         Returns True if the lane is in a normal printing state (TOOLED or LOADED).
@@ -1115,3 +1112,6 @@ class AFCLane:
                     self._perform_infinite_runout()
                 else:
                     self._perform_pause_runout()
+
+def load_config_prefix(config):
+    return AFCLane(config)

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -496,7 +496,7 @@ class AFCLane:
         self.status = AFCLaneState.NONE
         msg = "Runout triggered for lane {} and runout lane is not setup to switch to another lane".format(self.name)
         msg += "\nPlease manually load next spool into toolhead and then hit resume to continue"
-        self.afc.function.afc_led(self.led_not_ready, self.led_index)
+        self.afc.function.afc_led(self.afc.led_not_ready, self.led_index)
         self.afc.error.AFC_error(msg)
 
     def load_callback(self, eventtime, state):

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -838,6 +838,81 @@ class AFCLane:
             return self.buffer_obj.trailing_state
         else: return None
 
+   
+    def _is_normal_printing_state(self):
+        """
+        Returns True if the lane is in a normal printing state (TOOLED or LOADED).
+        Prevents runout logic from triggering during transitions or maintenance.
+        """
+        return self.status in (AFCLaneState.TOOLED, AFCLaneState.LOADED)
+
+    def handle_toolhead_runout(self, sensor=None):
+        """
+        Handles runout detection at the toolhead sensor.
+        If all upstream sensors (prep, load, hub) still detect filament, this indicates a break or jam at the toolhead.
+        Otherwise, triggers normal runout handling logic. Only triggers during normal printing states and when printing.
+        :param sensor: Optional name of the triggering sensor for user notification.
+        """
+        # Only trigger runout logic if in a normal printing state AND printer is actively printing
+        if not (self._is_normal_printing_state() and self.afc.function.is_printing()):
+            return
+
+        # Check upstream sensors: prep, load, hub
+        prep_ok = self.prep_state
+        load_ok = self.load_state
+        hub_ok = self.hub_obj.state if self.hub_obj is not None else True
+
+        # If all upstream sensors are still True, this is a break/jam at the toolhead
+        if prep_ok and load_ok and hub_ok:
+            msg = (
+                f"Toolhead runout detected by {sensor} sensor, but upstream sensors still detect filament.\n"
+                "Possible filament break or jam at the toolhead. Please clear the jam and reload filament manually, then resume the print."
+            )
+            self.afc.error.pause_resume.send_pause_command()
+            self.afc.save_pos()
+            self.afc.error.AFC_error(msg)
+        else:
+            # Normal runout handling (fall back to existing logic)
+            if self.status != AFCLaneState.EJECTING:
+                if self.runout_lane != 'NONE':
+                    self._perform_infinite_runout()
+                else:
+                    self._perform_pause_runout()
+
+    def handle_hub_runout(self, sensor=None):
+        """
+        Handles runout detection at the hub sensor.
+        If both upstream sensors (prep, load) still detect filament but hub does not, this indicates a break or jam at the hub.
+        Otherwise, triggers normal runout handling logic. Only triggers during normal printing states and when printing.
+        :param sensor: Optional name of the triggering sensor for user notification.
+        """
+        # Only trigger runout logic if in a normal printing state AND printer is actively printing
+        if not (self._is_normal_printing_state() and self.afc.function.is_printing()):
+            return
+
+        # Check upstream sensors: prep, load
+        prep_ok = self.prep_state
+        load_ok = self.load_state
+        hub_ok = self.hub_obj.state if self.hub_obj is not None else False
+
+        # If both upstream sensors are still True, but hub is not, this is a break/jam at the hub
+        if prep_ok and load_ok and not hub_ok:
+            msg = (
+                f"Hub runout detected by {sensor or 'hub'} sensor, but upstream sensors still detect filament.\n"
+                "Possible filament break or jam at the hub. Please clear the jam and reload filament manually, then resume the print."
+            )
+            self.afc.error.pause_resume.send_pause_command()
+            self.afc.save_pos()
+            self.afc.error.AFC_error(msg)
+        else:
+            # Normal runout handling (fall back to existing logic)
+            if self.afc.function.is_printing() and self.status != AFCLaneState.EJECTING:
+                if self.runout_lane != 'NONE':
+                    self._perform_infinite_runout()
+                else:
+                    self._perform_pause_runout()
+
+
     cmd_SET_LANE_LOADED_help = "Sets current lane as loaded to toolhead, useful when manually loading lanes during prints if AFC detects an error when trying to unload/load a lane"
     cmd_SET_LANE_LOAD_options = {"LANE": {"type": "string", "default": "lane1"}}
     def cmd_SET_LANE_LOADED(self, gcmd):
@@ -1052,66 +1127,7 @@ class AFCLane:
         response['status'] = self.status
         return response
 
-    def _is_normal_printing_state(self):
-        """
-        Returns True if the lane is in a normal printing state (TOOLED or LOADED).
-        Prevents runout logic from triggering during transitions or maintenance.
-        """
-        return self.status in (AFCLaneState.TOOLED, AFCLaneState.LOADED)
-
-    def handle_toolhead_runout(self, sensor=None):
-        # Only trigger runout logic if in a normal printing state
-        if not self._is_normal_printing_state():
-            return
-
-        # Check upstream sensors: prep, load, hub
-        prep_ok = getattr(self, 'prep_state', True)
-        load_ok = getattr(self, 'load_state', True)
-        hub_ok = getattr(self.hub_obj, 'state', True) if hasattr(self, 'hub_obj') and self.hub_obj is not None else True
-
-        # If all upstream sensors are still True, this is a break/jam at the toolhead
-        if prep_ok and load_ok and hub_ok:
-            msg = (
-                f"Toolhead runout detected by {sensor} sensor, but upstream sensors still detect filament.\n"
-                "Possible filament break or jam at the toolhead. Please clear the jam and reload filament manually, then resume the print."
-            )
-            self.afc.error.pause_resume.send_pause_command()
-            self.afc.save_pos()
-            self.afc.error.AFC_error(msg)
-        else:
-            # Normal runout handling (fall back to existing logic)
-            if self.afc.function.is_printing() and self.status != AFCLaneState.EJECTING:
-                if self.runout_lane != 'NONE':
-                    self._perform_infinite_runout()
-                else:
-                    self._perform_pause_runout()
-
-    def handle_hub_runout(self, sensor=None):
-        # Only trigger runout logic if in a normal printing state AND printer is actively printing
-        if not (self._is_normal_printing_state() and self.afc.function.is_printing()):
-            return
-
-        # Check upstream sensors: prep, load
-        prep_ok = getattr(self, 'prep_state', True)
-        load_ok = getattr(self, 'load_state', True)
-        hub_ok = getattr(self.hub_obj, 'state', False) if hasattr(self, 'hub_obj') and self.hub_obj is not None else False
-
-        # If both upstream sensors are still True, but hub is not, this is a break/jam at the hub
-        if prep_ok and load_ok and not hub_ok:
-            msg = (
-                f"Hub runout detected by {sensor or 'hub'} sensor, but upstream sensors still detect filament.\n"
-                "Possible filament break or jam at the hub. Please clear the jam and reload filament manually, then resume the print."
-            )
-            self.afc.error.pause_resume.send_pause_command()
-            self.afc.save_pos()
-            self.afc.error.AFC_error(msg)
-        else:
-            # Normal runout handling (fall back to existing logic)
-            if self.afc.function.is_printing() and self.status != AFCLaneState.EJECTING:
-                if self.runout_lane != 'NONE':
-                    self._perform_infinite_runout()
-                else:
-                    self._perform_pause_runout()
+    
 
 def load_config_prefix(config):
     return AFCLane(config)


### PR DESCRIPTION
## Major Changes in this PR

- Enhanced filament runout, break, and jam detection for remaining sensors along the filament path (hub, toolhead).
- System now pauses the print if any sensor detects runout, with special handling for break/jam scenarios (e.g., hub or toolhead runout with upstream sensors still detecting filament).
- Runout logic is restricted to normal printing states only (not during transitions or maintenance).
- Only the currently loaded lane is checked for runout during printing, preventing false positives from unloaded lanes.

## Notes to Code Reviewers

- The main logic changes are in `extras/AFC_lane.py` (runout/pause handling, state checks) and `extras/AFC_hub.py` (hub sensor callback logic).
- Should address issues [#389](https://github.com/ArmoredTurtle/AFC-Klipper-Add-On/issues/389) and [#387](https://github.com/ArmoredTurtle/AFC-Klipper-Add-On/issues/387)

## How the changes in this PR are tested

- Manual testing performed by simulating filament runout, break, and jam at each sensor during active prints. 
Toolhead: Cutting filament before the toolhead to verify toolhead sensor runout is working.
Hub: Manually paused print, cut filament after hub, lane move -50 mm to clear hub sensor, insert short length of filament to trigger sensor again, resume print, remove short length. Confirmed hub runnout detected and paused print.
- Verified that the system pauses the print and notifies the user appropriately for each scenario.
- Confirmed that no false runout errors occur during transitions, maintenance, or for unloaded lanes.
- Ran a multicolor print to ensure no regressions issues during regular filament changes.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

