### PR TITLE
[Enhancement] Updating print assist to be more linear with spool weight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix output of `AFC_TOGGLE_MACRO` to correctly report state of WIPE macro
 
+## [2025-12-07]
+### Added
+- Updated spool assist cruise time calculations to be more linear with spool weight
+
 ## [2025-12-06]
 ### Fixed
 - Fixes issue where klipper would crash for HTLF units when homing and moving lanes during prep

--- a/config/AFC_Macro_Vars.cfg
+++ b/config/AFC_Macro_Vars.cfg
@@ -90,7 +90,7 @@ variable_pushback_dwell_time      : 20        # Time to dwell between the pushba
 # we make a safer but longer move if we are closer to the pin than this
 # specified margin. Usually setting these to the size of the toolhead
 # (plus a small margin) should be good enough 
-variable_safe_margin_xy           : 30, 30    # Approx toolhead width +5mm, height +5mm)
+variable_safe_margin_xy           : 30, 30
 
 # Some printers may need a boost of power to complete the cut without skipping steps.
 # One option is to increase the current for the steppers in printer.cfg. Another

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -193,7 +193,7 @@ class afc:
 
         self.global_print_current   = config.getfloat("global_print_current", None) # Global variable to set steppers current to a specified current when printing. Going lower than 0.6 may result in TurtleNeck buffer's not working correctly
         self.spool_ratio            = config.getfloat("spool_ratio",2)              # gear ratio for printed gearbox between N20 and spooler wheels
-        self.full_weight	        = config.getfloat("full_weight",1000)           # full weight of filament spill (no counting spool itself)
+        self.full_weight            = config.getfloat("full_weight",1000, minval=1)           # full weight of filament spool (not counting spool itself)
         self.enable_sensors_in_gui  = config.getboolean("enable_sensors_in_gui", False) # Set to True to show all sensor switches as filament sensors in mainsail/fluidd gui
         self.load_to_hub            = config.getboolean("load_to_hub", True)        # Fast loads filament to hub when inserted, set to False to disable. This is a global setting and can be overridden at AFC_stepper
         self.assisted_unload        = config.getboolean("assisted_unload", True)    # If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -192,7 +192,8 @@ class afc:
         self.resume_z_speed         = config.getfloat("resume_z_speed", self.speed) # Speed mm/s of resume move in Z. Set to 0 to use gcode speed
 
         self.global_print_current   = config.getfloat("global_print_current", None) # Global variable to set steppers current to a specified current when printing. Going lower than 0.6 may result in TurtleNeck buffer's not working correctly
-
+        self.spool_ratio            = config.getfloat("spool_ratio",2)              # gear ratio for printed gearbox between N20 and spooler wheels
+        self.full_weight	        = config.getfloat("full_weight",1000)           # full weight of filament spill (no counting spool itself)
         self.enable_sensors_in_gui  = config.getboolean("enable_sensors_in_gui", False) # Set to True to show all sensor switches as filament sensors in mainsail/fluidd gui
         self.load_to_hub            = config.getboolean("load_to_hub", True)        # Fast loads filament to hub when inserted, set to False to disable. This is a global setting and can be overridden at AFC_stepper
         self.assisted_unload        = config.getboolean("assisted_unload", True)    # If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1160,7 +1160,7 @@ class afc:
                         msg += "Buffer did not become compressed after {} short moves.\n".format(self.tool_max_load_checks)
                         msg += "Setting and increasing 'tool_max_load_checks' in AFC.cfg may improve loading reliability.\n\n"
                         msg += "Check that the filament is properly loaded into the toolhead extruder. If filament is loaded\n"
-                        msg += "into toolhead extruders gears, then manually run SET_LANE_LOADED LANE={cur_lane.name} then\n"
+                        msg += f"into toolhead extruders gears, then manually run SET_LANE_LOADED LANE={cur_lane.name} then\n"
                         msg += "manually extrude filament and clean nozzle."
                         if self.function.in_print():
                             msg += '\nOnce issue is resolved click resume to continue printing'

