### PR TITLE
[Enhancement] Added ability to use TD-1 for direct lanes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2025-12-14]
 ## Added
 - Ability to use TD-1 device on direct load lanes
-- td1_device_id is not required to scan filament
+- td1_device_id is now required to scan filament
 
 ## [2025-11-23]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-12-14]
+## Added
+- Ability to use TD-1 device on direct load lanes
+- td1_device_id is not required to scan filament
+
 ## [2025-11-23]
 ### Added
 - Toolchanger: Adding ability to control/swap toolheads that do not have a unit(BoxTurtle, HTLF, etc) attached to the toolhead.

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1152,6 +1152,7 @@ class afc:
                 cur_lane.unit_obj.lane_tool_loaded( cur_lane )
                 self.save_vars()
                 self.current_state = State.IDLE
+                cur_lane.get_td1_data_load()
                 load_time = self.afcDeltaTime.log_major_delta("{} is now loaded in toolhead".format(cur_lane.name), False)
                 self.afc_stats.average_tool_load_time.average_time(load_time)
 

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -231,7 +231,7 @@ class afcBoxTurtle(afcUnit):
         """
         bow_pos = 0
         cur_hub = cur_lane.hub_obj
-        #TODO: Add calibration support for direct loads
+        #TODO: Add calibration support for direct loads remove before completing pr
 
         # Verify TD-1 is still connected before trying to get data
         if not self.afc.td1_present:
@@ -244,18 +244,28 @@ class afcBoxTurtle(afcUnit):
                 return valid, msg, 0
 
         self.logger.raw(f"Calibrating bowden length to TD-1 device with {cur_lane.name}")
-        hub_pos, checkpoint, success = self.move_until_state(cur_lane, lambda: cur_hub.state, cur_hub.move_dis, tol,
-                                                             cur_lane.short_move_dis, 0, cur_lane.dist_hub + cur_lane.hub_obj.move_dis + 200, "Moving to hub")
+        if not cur_lane.is_direct_hub():
+            fault_dis = cur_lane.dist_hub + cur_lane.hub_obj.move_dis + 200
+            hub_pos, checkpoint, success = self.move_until_state(cur_lane, lambda: cur_hub.state,
+                                                                 cur_hub.move_dis, tol,
+                                                                 cur_lane.short_move_dis, 0,
+                                                                 fault_dis,
+                                                                 "Moving to hub")
 
-        if not success:
-            # if movement does not succeed fault and return values to calibration macro
-            msg = 'Failed {} after {}mm'.format(checkpoint, hub_pos)
-            cur_lane.do_enable(False)
-            return False, msg, hub_pos
+            if not success:
+                # if movement does not succeed fault and return values to calibration macro
+                msg = 'Failed {} after {}mm'.format(checkpoint, hub_pos)
+                cur_lane.do_enable(False)
+                return False, msg, hub_pos
 
         compare_time = datetime.now()
         while not self.get_td1_data(cur_lane, compare_time):
-            if bow_pos > cur_hub.afc_bowden_length:
+            max_bowden_length = 0
+            if cur_lane.is_direct_hub():
+                max_bowden_length = cur_lane.dist_hub
+            else:
+                max_bowden_length = cur_hub.afc_bowden_length
+            if bow_pos > max_bowden_length:
                 # fault if move to TD-1 is not detected
                 msg = 'TD-1 failed to detect filament after moving {}mm'.format(bow_pos)
                 cur_lane.do_enable(False)
@@ -269,19 +279,26 @@ class afcBoxTurtle(afcUnit):
 
         cur_lane.move(bow_pos * -1, cur_lane.long_moves_speed, cur_lane.long_moves_accel, True)
 
-        # Reset to hub
-        self.calc_position(cur_lane, lambda: cur_lane.hub_obj.state, 0,
-                           cur_lane.short_move_dis, tol, 200, checkpoint)
+        if not cur_lane.is_direct_hub():
+            # Reset to hub
+            self.calc_position(cur_lane, lambda: cur_lane.hub_obj.state, 0,
+                                cur_lane.short_move_dis, tol, 200, checkpoint)
 
-        cur_lane.move(cur_hub.hub_clear_move_dis * -1, cur_lane.short_moves_speed, cur_lane.short_moves_accel, True)
+            cur_lane.move(cur_hub.hub_clear_move_dis * -1, cur_lane.short_moves_speed, cur_lane.short_moves_accel, True)
 
         cal_msg = f"\n td1_bowden_length: New: {bow_pos} Old: {cur_hub.td1_bowden_length}"
-        cur_hub.td1_bowden_length = bow_pos
-        self.afc.function.ConfigRewrite(cur_hub.fullname, "td1_bowden_length", bow_pos, cal_msg)
+
+        if cur_lane.is_direct_hub():
+            cur_lane.td1_bowden_length = bow_pos
+            fullname = cur_lane.fullname
+        else:
+            cur_hub.td1_bowden_length = bow_pos
+            fullname = cur_hub.fullname
+
+        self.afc.function.ConfigRewrite(fullname, "td1_bowden_length", bow_pos, cal_msg)
 
         cur_lane.do_enable(False)
         self.afc.save_vars()
-        # self.logger.info(f"td1_bowden_length: {bow_pos}")
         return True, "td1_bowden_length calibration successful", bow_pos
 
     # Helper functions for movement and calibration

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -286,7 +286,7 @@ class afcBoxTurtle(afcUnit):
 
             cur_lane.move(cur_hub.hub_clear_move_dis * -1, cur_lane.short_moves_speed, cur_lane.short_moves_accel, True)
 
-        cal_msg = f"\n td1_bowden_length: New: {bow_pos} Old: {cur_hub.td1_bowden_length}"
+        cal_msg = f"\n td1_bowden_length: New: {bow_pos} Old: {cur_lane.td1_bowden_length}"
 
         if cur_lane.is_direct_hub():
             cur_lane.td1_bowden_length = bow_pos

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -4,6 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import traceback
+import textwrap
 
 from configparser import Error as error
 from datetime import datetime
@@ -231,17 +232,22 @@ class afcBoxTurtle(afcUnit):
         """
         bow_pos = 0
         cur_hub = cur_lane.hub_obj
