### PR TITLE
Fix: Prevent runout logic from triggering during tool changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-10-25]
+### Fixes
+- Resolved a bug where runout logic could potentially be triggered during a toolchange. 
+
 ## [2025-10-18]
 ### Fixes
 - On startup, or when assigning a spool to a lane, AFC will now check the weight of the spool to check if it is either zero, null,

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -979,6 +979,8 @@ class AFCLane:
         Returns True if the lane is in a normal printing state (TOOLED or LOADED).
         Prevents runout logic from triggering during transitions or maintenance.
         """
+        if self.afc.in_toolchange:
+            return False
         return self.status in (AFCLaneState.TOOLED, AFCLaneState.LOADED)
 
     def handle_toolhead_runout(self, sensor=None):


### PR DESCRIPTION
## Major Changes in this PR

This pull request introduces a minor update to the lane state logic in `extras/AFC_lane.py`. The change improves the accuracy of determining when the lane is in a normal printing state by preventing runout logic from triggering during toolchange operations.

Lane state logic improvement:

* Updated the `_is_normal_printing_state` method to return `False` if `self.afc.in_toolchange` is `True`, ensuring that runout logic does not activate during toolchange transitions.

Closes #550 

## Notes to Code Reviewers

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.