### PR TITLE
Fix: Correct spelling and grammar in comments and configuration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-08-24]
+### Added
+- You can now use the `install-afc.sh` script to delete the `AFC.var.unit` file if necessary. This option is located under
+  the `Utilities` menu.
+
 ## [2025-08-22]
 ### Added
 - Added a new command to test lane loading and unloading in an automated and random fashion (`AFC_TEST_LANES`). Please

--- a/config/AFC.cfg
+++ b/config/AFC.cfg
@@ -1,4 +1,3 @@
-;suppress inspection "SpellCheckingInspection" for whole file
 [AFC]
 VarFile: ../printer_data/config/AFC/AFC.var   # Path to the variables file for AFC configuration.
 

--- a/config/AFC.cfg
+++ b/config/AFC.cfg
@@ -1,3 +1,4 @@
+;suppress inspection "SpellCheckingInspection" for whole file
 [AFC]
 VarFile: ../printer_data/config/AFC/AFC.var   # Path to the variables file for AFC configuration.
 

--- a/config/AFC_Macro_Vars.cfg
+++ b/config/AFC_Macro_Vars.cfg
@@ -38,7 +38,7 @@ variable_cut_accel                : 0
 variable_cut_direction            : "left"
 
 # This distance is used to move toolhead to cut filament
-# and to create a small saftely distance that aids in generating momentum
+# and to create a small safety distance that aids in generating momentum
 variable_pin_park_dist            : 6.0       # Distance in mm
 
 # Position of the toolhead when the cutter is fully compressed.
@@ -93,7 +93,7 @@ variable_pushback_dwell_time      : 20        # Time to dwell between the pushba
 variable_safe_margin_xy           : 30, 30    # Approx toolhead width +5mm, height +5mm)
 
 # Some printers may need a boost of power to complete the cut without skipping steps.
-# One option is to increase the current for thost steppers in printer.cfg. Another
+# One option is to increase the current for the steppers in printer.cfg. Another
 # option is to use these variables to set a current that is only used during the
 # cut motion. Different combinations of kinematics and cutter configurations engage
 # different combinations of steppers for that motion.  Set the needed variables.

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -252,8 +252,8 @@ class afc:
         if update_trsync:
             try:
                 import mcu
-                trsync_value = config.getfloat("trsync_timeout", 0.05)              # Timeout value to update in klipper mcu. Klippers default value is 0.025
-                trsync_single_value = config.getfloat("trsync_single_timeout", 0.5) # Single timeout value to update in klipper mcu. Klippers default value is 0.250
+                trsync_value = config.getfloat("trsync_timeout", 0.05)              # Timeout value to update in klipper mcu. Klipper's default value is 0.025
+                trsync_single_value = config.getfloat("trsync_single_timeout", 0.5) # Single timeout value to update in klipper mcu. Klipper's default value is 0.250
                 self.logger.info("Applying TRSYNC update")
 
                 # Making sure value exists as kalico(danger klipper) does not have TRSYNC_TIMEOUT value
@@ -382,7 +382,7 @@ class afc:
         in AFC.cfg and sees if a temperature exists for filament material.
 
         :param cur_lane: Current lane object
