### PR TITLE
Fixing issue where HTLF crashes during PREP with newest klipper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-12-06]
+### Fixed
+- Fixes issue where klipper would crash for HTLF units when homing and moving lanes during prep
+
 ## [2025-12-03]
 ### Fixed
 - Fixes bug where print current is not correctly set back to correct value after using LANE_MOVE macro.

--- a/extras/AFC_HTLF.py
+++ b/extras/AFC_HTLF.py
@@ -132,6 +132,9 @@ class AFC_HTLF(afcBoxTurtle):
                 return False
 
         self.prep_homed = True
+        # Adding delay or disabling stepper motor will crash klipper with newest
+        # motion queuing changes
+        self.afc.reactor.pause(self.afc.reactor.monotonic() + 0.1)
         self.selector_stepper_obj.do_enable(False)
         self.current_selected_lane = None
         return True


### PR DESCRIPTION
## Major Changes in this PR
Was able to replicate with newest klipper version, found that adding a slight delay keeps klipper from crashing when running PREP for HTLF units

Fixes #582

## How the changes in this PR are tested
Switched to klipper and made sure PREP was enabled to move lanes

Successfully running prep for HTLF:
<img width="597" height="167" alt="image" src="https://github.com/user-attachments/assets/970f6580-cb5e-4b18-ae66-f18881f0e020" />


## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.