### PR TITLE
Allow custom moonraker urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-07-19]
+### Fixes
+- Issue where localhost and http were hardcoded, allows user to specify custom url. Fixes issue 484.
+
 ## [2025-07-06]
 ### Fixes
 - Race condition between klipper and moonraker when trying to get stats from moonraker database

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -108,7 +108,8 @@ class afc:
         self.extrude_factor     = 1.
 
         # Config get section
-        self.moonraker_port         = config.get("moonraker_port", None)             # Port to connect to when interacting with moonraker. Used when there are multiple moonraker/klipper instances on a single host
+        self.moonraker_port         = config.get("moonraker_port", 7125)             # Port to connect to when interacting with moonraker. Used when there are multiple moonraker/klipper instances on a single host
+        self.moonraker_host         = config.get("moonraker_host", "http://localhost")
         self.moonraker_connect_to   = config.get("moonraker_timeout", 30)
         self.unit_order_list        = config.get('unit_order_list','')
         self.VarFile                = config.get('VarFile','../printer_data/config/AFC/AFC.var')# Path to the variables file for AFC configuration.
@@ -286,7 +287,7 @@ class afc:
         if self.moonraker_port is not None: moonraker_port = ":{}".format(self.moonraker_port)
 
         try:
-            self.moonraker = AFC_moonraker( moonraker_port, self.logger )
+            self.moonraker = AFC_moonraker( self.moonraker_host, moonraker_port, self.logger )
             if not self.moonraker.wait_for_moonraker( toolhead=self.toolhead, timeout=self.moonraker_connect_to ):
                 return False
             self.spoolman = self.moonraker.get_spoolman_server()

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -283,11 +283,9 @@ class afc:
         enough time to start before AFC tries to connect. This fixes a race condition that can
         happen between klipper and moonraker when first starting up.
         """
-        moonraker_port = ""
-        if self.moonraker_port is not None: moonraker_port = ":{}".format(self.moonraker_port)
 
         try:
-            self.moonraker = AFC_moonraker( self.moonraker_host, moonraker_port, self.logger )
+            self.moonraker = AFC_moonraker( self.moonraker_host, self.moonraker_port, self.logger )
             if not self.moonraker.wait_for_moonraker( toolhead=self.toolhead, timeout=self.moonraker_connect_to ):
                 return False
             self.spoolman = self.moonraker.get_spoolman_server()

--- a/extras/AFC_utils.py
+++ b/extras/AFC_utils.py
@@ -76,14 +76,15 @@ class AFC_moonraker:
         AFC logger object to log and print to console
     """
     ERROR_STRING = "Error getting data from moonraker, check AFC.log for more information"
-    def __init__(self, port:str, logger:object):
+    def __init__(self, host:str, port:str, logger:object):
         self.port           = port
         self.logger         = logger
-        self.local_host     = 'http://localhost{port}'.format( port=port )
-        self.database_url   = urljoin(self.local_host, "server/database/item")
+        self.host           = f'{host}{port}'
+        self.database_url   = urljoin(self.host, "server/database/item")
         self.afc_stats_key  = "afc_stats"
         self.afc_stats      = None
         self.last_stats_time= None
+        self.logger.debug(f"Moonraker url: {self.host}")
 
     def _get_results(self, url_string, print_error=True):
         """
@@ -127,7 +128,7 @@ class AFC_moonraker:
         """
         self.logger.info(f"Waiting max {timeout}s for moonraker to connect")
         for i in range(0,timeout):
-            resp = self._get_results(urljoin(self.local_host, 'server/info'), print_error=False)
+            resp = self._get_results(urljoin(self.host, 'server/info'), print_error=False)
             if resp is not None:
                 self.logger.debug(f"Connected to moonraker after {i} tries")
                 return True
@@ -143,7 +144,7 @@ class AFC_moonraker:
 
         :returns: Returns string for spoolmans IP, returns None if its not configured
         """
-        resp = self._get_results(urljoin(self.local_host, 'server/config'))
+        resp = self._get_results(urljoin(self.host, 'server/config'))
         # Check to make sure response is valid and spoolman exists in dictionary
         if resp is not None and 'orig' in resp and 'spoolman' in resp['orig']:
             return resp['orig']['spoolman']['server']     # check for spoolman and grab url
@@ -160,7 +161,7 @@ class AFC_moonraker:
                  Returns zero if not found in metadata.
         """
         change_count = 0
-        resp = self._get_results(urljoin(self.local_host,
+        resp = self._get_results(urljoin(self.host,
                                     'server/files/metadata?filename={}'.format(quote(filename))))
         if resp is not None and 'filament_change_count' in resp:
             change_count =  resp['filament_change_count']
@@ -233,7 +234,7 @@ class AFC_moonraker:
             "request_method": "GET",
             "path": f"/v1/spool/{id}"
         }
-        spool_url = urljoin(self.local_host, 'server/spoolman/proxy')
+        spool_url = urljoin(self.host, 'server/spoolman/proxy')
         req = Request( spool_url, urlencode(request_payload).encode() )
 
         resp = self._get_results(req)

--- a/extras/AFC_utils.py
+++ b/extras/AFC_utils.py
@@ -79,7 +79,7 @@ class AFC_moonraker:
     def __init__(self, host:str, port:str, logger:object):
         self.port           = port
         self.logger         = logger
-        self.host           = f'{host}{port}'
+        self.host           = f'{host.rstrip("/")}:{port}'
         self.database_url   = urljoin(self.host, "server/database/item")
         self.afc_stats_key  = "afc_stats"
         self.afc_stats      = None


### PR DESCRIPTION
## Major Changes in this PR
- Added ability to configure custom URL for moonraker
- Defaulted moonrakers port to 7125

Fixes #484 

Documentation draft PR: https://github.com/ArmoredTurtle/AT-Documentation/pull/71

## Notes to Code Reviewers

## How the changes in this PR are tested
Tested with default local host and with printers hostname, both worked.
<img width="594" height="55" alt="image" src="https://github.com/user-attachments/assets/5b1db788-664d-436f-95e7-de1b5915aa82" />
<img width="541" height="54" alt="image" src="https://github.com/user-attachments/assets/3c14adc1-0690-4878-a6b6-3d7f647cde3b" />


## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design channel requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.