### PR TITLE
Custom load sequence and loaded but idle led status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-06-28]
+### Added
+- `led_tool_loaded_idle` led status color. This is used when a lane is loaded to a tool but that tool is not active. Primary use, toolchangers.
+  - This is available to be set globally, per unit or per lane.
+- `custom_load_cmd` to AFC_lane. This offers flexablilty for set ups that aren't using the standard AFC load sequence.
+  - Setting this will override the standard AFC load sequence.
+  - This will still check the toolhead presensor state to confirm load *pre extruder toolhead sensor required*
+
+### Changed
+- The load sequence for the command `TOOL_LOAD` is now pulled out to it's own function for more flexiblility
+- The status of a tool loaded lane that is not the current extruder will now be set to `led_tool_loaded_idle` for a more clear led status.
+
 ## [2025-06-26]
 ### Added
 - `TOOL_SWAP` state and `tool_swap` method: Enables robust tool swapping between extruders.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2025-06-28]
+## [2025-06-29]
 ### Added
 - `led_tool_loaded_idle` led status color. This is used when a lane is loaded to a tool but that tool is not active. Primary use, toolchangers.
   - This is available to be set globally, per unit or per lane.
-- `custom_load_cmd` to AFC_lane. This offers flexablilty for set ups that aren't using the standard AFC load sequence.
+- `custom_load_cmd` to AFC_lane. This offers flexiblilty for set ups that aren't using the standard AFC load sequence.
   - Setting this will override the standard AFC load sequence.
   - This will still check the toolhead presensor state to confirm load *pre extruder toolhead sensor required*
+- `custom_unload_cmd` to AFC_lane. This offers flexibility in how the system unloads
+  - This will override and bypass the standard AFC load sequence.
+  - There is no check for toolhead sensor after completion so it will assume the unload was successful.
 
 ### Changed
 - The load sequence for the command `TOOL_LOAD` is now pulled out to it's own function for more flexiblility
+- The unload sequence for the command `TOOL_UNLOAD` is now pulled out to it's own function for more flexibility
 - The status of a tool loaded lane that is not the current extruder will now be set to `led_tool_loaded_idle` for a more clear led status.
 
 ## [2025-06-26]

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -123,21 +123,23 @@ class afc:
         self.temp_wait_tolerance    = config.getfloat("temp_wait_tolerance", 5.0)         # Temperature tolerance in degrees Celsius for wait commands like M109
 
         #LED SETTINGS
+        # All variables use: (R,G,B,W) 0 = off, 1 = full brightness.
         self.ind_lights = None
         # led_name is not used, either use or needs to be removed, removing this would break everyones config as well
         self.led_name               = config.get('led_name',None)
         self.led_off                = "0,0,0,0"
-        self.led_fault              = config.get('led_fault','1,0,0,0')             # LED color to set when faults occur in lane        (R,G,B,W) 0 = off, 1 = full brightness.
-        self.led_ready              = config.get('led_ready','1,1,1,1')             # LED color to set when lane is ready               (R,G,B,W) 0 = off, 1 = full brightness.
-        self.led_not_ready          = config.get('led_not_ready','1,1,0,0')         # LED color to set when lane not ready              (R,G,B,W) 0 = off, 1 = full brightness.
-        self.led_loading            = config.get('led_loading','1,0,0,0')           # LED color to set when lane is loading             (R,G,B,W) 0 = off, 1 = full brightness.
-        self.led_prep_loaded        = config.get('led_loading','1,1,0,0')           # LED color to set when lane is loaded              (R,G,B,W) 0 = off, 1 = full brightness.
-        self.led_unloading          = config.get('led_unloading','1,1,.5,0')        # LED color to set when lane is unloading           (R,G,B,W) 0 = off, 1 = full brightness.
-        self.led_tool_loaded        = config.get('led_tool_loaded','1,1,0,0')       # LED color to set when lane is loaded into tool    (R,G,B,W) 0 = off, 1 = full brightness.
-        self.led_advancing          = config.get('led_buffer_advancing','0,0,1,0')  # LED color to set when buffer is advancing         (R,G,B,W) 0 = off, 1 = full brightness.
-        self.led_trailing           = config.get('led_buffer_trailing','0,1,0,0')   # LED color to set when buffer is trailing          (R,G,B,W) 0 = off, 1 = full brightness.
-        self.led_buffer_disabled    = config.get('led_buffer_disable', '0,0,0,0.25')# LED color to set when buffer is disabled          (R,G,B,W) 0 = off, 1 = full brightness.
-        self.led_spool_illum        = config.get('led_spool_illuminate', "1,1,1,1") # LED color to illuminate under spool
+        self.led_fault              = config.get('led_fault','1,0,0,0')                # LED color to set when faults occur in lane
+        self.led_ready              = config.get('led_ready','1,1,1,1')                # LED color to set when lane is ready
+        self.led_not_ready          = config.get('led_not_ready','1,1,0,0')            # LED color to set when lane not ready
+        self.led_loading            = config.get('led_loading','1,0,0,0')              # LED color to set when lane is loading
+        self.led_prep_loaded        = config.get('led_loading','1,1,0,0')              # LED color to set when lane is loaded
+        self.led_unloading          = config.get('led_unloading','1,1,.5,0')           # LED color to set when lane is unloading
+        self.led_tool_loaded        = config.get('led_tool_loaded','1,1,0,0')          # LED color to set when lane is loaded into tool
+        self.led_tool_loaded_idle   = config.get('led_tool_loaded_idle','0.4,0.4,0,0') # LED color to set when lane is loaded into tool and idle
+        self.led_advancing          = config.get('led_buffer_advancing','0,0,1,0')     # LED color to set when buffer is advancing
+        self.led_trailing           = config.get('led_buffer_trailing','0,1,0,0')      # LED color to set when buffer is trailing
+        self.led_buffer_disabled    = config.get('led_buffer_disable', '0,0,0,0.25')   # LED color to set when buffer is disabled
+        self.led_spool_illum        = config.get('led_spool_illuminate', "1,1,1,1")    # LED color to illuminate under spool
 
         # TOOL Cutting Settings
         self.tool                   = ''