-        #TODO: Add calibration support for direct loads remove before completing pr
 
-        # Verify TD-1 is still connected before trying to get data
-        if not self.afc.td1_present:
-            msg = "TD-1 device not detected anymore, please check before continuing to calibrate TD-1 bowden length"
+        if cur_lane.td1_device_id is None:
+            msg = textwrap.dedent(f"""/
+                Cannot calibrate TD-1 for {cur_lane.name}, td1_device_id is a required 
+                field in AFC_hub or per AFC_lane"""
+            )
             return False, msg, 0
 
-        if cur_lane.td1_device_id:
-            valid, msg = self.afc.function.check_for_td1_id(cur_lane.td1_device_id)
-            if not valid:
-                return valid, msg, 0
+        # Verify TD-1 is still connected before trying to get data
+        valid, msg = self.afc.function.check_for_td1_id(cur_lane.td1_device_id)
+        if not valid:
+            msg = textwrap.dedent(f"""\
+                TD-1 device(SN: {cur_lane.td1_device_id}) not detected anymore, please check 
+                before continuing to calibrate TD-1 bowden length"""
+            )
+            return valid, msg, 0
 
         self.logger.raw(f"Calibrating bowden length to TD-1 device with {cur_lane.name}")
         if not cur_lane.is_direct_hub():

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -4,7 +4,6 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import traceback
-import textwrap
 
 from configparser import Error as error
 from datetime import datetime
@@ -213,6 +212,7 @@ class afcBoxTurtle(afcUnit):
                 cur_lane.loaded_to_hub  = True
 
             cur_lane.do_enable(False)
+            cur_lane.unit_obj.return_to_home()
             self.afc.save_vars()
             return True, f"{variable_name} successful", bowden_dist
         else:
@@ -234,19 +234,15 @@ class afcBoxTurtle(afcUnit):
         cur_hub = cur_lane.hub_obj
 
         if cur_lane.td1_device_id is None:
-            msg = textwrap.dedent(f"""/
-                Cannot calibrate TD-1 for {cur_lane.name}, td1_device_id is a required 
-                field in AFC_hub or per AFC_lane"""
-            )
+            msg = f"Cannot calibrate TD-1 for {cur_lane.name}, td1_device_id is a required "
+            msg += "field in AFC_hub or per AFC_lane"
             return False, msg, 0
 
         # Verify TD-1 is still connected before trying to get data
         valid, msg = self.afc.function.check_for_td1_id(cur_lane.td1_device_id)
         if not valid:
-            msg = textwrap.dedent(f"""\
-                TD-1 device(SN: {cur_lane.td1_device_id}) not detected anymore, please check 
-                before continuing to calibrate TD-1 bowden length"""
-            )
+            msg = f"TD-1 device(SN: {cur_lane.td1_device_id}) not detected anymore, "
+            msg += "please check before continuing to calibrate TD-1 bowden length"
             return valid, msg, 0
 
         self.logger.raw(f"Calibrating bowden length to TD-1 device with {cur_lane.name}")
