### PR TITLE
Fix: Clarify error message during AFC calibration for filament issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-11-03]
+### Fixes
+- Clarified fix message if during AFC calibration, the filament fails to reach to hub sensor.
+
 ## [2025-11-01]
 ### Changed
 - Removed code for Belay.

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -383,12 +383,12 @@ class afcBoxTurtle(afcUnit):
         if not success:
             if checkpoint == "retract to extruder":
                 msg = (
-                    """\nLane failed during calibration after {}mm. Check position of filament and
+                    """\n{} failed during calibration after {}mm. Check position of filament and
                     reset filament using BT_LANE_MOVE macro if necessary. If filament is between
                     the extruder and the hub, and is moving smoothly, you may need to increase the
                     dist_hub value. Once adjusted, please try again. This can be adjusted by
                     using the SET_HUB_DIST LANE=<lane> LENGTH=<+/- distance> macro. Once you are
-                    satisfied, you can save the values with SAVE_HUB_DIST LANE=<lane> macro.\n""".format(pos)
+                    satisfied, you can save the values with SAVE_HUB_DIST LANE=<lane> macro.\n""".format(cur_lane.name, pos)
                 )
             else:
                 msg = 'Lane failed to calibrate {} after {}mm'.format(checkpoint, pos)

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -385,9 +385,9 @@ class afcBoxTurtle(afcUnit):
                 msg = (
                     """\nLane failed during calibration after {}mm. Check position of filament and
                     reset filament using BT_LANE_MOVE macro if necessary. If filament is between
-                    the extruder and the hub, and is moving smoothly, you may need to increase the 
+                    the extruder and the hub, and is moving smoothly, you may need to increase the
                     dist_hub value. Once adjusted, please try again. This can be adjusted by
-                    using the SET_HUB_DIST LANE=<lane> LENGTH=<+/- distance> macro. Once you are 
+                    using the SET_HUB_DIST LANE=<lane> LENGTH=<+/- distance> macro. Once you are
                     satisfied, you can save the values with SAVE_HUB_DIST LANE=<lane> macro.\n""".format(pos)
                 )
             else:

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -383,10 +383,12 @@ class afcBoxTurtle(afcUnit):
         if not success:
             if checkpoint == "retract to extruder":
                 msg = (
-                    """Lane failed during calibration after {}mm. Check position of filament and 
-                    reset filament using BT_LANE_MOVE macro if necessary. If filament is between 
+                    """\nLane failed during calibration after {}mm. Check position of filament and
+                    reset filament using BT_LANE_MOVE macro if necessary. If filament is between
                     the extruder and the hub, and is moving smoothly, you may need to increase the 
-                    dist_hub value. Once adjusted, please try again.""".format(pos)
+                    dist_hub value. Once adjusted, please try again. This can be adjusted by
+                    using the SET_HUB_DIST LANE=<lane> LENGTH=<+/- distance> macro. Once you are 
+                    satisfied, you can save the values with SAVE_HUB_DIST LANE=<lane> macro.\n""".format(pos)
                 )
             else:
                 msg = 'Lane failed to calibrate {} after {}mm'.format(checkpoint, pos)

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -381,7 +381,15 @@ class afcBoxTurtle(afcUnit):
                                                       tol, cur_lane.dist_hub + 100, "retract to extruder")
 
         if not success:
-            msg = 'Lane failed to calibrate {} after {}mm'.format(checkpoint, pos)
+            if checkpoint == "retract to extruder":
+                msg = (
+                    """Lane failed during calibration after {}mm. Check position of filament and 
+                    reset filament using BT_LANE_MOVE macro if necessary. If filament is between 
+                    the extruder and the hub, and is moving smoothly, you may need to increase the 
+                    dist_hub value. Once adjusted, please try again.""".format(pos)
+                )
+            else:
+                msg = 'Lane failed to calibrate {} after {}mm'.format(checkpoint, pos)
             cur_lane.status = AFCLaneState.NONE
             cur_lane.unit_obj.return_to_home()
             return False, msg, 0


### PR DESCRIPTION
## Major Changes in this PR

This pull request addresses a calibration issue in the AFC system and improves user feedback when filament fails to reach the hub sensor during calibration. The most important changes clarify the error message shown to users and document this fix in the changelog.

### User feedback improvements

* Enhanced the failure message in `calibrate_lane` within `extras/AFC_BoxTurtle.py` to provide clearer guidance if the filament fails to reach the hub sensor during AFC calibration, including troubleshooting steps and suggestions for adjusting `dist_hub`.

### Documentation updates

* Added a fix entry to `CHANGELOG.md` describing the clarified message for AFC calibration failures related to the filament not reaching the hub sensor.

## Notes to Code Reviewers

Closes #559 

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.