@@ -1045,105 +1047,9 @@ class afc:
                 self.save_vars()
                 cur_lane.unit_obj.lane_loading( cur_lane )
 
-                if self._check_extruder_temp(cur_lane):
-                    self.afcDeltaTime.log_with_time("Done heating toolhead")
-
-                # Enable the lane for filament movement.
-                cur_lane.do_enable(True)
-
-                # Move filament to the hub if it's not already loaded there.
-                if not cur_lane.loaded_to_hub or cur_lane.hub == 'direct':
-                    cur_lane.move_advanced(cur_lane.dist_hub, SpeedMode.HUB, assist_active = AssistActive.DYNAMIC)
-                    self.afcDeltaTime.log_with_time("Loaded to hub")
-
-                cur_lane.loaded_to_hub = True
-                hub_attempts = 0
-
-                # Ensure filament moves past the hub.
-                while not cur_hub.state and cur_lane.hub != 'direct':
-                    if hub_attempts == 0:
-                        cur_lane.move_advanced(cur_hub.move_dis, SpeedMode.SHORT)
-                    else:
-                        cur_lane.move_advanced(cur_lane.short_move_dis, SpeedMode.SHORT)
-                    hub_attempts += 1
-                    if hub_attempts > 20:
-                        message = 'filament did not trigger hub sensor, CHECK FILAMENT PATH\n||=====||==>--||-----||\nTRG   LOAD   HUB   TOOL.'
-                        if self.function.in_print():
-                            message += '\nOnce issue is resolved please manually load {} with {} macro and click resume to continue printing.'.format(cur_lane.name, cur_lane.map)
-                            message += '\nIf you have to retract filament back, use LANE_MOVE macro for {}.'.format(cur_lane.name)
-                        self.error.handle_lane_failure(cur_lane, message)
-                        return False
-
-                self.afcDeltaTime.log_with_time("Filament loaded to hub")
-
-                # Move filament towards the toolhead.
-                if cur_lane.hub != 'direct':
-                    cur_lane.move_advanced(cur_hub.afc_bowden_length, SpeedMode.LONG, assist_active = AssistActive.YES)
-
-                # Ensure filament reaches the toolhead.
-                tool_attempts = 0
-                if cur_extruder.tool_start:
-                    while not cur_lane.get_toolhead_pre_sensor_state():
-                        tool_attempts += 1
-                        cur_lane.move(cur_lane.short_move_dis, cur_extruder.tool_load_speed, cur_lane.long_moves_accel)
-                        if tool_attempts > int(self.tool_homing_distance/cur_lane.short_move_dis):
-                            message = 'filament failed to trigger pre extruder gear toolhead sensor, CHECK FILAMENT PATH\n||=====||====||==>--||\nTRG   LOAD   HUB   TOOL'
-                            message += '\nTo resolve set lane loaded with `SET_LANE_LOADED LANE={}` macro.'.format(cur_lane.name)
-                            message += '\nManually move filament with LANE_MOVE macro for {} until filament is right before toolhead extruder gears,'.format(cur_lane.name)
-                            message += '\n then load into extruder gears with extrude button in your gui of choice until the color fully changes'
-                            if self.function.in_print():
-                                message += '\nOnce filament is fully loaded click resume to continue printing'
-                            self.error.handle_lane_failure(cur_lane, message)
-                            return False
-
-                self.afcDeltaTime.log_with_time("Filament loaded to pre-sensor")
-
-                # Synchronize lane's extruder stepper and finalize tool loading.
-                cur_lane.status = AFCLaneState.TOOL_LOADED
-                self.save_vars()
-                cur_lane.sync_to_extruder()
-
-                if cur_extruder.tool_end:
-                    while not cur_extruder.tool_end_state:
-                        tool_attempts += 1
-                        self.move_e_pos( cur_lane.short_move_dis, cur_extruder.tool_load_speed, "Tool end", wait_tool=True )
-                        if tool_attempts > 20:
-                            message = 'filament failed to trigger post extruder gear toolhead sensor, CHECK FILAMENT PATH\n||=====||====||==>--||\nTRG   LOAD   HUB   TOOL'
-                            message += '\nTo resolve set lane loaded with `SET_LANE_LOADED LANE={}` macro.'.format(cur_lane.name)
-                            message += '\nAlso might be a good idea to verify that post extruder gear toolhead sensor is working.'
-                            if self.function.in_print():
-                                message += '\nOnce issue is resolved click resume to continue printing'
-                            self.error.handle_lane_failure(cur_lane, message)
-                            return False
-
-                    self.afcDeltaTime.log_with_time("Filament loaded to post-sensor")
-
-                # Adjust tool position for loading.
-                self.move_e_pos( cur_extruder.tool_stn, cur_extruder.tool_load_speed, "tool stn" )
-
-                self.afcDeltaTime.log_with_time("Filament loaded to nozzle")
-
-                # Check if ramming is enabled, if it is, go through ram load sequence.
-                # Lane will load until Advance sensor is True
-                # After the tool_stn distance the lane will retract off the sensor to confirm load and reset buffer
-                if cur_extruder.tool_start == "buffer":
-                    cur_lane.unsync_to_extruder()
-                    load_checks = 0
-                    while cur_lane.get_toolhead_pre_sensor_state():
-                        cur_lane.move_advanced(cur_lane.short_move_dis * -1, SpeedMode.SHORT)
-                        load_checks += 1
-                        self.reactor.pause(self.reactor.monotonic() + 0.1)
-                        if load_checks > self.tool_max_load_checks:
-                            msg = ''
-                            msg += "Buffer did not become compressed after {} short moves.\n".format(self.tool_max_load_checks)
-                            msg += "Tool may not be loaded"
-                            self.logger.info("<span class=warning--text>{}</span>".format(msg))
-                            break
-                    cur_lane.sync_to_extruder()
-                # Update tool and lane status.
-                cur_lane.set_loaded()
-                cur_lane.enable_buffer()
-                self.save_vars()
+                # Run the load sequence, which may include custom gcode commands.
+                if not self.load_sequence(cur_lane, cur_hub, cur_extruder):
+                    return False
 
                 # Activate the tool-loaded LED and handle filament operations if enabled.
                 cur_lane.unit_obj.lane_tool_loaded( cur_lane )
