### PR TITLE
Fix MAP command handling to ensure case insensitivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-07-30]
+### Fixed
+- Updated the `SET_MAP` command to correctly handle `MAP` parameters in either upper or lower case text. 
+
 ## [2025-07-27]
 ### Updated
 - The `install-afc.sh` script will now only copy relevant MCU files when installing a new unit. 

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -64,7 +64,10 @@ class AFCSpool:
         if lane is None:
             self.logger.info("No LANE Defined")
             return
+
         map_cmd = gcmd.get('MAP', None)
+        map_cmd = map_cmd.upper()
+
         lane_switch=self.afc.tool_cmds[map_cmd]
         self.logger.debug("lane to switch is {}".format(lane_switch))
         if lane not in self.afc.lanes:


### PR DESCRIPTION
## Major Changes in this PR

This pull request fixes an issue with the `SET_MAP` command to ensure it correctly handles `MAP` parameters regardless of their case. The changes include updates to both the `CHANGELOG.md` file and the `cmd_SET_MAP` method in `extras/AFC_spool.py`.

### Fixes to `SET_MAP` command:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R11): Added an entry under the "Fixed" section for the `2025-07-30` release, documenting that the `SET_MAP` command now correctly handles `MAP` parameters in both upper and lower case.
* [`extras/AFC_spool.py`](diffhunk://#diff-13e9a07c4eadfbd5a3e17927b682551beac5c0ce7d2ccf5315cff8bdb139985fR67-R70): Modified the `cmd_SET_MAP` method to convert the `MAP` parameter to uppercase using `map_cmd.upper()` before processing, ensuring consistent handling of the parameter.

## Notes to Code Reviewers

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.