### PR TITLE
Fix lane_move current issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2025-12-03]
+### Fixed
+- Fixes bug where print current is not correctly set back to correct value after using LANE_MOVE macro.
+
 ## [2025-11-25]
 ### Added
 - **Buffer Fault Detection System**: New filament fault detection feature for AFC buffers to detect clogs, and feeding issues.

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -704,7 +704,6 @@ class afc:
         cur_lane.unit_obj.return_to_home()
         # Put CAM back to lane if it is loaded to the toolhead
         self.function.select_loaded_lane()
-        cur_lane.set_print_current() # Set current back to print current after lane move
 
     def _get_resume_speed(self):
         """

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -702,8 +702,9 @@ class afc:
         cur_lane.do_enable(False)
         self.current_state = State.IDLE
         cur_lane.unit_obj.return_to_home()
-        # Put CAM back to lane if its loaded to toolhead
+        # Put CAM back to lane if it is loaded to the toolhead
         self.function.select_loaded_lane()
+        cur_lane.set_print_current() # Set current back to print current after lane move
 
     def _get_resume_speed(self):
         """

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -457,6 +457,7 @@ class afcFunction:
         current_lane = self.get_current_lane_obj()
         if current_lane is not None:
             current_lane.unit_obj.select_lane(current_lane)
+            current_lane.set_print_current() # Set current back to print current after lane move
 
     def log_toolhead_pos(self, move_pre=""):
         """

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -191,7 +191,9 @@ class AFCExtruderStepper(AFCLane):
         :param current: Sets TMC current to specified value
         """
         if self.tmc_print_current is not None and current is not None:
-            self.gcode.run_script_from_command("SET_TMC_CURRENT STEPPER='{}' CURRENT={}".format(self.name, current))
+            command = "SET_TMC_CURRENT STEPPER='{}' CURRENT={}".format(self.name, current)
+            self.logger.debug(f"Running macro: {command}")
+            self.gcode.run_script_from_command(command)
 
     def set_load_current(self):
         """


### PR DESCRIPTION
## Major Changes in this PR

This pull request addresses a bug related to the print current setting during the LANE_MOVE macro operation. The main change ensures that after moving a lane, the print current is properly restored, preventing issues with subsequent operations.

Bug fix for lane movement:

* Added a call to `cur_lane.set_print_current()` in the `cmd_LANE_MOVE` method in `extras/AFC.py` to correctly restore the print current after a lane move.
* Documented the bug fix in the `CHANGELOG.md` under the "Fixed" section for the 2025-12-03 release.

## Notes to Code Reviewers

Closes #578 

## How the changes in this PR are tested

I can't test this right now, so not sure :)

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.