@@ -1205,6 +1111,132 @@ class afc:
                         message += '\nOnce issue is resolved please manually load {} with {} macro and click resume to continue printing.'.format(cur_lane.name, cur_lane.map)
                     self.error.handle_lane_failure(cur_lane, message)
                     return False
+        return True
+
+    def load_sequence(self, cur_lane, cur_hub, cur_extruder):
+        """
+        This function controls the loading sequence and allows for custom gcode commands to be executed
+        during the loading process.
+
+        :param cur_lane: The lane object to be loaded.
+        """
+        # Placeholder for custom load sequence
+        if cur_lane.custom_load_cmd:
+            self.logger.info("Running custom load command for lane {}".format(cur_lane.name))
+            self.gcode.run_script_from_command(cur_lane.custom_load_cmd)
+            if cur_lane.get_toolhead_pre_sensor_state():
+                cur_lane.status = AFCLaneState.TOOL_LOADED
+                self.save_vars()
+            else:
+                message = 'Custom load command did not trigger pre extruder gear toolhead sensor, CHECK FILAMENT PATH\n||=====||====||==>--||\nTRG   LOAD   HUB   TOOL'
+                message += '\nTo resolve set lane loaded with `SET_LANE_LOADED LANE={}` macro.'.format(cur_lane.name)
+                message += '\nManually move filament until filament is right before toolhead extruder gears,'
+                message += '\n then load into extruder gears with extrude button in your gui of choice until the color fully changes'
+                if self.function.in_print():
+                    message += '\nOnce filament is fully loaded click resume to continue printing'
+                self.error.handle_lane_failure(cur_lane, message)
+                return False
+        else:
+            if self._check_extruder_temp(cur_lane):
+                self.afcDeltaTime.log_with_time("Done heating toolhead")
+
+            # Enable the lane for filament movement.
+            cur_lane.do_enable(True)
+
+            # Move filament to the hub if it's not already loaded there.
+            if not cur_lane.loaded_to_hub or cur_lane.hub == 'direct':
+                cur_lane.move_advanced(cur_lane.dist_hub, SpeedMode.HUB, assist_active = AssistActive.DYNAMIC)
+                self.afcDeltaTime.log_with_time("Loaded to hub")
+
+            cur_lane.loaded_to_hub = True
+            hub_attempts = 0
+
+            # Ensure filament moves past the hub.
+            while not cur_hub.state and cur_lane.hub != 'direct':
+                if hub_attempts == 0:
+                    cur_lane.move_advanced(cur_hub.move_dis, SpeedMode.SHORT)
+                else:
+                    cur_lane.move_advanced(cur_lane.short_move_dis, SpeedMode.SHORT)
+                hub_attempts += 1
+                if hub_attempts > 20:
+                    message = 'filament did not trigger hub sensor, CHECK FILAMENT PATH\n||=====||==>--||-----||\nTRG   LOAD   HUB   TOOL.'
+                    if self.function.in_print():
+                        message += '\nOnce issue is resolved please manually load {} with {} macro and click resume to continue printing.'.format(cur_lane.name, cur_lane.map)
+                        message += '\nIf you have to retract filament back, use LANE_MOVE macro for {}.'.format(cur_lane.name)
+                    self.error.handle_lane_failure(cur_lane, message)
+                    return False
+
+            self.afcDeltaTime.log_with_time("Filament loaded to hub")
+
+            # Move filament towards the toolhead.
+            if cur_lane.hub != 'direct':
+                cur_lane.move_advanced(cur_hub.afc_bowden_length, SpeedMode.LONG, assist_active = AssistActive.YES)
+
+            # Ensure filament reaches the toolhead.
+            tool_attempts = 0
+            if cur_extruder.tool_start:
+                while not cur_lane.get_toolhead_pre_sensor_state():
+                    tool_attempts += 1
+                    cur_lane.move(cur_lane.short_move_dis, cur_extruder.tool_load_speed, cur_lane.long_moves_accel)
+                    if tool_attempts > int(self.tool_homing_distance/cur_lane.short_move_dis):
+                        message = 'filament failed to trigger pre extruder gear toolhead sensor, CHECK FILAMENT PATH\n||=====||====||==>--||\nTRG   LOAD   HUB   TOOL'
+                        message += '\nTo resolve set lane loaded with `SET_LANE_LOADED LANE={}` macro.'.format(cur_lane.name)
+                        message += '\nManually move filament with LANE_MOVE macro for {} until filament is right before toolhead extruder gears,'.format(cur_lane.name)
+                        message += '\n then load into extruder gears with extrude button in your gui of choice until the color fully changes'
+                        if self.function.in_print():
+                            message += '\nOnce filament is fully loaded click resume to continue printing'
+                        self.error.handle_lane_failure(cur_lane, message)
+                        return False
+
+            self.afcDeltaTime.log_with_time("Filament loaded to pre-sensor")
+
+            # Synchronize lane's extruder stepper and finalize tool loading.
+            cur_lane.status = AFCLaneState.TOOL_LOADED
+            self.save_vars()
+            cur_lane.sync_to_extruder()
+
+            if cur_extruder.tool_end:
+                while not cur_extruder.tool_end_state:
+                    tool_attempts += 1
+                    self.move_e_pos( cur_lane.short_move_dis, cur_extruder.tool_load_speed, "Tool end", wait_tool=True )
+                    if tool_attempts > 20:
+                        message = 'filament failed to trigger post extruder gear toolhead sensor, CHECK FILAMENT PATH\n||=====||====||==>--||\nTRG   LOAD   HUB   TOOL'
+                        message += '\nTo resolve set lane loaded with `SET_LANE_LOADED LANE={}` macro.'.format(cur_lane.name)
+                        message += '\nAlso might be a good idea to verify that post extruder gear toolhead sensor is working.'
+                        if self.function.in_print():
+                            message += '\nOnce issue is resolved click resume to continue printing'
+                        self.error.handle_lane_failure(cur_lane, message)
+                        return False
+
+                self.afcDeltaTime.log_with_time("Filament loaded to post-sensor")
+
+            # Adjust tool position for loading.
+            self.move_e_pos( cur_extruder.tool_stn, cur_extruder.tool_load_speed, "tool stn" )
+
+            self.afcDeltaTime.log_with_time("Filament loaded to nozzle")
+
+            # Check if ramming is enabled, if it is, go through ram load sequence.
+            # Lane will load until Advance sensor is True
+            # After the tool_stn distance the lane will retract off the sensor to confirm load and reset buffer
+            if cur_extruder.tool_start == "buffer":
+                cur_lane.unsync_to_extruder()
+                load_checks = 0
+                while cur_lane.get_toolhead_pre_sensor_state():
+                    cur_lane.move_advanced(cur_lane.short_move_dis * -1, SpeedMode.SHORT)
+                    load_checks += 1
+                    self.reactor.pause(self.reactor.monotonic() + 0.1)
+                    if load_checks > self.tool_max_load_checks:
+                        msg = ''
+                        msg += "Buffer did not become compressed after {} short moves.\n".format(self.tool_max_load_checks)
+                        msg += "Tool may not be loaded"
+                        self.logger.info("<span class=warning--text>{}</span>".format(msg))
+                        break
+                cur_lane.sync_to_extruder()
+
+        # Update tool and lane status.
+        cur_lane.set_loaded()
+        cur_lane.enable_buffer()
+        self.save_vars()
         return True
 
     cmd_TOOL_UNLOAD_help = "Unload from tool head"
