### PR TITLE
Fix: Update docstring for TEST_LANE command examples

### DIFF
--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -687,10 +687,12 @@ class afcFunction:
         -----
         `TEST_LANE LANE=<lane_name> ITERATION=<number_of_iterations>`
 
-        Examples
+        Example
         -----
         ```
         TEST_LANE LANE=lane1 ITERATION=3
+        ```
+        ```
         TEST_LANE LANE=all ITERATION=5
         ```
         """


### PR DESCRIPTION
## Major Changes in this PR

This pull request makes a minor documentation update to the `cmd_TEST_LANE` function in `extras/AFC_functions.py`, clarifying the example section and improving readability.

* Documentation update: Changed the "Examples" section to "Example" and separated the example commands into distinct code blocks for clarity in the docstring of `cmd_TEST_LANE`.

## Notes to Code Reviewers

Just fixes the docstring for proper display in the docs.

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.