@@ -302,8 +298,8 @@ class afcBoxTurtle(afcUnit):
             fullname = cur_hub.fullname
 
         self.afc.function.ConfigRewrite(fullname, "td1_bowden_length", bow_pos, cal_msg)
-
         cur_lane.do_enable(False)
+        cur_lane.unit_obj.return_to_home()
         self.afc.save_vars()
         return True, "td1_bowden_length calibration successful", bow_pos
 

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -261,12 +261,12 @@ class afcBoxTurtle(afcUnit):
                 return False, msg, hub_pos
 
         compare_time = datetime.now()
+        max_bowden_length = 0
+        if cur_lane.is_direct_hub():
+            max_bowden_length = cur_lane.dist_hub
+        else:
+            max_bowden_length = cur_hub.afc_bowden_length
         while not self.get_td1_data(cur_lane, compare_time):
-            max_bowden_length = 0
-            if cur_lane.is_direct_hub():
-                max_bowden_length = cur_lane.dist_hub
-            else:
-                max_bowden_length = cur_hub.afc_bowden_length
             if bow_pos > max_bowden_length:
                 # fault if move to TD-1 is not detected
                 msg = 'TD-1 failed to detect filament after moving {}mm'.format(bow_pos)

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -177,7 +177,6 @@ class AFCExtruder:
                 )
 
 
-
     def handle_connect(self):
         """
         Handle the connection event.

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -1495,7 +1495,7 @@ class afcFunction:
 
         # Create buttons for each lane and group every 4 lanes together
         for lane in self.afc.lanes.values():
-            if lane.load_state:
+            if lane.td1_device_id and lane.load_state:
                 button_label = "{}".format(lane)
                 button_command = "AFC_GET_TD_ONE_LANE_DATA LANE={}".format(lane)
                 button_style = "primary" if index % 2 == 0 else "secondary"
@@ -1546,7 +1546,9 @@ class afcFunction:
         if lane.lower() == "all":
             self.logger.info("Capturing TD-1 data for all lanes")
             for cur_lane in self.afc.lanes.values():
-                if cur_lane.load_state and cur_lane.prep_state:
+                if (cur_lane.td1_device_id
+                    and cur_lane.load_state
+                    and cur_lane.prep_state):
                     success, msg = cur_lane.get_td1_data()
                     if not success:
                         self.afc.gcode.run_script_from_command(f"AFC_CALI_FAIL TITLE='Get TD-1 data Failed' FAIL={cur_lane} DISTANCE=0 msg='{msg}' RESET=0")

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -1193,7 +1193,7 @@ class afcFunction:
             if (td1_lane.is_direct_hub()
                 and td1_lane.tool_loaded):
                 msg = textwrap.dedent(f"""\