-        :return truple : float for temperature to heat extruder to,
+        :return tuple : float for temperature to heat extruder to,
                          bool True if user is using min_extruder_temp value
         """
         try:

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -123,7 +123,7 @@ class afcBoxTurtle(afcUnit):
                                                              cur_lane.short_move_dis, 0, cur_lane.dist_hub + 200, "Moving to hub")
 
         if not success:
-            # if movement does not suceed fault and return values to calibration macro
+            # if movement does not succeed fault and return values to calibration macro
             msg = 'Failed {} after {}mm'.format(checkpoint, hub_pos)
             return False, msg, hub_pos
 
@@ -229,7 +229,7 @@ class afcBoxTurtle(afcUnit):
         return True, msg, tuned_hub_pos
 
     def move_until_state(self, cur_lane, state, move_dis, tolerance, short_move, pos=0, fault_dis=250, checkpoint=None):
-        # moves filament until specified sensor, returns values for further czlibration
+        # moves filament until specified sensor, returns values for further calibration
         while not state():
             cur_lane.move(move_dis, cur_lane.short_moves_speed, cur_lane.short_moves_accel)
             pos += move_dis

--- a/extras/AFC_HTLF.py
+++ b/extras/AFC_HTLF.py
@@ -31,7 +31,7 @@ class AFC_HTLF(afcBoxTurtle):
         self.current_selected_lane  = None
         self.home_state             = False
         self.mm_move_per_rotation   = config.getint("mm_move_per_rotation", 32)                                     # How many mm moves pulley a full rotation
-        self.cam_angle              = config.getint("cam_angle")                                                    # CAM lobe angle thats currently installed. 30,45,60 (recommend using 60)
+        self.cam_angle              = config.getint("cam_angle")                                                    # CAM lobe angle that is currently installed. 30,45,60 (recommend using 60)
         self.home_pin               = config.get("home_pin")                                                        # Pin for homing sensor
         self.MAX_ANGLE_MOVEMENT     = config.getint("MAX_ANGLE_MOVEMENT", 215)                                      # Max angle to move lobes, this is when lobe 1 is fully engaged with its lane
         self.enable_sensors_in_gui  = config.getboolean("enable_sensors_in_gui", self.afc.enable_sensors_in_gui)    # Set to True to show prep and load sensors switches as filament sensors in mainsail/fluidd gui, overrides value set in AFC.cfg
@@ -155,7 +155,7 @@ class AFC_HTLF(afcBoxTurtle):
         """
         self.failed_to_home = False
         if self.current_selected_lane != lane:
-            self.logger.debug("HTLF: {} Homing to endstop".format(self.name))
+            self.logger.debug("HTLF: {} Homing to endstop.".format(self.name))
             if self.return_to_home():
                 self.selector_stepper_obj.move(self.calculate_lobe_movement( lane.index ), 50, 50, False)
                 self.logger.debug("HTLF: {} selected".format(lane))

--- a/extras/AFC_assist.py
+++ b/extras/AFC_assist.py
@@ -640,7 +640,7 @@ class Espooler:
 
     def break_espooler(self):
         """
-        Helper function to "brake" n20 motors to hopefully help with keeping down backfeeding into MCU board
+        Helper function to "brake" n20 motors to hopefully help with keeping down back-feeding into MCU board
         """
         print_time = self.afc.toolhead.get_last_move_time()
         if self.afc_motor_enb is not None:

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -230,7 +230,7 @@ class afcError:
             # Verify that printer is in absolute mode
             self.afc.function.check_absolute_mode("AFC_PAUSE")
             move_z_pos = self.afc.last_gcode_position[2] + self.afc.z_hop
-            # Check to see if current position is less than saved postion plus z-hop
+            # Check to see if current position is less than saved position plus z-hop
             if self.afc.gcode_move.last_position[2] <= move_z_pos:
                 # Move Z up by z-hop value
                 self.afc.move_z_pos(move_z_pos, "AFC_PAUSE")

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -29,7 +29,7 @@ class AFCExtruder:
         self.tool_end                   = config.get('pin_tool_end', None)                                              # Pin for sensor after(post) extruder gears (optional)
         self.tool_stn                   = config.getfloat("tool_stn", 72)                                               # Distance in mm from the toolhead sensor to the tip of the nozzle in mm, if `tool_end` is defined then distance is from this sensor
         self.tool_stn_unload            = config.getfloat("tool_stn_unload", 100)                                       # Distance to move in mm while unloading toolhead
-        self.tool_sensor_after_extruder = config.getfloat("tool_sensor_after_extruder", 0)                              # Extra distance to move in mm once pre/post sensors are clear. Useful for when only using post sensor, so this distance can be the amout to move to clear extruder gears
+        self.tool_sensor_after_extruder = config.getfloat("tool_sensor_after_extruder", 0)                              # Extra distance to move in mm once the pre- / post-sensors are clear. Useful for when only using post sensor, so this distance can be the amount to move to clear extruder gears
         self.tool_unload_speed          = config.getfloat("tool_unload_speed", 25)                                      # Unload speed in mm/s when unloading toolhead. Default is 25mm/s.
         self.tool_load_speed            = config.getfloat("tool_load_speed", 25)                                        # Load speed in mm/s when loading toolhead. Default is 25mm/s.
         self.buffer_name                = config.get('buffer', None)                                                    # Buffer to use for extruder, this variable can be overridden per lane

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -424,7 +424,7 @@ class afcFunction:
 
     def log_toolhead_pos(self, move_pre=""):
         """
-        Helper function for printing postion data to log
+        Helper function for printing position data to log
 
         :param move_pre: String that get appended before the position data
         """
