### PR TITLE
Update velocity checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-07-17]
+### Fixed
+- The `install-afc.sh` script will no longer tell you it removed the `velocity` setting if it didn't exist.
+
 ## [2025-07-20]
 ### Added
 - Software defined physical buttons are now available and supported. See documentation for more information on how to set them up.

--- a/include/update_functions.sh
+++ b/include/update_functions.sh
@@ -43,10 +43,12 @@ remove_velocity() {
   local files config_file
   files=$(grep -rlP '^\[AFC_buffer ' "${afc_config_dir}"/*.cfg)
   for config_file in $files; do
-    section=$(grep -oP '^\[AFC_buffer \K[^\]]+' "$config_file")
+  section=$(grep -oP '^\[AFC_buffer \K[^\]]+' "$config_file")
+  if grep -qP "^\s*velocity\s*" "$config_file"; then
     crudini --del "$config_file" "AFC_buffer $section" velocity
     export update_message+="""
 Removed deprecated velocity setting from $config_file.
     """
-  done
+  fi
+done
 }

--- a/include/update_functions.sh
+++ b/include/update_functions.sh
@@ -43,12 +43,12 @@ remove_velocity() {
   local files config_file
   files=$(grep -rlP '^\[AFC_buffer ' "${afc_config_dir}"/*.cfg)
   for config_file in $files; do
-  section=$(grep -oP '^\[AFC_buffer \K[^\]]+' "$config_file")
-  if grep -qP "^\s*velocity\s*" "$config_file"; then
-    crudini --del "$config_file" "AFC_buffer $section" velocity
-    export update_message+="""
+    section=$(grep -oP '^\[AFC_buffer \K[^\]]+' "$config_file")
+    if grep -qP "^\s*velocity\s*" "$config_file"; then
+      crudini --del "$config_file" "AFC_buffer $section" velocity
+      export update_message+="""
 Removed deprecated velocity setting from $config_file.
-    """
-  fi
-done
+      """
+    fi
+  done
 }


### PR DESCRIPTION
## Major Changes in this PR

This pull request addresses a bug in the `install-afc.sh` script related to the removal of the `velocity` setting. The main improvement ensures that the script only reports the removal of the `velocity` setting if it actually existed in the configuration file, preventing misleading messages.

Bug fix for configuration update:

* Updated the `remove_velocity()` function in `include/update_functions.sh` to check for the existence of the `velocity` setting before attempting to remove it and reporting its removal.

Documentation update:

* Added a note in `CHANGELOG.md` documenting that the `install-afc.sh` script will no longer claim to have removed the `velocity` setting if it didn't exist.

## Notes to Code Reviewers

## How the changes in this PR are tested

Ran install script, verified message wasn't shown.

Added velocity setting and re-ran and verified message was shown.

Re-ran again and verified message wasn't shown.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.