-                    {self.name} loaded to toolhead, unload from toolhead before trying to calibrate
+                    {td1_lane.name} loaded to toolhead, unload from toolhead before trying to calibrate
                     td1_bowden_length."""
                 )
                 self.afc.error.AFC_error(msg, pause=False)

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -14,7 +14,6 @@ import random
 import re
 import traceback
 import configparser
-import textwrap
 
 from configfile import error
 from datetime import datetime
@@ -1192,10 +1191,8 @@ class afcFunction:
             td1_lane = self.afc.lanes[td1]
             if (td1_lane.is_direct_hub()
                 and td1_lane.tool_loaded):
-                msg = textwrap.dedent(f"""\
-                    {td1_lane.name} loaded to toolhead, unload from toolhead before trying to calibrate
-                    td1_bowden_length."""
-                )
+                msg = f"{td1_lane.name} loaded to toolhead, unload from toolhead before "
+                msg += "trying to calibrate td1_bowden_length."
                 self.afc.error.AFC_error(msg, pause=False)
                 return
             if td1_lane.hub_obj.state:
@@ -1206,7 +1203,7 @@ class afcFunction:
 
             checked, msg, pos = td1_lane.unit_obj.calibrate_td1( td1_lane, dis, tol)
             if not checked:
-                fail_string = f"{td1} failed to calibrate bowden length {msg}"
+                fail_string = f"{td1} failed to calibrate TD-1 bowden length, {msg}"
                 self.afc.error.AFC_error(fail_string, pause=False)
                 self.afc.gcode.run_script_from_command(f"AFC_CALI_FAIL TITLE='{title} Failed' FAIL={td1} DISTANCE={pos} msg='{fail_string}' RESET=1")
                 return

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -14,6 +14,7 @@ import random
 import re
 import traceback
 import configparser
+import textwrap
 
 from configfile import error
 from datetime import datetime
@@ -1189,6 +1190,14 @@ class afcFunction:
         if td1 is not None:
             title = "TD-1 Calibration"
             td1_lane = self.afc.lanes[td1]
+            if (td1_lane.is_direct_hub()
+                and td1_lane.tool_loaded):
+                msg = textwrap.dedent(f"""\
+                    {self.name} loaded to toolhead, unload from toolhead before trying to calibrate
+                    td1_bowden_length."""
+                )
+                self.afc.error.AFC_error(msg, pause=False)
+                return
             if td1_lane.hub_obj.state:
                 msg = f"{td1_lane.hub_obj.name} hub is triggered, make sure hub is clear before trying to calibrate TD-1 bowden length"
                 self.afc.error.AFC_error(msg, pause=False)

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import math
 import traceback
-import textwrap
 
 from contextlib import contextmanager
 from configfile import error
@@ -656,7 +655,8 @@ class AFCLane:
                 self.set_loaded()
 
                 # Check if user wants to get TD-1 data when loading
-                if not self.tool_loaded:
+                if (self.td1_device_id
+                    and not self.tool_loaded):
                     self._prep_capture_td1()
 
                 if self.hub == 'direct_load':
@@ -749,7 +749,8 @@ class AFCLane:
                         self.loaded_to_hub = True
 
                     self.do_enable(False)
-                    if self.load_state == True and self.prep_state == True:
+                    if (self.td1_device_id
+                        and self.load_state == True and self.prep_state == True):
                         self.set_loaded()
                         # Check if user wants to get TD-1 data when loading
                         # TODO: When implementing multi-extruder this could still happen if a lane is loaded for a
@@ -1185,19 +1186,15 @@ class AFCLane:
         msg = ""
         
         if self.td1_device_id is None:
-            msg = textwrap.dedent(f"""/
-                Cannot grab TD-1 data for {self.name}, td1_device_id is a required 
-                field in AFC_hub or per AFC_lane"""
-            )
+            msg = f"Cannot grab TD-1 data for {self.name}, td1_device_id is a required "
+            msg += "field in AFC_hub or per AFC_lane"
             self.afc.error.AFC_error(msg, pause=False)
             return False, msg
 
         if self.td1_bowden_length is None:
-            msg = textwrap.dedent(f"""\
-                td1_bowden_length is not set for {self.name}.
-                Please run AFC_CALIBRATION to calibrate TD1 length for lane before trying to
-                capture TD1 data."""
-            )
+            msg = f"td1_bowden_length is not set for {self.name}. "
+            msg += "Please run AFC_CALIBRATION to calibrate TD1 length for "
+            msg += "lane before trying to capture TD1 data."
             self.afc.error.AFC_error(msg, pause=False)
             return False, msg
 
@@ -1213,10 +1210,8 @@ class AFCLane:
 
         if (self.is_direct_hub()
             and self.tool_loaded):
-            msg = textwrap.dedent(f"""\
-                {self.name} loaded to toolhead, unload from toolhead before trying to capture
-                TD1 data."""
-            )
+            msg = f"{self.name} loaded to toolhead, unload from toolhead before trying "
+            msg += "to capture TD1 data."
             self.afc.error.AFC_error(msg, pause=False)
             return False, msg
 
@@ -1277,6 +1272,7 @@ class AFCLane:
                     max_move_tries += 1
 
                 self.move_auto_speed(self.hub_obj.hub_clear_move_dis * -1)
+            self.unit_obj.return_to_home()
             self.do_enable(False)
 
         else:

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -1168,7 +1168,7 @@ class AFCLane:
 
     def get_td1_data_load(self):
         if self.afc.td1_present:
-            valid = True
+            valid = False
             if self.td1_device_id:
                 valid, _ = self.afc.function.check_for_td1_id(self.td1_device_id)
             
@@ -1183,6 +1183,15 @@ class AFCLane:
         max_move_tries = 0
         status = True
         msg = ""
+        
+        if self.td1_device_id is None:
+            msg = textwrap.dedent(f"""/
+                Cannot grab TD-1 data for {self.name}, td1_device_id is a required 
+                field in AFC_hub or per AFC_lane"""
+            )
+            self.afc.error.AFC_error(msg, pause=False)
+            return False, msg
+
         if self.td1_bowden_length is None:
             msg = textwrap.dedent(f"""\
                 td1_bowden_length is not set for {self.name}.
