### PR TITLE
Fix: Improve lane reset error handling and input validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-09-07]
+### Fixes
+- The `AFC_LANE_RESET` macro will properly check for input instead of crashing Klipper.
+
 ## [2025-09-05]
 ### Added
 - Check to verify that pin_tool_start/end is not set to `Unknown`, throws error if pins are set to `Unknown`.

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -1137,14 +1137,28 @@ class afcFunction:
         prompt = AFCprompt(gcmd, self.logger)
         lane = gcmd.get('LANE', None)
         long_dis = gcmd.get('DISTANCE', None)
-        cur_lane = self.afc.lanes[lane]
-        CUR_HUB = cur_lane.hub_obj
-        short_move = cur_lane.short_move_dis * 2
 
-        if lane is not None and lane not in self.afc.lanes:
+        if not lane:
+            prompt.p_end()
+            self.afc.error.AFC_error("No lane selected to reset, please provide a lane to reset.", pause=False)
+            return
+
+        if lane not in self.afc.lanes:
             prompt.p_end()
             self.afc.error.AFC_error("'{}' is not a valid lane".format(lane), pause=False)
             return
+
+        if long_dis is not None:
+            try:
+                long_dis = abs(float(long_dis))
+            except (ValueError, TypeError):
+                prompt.p_end()
+                self.afc.error.AFC_error("DISTANCE must be a positive number.", pause=False)
+                return
+
+        cur_lane = self.afc.lanes[lane]
+        CUR_HUB = cur_lane.hub_obj
+        short_move = cur_lane.short_move_dis * 2
 
         if not CUR_HUB.state:
             prompt.p_end()

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -1150,7 +1150,9 @@ class afcFunction:
 
         if long_dis is not None:
             try:
-                long_dis = abs(float(long_dis))
+                long_dis = float(long_dis)
+                if long_dis <= 0:
+                    raise ValueError("DISTANCE must be a positive number.")
             except (ValueError, TypeError):
                 prompt.p_end()
                 self.afc.error.AFC_error("DISTANCE must be a valid number.", pause=False)

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -1153,7 +1153,7 @@ class afcFunction:
                 long_dis = abs(float(long_dis))
             except (ValueError, TypeError):
                 prompt.p_end()
-                self.afc.error.AFC_error("DISTANCE must be a positive number.", pause=False)
+                self.afc.error.AFC_error("DISTANCE must be a valid number.", pause=False)
                 return
 
         cur_lane = self.afc.lanes[lane]


### PR DESCRIPTION
## Major Changes in this PR

This pull request addresses a bug in the `AFC_LANE_RESET` macro to prevent crashes when no lane is provided, and ensures better input validation for the `DISTANCE` parameter. The main changes are focused on improving input checks and error handling in the `cmd_AFC_LANE_RESET` function.

**Bug Fixes and Input Validation:**

* Added a check to ensure the `lane` parameter is provided before attempting to reset, preventing crashes if it is missing.
* Improved validation for the `DISTANCE` parameter to ensure it is a positive number, with appropriate error handling if the input is invalid.

**Documentation:**

* Updated `CHANGELOG.md` to document the fix for the `AFC_LANE_RESET` macro crash issue.

## Notes to Code Reviewers

Fixes #528 

## How the changes in this PR are tested
```
3:31 PM
No lane selected to reset, please provide a lane to reset.
3:31 PM
action:prompt_end
3:31 PM
AFC_LANE_RESET
```
```
3:33 PM
DISTANCE must be a positive number.
3:33 PM
action:prompt_end
3:33 PM
AFC_LANE_RESET lane=lane1 distance=asdf
```

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.