### PR TITLE
bypass tool max unload attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Software defined physical buttons are now available and supported. See documentation for more information on how to set them up.
 - New command `SET_NEXT_SPOOL_ID` to be used with a QR scanner tool or macro that automatically sets the id of the next spool loaded.
+- Support setting tool_max_unload_attempts to zero to bypass buffer unloading checks
 
 ## [2025-07-19]
 ### Fixes

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1329,7 +1329,7 @@ class afc:
         if cur_extruder.tool_start == "buffer":
             # if ramming is enabled, AFC will retract to collapse buffer before unloading
             cur_lane.unsync_to_extruder()
-            while not cur_lane.get_trailing():
+            while not cur_lane.get_trailing() and self.tool_max_unload_attempts > 0:
                 # attempt to return buffer to trailing pin
                 cur_lane.move_advanced(cur_lane.short_move_dis * -1, SpeedMode.SHORT)
                 num_tries += 1


### PR DESCRIPTION
## Major Changes in this PR

#331 caused a regression for toolheads with a cutter above the extruder gears and no toolhead filament sensor, where the buffer doesn't get compressed when the filament is unloaded. This change adds the ability to set tool_max_unload_attempts to zero for this special case to bypass these checks.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design channel requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description