@@ -1212,17 +1221,10 @@ class AFCLane:
             return False, msg
 
         # Verify TD-1 is still connected before trying to get data
-        if not self.afc.td1_present:
-            msg = "TD-1 device not detected anymore, please check before continuing to capture TD-1 data"
+        valid, msg = self.afc.function.check_for_td1_id(self.td1_device_id)
+        if not valid:
             self.afc.error.AFC_error(msg, pause=False)
             return False, msg
-
-        # If user has specified a specific ID, verify that its connected and found
-        if self.td1_device_id:
-            valid, msg = self.afc.function.check_for_td1_id(self.td1_device_id)
-            if not valid:
-                self.afc.error.AFC_error(msg, pause=False)
-                return False, msg
         else:
             error, msg = self.afc.function.check_for_td1_error()
             if error:

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -1167,6 +1167,15 @@ class AFCLane:
             }
             self.afc.moonraker.send_lane_data(lane_data)
 
+    def get_td1_data_load(self):
+        if self.afc.td1_present:
+            valid = True
+            if self.td1_device_id:
+                valid, _ = self.afc.function.check_for_td1_id(self.td1_device_id)
+            
+            if valid:
+                self.unit_obj.get_td1_data(self, datetime.now(), ignore_time=True)
+
     def get_td1_data(self):
         """
         Captures TD-1 data for lane. Has error checking to verify that lane is loaded, hub is not blocked

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -1168,6 +1168,10 @@ class AFCLane:
             self.afc.moonraker.send_lane_data(lane_data)
 
     def get_td1_data_load(self):
+        """
+        Captures TD-1 data for a lane after being loaded into toolhead. When capturing
+        data scan time is ignored as its assumed its scanned when loaded into toolhead.
+        """
         if self.afc.td1_present:
             valid = False
             if self.td1_device_id:

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -157,7 +157,7 @@ class AFCLane:
         self.assisted_unload    = config.getboolean("assisted_unload", None) # If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
         self.td1_when_loaded    = config.getboolean("capture_td1_when_loaded", None)
         self.td1_device_id      = config.get("td1_device_id", None)
-        self.td1_bowden_length  = config.get("td1_bowden_length", None)
+        self.td1_bowden_length  = config.getfloat("td1_bowden_length", None)
 
 
         self.printer.register_event_handler("AFC_unit_{}:connect".format(self.unit),self.handle_unit_connect)
@@ -402,9 +402,8 @@ class AFCLane:
         if self.td1_when_loaded             is None: self.td1_when_loaded   = self.unit_obj.td1_when_loaded
         if self.td1_device_id               is None: self.td1_device_id     = self.unit_obj.td1_device_id
         if self.td1_bowden_length           is None:
-            if self.hub_obj:
+            if not self.is_direct_hub():
                 self.td1_bowden_length = self.hub_obj.td1_bowden_length
-
         if self.rev_long_moves_speed_factor < 0.5: self.rev_long_moves_speed_factor = 0.5
         if self.rev_long_moves_speed_factor > 1.2: self.rev_long_moves_speed_factor = 1.2
 
@@ -1186,7 +1185,7 @@ class AFCLane:
         msg = ""
         if self.td1_bowden_length is None:
             msg = textwrap.dedent(f"""\
