### PR TITLE
Fixing error with hub runout, changed variable name to correct name

### DIFF
--- a/extras/AFC_hub.py
+++ b/extras/AFC_hub.py
@@ -82,7 +82,7 @@ class afc_hub:
         current_lane_name = getattr(self.afc, 'current', None)
         if current_lane_name and current_lane_name in self.lanes:
             lane = self.lanes[current_lane_name]
-            lane.handle_hub_runout(sensor_name=self.name)
+            lane.handle_hub_runout(sensor=self.name)
 
     def hub_cut(self, cur_lane):
         servo_string = 'SET_SERVO SERVO={servo} ANGLE={{angle}}'.format(servo=self.cut_servo_name)


### PR DESCRIPTION
## Major Changes in this PR
- Fixing error with hub runout, changed variable name to sensor instead of sensor_name
- 
## Notes to Code Reviewers

## How the changes in this PR are tested
- Printer was crashing because of previous PR, now printer does not crash.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [ ] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design channel requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.