### PR TITLE
Adding a check to make sure 'standalone' extruder don't have buffer for pin_tool_start defined

### DIFF
--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -171,6 +171,12 @@ class AFCExtruder:
             self.no_lanes = True
             self.logger.info(f"{self.name} no lanes")
 
+            if self.tool_start == "buffer":
+                raise error(
+                    f"buffer is not valid config for pin_tool_start when using {self.name} as a standalone extruder"
+                )
+
+
 
     def handle_connect(self):
         """

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -362,7 +362,9 @@ class AFCLane:
                 raise error(error_string)
 
         # Checking if buffer was defined in extruder if not defined in unit/stepper
-        elif self.buffer_obj is None and self.extruder_obj.tool_start == "buffer":
+        elif (self.buffer_obj is None
+              and self.extruder_obj.tool_start == "buffer"
+              and len(self.extruder_obj.lanes) > 1):
             if self.extruder_obj.buffer_name is not None:
                 self.buffer_obj = self.printer.lookup_object("AFC_buffer {}".format(self.extruder_obj.buffer_name))
             else:


### PR DESCRIPTION
## Major Changes in this PR
- Added a check to make sure `buffer` is not defined for standalone toolheads as this is not a valid config.

## Notes to Code Reviewers

## How the changes in this PR are tested
Tested with toolchanger and created a standalone toolhead with buffer as pin_tool_start

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [ ] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.