-                td1_bowden_length is not set for lane '{self.name}'\n
+                td1_bowden_length is not set for {self.name}.
                 Please run AFC_CALIBRATION to calibrate TD1 length for lane before trying to
                 capture TD1 data."""
             )

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import math
 import traceback
+import textwrap
 
 from contextlib import contextmanager
 from configfile import error
@@ -156,6 +157,7 @@ class AFCLane:
         self.assisted_unload    = config.getboolean("assisted_unload", None) # If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
         self.td1_when_loaded    = config.getboolean("capture_td1_when_loaded", None)
         self.td1_device_id      = config.get("td1_device_id", None)
+        self.td1_bowden_length  = config.get("td1_bowden_length", None)
 
 
         self.printer.register_event_handler("AFC_unit_{}:connect".format(self.unit),self.handle_unit_connect)
@@ -399,6 +401,9 @@ class AFCLane:
         if self.max_move_dis                is None: self.max_move_dis      = self.unit_obj.max_move_dis
         if self.td1_when_loaded             is None: self.td1_when_loaded   = self.unit_obj.td1_when_loaded
         if self.td1_device_id               is None: self.td1_device_id     = self.unit_obj.td1_device_id
+        if self.td1_bowden_length           is None:
+            if self.hub_obj:
+                self.td1_bowden_length = self.hub_obj.td1_bowden_length
 
         if self.rev_long_moves_speed_factor < 0.5: self.rev_long_moves_speed_factor = 0.5
         if self.rev_long_moves_speed_factor > 1.2: self.rev_long_moves_speed_factor = 1.2
@@ -1170,6 +1175,15 @@ class AFCLane:
         max_move_tries = 0
         status = True
         msg = ""
+        if self.td1_bowden_length is None:
+            msg = textwrap.dedent(f"""\
+                td1_bowden_length is not set for lane '{self.name}'\n
+                Please run AFC_CALIBRATION to calibrate TD1 length for lane before trying to
+                capture TD1 data."""
+            )
+            self.afc.error.AFC_error(msg, pause=False)
+            return False, msg
+
         if not self.load_state and not self.prep_state:
             msg = f"{self.name} not loaded, cannot capture TD-1 data for lane"
             self.afc.error.AFC_error(msg, pause=False)
@@ -1177,6 +1191,15 @@ class AFCLane:
 
         if self.hub_obj.state:
             msg = f"Hub for {self.name} detects filament, cannot capture TD-1 data for lane"
+            self.afc.error.AFC_error(msg, pause=False)
+            return False, msg
+
+        if (self.is_direct_hub()
+            and self.tool_loaded):
+            msg = textwrap.dedent(f"""\
+                {self.name} loaded to toolhead, unload from toolhead before trying to capture
+                TD1 data."""
+            )
             self.afc.error.AFC_error(msg, pause=False)
             return False, msg
 
@@ -1198,50 +1221,52 @@ class AFCLane:
                 return False, msg
 
         if not self.hub_obj.state:
-            if not self.loaded_to_hub:
-                self.move_auto_speed(self.dist_hub)
+            if not self.is_direct_hub():
+                if not self.loaded_to_hub:
+                    self.move_auto_speed(self.dist_hub)
 
-            while not self.hub_obj.state:
-                if max_move_tries >= self.afc.max_move_tries:
-                    fail_message = f"Failed to trigger hub {self.hub_obj.name} for {self.name}\n"
-                    fail_message += "Cannot capture TD-1 data, verify that hub switch is properly working before continuing"
-                    self.afc.error.AFC_error(fail_message, pause=False)
-                    self.do_enable(False)
-                    return False, fail_message
+                while not self.hub_obj.state:
+                    if max_move_tries >= self.afc.max_move_tries:
+                        fail_message = f"Failed to trigger hub {self.hub_obj.name} for {self.name}\n"
+                        fail_message += "Cannot capture TD-1 data, verify that hub switch is properly working before continuing"
+                        self.afc.error.AFC_error(fail_message, pause=False)
+                        self.do_enable(False)
+                        return False, fail_message
 
-                if max_move_tries == 0:
-                    self.move_auto_speed(self.hub_obj.move_dis)
-                else:
-                    self.move_auto_speed(self.short_move_dis)
-                max_move_tries += 1
+                    if max_move_tries == 0:
+                        self.move_auto_speed(self.hub_obj.move_dis)
+                    else:
+                        self.move_auto_speed(self.short_move_dis)
+                    max_move_tries += 1
 
             compare_time = datetime.now()
-            self.move_auto_speed(self.hub_obj.td1_bowden_length)
+            self.move_auto_speed(self.td1_bowden_length)
             self.afc.reactor.pause(self.afc.reactor.monotonic() + 5)
 
             success = self.unit_obj.get_td1_data(self, compare_time)
             if not success:
-                msg = f"Not able to gather TD-1 data after moving {self.hub_obj.td1_bowden_length}mm"
+                msg = f"Not able to gather TD-1 data after moving {self.td1_bowden_length}mm"
                 self.afc.error.AFC_error(msg, pause=False)
                 status = False
 
-            self.move_auto_speed(self.hub_obj.td1_bowden_length * -1)
+            self.move_auto_speed(self.td1_bowden_length * -1)
             if success:
                 self.send_lane_data()
 
-            max_move_tries = 0
-            while( self.hub_obj.state ):
-                if max_move_tries >= self.afc.max_move_tries:
-                    fail_message = f"Failed to un-trigger hub {self.hub_obj.name} for {self.name}\n"
-                    fail_message += "Verify that hub switch is properly working before continuing"
-                    self.afc.error.AFC_error(fail_message, pause=False)
-                    self.do_enable(False)
-                    return False, fail_message
+            if not self.is_direct_hub():
+                max_move_tries = 0
+                while( self.hub_obj.state ):
+                    if max_move_tries >= self.afc.max_move_tries:
+                        fail_message = f"Failed to un-trigger hub {self.hub_obj.name} for {self.name}\n"
+                        fail_message += "Verify that hub switch is properly working before continuing"
+                        self.afc.error.AFC_error(fail_message, pause=False)
+                        self.do_enable(False)
+                        return False, fail_message
 
-                self.move_auto_speed(self.short_move_dis * -1)
-                max_move_tries += 1
+                    self.move_auto_speed(self.short_move_dis * -1)
+                    max_move_tries += 1
 
-            self.move_auto_speed(self.hub_obj.hub_clear_move_dis * -1)
+                self.move_auto_speed(self.hub_obj.hub_clear_move_dis * -1)
             self.do_enable(False)
 
         else:

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -1172,7 +1172,7 @@ class AFCLane:
             valid = False
             if self.td1_device_id:
                 valid, _ = self.afc.function.check_for_td1_id(self.td1_device_id)
-            
+
             if valid:
                 self.unit_obj.get_td1_data(self, datetime.now(), ignore_time=True)
 
@@ -1184,7 +1184,7 @@ class AFCLane:
         max_move_tries = 0
         status = True
         msg = ""
-        
+
         if self.td1_device_id is None:
             msg = f"Cannot grab TD-1 data for {self.name}, td1_device_id is a required "
             msg += "field in AFC_hub or per AFC_lane"

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -77,7 +77,8 @@ class afcPrep:
                 else:
                     self.logger.info("Capturing TD-1 data for all loaded lanes")
                     for lane in self.afc.lanes.values():
-                        if lane.load_state and lane.prep_state:
+                        if (lane.td1_device_id
+                            and lane.load_state and lane.prep_state):
                             return_status, msg = lane.get_td1_data()
                             if not return_status:
                                 break

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -477,7 +477,7 @@ class afcUnit:
     def calibrate_lane(self, cur_lane, tol):
         self._print_function_not_defined(self.calibrate_lane.__name__)
 
-    def get_td1_data(self, cur_lane, compare_time):
+    def get_td1_data(self, cur_lane, compare_time, ignore_time=False):
         """
         Queries moonrakers endpoint to get td1 data and check to see if data is valid and time
         in data is greater than passed in time as this is how determination is made that filament