@@ -1768,7 +1800,6 @@ class afc:
         if wait and deadband is not None and temp > 0:
             self._wait_for_temp_within_tolerance(heater, temp, deadband)
             return
-
 
         # Default: wait if needed
         current_temp = heater.get_temp(self.reactor.monotonic())[0]

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -416,13 +416,15 @@ class afcFunction:
 
         # Disable extruder steppers for non active lanes
         for key, obj in self.afc.lanes.items():
-            self.logger.debug("Checking lane: {}".format(key))
             if cur_lane_loaded is None or key != cur_lane_loaded.name:
-                self.logger.debug("Disabling lane: {}".format(key))
                 obj.do_enable(False)
                 obj.disable_buffer()
                 if obj.prep_state and obj.load_state:
-                    self.afc_led(obj.led_ready, obj.led_index)
+                    if obj.tool_loaded:
+                        # If tool is loaded, set led to tool loaded color
+                        self.afc_led(obj.led_tool_loaded_idle, obj.led_index)
+                    else:
+                        self.afc_led(obj.led_ready, obj.led_index)
                 else:
                     self.afc_led(obj.led_not_ready, obj.led_index)
 

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -115,6 +115,10 @@ class AFCLane:
         self.max_move_dis       = config.getfloat("max_move_dis", None)                 # Maximum distance to move filament. AFC breaks filament moves over this number into multiple moves. Useful to lower this number if running into timer too close errors when doing long filament moves. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
         self.n20_break_delay_time= config.getfloat("n20_break_delay_time", None)        # Time to wait between breaking n20 motors(nSleep/FWD/RWD all 1) and then releasing the break to allow coasting. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
 