--- a/extras/AFC_assist.py
+++ b/extras/AFC_assist.py
@@ -290,8 +290,8 @@ class Espooler_values:
         #rotations = mm_movement / self.spool_circum
         #correction_factor = 1.0 + ( 1.68 * math.exp(-rotations * 5.0) )
         #cruise_time = rotations * self.cycles_per_rotation * correction_factor
-        spool_rot_s=(self.espool_rot_dist*((self.max_motor_rpm/60)/self.spool_ratio)) / (self.outer_circ())
-        w_r=(weight/self.full_weight+1)*self.delta_circ()
+        spool_rot_s=(self.espool_rot_dist*((self.max_motor_rpm/60)/self.spool_ratio)) / self.outer_circ
+        w_r=(weight/self.full_weight+1)*self.delta_circ
         self._cruise_time=self.delta_movement/w_r/spool_rot_s
         return self._cruise_time #*1000
 
@@ -349,14 +349,14 @@ class Espooler_values:
         """
         Returns circumference for outer diameter
         """
-        return self._spool_outer_diameter * math.pi()
+        return self._spool_outer_diameter * math.pi
 
     @property
     def delta_circ(self) -> float:
         """
         Returns circumference for outer spool diameter - inner spool diameter
         """
-        return (self._spool_outer_diameter - self._spool_inner_diameter)*math.pi()
+        return (self._spool_outer_diameter - self._spool_inner_diameter)*math.pi
 
     @property
     def scaling(self) -> float:

--- a/extras/AFC_assist.py
+++ b/extras/AFC_assist.py
@@ -21,6 +21,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.for
 PIN_MIN_TIME = 0.100
 RESEND_HOST_TIME = 0.300 + PIN_MIN_TIME
 MAX_SCHEDULE_TIME = 5.0
+RPM_TO_RPS = 60
 
 class AFCassistMotor:
     def __init__(self, config, type):
@@ -268,9 +269,7 @@ class Espooler_values:
         self._max_motor_rpm          = config.getfloat("max_motor_rpm",         None)
         # Delta amount in mm from last move to trigger assist. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
         self._delta_movement         = config.getfloat("delta_movement",        None)
-        # Amount to move in mm once filament has moved by delta movement amount. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
-        self._mm_movement            = config.getfloat("mm_movement",           None)
-        # Scaling factor for the following variables: kick_start_time, spool_outer_diameter, cycles_per_rotation, pwm_value, delta_movement, mm_movement. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
+        # Scaling factor for the following variables: kick_start_time, spool_outer_diameter, delta_movement. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
         self._scaling                = config.getfloat("spoolrate",             None)
         # Gear ratio of spooler printed drivetrain
         self._spool_ratio            = config.getfloat("spool_ratio",           None)
@@ -287,13 +286,11 @@ class Espooler_values:
         :param weight: Current spool weight
         :return float: Amount of time to be enabled to move mm amount
         """
-        #rotations = mm_movement / self.spool_circum
-        #correction_factor = 1.0 + ( 1.68 * math.exp(-rotations * 5.0) )
-        #cruise_time = rotations * self.cycles_per_rotation * correction_factor
-        spool_rot_s=(self.espool_rot_dist*((self.max_motor_rpm/60)/self.spool_ratio)) / self.outer_circ
-        w_r=(weight/self.full_weight+1)*self.delta_circ
-        self._cruise_time=self.delta_movement/w_r/spool_rot_s
-        return self._cruise_time #*1000
+        rps = self.max_motor_rpm / RPM_TO_RPS
+        spool_rot_s = (self.espool_rot_dist * (rps / self.spool_ratio)) / self.outer_circ
+        w_r = (weight / self.full_weight+1) * self.delta_circ
+        self.cruise_time = self.delta_movement / w_r / spool_rot_s
+        return self.cruise_time
 
     def handle_connect(self, lane_obj):
         """