@@ -487,6 +487,8 @@ class afcUnit:
                          assigned to the lane.
         :param compare_time: Time to compare returned data to, which helps verify that the data is valid and
                              filament has reached TD-1 device
+        :parma ignore_time: Override to just capture TD-1 data anyways, useful when loading filament to toolhead
+                            and want to capture data once loaded.
 
         :return boolean: True once filament is detected in TD-1 device
         """
@@ -518,13 +520,14 @@ class afcUnit:
                 self.afc.logger.error("Error trying to format TD-1 scan time, check AFC.log for more information", f"{e}")
                 return False
 
-
             if scan_time > compare_time.astimezone():
                 valid_data = True
             elif ( compare_time.astimezone() - scan_time ) < t_delta:
                 valid_data = True
 
-            if valid_data and data['td'] is not None and data['color'] is not None:
+            if ( (valid_data or ignore_time)
+                 and data['td'] is not None
+                 and data['color'] is not None ):
                 cur_lane.td1_data = data
                 self.logger.info(f"{cur_lane.name} TD-1 data captured")
                 self.afc.save_vars()

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -500,12 +500,11 @@ class afcUnit:
             self.logger.debug(f"Data: {td1_data}, Compare_time: {compare_time}")
             data = list(td1_data.values())[0]
 
-            if cur_lane.td1_device_id is not None:
-                if cur_lane.td1_device_id in td1_data:
-                    data = td1_data[cur_lane.td1_device_id]
-                else:
-                    self.afc.error.AFC_error(f"TD-1 Device ID ({cur_lane.td1_device_id}) supplied, but ID not found.", pause=False)
-                    return False
+            if cur_lane.td1_device_id in td1_data:
+                data = td1_data[cur_lane.td1_device_id]
+            else:
+                self.afc.error.AFC_error(f"TD-1 Device ID ({cur_lane.td1_device_id}) supplied, but ID not found.", pause=False)
+                return False
 
             if data["scan_time"] is None:
                 return False

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -479,7 +479,8 @@ class afcUnit:
     def calibrate_lane(self, cur_lane, tol):
         self._print_function_not_defined(self.calibrate_lane.__name__)
 
-    def get_td1_data(self, cur_lane, compare_time, ignore_time=False):
+    def get_td1_data(self, cur_lane: AFCLane, compare_time: datetime,
+                     ignore_time: bool=False) -> bool:
         """
         Queries moonrakers endpoint to get td1 data and check to see if data is valid and time
         in data is greater than passed in time as this is how determination is made that filament

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -207,12 +207,13 @@ class afcUnit:
 
         direct_hubs = any( lane.is_direct_hub() for lane in self.afc.lanes.values())
         lanes_loaded = any( lane.load_state and not lane.is_direct_hub() for lane in self.afc.lanes.values())
