### PR TITLE
Fixing issue where klipper would crash when trying to do infinite spool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-07-19]
+### Fixes
+- Error with infinite spool where klipper would crash if runout was set to `None` instead of `"NONE"`
+
 ## [2025-07-06]
 ### Fixes
 - Race condition between klipper and moonraker when trying to get stats from moonraker database

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -71,7 +71,7 @@ class AFCLane:
         self.weight             = 0
         self._material          = None
         self.extruder_temp      = None
-        self.runout_lane        = 'NONE'
+        self.runout_lane        = None
         self.status             = AFCLaneState.NONE
         self.multi_hubs_found   = False
         self.drive_stepper      = None
@@ -520,8 +520,8 @@ class AFCLane:
                 self.weight = 1000 # Defaulting weight to 1000 upon load
             else:
                 if self.unit_obj.check_runout(self):
-                    # Checking to make sure runout_lane is set and does not equal 'NONE'
-                    if  self.runout_lane != 'NONE':
+                    # Checking to make sure runout_lane is set
+                    if  self.runout_lane is not None:
                         self._perform_infinite_runout()
                     else:
                         self._perform_pause_runout()
@@ -601,8 +601,8 @@ class AFCLane:
                         self.weight = 1000 # Defaulting weight to 1000 upon load
 
                 elif self.prep_state == False and self.name == self.afc.current and self.afc.function.is_printing() and self.load_state and self.status != AFCLaneState.EJECTING:
-                    # Checking to make sure runout_lane is set and does not equal 'NONE'
-                    if  self.runout_lane != 'NONE':
+                    # Checking to make sure runout_lane is set
+                    if  self.runout_lane is not None:
                         self._perform_infinite_runout()
                     else:
                         self._perform_pause_runout()

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -127,7 +127,7 @@ class afcPrep:
                                 cur_lane.weight = 0
 
                     if 'runout_lane' in units[cur_lane.unit][cur_lane.name]: cur_lane.runout_lane = units[cur_lane.unit][cur_lane.name]['runout_lane']
-                    if cur_lane.runout_lane == '' or cur_lane.runout_lane == 'NONE' : cur_lane.runout_lane = None
+                    if cur_lane.runout_lane == '' or cur_lane.runout_lane == 'NONE': cur_lane.runout_lane = None
                     if 'map' in units[cur_lane.unit][cur_lane.name]: cur_lane.map = units[cur_lane.unit][cur_lane.name]['map']
                     if cur_lane.map != None:
                         self.afc.tool_cmds[cur_lane.map] = cur_lane.name

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -127,7 +127,7 @@ class afcPrep:
                                 cur_lane.weight = 0
 
                     if 'runout_lane' in units[cur_lane.unit][cur_lane.name]: cur_lane.runout_lane = units[cur_lane.unit][cur_lane.name]['runout_lane']
-                    if cur_lane.runout_lane == '': cur_lane.runout_lane='NONE'
+                    if cur_lane.runout_lane == '' or cur_lane.runout_lane == 'NONE' : cur_lane.runout_lane = None
                     if 'map' in units[cur_lane.unit][cur_lane.name]: cur_lane.map = units[cur_lane.unit][cur_lane.name]['map']
                     if cur_lane.map != None:
                         self.afc.tool_cmds[cur_lane.map] = cur_lane.name

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -299,7 +299,7 @@ class AFCSpool:
             self.logger.info("No LANE Defined")
             return
 
-        runout = gcmd.get('RUNOUT', '')
+        runout = gcmd.get('RUNOUT', 'NONE')
         # Check to make sure runout does not equal lane
         if lane == runout:
             self.logger.error("Lane({}) and runout({}) cannot be the same".format(lane, runout))
@@ -314,7 +314,7 @@ class AFCSpool:
             return
 
         cur_lane = self.afc.lanes[lane]
-        cur_lane.runout_lane = runout
+        cur_lane.runout_lane = None if runout == 'NONE' else runout
         self.afc.save_vars()
 
     cmd_RESET_AFC_MAPPING_help = "Resets all lane mapping in AFC"


### PR DESCRIPTION
## Major Changes in this PR
- Changed all `NONE` to `None` so that proper None comparison can be done for infinite spool

Fixes #485 
## Notes to Code Reviewers

## How the changes in this PR are tested
- Verified that prep sets `NONE` to `None` and that SET_RUNOUT sets `None` correctly
- Created test function with same logic to printout if runout logic would be triggered or not

https://github.com/user-attachments/assets/fba85939-8f41-4253-9be5-ee81706d1c9f

How the current logic on main/DEV works which crashes klipper since `None` is not valid

https://github.com/user-attachments/assets/a6a33e3a-d77b-4270-91f6-46cc7544917c







## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design channel requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.