### PR TITLE
[Bug]: Fixes Issue #520, catches JSON parse error and displays error to user to fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-08-30]
+### Added
+- Catch for JSON decode error when trying to read and load AFC.var.unit file
+
 ## [2025-08-24]
 ### Added
 - You can now use the `install-afc.sh` script to delete the `AFC.var.unit` file if necessary. This option is located under

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -27,7 +27,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 try: from extras.AFC_stats import AFCStats
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
 
-AFC_VERSION="1.0.28"
+AFC_VERSION="1.0.29"
 
 # Class for holding different states so its clear what all valid states are
 class State:

--- a/extras/AFC_logger.py
+++ b/extras/AFC_logger.py
@@ -33,6 +33,7 @@ class AFC_logger:
         self.afc     = afc_obj
         self.gcode   = printer.lookup_object('gcode')
         self.webhooks = printer.lookup_object('webhooks')
+        printer.register_event_handler( "gcode:request_restart", self._stop)
 
         log_path = printer.start_args['log_file']
         dirname = Path(log_path).parent
@@ -47,6 +48,9 @@ class AFC_logger:
         self.logger.addHandler(self.afc_queue_handler)
         self.logger.setLevel(logging.DEBUG)
         self.print_debug_console = False
+
+    def _stop(self, eventtime):
+        self.afc_ql.stop()
 
     def _add_monotonic(self, message):
         return "{:10.3f} {}".format(self.reactor.monotonic(), message)

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -73,7 +73,16 @@ class afcPrep:
         ## load Unit stored variables
         units={}
         if os.path.exists('{}.unit'.format(self.afc.VarFile)) and os.stat('{}.unit'.format(self.afc.VarFile)).st_size > 0:
-            units=json.load(open('{}.unit'.format(self.afc.VarFile)))
+            try:
+                units=json.load(open('{}.unit'.format(self.afc.VarFile)))
+            except json.JSONDecodeError as e:
+                # Displaying error for user to fix, do not want to continue just in case
+                # there is actual data in this file as we do not want to overwrite and put
+                # users boxturtles into a weird state if prep continues.
+                self.afc.error.AFC_error(f"Error when trying to open and decode {self.afc.VarFile}.unit file.\n" + \
+                                          "Please fix file or delete if file is empty, then restart klipper.", False)
+                return
+
         else:
             error_string = 'Error: {}.unit file not found. Please check the path in the '.format(self.afc.VarFile)
             error_string += 'AFC.cfg file and make sure the file and path exists.'

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -81,6 +81,7 @@ class afcPrep:
                 # users boxturtles into a weird state if prep continues.
                 self.afc.error.AFC_error(f"Error when trying to open and decode {self.afc.VarFile}.unit file.\n" + \
                                           "Please fix file or delete if file is empty, then restart klipper.", False)
+                self.logger.error("", traceback=f"{e}")
                 return
 
         else:


### PR DESCRIPTION
## Major Changes in this PR
- Catches JSON parse error and displays error to user to fix, this started to pop up when users were using newest klipper and once they rolled back some users would get a JSON parse error
- Noticed that duplicate lines can show up in AFC.log when restarting, added a callback that stops the logger when restarting.

Fixes #520 

## How the changes in this PR are tested
- Created a blank file with spaces and remove a comma to test both scenarios

<img width="814" height="201" alt="image" src="https://github.com/user-attachments/assets/d6ea2da6-118b-447d-8759-e2dc3232a073" />

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.