### PR TITLE
Add SET_NEXT_SPOOL_ID command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2025-07-20]
 ### Added
 - Software defined physical buttons are now available and supported. See documentation for more information on how to set them up.
+- New command `SET_NEXT_SPOOL_ID` to be used with a QR scanner tool or macro that automatically sets the id of the next spool loaded.
 
 ## [2025-07-19]
 ### Fixes

--- a/extras/AFC_assist.py
+++ b/extras/AFC_assist.py
@@ -3,6 +3,10 @@
 # Copyright (C) 2024 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+
+# ensure compatibility with python 3.8
+from __future__ import annotations
+
 import math
 import traceback
 

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -597,8 +597,7 @@ class AFCLane:
                     if self.load_state == True and self.prep_state == True:
                         self.status = AFCLaneState.LOADED
                         self.unit_obj.lane_loaded(self)
-                        self.material = self.afc.default_material_type
-                        self.weight = 1000 # Defaulting weight to 1000 upon load
+                        self.afc.spool._set_values(self)
 
                 elif self.prep_state == False and self.name == self.afc.current and self.afc.function.is_printing() and self.load_state and self.status != AFCLaneState.EJECTING:
                     # Checking to make sure runout_lane is set

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -10,6 +10,9 @@ class AFCSpool:
         self.printer = config.get_printer()
         self.printer.register_event_handler("klippy:connect", self.handle_connect)
 
+        # Temporary status variables
+        self.next_spool_id      = ''
+
     def handle_connect(self):
         """
         Handle the connection event.
@@ -26,6 +29,7 @@ class AFCSpool:
         self.printer.register_event_handler("afc_stepper:register_macros",self.register_lane_macros)
 
         self.gcode.register_command("RESET_AFC_MAPPING", self.cmd_RESET_AFC_MAPPING, desc=self.cmd_RESET_AFC_MAPPING_help)
+        self.gcode.register_command("SET_NEXT_SPOOL_ID", self.cmd_SET_NEXT_SPOOL_ID, desc=self.cmd_SET_NEXT_SPOOL_ID_help)
 
     def register_lane_macros(self, lane_obj):
         """
@@ -372,6 +376,40 @@ class AFCSpool:
 
         self.afc.save_vars()
         self.logger.info("Tool mappings reset" + ("" if runout_opt == "no" else " and runout lanes reset"))
+
+    cmd_SET_NEXT_SPOOL_ID_help = "Set the spool id to be loaded next into AFC"
+    def cmd_SET_NEXT_SPOOL_ID(self, gcmd):
+        """
+        Sets the spool ID to be loaded next into the AFC.
+
+        This can be used in a scanning macro to prepare the AFC for the next spool to be loaded.
+
+        Omit the SPOOL_ID parameter to clear the next spool ID.
+
+        Usage
+        -----
+        `SET_NEXT_SPOOL_ID SPOOL_ID=<spool_id>`
+
+        Example
+        -----
+        ```
+        SET_NEXT_SPOOL_ID SPOOL_ID=12345
+        ```
+        """
+        SpoolID = gcmd.get('SPOOL_ID', '')
+        previous_id = self.next_spool_id
+        if SpoolID != '':
+            try:
+                self.next_spool_id = str(int(SpoolID)) # make sure spool ID will round trip later
+            except ValueError:
+                self.logger.error("Invalid spool ID: {}".format(SpoolID))
+                self.next_spool_id = ''
+        else:
+            self.next_spool_id = ''
+        if previous_id:
+            self.logger.info(f"Spool ID '{previous_id}' being overwritten for next load: '{self.next_spool_id}'")
+        else:
+            self.logger.info(f"Spool ID set for next load: '{self.next_spool_id}'")
 
 def load_config(config):
     return AFCSpool(config)

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -251,6 +251,19 @@ class AFCSpool:
             value = filament[field]
         return value
 
+    def _set_values(self, cur_lane):
+        """
+        Helper function for setting lane spool values
+        """
+        # set defaults if there's no spool id, or the spoolman lookup fails
+        cur_lane.material = self.afc.default_material_type
+        cur_lane.weight = 1000 # Defaulting weight to 1000 upon load
+
+        if self.afc.spoolman is not None and self.next_spool_id is not None:
+            spool_id = self.next_spool_id
+            self.next_spool_id = ''
+            self.set_spoolID(cur_lane, spool_id)
+
     def _clear_values(self, cur_lane):
         """
         Helper function for clearing out lane spool values

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -259,7 +259,7 @@ class AFCSpool:
         cur_lane.material = self.afc.default_material_type
         cur_lane.weight = 1000 # Defaulting weight to 1000 upon load
 
-        if self.afc.spoolman is not None and self.next_spool_id is not None:
+        if self.afc.spoolman is not None and self.next_spool_id != '':
             spool_id = self.next_spool_id
             self.next_spool_id = ''
             self.set_spoolID(cur_lane, spool_id)


### PR DESCRIPTION
## Major Changes in this PR

Adds a `SET_NEXT_SPOOL_ID` command that can be used by a QR scanning utility to prep the AFC for the spool_id in the next load. This allows a user to load spools entirely at the machine without a separate manual step of keeping track of loaded spool numbers and entering them in mainsail.

## Notes to Code Reviewers

See here for the service that I'm using to automate the sending this command when QR codes are scanned: https://github.com/kekiefer/afc-spool-scan

## How the changes in this PR are tested

Manually run the SET_NEXT_SPOOL_ID to any ID registered in spoolman. One spool can be prepped at a time, and the next load to any lane should be automatically set up with that ID. This manual workflow will mirror what is automated through the separate service.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design channel requesting review