+        td1_ids = any( lane.td1_device_id for lane in self.afc.lanes.values())
 
         if not direct_hubs or lanes_loaded:
             buttons.append(("Calibrate afc_bowden_length", "UNIT_BOW_CALIBRATION UNIT={}".format(self.name), "secondary"))
 
         # Add button for TD-1 calibration if user has one connected and defined
-        if self.afc.td1_defined:
+        if self.afc.td1_defined and td1_ids:
             buttons.append(("Calibrate TD-1 Length", "AFC_UNIT_TD_ONE_CALIBRATION UNIT={}".format(self.name), "primary"))
 
         # Button back to previous step
@@ -357,7 +358,8 @@ class afcUnit:
                 'Config option: td1_bowden_length').format(self.name)
 
         for lane in self.lanes.values():
-            if lane.load_state:
+            if (lane.td1_device_id
+                and lane.load_state):
                 # Create a button for each lane
                 button_label = "{}".format(lane)
                 button_command = "CALIBRATE_AFC TD1={} DISTANCE=50".format(lane)
@@ -439,13 +441,13 @@ class afcUnit:
         """
         return
 
-    def return_to_home(self):
+    def return_to_home(self, prep=False):
         """
         Function to home unit if unit has homing sensor
         """
         return
 
-    def check_runout(self):
+    def check_runout(self, cur_lane):
         """
         Function to check if runout logic should be triggered, override in specific unit
         """

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -207,13 +207,13 @@ class afcUnit:
 
         direct_hubs = any( lane.is_direct_hub() for lane in self.afc.lanes.values())
         lanes_loaded = any( lane.load_state and not lane.is_direct_hub() for lane in self.afc.lanes.values())
-        td1_ids = any( lane.td1_device_id for lane in self.afc.lanes.values())
+        any_lane_has_td1_ids = any( lane.td1_device_id for lane in self.afc.lanes.values())
 
         if not direct_hubs or lanes_loaded:
             buttons.append(("Calibrate afc_bowden_length", "UNIT_BOW_CALIBRATION UNIT={}".format(self.name), "secondary"))
 
         # Add button for TD-1 calibration if user has one connected and defined
-        if self.afc.td1_defined and td1_ids:
+        if self.afc.td1_defined and any_lane_has_td1_ids:
             buttons.append(("Calibrate TD-1 Length", "AFC_UNIT_TD_ONE_CALIBRATION UNIT={}".format(self.name), "primary"))
 
         # Button back to previous step
@@ -490,7 +490,7 @@ class afcUnit:
                          assigned to the lane.
         :param compare_time: Time to compare returned data to, which helps verify that the data is valid and
                              filament has reached TD-1 device
-        :parma ignore_time: Override to just capture TD-1 data anyways, useful when loading filament to toolhead
+        :param ignore_time: Override to just capture TD-1 data anyways, useful when loading filament to toolhead
                             and want to capture data once loaded.
 
         :return boolean: True once filament is detected in TD-1 device
@@ -501,7 +501,6 @@ class afcUnit:
 
         if len(td1_data) > 0:
             self.logger.debug(f"Data: {td1_data}, Compare_time: {compare_time}")
-            data = list(td1_data.values())[0]
 
             if cur_lane.td1_device_id in td1_data:
                 data = td1_data[cur_lane.td1_device_id]


### PR DESCRIPTION
## Major Changes in this PR
- Added ability to use TD-1 for direct lanes, calibration and scanning filament now works.
- `td1_device_id` is now required field to be able to scan filament
- Added grabbing TD-1 data when loading to toolhead since filament is scanned when loading to toolhead

@weemantella

## Notes to Code Reviewers

## How the changes in this PR are tested
- Tested on toolchanger and verified that other lanes do not show up if TD-1 ID is not provided

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.