### PR TITLE
Removing AFC_STATUS and fixing units from showing in mainsail/fluidd when there are no lanes assigned to units

### DIFF
--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -255,8 +255,6 @@ class afc:
                                         self.cmd_AFC_STATS_options)
         self.function.register_commands(self.show_macros, 'AFC_QUIET_MODE', self.cmd_AFC_QUIET_MODE,
                                         self.cmd_AFC_QUIET_MODE_help, self.cmd_AFC_QUIET_MODE_options)
-        self.function.register_commands(self.show_macros, 'AFC_STATUS', self.cmd_AFC_STATUS,
-                                        self.cmd_AFC_STATUS_help)
         self.function.register_commands(self.show_macros, 'TURN_ON_AFC_LED', self.cmd_TURN_ON_AFC_LED,
                                         self.cmd_TURN_ON_AFC_LED_help)
         self.function.register_commands(self.show_macros, 'TURN_OFF_AFC_LED', self.cmd_TURN_OFF_AFC_LED,
@@ -1849,7 +1847,8 @@ class afc:
         for UNIT in self.units.keys():
             CUR_UNIT=self.units[UNIT]
             type  =CUR_UNIT.type.replace(" ","_")
-            unitdisplay.append(type.replace("'","") + " " + CUR_UNIT.name)
+            if len(self.units[UNIT].lanes) > 0:
+                unitdisplay.append(type.replace("'","") + " " + CUR_UNIT.name)
         str['units'] = list(unitdisplay)
         str['lanes'] = list(self.lanes.keys())
         str["extruders"] = list(self.tools.keys())
@@ -2007,78 +2006,6 @@ class afc:
                 return
             self.logger.debug(f"{heater.get_name()} temp: {cur_temp:.2f}C (waiting for {min_temp:.1f}..{max_temp:.1f})")
             eventtime = reactor.pause(eventtime + 1.0)
-
-
-    cmd_AFC_STATUS_help = "Return current status of AFC"
-    def cmd_AFC_STATUS(self, gcmd):
-        """
-        This function generates a status message for each unit and lane, indicating the preparation,
-        loading, hub, and tool states. The status message is formatted with HTML tags for display.
-
-        Usage
-        -----
-        `AFC_STATUS`
-
-        Example
-        -----
-        ```
-        AFC_STATUS
-        ```
-        """
-        status_msg = ''
-
-        for unit in self.units.values():
-            # Find the maximum length of lane names to determine the column width
-            max_lane_length = max(len(lane) for lane in unit.lanes.keys())
-
-            status_msg += '<span class=info--text>{} Status</span>\n'.format(unit.name)
-
-            # Create a dynamic format string that adjusts based on lane name length
-            header_format = '{:<{}} | Prep | Load |\n'
-            status_msg += header_format.format("LANE", max_lane_length)
-
-            for cur_lane in unit.lanes.values():
-                lane_msg = ''
-                if self.current is not None:
-                    if self.current == cur_lane.name:
-                        if not cur_lane.get_toolhead_pre_sensor_state() or not cur_lane.hub_obj.state:
-                            lane_msg += '<span class=warning--text>{:<{}} </span>'.format(cur_lane.name, max_lane_length)
-                        else:
-                            lane_msg += '<span class=success--text>{:<{}} </span>'.format(cur_lane.name, max_lane_length)
-                    else:
-                        lane_msg += '{:<{}} '.format(cur_lane.name, max_lane_length)
-                else:
-                    lane_msg += '{:<{}} '.format(cur_lane.name, max_lane_length)
-
-                if cur_lane.prep_state:
-                    lane_msg += '| <span class=success--text><--></span> |'
-                else:
-                    lane_msg += '|  <span class=error--text>xx</span>  |'
-                if cur_lane.load_state:
-                    lane_msg += ' <span class=success--text><--></span> |\n'
-                else:
-                    lane_msg += '  <span class=error--text>xx</span>  |\n'
-                status_msg += lane_msg
-
-            if cur_lane.hub_obj.state:
-                status_msg += 'HUB: <span class=success--text><-></span>'
-            else:
-                status_msg += 'HUB: <span class=error--text>x</span>'
-
-            extruder_msg = '  Tool: <span class=error--text>x</span>'
-            if cur_lane.extruder_obj.tool_start != "buffer":
-                if cur_lane.extruder_obj.tool_start_state:
-                    extruder_msg = '  Tool: <span class=success--text><-></span>'
-            else:
-                if cur_lane.tool_loaded and cur_lane.extruder_obj.lane_loaded in self.units[unit]:
-                    if cur_lane.get_toolhead_pre_sensor_state():
-                        extruder_msg = '  Tool: <span class=success--text><-></span>'
-
-            status_msg += extruder_msg
-            if cur_lane.extruder_obj.tool_start == 'buffer':
-                status_msg += '\n<span class=info--text>Ram sensor enabled</span>\n'
-
-        self.logger.raw(status_msg)
 
     cmd_TURN_OFF_AFC_LED_help = "Turns off all LEDs for AFC_led configurations"
     def cmd_TURN_OFF_AFC_LED(self, gcmd: Any) -> None:

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -970,6 +970,14 @@ class afcFunction:
                 ' First, select a unit to calibrate.'
                 ' *All values will be automatically updated in the appropriate config sections.')
         for index, (key, item) in enumerate(self.afc.units.items()):
+            # Only showing calibrations for units that have lanes
+            if len(self.afc.units.get(key).lanes) == 0:
+                continue
+
+            # Filtering out units that only have standalone lanes(toolchanger extruders without assist)
+            if not any( not l.extruder_obj.no_lanes for l in self.afc.units.get(key).lanes.values() ):
+                continue
+
             # Create a button for each unit
             button_label = "{}".format(key)
             button_command = 'UNIT_CALIBRATION UNIT={}'.format(key)
