### PR TITLE
AFC_assist.py: recover compatibility with Python 3.8

### DIFF
--- a/extras/AFC_assist.py
+++ b/extras/AFC_assist.py
@@ -3,6 +3,10 @@
 # Copyright (C) 2024 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+
+# ensure compatibility with python 3.8
+from __future__ import annotations
+
 import math
 import traceback
 


### PR DESCRIPTION
Commit 8dfcd03f "Add statistics for tracking..." added a class with annotations on the return type.

The style of subscripting build-in types was introduced in Python 3.9, but still can be valid in 3.8 if we import annotations from __future__.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design channel requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description