### PR TITLE
[fix] Issue where AFC would crash klipper when trying to find git version when git folder does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-12-17]
+### Fixed
+- Fixed issue where AFC would crash klipper when trying to find git version when git folder does not exist
+
 ## [2025-12-11]
 ### Fixed
 - Fix output of `AFC_TOGGLE_MACRO` to correctly report state of WIPE macro

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -348,8 +348,14 @@ class afc:
         import subprocess
         import os
         afc_dir  = os.path.dirname(os.path.realpath(__file__))
-        git_hash = subprocess.check_output(['git', '-C', '{}'.format(afc_dir), 'rev-parse', '--short', 'HEAD']).decode('ascii').strip()
-        git_commit_num = subprocess.check_output(['git', '-C', '{}'.format(afc_dir), 'rev-list', 'HEAD', '--count']).decode('ascii').strip()
+        git_hash = '_'
+        git_commit_num = '_'
+        try:
+            git_hash = subprocess.check_output(['git', '-C', '{}'.format(afc_dir), 'rev-parse', '--short', 'HEAD']).decode('ascii').strip()
+            git_commit_num = subprocess.check_output(['git', '-C', '{}'.format(afc_dir), 'rev-list', 'HEAD', '--count']).decode('ascii').strip()
+        except:
+            self.logger.debug(f"Error fetching repo info: {traceback.format_exc()}")
+
         string  = "AFC Version: v{}-{}-{}".format(AFC_VERSION, git_commit_num, git_hash)
 
         self.logger.info(string, console_only)


### PR DESCRIPTION
## Major Changes in this PR
Fixes issue that was found where AFC would crash klipper when ran in a docker type environment where a `.git` folder did not exist

Fixes #591

## How the changes in this PR are tested
- Renamed local `.git` folder to `.ggit` to reproduce error an verify that fix worked.

Reported error in AFC.log with dashes in AFC version
<img width="1512" height="261" alt="image" src="https://github.com/user-attachments/assets/04b32ae6-765e-45a1-997d-568d1db13ac8" />



## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.