### PR TITLE
[Bug] : Fixes issue where driver motor in HTLF would not sync with extruder properly when running PREP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - You can now use the `install-afc.sh` script to delete the `AFC.var.unit` file if necessary. This option is located under
   the `Utilities` menu.
 
+### Fixed
+- Issue where HTLF unit would not select lane and sync with extruder when running prep
+
 ## [2025-08-22]
 ### Added
 - Added a new command to test lane loading and unloading in an automated and random fashion (`AFC_TEST_LANES`). Please

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -27,7 +27,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 try: from extras.AFC_stats import AFCStats
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
 
-AFC_VERSION="1.0.26"
+AFC_VERSION="1.0.28"
 
 # Class for holding different states so its clear what all valid states are
 class State:

--- a/extras/AFC_HTLF.py
+++ b/extras/AFC_HTLF.py
@@ -83,6 +83,7 @@ class AFC_HTLF(afcBoxTurtle):
         if not self.prep_homed:
             self.return_to_home( prep = True)
         status = super().system_Test( cur_lane, delay, assignTcmd, enable_movement)
+        self.return_to_home()
 
         return self.prep_homed and status
 

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -553,8 +553,7 @@ class AFCLane:
             if load_state:
                 self.status = AFCLaneState.LOADED
                 self.unit_obj.lane_loaded(self)
-                self.material = self.afc.default_material_type
-                self.weight = 1000 # Defaulting weight to 1000 upon load
+                self.afc.spool._set_values(self)
             else:
                 # Don't run if user disabled sensor in gui
                 if not self.fila_load.runout_helper.sensor_enabled and self.afc.function.is_printing():
@@ -695,8 +694,7 @@ class AFCLane:
         :param update_current: Sets current to specified print current when True
         """
         if self.drive_stepper is not None:
-            self.drive_stepper.sync_to_extruder(self.extruder_name)
-            if update_current: self.drive_stepper.set_print_current()
+            self.drive_stepper.sync_to_extruder(update_current, extruder_name=self.extruder_name)
 
     def unsync_to_extruder(self, update_current=True):
         """
@@ -705,8 +703,7 @@ class AFCLane:
         :param update_current: Sets current to specified load current when True
         """
         if self.drive_stepper is not None:
-            self.drive_stepper.unsync_to_extruder(None)
-            if update_current: self.drive_stepper.set_load_current()
+            self.drive_stepper.unsync_to_extruder(update_current)
 
     def _set_current(self, current):
         return

--- a/extras/AFC_logger.py
+++ b/extras/AFC_logger.py
@@ -100,8 +100,8 @@ class AFC_logger:
         :param message: Error message to print to console and log
         :param traceback: Trackback to log to AFC.log file
         """
+        stack_name = f"{stack_name}: " if stack_name else ""
         for line in message.lstrip().rstrip().split("\n"):
-            stack_name = f"{stack_name}: " if stack_name else ""
             self.logger.error( self._format(f"ERROR: {stack_name}{line}") )
         self.send_callback( "!! {}".format(message) )
 

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -177,6 +177,7 @@ class afcPrep:
         current_lane = self.afc.function.get_current_lane_obj()
         if current_lane is not None:
             current_lane.unit_obj.select_lane(current_lane)
+            current_lane.sync_to_extruder()
 
         # Restore previous bypass state if virtual bypass is active
         bypass_name = "Bypass"

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -137,13 +137,16 @@ class AFCExtruderStepper(AFCLane):
         else:
             self.next_cmd_time = print_time
 
-    def sync_to_extruder(self, update_current=True):
+    def sync_to_extruder(self, update_current=True, extruder_name=None):
         """
         Helper function to sync lane to extruder and set print current if specified.
 
         :param update_current: Sets current to specified print current when True
         """
-        self.extruder_stepper.sync_to_extruder(self.extruder_name)
+        if extruder_name is None:
+            extruder_name = self.extruder_name
+
+        self.extruder_stepper.sync_to_extruder(extruder_name)
         if update_current: self.set_print_current()
 
     def unsync_to_extruder(self, update_current=True):


### PR DESCRIPTION
## Major Changes in this PR
- Fixes issue where driver motor in HTLF would not sync with extruder properly when running PREP
- Fixed issue where colon's were printed multiple times into AFC.log file when printing multiline debug messages

Fixes #510 

## Notes to Code Reviewers

## How the changes in this PR are tested
- Tested on my toolchanger with and HTLF where fixes were originally fixed before moving over to this separate branch.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.