@@ -1066,6 +1074,10 @@ class afcFunction:
 
         if afc_bl is not None and afc_bl not in self.afc.lanes:
             self.afc.error.AFC_error("'{}' is not a valid lane to calibrate bowden length".format(afc_bl), pause=False)
+            return
+
+        if len(self.afc.units.get(unit).lanes) == 0:
+            self.logger.warning(f"No lanes to calibrate for {self.name}")
             return
 
         if td1 is not None and not self.afc.td1_present:

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -1068,17 +1068,18 @@ class afcFunction:
             self.afc.error.AFC_error("'{}' is not a valid lane".format(lanes), pause=False)
             return
 
+        if (lanes is not None
+            and lanes != 'all'
+            and self.afc.lanes.get(lanes).extruder_obj.no_lanes):
+            self.afc.error.AFC_error(f"{lanes} is a standalone lane, cannot calibrate", pause=False)
+            return
+
         if unit is not None and unit not in self.afc.units:
             self.afc.error.AFC_error("'{}' is not a valid unit".format(unit), pause=False)
             return
 
         if afc_bl is not None and afc_bl not in self.afc.lanes:
             self.afc.error.AFC_error("'{}' is not a valid lane to calibrate bowden length".format(afc_bl), pause=False)
-            return
-
-        if (unit is not None
-            and len(self.afc.units.get(unit).lanes) == 0):
-            self.logger.warning(f"No lanes to calibrate for {self.name}")
             return
 
         if td1 is not None and not self.afc.td1_present:
@@ -1100,6 +1101,10 @@ class afcFunction:
                 else:
                     # Calibrate all lanes if no specific lane is provided
                     for cur_lane in self.afc.lanes.values():
+                        if cur_lane.extruder_obj.no_lanes:
+                            self.logger.info(f"{cur_lane.name} is a standalone lane, skipping calibration".format())
+                            continue
+
                         if not cur_lane.load_state or not cur_lane.prep_state:
                             self.logger.info("{} not loaded skipping to next loaded lane".format(cur_lane.name))
                             continue
@@ -1127,6 +1132,10 @@ class afcFunction:
                     self.logger.info('{}'.format(CUR_UNIT.name))
                     # Calibrate all lanes if no specific lane is provided
                     for cur_lane in CUR_UNIT.lanes.values():
+                        if cur_lane.extruder_obj.no_lanes:
+                            self.logger.info(f"{cur_lane.name} is a standalone lane, skipping calibration".format())
+                            continue
+
                         if not cur_lane.load_state or  not cur_lane.prep_state:
                             self.logger.info("{} not loaded skipping to next loaded lane".format(cur_lane.name))
                             continue

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -974,8 +974,8 @@ class afcFunction:
             if len(self.afc.units.get(key).lanes) == 0:
                 continue
 
-            # Filtering out units that only have standalone lanes(toolchanger extruders without assist)
-            if not any( not lane.extruder_obj.no_lanes for lane in self.afc.units.get(key).lanes.values() ):
+            # Filtering out units that only have standalone lanes (toolchanger extruders without assist)
+            if all( lane.extruder_obj.no_lanes for lane in self.afc.units.get(key).lanes.values() ):
                 continue
 
             # Create a button for each unit
@@ -1076,7 +1076,8 @@ class afcFunction:
             self.afc.error.AFC_error("'{}' is not a valid lane to calibrate bowden length".format(afc_bl), pause=False)
             return
 
-        if len(self.afc.units.get(unit).lanes) == 0:
+        if (unit is not None
+            and len(self.afc.units.get(unit).lanes) == 0):
             self.logger.warning(f"No lanes to calibrate for {self.name}")
             return
 

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -975,7 +975,7 @@ class afcFunction:
                 continue
 
             # Filtering out units that only have standalone lanes(toolchanger extruders without assist)
-            if not any( not l.extruder_obj.no_lanes for l in self.afc.units.get(key).lanes.values() ):
+            if not any( not lane.extruder_obj.no_lanes for lane in self.afc.units.get(key).lanes.values() ):
                 continue
 
             # Create a button for each unit

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -194,6 +194,10 @@ class afcUnit:
         UNIT_CALIBRATION UNIT=Turtle_1
         ```
         """
+        if len(self.lanes) == 0:
+            self.logger.warning(f"No lanes to calibrate for {self.name}")
+            return
+
         prompt = AFCprompt(gcmd, self.logger)
         buttons = []
         title = '{} Calibration'.format(self.name)


### PR DESCRIPTION
## Major Changes in this PR
- Removing AFC_STATUS macro since mainsail and soon to be fluidd have been released. Users should us this now instead of AFC_STATUS
- Fixes issue where units with zero lanes assigned would show up in mainsail/fluidd panel
- Fixes issue where units with zero lanes or standalone lanes would show up when running `AFC_CALIBRATION`, reports warning if user tries to manually run calibration commands with a unit that has zero lanes.

## Notes to Code Reviewers

## How the changes in this PR are tested
Before Change:
<img width="819" height="560" alt="image" src="https://github.com/user-attachments/assets/fed72960-b6cd-4efc-8d93-66bb1b5ff4bf" />
<img width="499" height="327" alt="image" src="https://github.com/user-attachments/assets/df3543ad-056d-438c-940f-dd893c779a36" />

After Change:
<img width="831" height="502" alt="image" src="https://github.com/user-attachments/assets/aeb4d2ea-0ccb-4209-81ee-0f779e27f83c" />
<img width="475" height="277" alt="image" src="https://github.com/user-attachments/assets/9447bba7-9391-4aa6-8d28-a392574d98c2" />



## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.