### PR TITLE
[Bug]: Fixes #507, allows users to use non TMC drivers without erroring out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Catch for JSON decode error when trying to read and load AFC.var.unit file
 
+### Fixes
+- Issue where TMC section search would error out if not defined. Search is now gated behind user enabling print_current variable. If a user is using a different driver, like a4988 for example, AFC will not error out as long as print_current variable is not defined.
+
 ## [2025-08-24]
 ### Added
 - You can now use the `install-afc.sh` script to delete the `AFC.var.unit` file if necessary. This option is located under

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -36,7 +36,8 @@ class AFCExtruderStepper(AFCLane):
         # Current to use while printing, set to a lower current to reduce stepper heat when printing.
         # Defaults to global_print_current, if not specified current is not changed.
         self.tmc_print_current = config.getfloat("print_current", self.afc.global_print_current)
-        self._get_tmc_values( config )
+        if self.tmc_print_current is not None:
+            self._get_tmc_values( config )
 
         # Get and save base rotation dist
         self.base_rotation_dist = self.extruder_stepper.stepper.get_rotation_distance()[0]
@@ -48,7 +49,9 @@ class AFCExtruderStepper(AFCLane):
         try:
             self.tmc_driver = next(config.getsection(s) for s in config.fileconfig.sections() if 'tmc' in s and config.get_name() in s)
         except:
-            raise self.gcode.error("Count not find TMC for stepper {}".format(self.name))
+            msg = f"Could not find TMC for stepper {self.name},"
+            msg += "\nplease add TMC section or disable 'print_current' from config file's"
+            raise self.gcode.error(msg)
 
         self.tmc_load_current = self.tmc_driver.getfloat('run_current')
 


### PR DESCRIPTION
## Major Changes in this PR
- Fixes issues where users may not have TMC config section defined if they are using a different driver like a4988 drivers
Fixed #507 

## How the changes in this PR are tested
- Commented out TMC section for lane1 to get message to appear, removed `global_print_current` and error went away since which means current would not be changed while printing.

<img width="865" height="294" alt="image" src="https://github.com/user-attachments/assets/0b9ff9d5-0788-4fdc-adaf-63707fb338e8" />

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [ ] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.