### PR TITLE
feat: add `dist_hub` to get_status in AFC_lane

### DIFF
--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -1133,6 +1133,7 @@ class AFCLane:
         response['filament_status'] = filament_stat[0]
         response['filament_status_led'] = filament_stat[1]
         response['status'] = self.status
+        response['dist_hub'] = self.dist_hub
         return response
 
 


### PR DESCRIPTION
## Major Changes in this PR

I just added the value `dist_hub` to the get_status response. This is needed for Mainsail to show the current value in the Settings panel.

## Notes to Code Reviewers

## How the changes in this PR are tested

Just changed the AFC-Klipper-Add-On branch on my Trident and tested the output via HTTP requests and Mainsail DEV mode.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [X] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.