### PR TITLE
Hot fix push to define tmc_load_current

### DIFF
--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -36,6 +36,7 @@ class AFCExtruderStepper(AFCLane):
         # Current to use while printing, set to a lower current to reduce stepper heat when printing.
         # Defaults to global_print_current, if not specified current is not changed.
         self.tmc_print_current = config.getfloat("print_current", self.afc.global_print_current)
+        self.tmc_load_current = None
         if self.tmc_print_current is not None:
             self._get_tmc_values( config )
 
@@ -167,7 +168,7 @@ class AFCExtruderStepper(AFCLane):
 
         :param current: Sets TMC current to specified value
         """
-        if self.tmc_print_current is not None:
+        if self.tmc_print_current is not None and current is not None:
             self.gcode.run_script_from_command("SET_TMC_CURRENT STEPPER='{}' CURRENT={}".format(self.name, current))
 
     def set_load_current(self):


### PR DESCRIPTION
## Major Changes in this PR
- With other TMC PR `tmc_load_current` will not be defined if print_current is not set. Initially setting tmc_load_current to None

## Notes to Code Reviewers

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [ ] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.