### PR TITLE
Fix AFC_TOGGLE_MACRO reporting of Wipe status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-12-11]
+### Fixed
+- Fix output of `AFC_TOGGLE_MACRO` to correctly report state of WIPE macro
+
 ## [2025-12-06]
 ### Fixed
 - Fixes issue where klipper would crash for HTLF units when homing and moving lanes during prep

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -579,7 +579,7 @@ class afc:
 
         self.logger.info("Tool Cut {}, Park {}".format(self.tool_cut, self.park))
         self.logger.info("Kick {}, Poop {}".format(self.kick, self.poop))
-        self.logger.info("Wipe {}, Form tip {}".format(self.tool_cut, self.form_tip))
+        self.logger.info("Wipe {}, Form tip {}".format(self.wipe, self.form_tip))
 
     cmd_AFC_QUIET_MODE_help = "Set quiet mode speed and enable/disable quiet mode"
     cmd_AFC_QUIET_MODE_options = {"SPEED": {"type": "float", "default": 50},


### PR DESCRIPTION
## Major Changes in this PR
AFC_TOGGLE_MACRO was reporting WIPE macro status against self.tool_cut, not self.wipe.  This PR corrects that.

## Notes to Code Reviewers

## How the changes in this PR are tested
Run `AFC_TOGGLE_MACRO WIPE=0` and `AFC_TOGGLE_MACRO WIPE=1` and confirm states are reported correctly.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.scp ext