### PR TITLE
[fix] Changing all lookup_object in __init__ functions to load_object function call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-12-18]
+### Fixed
+- Fixing issue where order mattered when creating flat config files, replaced lookup_object with load_object so klipper would not error out and instead load object if it was not already loaded.
+
 ## [2025-12-17]
 ### Fixed
 - Fixed issue where AFC would crash klipper when trying to find git version when git folder does not exist

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -48,7 +48,7 @@ class afc:
         self.config  = config
         self.printer = config.get_printer()
         self.reactor = self.printer.get_reactor()
-        self.webhooks = self.printer.lookup_object('webhooks')
+        self.webhooks = self.printer.load_object(config, 'webhooks')
         self.printer.register_event_handler("klippy:connect",self.handle_connect)
         self.logger  = AFC_logger(self.printer, self)
 
@@ -56,7 +56,7 @@ class afc:
         self.error      = self.printer.load_object(config, 'AFC_error')
         self.function   = self.printer.load_object(config, 'AFC_functions')
         self.function.afc = self
-        self.gcode      = self.printer.lookup_object('gcode')
+        self.gcode      = self.printer.load_object(config, 'gcode')
 
         # Registering stepper callback so that mux macro can be set properly with valid lane names
         self.printer.register_event_handler("afc_stepper:register_macros",self.register_lane_macros)

--- a/extras/AFC_assist.py
+++ b/extras/AFC_assist.py
@@ -26,7 +26,7 @@ RPM_TO_RPS = 60
 class AFCassistMotor:
     def __init__(self, config, type):
         self.printer = config.get_printer()
-        ppins = self.printer.lookup_object("pins")
+        ppins = self.printer.load_object(config, "pins")
         # Determine pin type
         self.is_pwm = config.getboolean("pwm", False)
         if self.is_pwm and type != "enb":
@@ -421,7 +421,7 @@ class Espooler:
     def __init__(self, name, config):
         self.name                   = name
         self.printer                = config.get_printer()
-        self.afc                    = self.printer.lookup_object("AFC")
+        self.afc                    = self.printer.load_object(config, "AFC")
         self.logger                 = self.afc.logger
         self.reactor                = self.printer.get_reactor()
         self.callback_timer         = self.reactor.register_timer( self.timer_callback )    # Defaults to never trigger

--- a/extras/AFC_buffer.py
+++ b/extras/AFC_buffer.py
@@ -18,7 +18,7 @@ class AFCTrigger:
 
     def __init__(self, config):
         self.printer    = config.get_printer()
-        self.afc        = self.printer.lookup_object('AFC')
+        self.afc        = self.printer.load_object(config, 'AFC')
         self.reactor    = self.afc.reactor
         self.gcode      = self.afc.gcode
         self.logger     = self.afc.logger

