### PR TITLE
Fixes to work with klipper version after v0.13.0-190-g5eb07966

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2025-09-09]
+## [2025-09-05]
+### Added
+- Check to verify that pin_tool_start/end is not set to `Unknown`, throws error if pins are set to `Unknown`.
+### Fixes
+- Issue with compatibility issue with klipper after version v0.13.0-190-g5eb07966
+
+## [2025-09-01]
 ### Fixes
 - Issue with older klipper version before debounce button was added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Check to verify that pin_tool_start/end is not set to `Unknown`, throws error if pins are set to `Unknown`.
 ### Fixes
-- Issue with compatibility issue with klipper after version v0.13.0-190-g5eb07966
+- Compatibility issue with klipper after version v0.13.0-190-g5eb07966
 
 ## [2025-09-01]
 ### Fixes

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -27,7 +27,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 try: from extras.AFC_stats import AFCStats
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
 
-AFC_VERSION="1.0.30"
+AFC_VERSION="1.0.31"
 
 # Class for holding different states so its clear what all valid states are
 class State:

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -42,6 +42,9 @@ class AFCExtruder:
 
         self.tool_start_state = False
         if self.tool_start is not None:
+            if "unknown" == self.tool_start.lower():
+                raise error(f"Unknown is not valid for pin_tool_start in [{self.fullname}] config.")
+
             if self.tool_start == "buffer":
                 self.logger.info("Setting up as buffer")
             else:
@@ -52,6 +55,9 @@ class AFCExtruder:
 
         self.tool_end_state = False
         if self.tool_end is not None:
