### PR TITLE
TOOL_UNLOAD fix

### DIFF
--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1716,6 +1716,7 @@ class afc:
                     self.afc_stats.reset_toolchange_wo_error()
         else:
             self.logger.info("{} already loaded".format(cur_lane.name))
+            self.next_lane_load = None
             if not self.error_state and self.current_toolchange == -1:
                 self.current_toolchange += 1
 


### PR DESCRIPTION
## Major Changes in this PR
- Fixed a issue where BT_TOOL_UNLOAD or TOOL_UNLOAD would not unload a lane if the same T macro was issued while that lane was already loaded. 

@weemantella 

## How the changes in this PR are tested
- Made sure TOOL_UNLOAD worked with this fix.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.