### PR TITLE
[fix] Adding check to verify log file was passed into klipper service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2025-12-17]
 ### Fixed
 - Fixed issue where AFC would crash klipper when trying to find git version when git folder does not exist
+- Fixed issue where AFC would cause error if log file variable was not passed into klipper service
 
 ## [2025-12-11]
 ### Fixed

--- a/extras/AFC_logger.py
+++ b/extras/AFC_logger.py
@@ -39,13 +39,13 @@ class AFC_logger:
         self.gcode   = printer.lookup_object('gcode')
         self.webhooks = printer.lookup_object('webhooks')
 
+        self.afc_ql = None
         log_path = printer.start_args.get('log_file', None)
         if log_path:
             dirname = Path(log_path).parent
             log_file = Path(dirname).joinpath("AFC.log")
             logger_name = os.path.splitext(os.path.basename(log_file))[0]
 
-            self.afc_ql = None
             self.logger = logging.getLogger(logger_name)
 
             if not any(isinstance(ql, QueueHandler) for ql in self.logger.handlers):
@@ -54,7 +54,7 @@ class AFC_logger:
                 self.afc_queue_handler = QueueHandler(self.afc_ql.bg_queue)
                 self.logger.addHandler(self.afc_queue_handler)
         else:
-            self.logger =  logging.getLogger()
+            self.logger = logging.getLogger()
 
         self.logger.propagate = False               # Stops logs from going into klippy.log
         self.logger.setLevel(logging.DEBUG)

--- a/extras/AFC_logger.py
+++ b/extras/AFC_logger.py
@@ -39,18 +39,22 @@ class AFC_logger:
         self.gcode   = printer.lookup_object('gcode')
         self.webhooks = printer.lookup_object('webhooks')
 
-        log_path = printer.start_args['log_file']
-        dirname = Path(log_path).parent
-        log_file = Path(dirname).joinpath("AFC.log")
-        logger_name = os.path.splitext(os.path.basename(log_file))[0]
+        log_path = printer.start_args.get('log_file', None)
+        if log_path:
+            dirname = Path(log_path).parent
+            log_file = Path(dirname).joinpath("AFC.log")
+            logger_name = os.path.splitext(os.path.basename(log_file))[0]
 
-        self.afc_ql = None
-        self.logger = logging.getLogger(logger_name)
-        if not any(isinstance(ql, QueueHandler) for ql in self.logger.handlers):
-            self.afc_ql = AFC_QueueListener(log_file)
-            self.afc_ql.setFormatter(logging.Formatter('%(asctime)s %(message)s', datefmt='%H:%M:%S'))
-            self.afc_queue_handler = QueueHandler(self.afc_ql.bg_queue)
-            self.logger.addHandler(self.afc_queue_handler)
+            self.afc_ql = None
+            self.logger = logging.getLogger(logger_name)
+
+            if not any(isinstance(ql, QueueHandler) for ql in self.logger.handlers):
+                self.afc_ql = AFC_QueueListener(log_file)
+                self.afc_ql.setFormatter(logging.Formatter('%(asctime)s %(message)s', datefmt='%H:%M:%S'))
+                self.afc_queue_handler = QueueHandler(self.afc_ql.bg_queue)
+                self.logger.addHandler(self.afc_queue_handler)
+        else:
+            self.logger =  logging.getLogger()
 
         self.logger.propagate = False               # Stops logs from going into klippy.log
         self.logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
## Major Changes in this PR
Adds check to verify that log file was passed into klipper service before trying to create AFC.log file
- Does not log to file if log file was not passed into service

Fixes #593

## How the changes in this PR are tested
Removed passing in log file to klipper service to replicate and verify fix

Logging to stdout instead
<img width="1392" height="742" alt="image" src="https://github.com/user-attachments/assets/08026a54-495c-4b53-b700-906bd573a66d" />

With fix implemented, no logging to stdout when log file is supplied
<img width="1604" height="250" alt="image" src="https://github.com/user-attachments/assets/7b3d75ea-7606-4edb-bd88-795969f999b4" />


## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.