### PR TITLE
Added check to verify that a lane is not loaded when enabling virtual bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2025-07-19]
 ### Fixes
+- Added a check when enabling virtual bypass to make sure a lane is not loaded when enabling.
 - Issue where localhost and http were hardcoded, allows user to specify custom url. Fixes issue 484.
 - Updated code to inform users when trying to assign spoolman ID to a lane and that same spool ID is already assigned to another lane.
 

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -476,6 +476,14 @@ class afc:
         try:
             if 'virtual' in self.bypass.name:
                 bypass_state = self.bypass.sensor_enabled
+
+                # Make sure lane is not loaded before enabling virtual bypass, force switch
+                # to disabled if a lane is loaded
+                if bypass_state and self.current is not None:
+                    self.logger.error(f"Cannot set virtual bypass, {self.current} is currently loaded.")
+                    self.bypass.sensor_enabled = False
+                    return False
+
                 # Update filament present to match enable button so it updates in guis
                 self.bypass.filament_present = bypass_state
 

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -27,7 +27,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 try: from extras.AFC_stats import AFCStats
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
 
-AFC_VERSION="1.0.22"
+AFC_VERSION="1.0.25"
 
 # Class for holding different states so its clear what all valid states are
 class State:

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -936,6 +936,18 @@ class AFCLane:
             self.afc.error.AFC_error("Lane:{} is not loaded, cannot set loaded to toolhead for this lane.".format(self.name), pause=False)
             return
 
+        # Do not set lane as loaded if virtual bypass or normal bypass is enabled/triggered
+        if self.afc.bypass.sensor_enabled:
+            disable_msg = ""
+            msg = f"Cannot set {self.name} as loaded, "
+
+            if 'virtual' in self.afc.bypass.name:
+                msg += "virtual "
+                disable_msg = " and disable"
+            msg += f"bypass is enabled.\nPlease unload{disable_msg} before trying to set lanes as loaded."
+            self.logger.error(msg)
+            return
+
         self.afc.function.unset_lane_loaded()
 
         self.set_loaded()


### PR DESCRIPTION
## Major Changes in this PR
- Added check to verify that a lane is not loaded when enabling virtual bypass, and display message if lane is loaded when enabling.
- 
## Notes to Code Reviewers

## How the changes in this PR are tested
https://github.com/user-attachments/assets/846a9f8b-f268-4943-99eb-ce0485dd559d

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [ ] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design channel requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.