### PR TITLE
[Bug] Fixes #526, Adding a check for a single parameter since older klipper versions note_filament_present function is different

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-09-09]
+### Fixes
+- Issue with older klipper version before debounce button was added
+
 ## [2025-08-30]
 ### Added
 - Catch for JSON decode error when trying to read and load AFC.var.unit file

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -27,7 +27,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 try: from extras.AFC_stats import AFCStats
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
 
-AFC_VERSION="1.0.29"
+AFC_VERSION="1.0.30"
 
 # Class for holding different states so its clear what all valid states are
 class State:

--- a/extras/AFC_utils.py
+++ b/extras/AFC_utils.py
@@ -99,7 +99,8 @@ class DebounceButton:
         self.button_action = self._old_note_filament_present
         # Overriding filament sensor filament present to button handler in this class
         # Checking parameter length since kalico's note_filament_present function is different
-        if len(sig.parameters) > 2:
+        # and also checking for older klipper versions before hash 272e8155
+        if len(sig.parameters) > 2 or len(sig.parameters) == 1:
             filament_sensor.runout_helper.note_filament_present = self.button_handler
         else:
             filament_sensor.runout_helper.note_filament_present = self._button_handler


### PR DESCRIPTION
## Major Changes in this PR
- Needed to add another length check for note_filament_present function to support older klipper version before `272e8155` hash

Fixes #526 

## How the changes in this PR are tested
- Changed to an older hash that users reported errors on and verified that the fix did not crash klipper

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.