@@ -301,8 +298,8 @@ class Espooler_values:
         lane this function will update values from their unit.
         """
         if self._kick_start_time      is None: self.kick_start_time      = lane_obj.unit_obj.kick_start_time
-        if self._spool_outer_diameter is None: self._spool_outer_diameter= lane_obj.outer_diameter
-        if self._spool_inner_diameter is None: self._spool_inner_diameter= lane_obj.inner_diameter
+        if self._spool_outer_diameter is None: self.spool_outer_diameter = lane_obj.outer_diameter
+        if self._spool_inner_diameter is None: self.spool_inner_diameter = lane_obj.inner_diameter
         if self._max_motor_rpm        is None: self.max_motor_rpm        = lane_obj.max_motor_rpm
         if self._espool_rot_dist      is None: self.espool_rot_dist      = lane_obj.unit_obj.espool_rot_dist
         if self._delta_movement       is None: self.delta_movement       = lane_obj.unit_obj.delta_movement
@@ -328,7 +325,6 @@ class Espooler_values:
         Returns software kick start time, this value is scaled by scaling factor
         """
         return self._kick_start_time * self._scaling
-
     @kick_start_time.setter
     def kick_start_time(self, value: float):
         self._kick_start_time = value
@@ -339,24 +335,22 @@ class Espooler_values:
         Returns delta movement, this value is scaled by scaling factor
         """
         return self._delta_movement * self._scaling
-
     @delta_movement.setter
     def delta_movement(self, value: float):
         self._delta_movement = value
-    
+
     @property
     def outer_circ(self) -> float:
         """
         Returns circumference for outer diameter
         """
-        return self._spool_outer_diameter * math.pi
-
+        return self.spool_outer_diameter * math.pi
     @property
     def delta_circ(self) -> float:
         """
         Returns circumference for outer spool diameter - inner spool diameter
         """
-        return (self._spool_outer_diameter - self._spool_inner_diameter)*math.pi
+        return (self.spool_outer_diameter - self.spool_inner_diameter)*math.pi
 
     @property
     def scaling(self) -> float:
@@ -364,10 +358,51 @@ class Espooler_values:
         Return scaling factor
         """
         return self._scaling
-
     @scaling.setter
     def scaling(self, value: float):
         self._scaling = value
