### PR TITLE
Fix docstring

### DIFF
--- a/extras/AFC_buffer.py
+++ b/extras/AFC_buffer.py
@@ -375,12 +375,12 @@ class AFCTrigger:
 
         Usage
         -----
-        `SET_ERROR_SENSITIVITY BUFFER=<buffer_name> SENSITIVITY=<0-10>`
+        `AFC_SET_ERROR_SENSITIVITY BUFFER=<buffer_name> SENSITIVITY=<0-10>`
 
         Example
         -----
         ```
-        SET_ERROR_SENSITIVITY BUFFER=TN SENSITIVITY=5.0
+        AFC_SET_ERROR_SENSITIVITY BUFFER=TN SENSITIVITY=5.0
         ```
         """
         sensitivity = gcmd.get_float('SENSITIVITY', minval=0, maxval=10)


### PR DESCRIPTION
## Major Changes in this PR

This pull request makes a small update to the usage documentation for the `cmd_AFC_SET_ERROR_SENSITIVITY` command, ensuring the command name is correctly referenced in both the usage and example sections. 

- Updated the usage and example documentation to use the correct command name `AFC_SET_ERROR_SENSITIVITY` instead of `SET_ERROR_SENSITIVITY` in the `cmd_AFC_SET_ERROR_SENSITIVITY` method in `extras/AFC_buffer.py`.

## Notes to Code Reviewers

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.