@@ -480,7 +480,7 @@ class afcFunction:
     def gcode_get_value( self, gcmd, get_attr, variable, variable_name, section_name, key_name=None, cast_to_bool=False ):
         """
         Helper type function to get values for macros. This function will also use passed in variable
-        as defualt value. If user passed in a new value for variable_name, then config file is updated
+        as default value. If user passed in a new value for variable_name, then config file is updated
         with new value. Do not call this function if a macro variable is required.
 
         :param gcmd: Klipper gcode command
@@ -1053,7 +1053,7 @@ class afcFunction:
         buttons = []
         footer = []
         title = 'AFC Calibration Failed'
-        text = 'Calibration failed  for {}. First: reset lane, Second: review messages in console and take necessary action and re-run colibration.'.format(cali)
+        text = 'Calibration failed  for {}. First: reset lane, Second: review messages in console and take necessary action and re-run calibration.'.format(cali)
         buttons.append(("Reset lane", "AFC_LANE_RESET LANE={} DISTANCE={}".format(cali, dis), "primary"))
         footer.append(('EXIT', 'prompt_end', 'info'))
 

--- a/extras/AFC_hub.py
+++ b/extras/AFC_hub.py
@@ -49,7 +49,7 @@ class afc_hub:
 
         self.config_bowden_length   = self.afc_bowden_length                        # Used by SET_BOWDEN_LENGTH macro
         self.config_unload_bowden_length = self.afc_unload_bowden_length
-        self.enable_sensors_in_gui  = config.getboolean("enable_sensors_in_gui",    self.afc.enable_sensors_in_gui) # Set to True to show hub sensor switche as filament sensor in mainsail/fluidd gui, overrides value set in AFC.cfg
+        self.enable_sensors_in_gui  = config.getboolean("enable_sensors_in_gui",    self.afc.enable_sensors_in_gui) # Set to True to show hub sensor switches as filament sensor in mainsail/fluidd gui, overrides value set in AFC.cfg
         self.debounce_delay         = config.getfloat("debounce_delay",             self.afc.debounce_delay)
         self.enable_runout          = config.getboolean("enable_hub_runout",        self.afc.enable_hub_runout)
 

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -450,7 +450,7 @@ class AFCLane:
 
     def move_advanced(self, distance, speed_mode: SpeedMode, assist_active: AssistActive = AssistActive.NO):
         """