+
+    @property
+    def full_weight(self) -> float:
+        return self._full_weight
+    @full_weight.setter
+    def full_weight(self, value: float) -> None:
+        self._full_weight = value
+
+    @property
+    def spool_ratio(self) -> float:
+        return self._spool_ratio
+    @spool_ratio.setter
+    def spool_ratio(self, value: float) -> None:
+        self._spool_ratio = value
+
+    @property
+    def max_motor_rpm(self) -> float:
+        return self._max_motor_rpm
+    @max_motor_rpm.setter
+    def max_motor_rpm(self, value: float) -> None:
+        self._max_motor_rpm = value
+
+    @property
+    def espool_rot_dist(self) -> float:
+        return self._espool_rot_dist
+    @espool_rot_dist.setter
+    def espool_rot_dist(self, value: float) -> None:
+        self._espool_rot_dist = value
+
+    @property
+    def spool_outer_diameter(self) -> float:
+        return self._spool_outer_diameter
+    @spool_outer_diameter.setter
+    def spool_outer_diameter(self, value: float) -> None:
+        self._spool_outer_diameter = value
+
+    @property
+    def spool_inner_diameter(self) -> float:
+        return self._spool_inner_diameter
+    @spool_inner_diameter.setter
+    def spool_inner_diameter(self, value: float) -> None:
+        self._spool_inner_diameter = value
 
 class Espooler:
     """
@@ -771,11 +806,13 @@ class Espooler:
         BREAK_DELAY - Time in seconds to wait between breaking n20 motors(nSleep/FWD/RWD all 1) and then releasing the break to allow coasting.<br>
         KICK_START_TIME - Time in seconds to enable spooler at full speed to help with getting the spool to spin<br>
         SPOOL_OUTER_DIAMETER - Current spools outer diameter<br>
-        CYCLES_PER_ROTATION - Time it takes to in milliseconds to turn a spool a full rotation<br>
-        PWM_VALUE - PWM cycle time<br>
-        MM_MOVEMENT - Amount to move during the assist in mm once filament has moved by `delta_movement` amount<br>
+        SPOOL_INNER_DIAMETER - Current spools inner diameter<br>
+        FULL_WEIGHT - Weight of filament on new spool<br>
+        SPOOL_RATIO - Gear ratio of spooler printed drivetrain<br>
+        MAX_MOTOR_RPM - Max RPM of spooler motor<br>
+        ESPOOL_ROT_DIST - Rotation distance estimation of espooler wheels<br>
         DELTA_MOVEMENT - Delta amount in mm to move from last assist to trigger another assist move<br>
-        SPOOLRATE - Scaling factor for the following variables: kick_start_time, spool_outer_diameter, cycles_per_rotation, pwm_value, delta_movement, mm_movement<br>
+        SPOOLRATE - Scaling factor for the following variables: kick_start_time, spool_outer_diameter, delta_movement<br>
         TIMER_DELAY - Number of seconds to wait before checking filament movement for espooler assist<br>
         ASSIST_WEIGHT - Weight spool has to be below to activate print assist<br>
         ENABLE_ASSIST - Setting to 1 enables espooler assist while printing<br>
@@ -796,8 +833,18 @@ class Espooler:
                                                                                     "BREAK_DELAY", self.lane_obj.fullname, "n20_break_delay_time")
         self.espooler_values.kick_start_time        = self.function.gcode_get_value(gcmd, "get_float", self.espooler_values.kick_start_time,
                                                                                     "KICK_START_TIME", self.lane_obj.fullname)
-        self.espooler_values._spool_outer_diameter  = self.function.gcode_get_value(gcmd, "get_float", self.espooler_values._spool_outer_diameter,
+        self.espooler_values.spool_outer_diameter   = self.function.gcode_get_value(gcmd, "get_float", self.espooler_values.spool_outer_diameter,
                                                                                     "SPOOL_OUTER_DIAMETER", self.lane_obj.fullname)
+        self.espooler_values.spool_inner_diameter   = self.function.gcode_get_value(gcmd, "get_float", self.espooler_values.spool_inner_diameter,
+                                                                                    "SPOOL_INNER_DIAMETER", self.lane_obj.fullname)
+        self.espooler_values.full_weight            = self.function.gcode_get_value(gcmd, "get_float", self.espooler_values.full_weight,
+                                                                                    "FULL_WEIGHT", self.lane_obj.fullname)
+        self.espooler_values.spool_ratio            = self.function.gcode_get_value(gcmd, "get_float", self.espooler_values.spool_ratio,
+                                                                                    "SPOOL_RATIO", self.lane_obj.fullname)
+        self.espooler_values.max_motor_rpm          = self.function.gcode_get_value(gcmd, "get_float", self.espooler_values.max_motor_rpm,
+                                                                                    "MAX_MOTOR_RPM", self.lane_obj.fullname)
+        self.espooler_values.espool_rot_dist        = self.function.gcode_get_value(gcmd, "get_float", self.espooler_values.espool_rot_dist,
+                                                                                    "ESPOOL_ROT_DIST", self.lane_obj.fullname)
         self.espooler_values.delta_movement         = self.function.gcode_get_value(gcmd, "get_float", self.espooler_values.delta_movement,
                                                                                     "DELTA_MOVEMENT", self.lane_obj.fullname)
         self.espooler_values.scaling                = self.function.gcode_get_value(gcmd, "get_float", self.espooler_values.scaling,

--- a/extras/AFC_assist.py
+++ b/extras/AFC_assist.py
@@ -259,12 +259,13 @@ class Espooler_values:
 
     """
     def __init__(self, config):
