### PR TITLE
Add Spoolman spool_id to lane_data namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixes bug where print current is not correctly set back to correct value after using LANE_MOVE macro.
 
+## [2025-11-26]
+### Added
+- Added `spool_id` field to `lane_data` namespace for Spoolman integration (#575)
+
 ## [2025-11-25]
 ### Added
 - **Buffer Fault Detection System**: New filament fault detection feature for AFC buffers to detect clogs, and feeding issues.

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -982,7 +982,7 @@ class afc:
             self.save_vars()
 
             # Removing spool from vars since it was ejected
-            self.spool.set_spoolID(cur_lane, "")
+            self.spool.set_spoolID(cur_lane, None)
             self.logger.info("LANE {} eject done".format(cur_lane.name))
             self.function.afc_led(cur_lane.led_not_ready, cur_lane.led_index)
 

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -1073,7 +1073,8 @@ class AFCLane:
                     "nozzle_temp"   : self.extruder_temp,
                     "scan_time"     : scan_time,
                     "td"            : td,
-                    "lane"          : lane_number
+                    "lane"          : lane_number,
+                    "spool_id"      : self.spool_id
                 }
             }
             self.afc.moonraker.send_lane_data(lane_data)

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -1095,7 +1095,8 @@ class AFCLane:
                     "nozzle_temp"   : "",
                     "scan_time"     : "",
                     "td"            : "",
-                    "lane"          : lane_number
+                    "lane"          : lane_number,
+                    "spool_id"      : ""
                 }
             }
             self.afc.moonraker.send_lane_data(lane_data)

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -1096,7 +1096,7 @@ class AFCLane:
                     "scan_time"     : "",
                     "td"            : "",
                     "lane"          : lane_number,
-                    "spool_id"      : ""
+                    "spool_id"      : None
                 }
             }
             self.afc.moonraker.send_lane_data(lane_data)

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -11,7 +11,7 @@ class AFCSpool:
         self.printer.register_event_handler("klippy:connect", self.handle_connect)
 
         # Temporary status variables
-        self.next_spool_id      = ''
+        self.next_spool_id      = None
 
     def handle_connect(self):
         """
@@ -248,7 +248,12 @@ class AFCSpool:
             # Check if spool id is already assigned to a different lane, don't assign to current lane if id
             # is already assigned
             if SpoolID != '':
-                SpoolID = int(SpoolID)
+                try:
+                    SpoolID = int(SpoolID)
+                except ValueError:
+                    self.logger.error("Invalid spool ID: {}".format(SpoolID))
+                    return
+
                 if cur_lane.spool_id != SpoolID and any( SpoolID == lane.spool_id for lane in self.afc.lanes.values()):
                     self.logger.error(f"SpoolId {SpoolID} already assigned to a lane, cannot assign to {lane}.")
                     return
@@ -281,16 +286,16 @@ class AFCSpool:
         cur_lane.material = self.afc.default_material_type
         cur_lane.weight = 1000 # Defaulting weight to 1000 upon load
 
-        if self.afc.spoolman is not None and self.next_spool_id != '':
+        if self.afc.spoolman is not None and self.next_spool_id is not None:
             spool_id = self.next_spool_id
-            self.next_spool_id = ''
+            self.next_spool_id = None
             self.set_spoolID(cur_lane, spool_id)
 
     def clear_values(self, cur_lane):
         """
         Helper function for clearing out lane spool values
         """
-        cur_lane.spool_id = ''
+        cur_lane.spool_id = None
         cur_lane.material = ''
         cur_lane.color = ''
         cur_lane.weight = 0
@@ -300,7 +305,7 @@ class AFCSpool:
 
     def set_spoolID(self, cur_lane, SpoolID, save_vars=True):
         if self.afc.spoolman is not None:
-            if SpoolID !='':
+            if SpoolID not in ('', None):
                 try:
                     result = self.afc.moonraker.get_spool(SpoolID)
                     cur_lane.spool_id = SpoolID
@@ -454,12 +459,12 @@ class AFCSpool:
         previous_id = self.next_spool_id
         if SpoolID != '':
             try:
-                self.next_spool_id = str(int(SpoolID)) # make sure spool ID will round trip later
+                self.next_spool_id = int(SpoolID)
             except ValueError:
                 self.logger.error("Invalid spool ID: {}".format(SpoolID))
-                self.next_spool_id = ''
+                self.next_spool_id = None
         else:
-            self.next_spool_id = ''
+            self.next_spool_id = None
         if previous_id:
             self.logger.info(f"Spool ID '{previous_id}' being overwritten for next load: '{self.next_spool_id}'")
         else:


### PR DESCRIPTION
## Major Changes in this PR
Adds Spoolman `spool_id` field to the `lane_data` namespace in Moonraker's database API.

## Notes to Code Reviewers
Single line addition in `extras/AFC_lane.py` in the `send_lane_data()` method. The change includes `self.spool_id` in the lane data payload sent to Moonraker, making it available via the `/server/database/item?namespace=lane_data` endpoint.

## How the changes in this PR are tested
- Tested locally with BoxTurtle setup
- Verified `spool_id` is correctly populated when set via `SET_SPOOL_ID` command
- Verified `spool_id` is correctly populated when set via `SET_NEXT_SPOOL_ID` workflow
- Confirmed the field appears in Moonraker database API response
- No breaking changes to existing functionality

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

 **Update:** Fixed type consistency - `spool_id` now uses `int` or `None` throughout the codebase (removed string casting and empty string usage).

Resolves #575
AT-Doc: https://github.com/ArmoredTurtle/AT-Documentation/pull/133