--- a/extras/AFC_button.py
+++ b/extras/AFC_button.py
@@ -11,11 +11,11 @@ class AFCButton:
     """
     def __init__(self, config):
         self.printer = config.get_printer()
-        self.gcode = self.printer.lookup_object('gcode')
+        self.gcode = self.printer.load_object(config, 'gcode')
         self.printer.register_event_handler("klippy:ready", self._handle_ready)
         self.reactor = self.printer.get_reactor()
 
-        self.afc = self.printer.lookup_object('AFC')
+        self.afc = self.printer.load_object(config, 'AFC')
         self.lane_id = config.get_name().split()[-1]
         self.lane_obj = None
         self.long_press_duration = config.getfloat('long_press_duration', 1.2)

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -16,9 +16,9 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 class AFCExtruder:
     def __init__(self, config):
         self.printer    = config.get_printer()
-        buttons         = self.printer.load_object(config, "buttons")
-        self.afc        = self.printer.lookup_object('AFC')
-        self.gcode      = self.printer.lookup_object('gcode')
+        buttons         = self.printer.load_object(config, 'buttons')
+        self.afc        = self.printer.load_object(config, 'AFC')
+        self.gcode      = self.printer.load_object(config, 'gcode')
         self.logger     = self.afc.logger
         self.reactor    = None
         self.printer.register_event_handler("klippy:connect", self.handle_connect)

--- a/extras/AFC_form_tip.py
+++ b/extras/AFC_form_tip.py
@@ -8,8 +8,8 @@ class afc_tip_form:
     def __init__(self, config):
         self.printer        = config.get_printer()
         self.reactor        = self.printer.get_reactor()
-        self.afc            = self.printer.lookup_object('AFC')
-        self.gcode          = self.printer.lookup_object('gcode')
+        self.afc            = self.printer.load_object(config, 'AFC')
+        self.gcode          = self.printer.load_object(config, 'gcode')
         self.logger         = self.afc.logger
 
          # TIP FORMING

--- a/extras/AFC_hub.py
+++ b/extras/AFC_hub.py
@@ -17,7 +17,7 @@ class afc_hub:
     def __init__(self, config):
         self.printer    = config.get_printer()
         self.printer.register_event_handler("klippy:connect", self.handle_connect)
-        self.afc        = self.printer.lookup_object('AFC')
+        self.afc        = self.printer.load_object(config, 'AFC')
         self.reactor    = self.printer.get_reactor()
 
         self.fullname   = config.get_name()

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -50,8 +50,8 @@ class AFCLane:
     UPDATE_WEIGHT_DELAY = 10.0
     def __init__(self, config):
         self.printer            = config.get_printer()
-        self.afc                = self.printer.lookup_object('AFC')
-        self.gcode              = self.printer.lookup_object('gcode')
+        self.afc                = self.printer.load_object(config, 'AFC')
+        self.gcode              = self.printer.load_object(config, 'gcode')
         self.reactor            = self.printer.get_reactor()
         self.extruder_stepper   = None
         self.logger             = self.afc.logger

--- a/extras/AFC_led.py
+++ b/extras/AFC_led.py
@@ -16,10 +16,10 @@ class AFCled:
         self.mutex      = printer.get_reactor().mutex()
         self.fullname   = config.get_name()
         self.name       = self.fullname.split()[-1]
-        self.afc        = self.printer.lookup_object('AFC')
+        self.afc        = self.printer.load_object(config, 'AFC')
         self.afc.led_obj[self.name] = self
         # Configure neopixel
-        ppins = printer.lookup_object('pins')
+        ppins = printer.load_object(config, 'pins')
         pin_params = ppins.lookup_pin(config.get('pin'))
         self.mcu = pin_params['chip']
         self.oid = self.mcu.create_oid()

--- a/extras/AFC_poop.py
+++ b/extras/AFC_poop.py
@@ -8,9 +8,9 @@ class afc_poop:
     def __init__(self, config):
         self.config     = config
         self.printer    = config.get_printer()
-        self.afc        = self.printer.lookup_object('AFC')
+        self.afc        = self.printer.load_object(config, 'AFC')
         self.reactor    = self.printer.get_reactor()
-        self.gcode      = self.printer.lookup_object('gcode')
+        self.gcode      = self.printer.load_object(config, 'gcode')
         self.logger     = self.afc.logger
 
         self.verbose = config.getboolean('verbose', False)

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -17,10 +17,10 @@ except: raise error(ERROR_STR.format(import_lib="AFC_respond", trace=traceback.f
 class afcUnit:
     def __init__(self, config):
         self.printer        = config.get_printer()
-        self.gcode          = self.printer.lookup_object('gcode')
+        self.gcode          = self.printer.load_object(config, 'gcode')
         self.printer.register_event_handler("klippy:connect", self.handle_connect)
         self.printer.register_event_handler("afc:moonraker_connect", self.handle_moonraker_connect)
-        self.afc            = self.printer.lookup_object('AFC')
+        self.afc            = self.printer.load_object(config, 'AFC')
         self.logger         = self.afc.logger
 
         self.lanes      = {}


### PR DESCRIPTION
## Major Changes in this PR
- Replacing `lookup_object` with `load_object` when initializing objects so that config order does not matter as much.
Fixes #592

## Notes to Code Reviewers

## How the changes in this PR are tested
- Added `[include AFC_Hardware.cfg]` to top of AFC.cfg file and was able to replicate issue as described in #592
- After making fixes klipper was able to start correctly, then I added `[include AFC_Turtle_1_Pro.cfg]` at top of AFC.cfg file to verify that this also does not cause any error when loading.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.