+        # Custom Load/unload Commands
+        self.custom_load_cmd = config.get('custom_load_cmd', None)  # Custom command to run when loading lane, this will bypass the typical load sequence and run the command instead.
+        self.custom_unload_cmd = config.get('custom_unload_cmd', None)  # Custom command to run when unloading lane, this will bypass the typical unload sequence and run the command instead.
+
         self.rev_long_moves_speed_factor = config.getfloat("rev_long_moves_speed_factor", None)     # scalar speed factor when reversing filamentalist
 
         self.dist_hub           = config.getfloat('dist_hub', 60)                       # Bowden distance between Box Turtle extruder and hub
@@ -142,9 +146,6 @@ class AFCLane:
         if self.load is not None:
             buttons.register_buttons([self.load], self.load_callback)
         else: self.load_state = True
-
-        # Custom Load Command
-        self.custom_load_cmd = config.get('custom_load_cmd', None)  # Custom command to run when loading lane, this will bypass the typical load sequence and run the command instead.
 
         self.espooler = AFC_assist.Espooler(self.name, config)
         self.lane_load_count = None

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -35,13 +35,17 @@ class afcUnit:
         self.hub                         = config.get("hub", None)                                           # Hub name(AFC_hub) that belongs to this unit, can be overridden in AFC_stepper section
         self.extruder                    = config.get("extruder", None)                                      # Extruder name(AFC_extruder) that belongs to this unit, can be overridden in AFC_stepper section
         self.buffer_name                 = config.get('buffer', None)                                        # Buffer name(AFC_buffer) that belongs to this unit, can be overridden in AFC_stepper section