-        Wrapper for move function and isused to compute several arguments
+        Wrapper for move function and is used to compute several arguments
         to move the lane accordingly.
         Parameters:
         distance (float): The distance to move.

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -252,7 +252,7 @@ class AFCSpool:
     def _get_filament_values( self, filament, field, default=None):
         '''
         Helper function for checking if field is set and returns value if it exists,
-        otherwise retruns None
+        otherwise returns None
 
         :param filament: Dictionary for filament values
         :param field:    Field name to check for in dictionary

--- a/extras/AFC_stats.py
+++ b/extras/AFC_stats.py
@@ -16,7 +16,7 @@ class AFCStats_var:
     increment, reset, set time and average time for time values. This class also
     has the ability to update moonrakers database with value.
 
-    Upon initializing this class, value is retrevied from dictionary if it exists
+    Upon initializing this class, value is retrieved from dictionary if it exists
     and sets internal value to this, or zero if it does not exist.
 
     Parameters
@@ -210,7 +210,7 @@ class AFCStats:
 
     def reset_toolchange_wo_error(self):
         """
-        Helper function for reseting number of toolchanges without errors and
+        Helper function for resetting number of toolchanges without errors and
         sets last error date/time as current
         """
         self.tc_without_error.reset_count()

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -180,7 +180,7 @@ class AFCExtruderStepper(AFCLane):
         """
         Helper function for updating steppers rotation distance
 
-        :param multipler: Multipler to set rotation distance. Rotation distance is updated by taking
+        :param multiplier: Multiplier to set rotation distance. Rotation distance is updated by taking
                           base rotation distance and dividing by multiplier.
         """
         self.extruder_stepper.stepper.set_rotation_distance( self.base_rotation_dist / multiplier )

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -336,7 +336,7 @@ class afcUnit:
 
     def return_to_home(self ):
         """
-        Funtion to home unit if unit has homing sensor
+        Function to home unit if unit has homing sensor
         """
         return
 

--- a/extras/AFC_utils.py
+++ b/extras/AFC_utils.py
@@ -215,7 +215,7 @@ class AFC_moonraker:
         Queries moonraker to see if spoolman is configured, returns True when
         spoolman is configured
 
-        :returns: Returns string for spoolmans IP, returns None if its not configured
+        :returns: Returns string for Spoolman IP, returns None if it is not configured
         """
         resp = self._get_results(urljoin(self.host, 'server/config'))
         # Check to make sure response is valid and spoolman exists in dictionary

--- a/include/menus/utilities_menu.sh
+++ b/include/menus/utilities_menu.sh
@@ -43,6 +43,7 @@ printf "\e[49m           \e[38;5;239;49m▄\e[38;5;101;49m▄\e[38;5;242;49m▄\
     printf "█%b        Use the provided option selection to cycle through available choices%b         █\n" "$RESET" "$MENU_GREEN"
     printf "%b▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀%b \n" "$MENU_GREEN" "$RESET"
     echo ""
+    printf "1. Remove AFC.var.unit file\n"
     printf "R. Rename existing unit\n"
     echo ""
     printf "M. Return to Main Menu\n"
@@ -53,6 +54,8 @@ printf "\e[49m           \e[38;5;239;49m▄\e[38;5;101;49m▄\e[38;5;242;49m▄\
     choice="${choice^^}"
 
     case $choice in
+      1)
+        del_var_file ;;
       R)
         rename_unit_prompt ;;
       M)

--- a/include/utils.sh
+++ b/include/utils.sh
@@ -196,3 +196,22 @@ start_service() {
     sudo service "${service_name}" start
   fi
 }
+
+del_var_file() {
+  local confirm
+  # Function to remove the user's AFC.var.unit file in a simple fashion.
+  echo "This is generally a troubleshooting step and should not be needed during normal operation."
+  read -p "Do you want to proceed? (y/n): " confirm
+  confirm="${confirm,,}"
+  if [[ "$confirm" != "y" ]]; then
+    unit_message="Operation cancelled by user.\n"
+  else
+    if [ -f "${afc_config_dir}/AFC.var.unit" ]; then
+      rm "${afc_config_dir}/AFC.var.unit"
+      unit_message="Removed old AFC.var.unit file.\n"
+    else
+      unit_message="No AFC.var.unit file found to remove.\n"
+    fi
+  fi
+  export unit_message
+}

--- a/templates/AFC_QuattroBox_17.cfg
+++ b/templates/AFC_QuattroBox_17.cfg
@@ -24,7 +24,7 @@ extruder: extruder
 buffer: QuattroBox_1                  #Turtleneck as standard Buffer
 led_logo_index: AFC_Indicator: 9-36   # A comma separated list, can be ranged list eg. 1-4, 6, 11, 16-18
 led_logo_color: 1,0.15,0.66,0                # Sets custom color to logo when no lane is loaded in toolhead, defaults off
-# led_logo_loading: 0,0,1,0              # Sets custom color to set logo when loading a lane to toolhead, defautls to blue
+# led_logo_loading: 0,0,1,0              # Sets custom color to set logo when loading a lane to toolhead, defaults to blue
 # led_spool_illuminate: 1,1,1,1          # Sets custom color to illuminate spool when filament is loaded, defaults to white
 
 [AFC_stepper lane1]


### PR DESCRIPTION
## Major Changes in this PR


This is mostly just spelling / grammar updates. I did add a function to allow someone to delete their `AFC.var.unit` file using the install script since I've seen a few people not know how to do anything and it was a 30 second addition.

## Notes to Code Reviewers

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.