+            if "unknown" == self.tool_end.lower():
+                raise error(f"Unknown is not valid for pin_tool_end in [{self.fullname}] config.")
+
             buttons.register_buttons([self.tool_end], self.tool_end_callback)
             self.fila_tool_end, self.debounce_button_end = add_filament_switch("tool_end", self.tool_end, self.printer,
                                                                                 self.enable_sensors_in_gui, self.handle_end_runout, self.enable_runout,

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -48,6 +48,7 @@ class AFCExtruderStepper(AFCLane):
         # Current to use while printing, set to a lower current to reduce stepper heat when printing.
         # Defaults to global_print_current, if not specified current is not changed.
         self.tmc_print_current = config.getfloat("print_current", self.afc.global_print_current)
+        self.tmc_load_current = None
         if self.tmc_print_current is not None:
             self._get_tmc_values( config )
 
@@ -185,7 +186,7 @@ class AFCExtruderStepper(AFCLane):
 
         :param current: Sets TMC current to specified value
         """
-        if self.tmc_print_current is not None:
+        if self.tmc_print_current is not None and current is not None:
             self.gcode.run_script_from_command("SET_TMC_CURRENT STEPPER='{}' CURRENT={}".format(self.name, current))
 
     def set_load_current(self):

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -94,18 +94,20 @@ class AFCExtruderStepper(AFCLane):
             print_time = print_time + accel_t + cruise_t + accel_t
 
             if self.motion_queuing is None:
-                self.extruder_stepper.stepper.generate_steps(print_time) # old
-                self.trapq_finalize_moves(self.trapq, print_time + 99999.9, #old
-                                        print_time + 99999.9) #old
+                self.extruder_stepper.stepper.generate_steps(print_time)
+                self.trapq_finalize_moves(self.trapq, print_time + 99999.9,
+                                        print_time + 99999.9)
+                toolhead.note_mcu_movequeue_activity(print_time)
+            else:
+                self.motion_queuing.note_mcu_movequeue_activity(print_time)
 
-            toolhead.note_mcu_movequeue_activity(print_time)
             toolhead.dwell(accel_t + cruise_t + accel_t)
             toolhead.flush_step_generation()
             self.extruder_stepper.stepper.set_trapq(prev_trapq)
             self.extruder_stepper.stepper.set_stepper_kinematics(prev_sk)
             if self.motion_queuing is not None:
                 self.motion_queuing.wipe_trapq(self.trapq)
-            toolhead.wait_moves() # keep for both maybe...
+            toolhead.wait_moves()
 
     def move(self, distance, speed, accel, assist_active=False):
         """

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -22,7 +22,7 @@ class AFCExtruderStepper(AFCLane):
         super().__init__(config)
 
         self.extruder_stepper   = extruder.ExtruderStepper(config)
-        
+
         # Check for Klipper new motion queuing update
         try:
             self.motion_queuing = self.printer.load_object(config, "motion_queuing")
@@ -30,7 +30,7 @@ class AFCExtruderStepper(AFCLane):
             self.motion_queuing = None
 
         self.next_cmd_time = 0.
-        
+
         ffi_main, ffi_lib = chelper.get_ffi()
         self.stepper_kinematics = ffi_main.gc(
             ffi_lib.cartesian_stepper_alloc(b'x'), ffi_lib.free)
@@ -42,7 +42,7 @@ class AFCExtruderStepper(AFCLane):
             self.trapq                  = ffi_main.gc(ffi_lib.trapq_alloc(), ffi_lib.trapq_free)
             self.trapq_append           = ffi_lib.trapq_append
             self.trapq_finalize_moves   = ffi_lib.trapq_finalize_moves
-        
+
         self.assist_activate=False
 
         # Current to use while printing, set to a lower current to reduce stepper heat when printing.

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -22,15 +22,27 @@ class AFCExtruderStepper(AFCLane):
         super().__init__(config)
 
         self.extruder_stepper   = extruder.ExtruderStepper(config)
+        
+        # Check for Klipper new motion queuing update
+        try:
+            self.motion_queuing = self.printer.load_object(config, "motion_queuing")
+        except error:
+            self.motion_queuing = None
 
-        self.motion_queue = None
         self.next_cmd_time = 0.
+        
         ffi_main, ffi_lib = chelper.get_ffi()
-        self.trapq = ffi_main.gc(ffi_lib.trapq_alloc(), ffi_lib.trapq_free)
-        self.trapq_append = ffi_lib.trapq_append
-        self.trapq_finalize_moves = ffi_lib.trapq_finalize_moves
         self.stepper_kinematics = ffi_main.gc(
             ffi_lib.cartesian_stepper_alloc(b'x'), ffi_lib.free)
+
+        if self.motion_queuing is not None:
+            self.trapq          = self.motion_queuing.allocate_trapq()
+            self.trapq_append   = self.motion_queuing.lookup_trapq_append()
+        else:
+            self.trapq                  = ffi_main.gc(ffi_lib.trapq_alloc(), ffi_lib.trapq_free)
+            self.trapq_append           = ffi_lib.trapq_append
+            self.trapq_finalize_moves   = ffi_lib.trapq_finalize_moves
+        
         self.assist_activate=False
 
         # Current to use while printing, set to a lower current to reduce stepper heat when printing.
@@ -68,25 +80,31 @@ class AFCExtruderStepper(AFCLane):
 
 
         with self.assist_move(speed, distance < 0, assist_active):
+            # Code based off force_move.py manual_move function
             toolhead = self.printer.lookup_object('toolhead')
             toolhead.flush_step_generation()
-            prev_sk = self.extruder_stepper.stepper.set_stepper_kinematics(self.stepper_kinematics)
-            prev_trapq = self.extruder_stepper.stepper.set_trapq(self.trapq)
+            prev_sk     = self.extruder_stepper.stepper.set_stepper_kinematics(self.stepper_kinematics)
+            prev_trapq  = self.extruder_stepper.stepper.set_trapq(self.trapq)
             self.extruder_stepper.stepper.set_position((0., 0., 0.))
             axis_r, accel_t, cruise_t, cruise_v = calc_move_time(distance, speed, accel)
             print_time = toolhead.get_last_move_time()
             self.trapq_append(self.trapq, print_time, accel_t, cruise_t, accel_t,
                               0., 0., 0., axis_r, 0., 0., 0., cruise_v, accel)
             print_time = print_time + accel_t + cruise_t + accel_t
-            self.extruder_stepper.stepper.generate_steps(print_time)
-            self.trapq_finalize_moves(self.trapq, print_time + 99999.9,
-                                      print_time + 99999.9)
-            self.extruder_stepper.stepper.set_trapq(prev_trapq)
-            self.extruder_stepper.stepper.set_stepper_kinematics(prev_sk)
+
+            if self.motion_queuing is None:
+                self.extruder_stepper.stepper.generate_steps(print_time) # old
+                self.trapq_finalize_moves(self.trapq, print_time + 99999.9, #old
+                                        print_time + 99999.9) #old
+
             toolhead.note_mcu_movequeue_activity(print_time)
             toolhead.dwell(accel_t + cruise_t + accel_t)
             toolhead.flush_step_generation()
-            toolhead.wait_moves()
+            self.extruder_stepper.stepper.set_trapq(prev_trapq)
+            self.extruder_stepper.stepper.set_stepper_kinematics(prev_sk)
+            if self.motion_queuing is not None:
+                self.motion_queuing.wipe_trapq(self.trapq)
+            toolhead.wait_moves() # keep for both maybe...
 
     def move(self, distance, speed, accel, assist_active=False):
         """

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -17,6 +17,8 @@ except: raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".f
 try: from extras.AFC_lane import AFCLane
 except: raise error(ERROR_STR.format(import_lib="AFC_lane", trace=traceback.format_exc()))
 
+LARGE_TIME_OFFSET = 99999.9
+
 class AFCExtruderStepper(AFCLane):
     def __init__(self, config):
         super().__init__(config)
@@ -26,7 +28,7 @@ class AFCExtruderStepper(AFCLane):
         # Check for Klipper new motion queuing update
         try:
             self.motion_queuing = self.printer.load_object(config, "motion_queuing")
-        except error:
+        except Exception:
             self.motion_queuing = None
 
         self.next_cmd_time = 0.
@@ -95,8 +97,8 @@ class AFCExtruderStepper(AFCLane):
 
             if self.motion_queuing is None:
                 self.extruder_stepper.stepper.generate_steps(print_time)
-                self.trapq_finalize_moves(self.trapq, print_time + 99999.9,
-                                        print_time + 99999.9)
+                self.trapq_finalize_moves(self.trapq, print_time + LARGE_TIME_OFFSET,
+                                        print_time + LARGE_TIME_OFFSET)
                 toolhead.note_mcu_movequeue_activity(print_time)
             else:
                 self.motion_queuing.note_mcu_movequeue_activity(print_time)


### PR DESCRIPTION
## Major Changes in this PR
- Updates to make AFC forwards and backwards compatible with Klipper
- Added check to make sure pin_tool_start/end is not set to `Unknown`

Fixes #515 

## How the changes in this PR are tested
- Verified that this works with Klipper before and after v0.13.0-190 and that Kalico still works
- Members in discord also verify that this works with new klipper

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.