-        self.led_fault                   = config.get('led_fault', self.afc.led_fault)                       # LED color to set when faults occur in lane        (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in AFC.cfg file
-        self.led_ready                   = config.get('led_ready', self.afc.led_ready)                       # LED color to set when lane is ready               (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in AFC.cfg file
-        self.led_not_ready               = config.get('led_not_ready', self.afc.led_not_ready)               # LED color to set when lane not ready              (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in AFC.cfg file
-        self.led_loading                 = config.get('led_loading', self.afc.led_loading)                   # LED color to set when lane is loading             (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in AFC.cfg file
-        self.led_prep_loaded             = config.get('led_loading', self.afc.led_loading)                   # LED color to set when lane is loaded              (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in AFC.cfg file
-        self.led_unloading               = config.get('led_unloading', self.afc.led_unloading)               # LED color to set when lane is unloading           (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in AFC.cfg file
-        self.led_tool_loaded             = config.get('led_tool_loaded', self.afc.led_tool_loaded)           # LED color to set when lane is loaded into tool    (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in AFC.cfg file
+
+        # LED SETTINGS
+        # All variables use: (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in AFC.cfg file
+        self.led_fault                   = config.get('led_fault', self.afc.led_fault)                       # LED color to set when faults occur in lane
+        self.led_ready                   = config.get('led_ready', self.afc.led_ready)                       # LED color to set when lane is ready
+        self.led_not_ready               = config.get('led_not_ready', self.afc.led_not_ready)               # LED color to set when lane not ready
+        self.led_loading                 = config.get('led_loading', self.afc.led_loading)                   # LED color to set when lane is loading
+        self.led_prep_loaded             = config.get('led_loading', self.afc.led_loading)                   # LED color to set when lane is loaded
+        self.led_unloading               = config.get('led_unloading', self.afc.led_unloading)               # LED color to set when lane is unloading
+        self.led_tool_loaded             = config.get('led_tool_loaded', self.afc.led_tool_loaded)           # LED color to set when lane is loaded into tool
+        self.led_tool_loaded_idle        = config.get('led_tool_loaded_idle', self.afc.led_tool_loaded_idle) # LED color to set when lane is loaded into tool and idle
         self.led_spool_illum             = config.get('led_spool_illuminate', self.afc.led_spool_illum)      # LED color to illuminate under spool
         self.led_logo_index              = config.get('led_logo_index', None)                                # LED Logo index
         self.led_logo_color              = self.afc.function.HexConvert(config.get('led_logo_color', '0,0,0,0'))# Default logo color when nothing is loaded


### PR DESCRIPTION
## Major Changes in this PR
This PR introduces the ability to set a custom load/unload command per lane. The primary use is for systems that function outside of the typical AFC configuration. This allows for a custom command to be called that will override the standard load sequence.
    - If defined this will override and bypass the standard load/unload sequence
    - A pre-extruder filament sensor is currently required
    - This is defined under the `[AFC_lane]` or `[AFC_stepper]` as `custom_load_cmd`/`custom_unload_cmd`
- The second feature that is added is a LED status for when a tool is loaded but is not the active extruder. This is for use in toolchangers for a more clear led status for the system
    - This can be set globally, at the unit, or lane level.
    - `led_tool_loaded_idle`

## Notes to Code Reviewers
This is pretty straightforward. The standard flow is not interrupted if the command is not defined.

## How the changes in this PR are tested
1. Define a custom load command and execute it
2. Run a standard load

- Both are successful, and the functionality holds

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design channel requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.