+        self.printer = None
         # Time in seconds to enable spooler at full speed to help with getting the spool to spin. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
         self._kick_start_time        = config.getfloat("kick_start_time",       None)
         # Current spools outer diameter
-        self._spool_outer_diameter   = config.getfloat("spool_outer_diameter",  None)
+        self._spool_outer_diameter   = config.getfloat("spool_outer_diameter",  None, minval=100)
         # Current spools outer diameter
-        self._spool_inner_diameter   = config.getfloat("spool_inner_diameter",  None)
+        self._spool_inner_diameter   = config.getfloat("spool_inner_diameter",  None, minval=1)
         # Max RPM of spooler motor
         self._max_motor_rpm          = config.getfloat("max_motor_rpm",         None)
         # Delta amount in mm from last move to trigger assist. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
@@ -274,21 +275,21 @@ class Espooler_values:
         # Gear ratio of spooler printed drivetrain
         self._spool_ratio            = config.getfloat("spool_ratio",           None)
         # Weight of filament on new spool
-        self._full_weight            = config.getfloat("full_weight",           None)
+        self._full_weight            = config.getfloat("full_weight",           None, minval=1)
         # rotation distance estimation of espooler wheels
         self._espool_rot_dist        = config.getfloat("espool_rot_dist",       None)
 
     def calculate_cruise_time(self, weight: int) -> float:
         """
         This function calculates cruise time which is the amount of time to enable
-        motors to rotate spool mm movement amount
+        motors to rotate spool
 
         :param weight: Current spool weight
-        :return float: Amount of time to be enabled to move mm amount
+        :return float: Amount of time to be enabled
         """
         rps = self.max_motor_rpm / RPM_TO_RPS
         spool_rot_s = (self.espool_rot_dist * (rps / self.spool_ratio)) / self.outer_circ
-        w_r = (weight / self.full_weight+1) * self.delta_circ
+        w_r = ((weight / self.full_weight) + 1) * self.delta_circ
         self.cruise_time = self.delta_movement / w_r / spool_rot_s
         return self.cruise_time
 
@@ -308,6 +309,7 @@ class Espooler_values:
         if self._full_weight          is None: self.full_weight          = lane_obj.unit_obj.full_weight
 
         self._cruise_time   = self.calculate_cruise_time(self.full_weight)
+        self.printer = lane_obj.printer
 
     @property
     def cruise_time(self) -> float:
@@ -366,42 +368,42 @@ class Espooler_values:
     def full_weight(self) -> float:
         return self._full_weight
     @full_weight.setter
-    def full_weight(self, value: float) -> None:
+    def full_weight(self, value: float):
         self._full_weight = value
 
     @property
     def spool_ratio(self) -> float:
         return self._spool_ratio
     @spool_ratio.setter
-    def spool_ratio(self, value: float) -> None:
+    def spool_ratio(self, value: float):
         self._spool_ratio = value
 
     @property
     def max_motor_rpm(self) -> float:
         return self._max_motor_rpm
     @max_motor_rpm.setter
-    def max_motor_rpm(self, value: float) -> None:
+    def max_motor_rpm(self, value: float):
         self._max_motor_rpm = value
 
     @property
     def espool_rot_dist(self) -> float:
         return self._espool_rot_dist
     @espool_rot_dist.setter
-    def espool_rot_dist(self, value: float) -> None:
+    def espool_rot_dist(self, value: float):
         self._espool_rot_dist = value
 
     @property
     def spool_outer_diameter(self) -> float:
         return self._spool_outer_diameter
     @spool_outer_diameter.setter
-    def spool_outer_diameter(self, value: float) -> None:
+    def spool_outer_diameter(self, value: float):
         self._spool_outer_diameter = value
 
     @property
     def spool_inner_diameter(self) -> float:
         return self._spool_inner_diameter
     @spool_inner_diameter.setter
-    def spool_inner_diameter(self, value: float) -> None:
+    def spool_inner_diameter(self, value: float):
         self._spool_inner_diameter = value
 
 class Espooler:
@@ -584,7 +586,7 @@ class Espooler:
         """
         print_time = time = 0.0
         if self.lane_obj.weight < self.enable_assist_weight:
-            time=self.afc.toolhead.get_last_move_time()
+            time = self.afc.toolhead.get_last_move_time()
             print_time = self._kick_start()
 
             self.move_forwards( print_time, 1 )

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -158,7 +158,7 @@ class AFCLane:
 
         self.filament_diameter  = config.getfloat("filament_diameter", 1.75)    # Diameter of filament being used
         self.filament_density   = config.getfloat("filament_density", 1.24)     # Density of filament being used
-        self.inner_diameter     = config.getfloat("spool_inner_diameter", 75)  # Inner diameter in mm
+        self.inner_diameter     = config.getfloat("spool_inner_diameter", 75)   # Inner diameter in mm
         self.outer_diameter     = config.getfloat("spool_outer_diameter", 200)  # Outer diameter in mm
         self.empty_spool_weight = config.getfloat("empty_spool_weight", 190)    # Empty spool weight in g
         self.max_motor_rpm      = config.getfloat("assist_max_motor_rpm", 465)  # Max motor RPM

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -158,10 +158,10 @@ class AFCLane:
 
         self.filament_diameter  = config.getfloat("filament_diameter", 1.75)    # Diameter of filament being used
         self.filament_density   = config.getfloat("filament_density", 1.24)     # Density of filament being used
-        self.inner_diameter     = config.getfloat("spool_inner_diameter", 100)  # Inner diameter in mm
+        self.inner_diameter     = config.getfloat("spool_inner_diameter", 75)  # Inner diameter in mm
         self.outer_diameter     = config.getfloat("spool_outer_diameter", 200)  # Outer diameter in mm
         self.empty_spool_weight = config.getfloat("empty_spool_weight", 190)    # Empty spool weight in g
-        self.max_motor_rpm      = config.getfloat("assist_max_motor_rpm", 500)  # Max motor RPM
+        self.max_motor_rpm      = config.getfloat("assist_max_motor_rpm", 465)  # Max motor RPM
         self.rwd_speed_multi    = config.getfloat("rwd_speed_multiplier", 0.5)  # Multiplier to apply to rpm
         self.fwd_speed_multi    = config.getfloat("fwd_speed_multiplier", 0.5)  # Multiplier to apply to rpm
         self.diameter_range     = self.outer_diameter - self.inner_diameter     # Range for effective diameter

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -158,9 +158,9 @@ class AFCLane:
 
         self.filament_diameter  = config.getfloat("filament_diameter", 1.75)    # Diameter of filament being used
         self.filament_density   = config.getfloat("filament_density", 1.24)     # Density of filament being used
-        self.inner_diameter     = config.getfloat("spool_inner_diameter", 75)   # Inner diameter in mm
-        self.outer_diameter     = config.getfloat("spool_outer_diameter", 200)  # Outer diameter in mm
-        self.empty_spool_weight = config.getfloat("empty_spool_weight", 190)    # Empty spool weight in g
+        self.inner_diameter     = config.getfloat("spool_inner_diameter", 75, minval=1)   # Inner diameter in mm
+        self.outer_diameter     = config.getfloat("spool_outer_diameter", 200, minval=100)  # Outer diameter in mm
+        self.empty_spool_weight = config.getfloat("empty_spool_weight", 190, minval=1)    # Empty spool weight in g
         self.max_motor_rpm      = config.getfloat("assist_max_motor_rpm", 465)  # Max motor RPM
         self.rwd_speed_multi    = config.getfloat("rwd_speed_multiplier", 0.5)  # Multiplier to apply to rpm
         self.fwd_speed_multi    = config.getfloat("fwd_speed_multiplier", 0.5)  # Multiplier to apply to rpm

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -317,6 +317,7 @@ class AFCSpool:
                     cur_lane.filament_diameter  = self._get_filament_values(result['filament'], 'diameter')
                     cur_lane.empty_spool_weight = self._get_filament_values(result, 'spool_weight', default=190)
                     cur_lane.weight             = self._get_filament_values(result, 'remaining_weight')
+                    cur_lane.espooler.espooler_values.full_weight = self._get_filament_values(result, 'initial_weight', default=1000)
 
                     weight_check = self.disable_weight_check
 

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -69,7 +69,10 @@ class afcUnit:
         self.timer_delay            = config.getfloat("timer_delay",            5)
         # Setting to True enables full speed espoolers for kick_start_time amount
         self.enable_kick_start      = config.getboolean("enable_kick_start",    True)
-
+        self.spool_ratio            = config.getfloat("spool_ratio",2) #gear ratio for printed gearbox between N20 and spooler wheels
+        self.full_weight	        = config.getfloat("full_weight",1000)           # full weight of filament spill (no counting spool itself)
+        self.espool_rot_dist        = config.getfloat("espool_rot_dist",132.9)
+        
         # Time in seconds to enable spooler at full speed to help with getting the spool to spin
         self.kick_start_time        = config.getfloat("kick_start_time",        0.070)
         # Cycles per rotation in milliseconds

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -70,7 +70,7 @@ class afcUnit:
         # Setting to True enables full speed espoolers for kick_start_time amount
         self.enable_kick_start      = config.getboolean("enable_kick_start",    True)
         self.spool_ratio            = config.getfloat("spool_ratio",2) #gear ratio for printed gearbox between N20 and spooler wheels
-        self.full_weight	        = config.getfloat("full_weight",1000)           # full weight of filament spill (no counting spool itself)
+        self.full_weight            = config.getfloat("full_weight",1000)           # full weight of filament spool (no counting spool itself)
         self.espool_rot_dist        = config.getfloat("espool_rot_dist",132.9)
 
         # Time in seconds to enable spooler at full speed to help with getting the spool to spin

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -72,18 +72,12 @@ class afcUnit:
         self.spool_ratio            = config.getfloat("spool_ratio",2) #gear ratio for printed gearbox between N20 and spooler wheels
         self.full_weight	        = config.getfloat("full_weight",1000)           # full weight of filament spill (no counting spool itself)
         self.espool_rot_dist        = config.getfloat("espool_rot_dist",132.9)
-        
+
         # Time in seconds to enable spooler at full speed to help with getting the spool to spin
         self.kick_start_time        = config.getfloat("kick_start_time",        0.070)
-        # Cycles per rotation in milliseconds
-        self.cycles_per_rotation    = config.getfloat("cycles_per_rotation",    800)
-        # PWM cycle time
-        self.pwm_value              = config.getfloat("pwm_value",              0.6706)
         # Delta amount in mm from last move to trigger assist
         self.delta_movement         = config.getfloat("delta_movement",         150)
-        # Amount to move in mm once filament has moved by delta movement amount
-        self.mm_movement            = config.getfloat("mm_movement",            150)
-        # Scaling factor for the following variables: kick_start_time, spool_outer_diameter, cycles_per_rotation, pwm_value, delta_movement, mm_movement
+        # Scaling factor for the following variables: kick_start_time, spool_outer_diameter, delta_movement
         self.scaling                = config.getfloat("spoolrate",              1.0)
 
         # If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool. Setting value here overrides values set in AFC.cfg file


### PR DESCRIPTION
## Major Changes in this PR
- Updates are from @dragoonmc that makes the print assist scale more linearly with spool weight allowing it to be on all the time instead of only on light spools

Breaking changes if user have the following variables defined then they will need to remove them:
- cycles_per_rotation, pwm_value, mm_movement

Graph of cruise time compared to spool weight
<img width="605" height="340" alt="image" src="https://github.com/user-attachments/assets/abc952e2-8917-4472-8367-91073e8536ca" />

## Notes to Code Reviewers

## How the changes in this PR are tested
- Tested changes with spools weighing between 100-200 grams

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.