### PR TITLE
[fix] Updating AFC_CUT so that its safer for toolheads that cut with forwards/backwards movements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-12-26]
+### Changed:
+- Updated AFC_CUT macro to move to pin first before doing filament retraction.
+- Updated AFC_CUT macro so that is more safe for toolheads with cutters that move in the forwards/backwards movement. 
+- Updated AFC_CUT macro to clear pin once cutting is done so that is safer for toolheads with forward/backward cutters.
+
 ## [2025-12-18]
 ### Fixed
 - Fixing issue where order mattered when creating flat config files, replaced lookup_object with load_object so klipper would not error out and instead load object if it was not already loaded.

--- a/config/macros/Cut.cfg
+++ b/config/macros/Cut.cfg
@@ -229,7 +229,7 @@ gcode:
 
     # Reset acceleration values to what it was before
     SET_VELOCITY_LIMIT ACCEL={saved_accel}
-	_CLEAR_PIN PIN_PARK_X_LOC={pin_park_x_loc} PIN_PARK_Y_LOC={pin_park_y_loc}
+    _CLEAR_PIN PIN_PARK_X_LOC={pin_park_x_loc} PIN_PARK_Y_LOC={pin_park_y_loc}
     AFC_ENABLE_SKEW
 
     # Restore state and optionally position
@@ -249,33 +249,33 @@ gcode:
     {% set vars = printer['gcode_macro _AFC_CUT_TIP_VARS'] %}
     {% set cut_direction = vars['cut_direction']|default('')|lower %}
     {% set act_x = printer.toolhead.position.x|float %}
-	{% set act_y = printer.toolhead.position.y|float %}
+    {% set act_y = printer.toolhead.position.y|float %}
     {% set max_x = printer.toolhead.axis_maximum.x|float %}
-	{% set max_y = printer.toolhead.axis_maximum.y|float %}
+    {% set max_y = printer.toolhead.axis_maximum.y|float %}
     {% set safe_margin_x, safe_margin_y = vars.safe_margin_xy|map('float') %}
 
     # Make traveling to cutter safer overall
-	{% if cut_direction == "front" or cut_direction == "back" or cut_direction == "left" or cut_direction == "right"%}
-		#assume left side pin
-		{% if (pin_park_x_loc) < (max_x/2) %}
-			{% if act_x <= safe_margin_x+pin_park_x_loc %}
-				G1 X{safe_margin_x+pin_park_x_loc} Y{pin_park_y_loc} F{travel_speed}
-				G1 X{pin_park_x_loc} F{travel_speed}
-			{% else %}
-				G1 X{pin_park_x_loc} Y{pin_park_y_loc} F{travel_speed}
-			{% endif %}
-		#assume right side pin
-		{% elif (pin_park_x_loc) > (max_x/2) %}
-			{% if act_x >= pin_park_x_loc-safe_margin_x %}
-				G1 X{pin_park_x_loc-safe_margin_x} Y{pin_park_y_loc} F{travel_speed}
-				G1 X{pin_park_x_loc} F{travel_speed}
-			{% else %}
-				G1 X{pin_park_x_loc} Y{pin_park_y_loc} F{travel_speed}
-			{% endif %}
-		{% endif %}
-	{% else %}
-		{ action_raise_error("Invalid cut direction. Check the cut_direction in your AFC_Macro_Vars.cfg file!") }
-	{% endif %}
+    {% if cut_direction == "front" or cut_direction == "back" or cut_direction == "left" or cut_direction == "right"%}
+        #assume left side pin
+        {% if (pin_park_x_loc) < (max_x/2) %}
+            {% if act_x <= safe_margin_x+pin_park_x_loc %}
+                G1 X{safe_margin_x+pin_park_x_loc} Y{pin_park_y_loc} F{travel_speed}
+                G1 X{pin_park_x_loc} F{travel_speed}
+            {% else %}
+                G1 X{pin_park_x_loc} Y{pin_park_y_loc} F{travel_speed}
+            {% endif %}
+        #assume right side pin
+        {% elif (pin_park_x_loc) > (max_x/2) %}
+            {% if act_x >= pin_park_x_loc-safe_margin_x %}
+                G1 X{pin_park_x_loc-safe_margin_x} Y{pin_park_y_loc} F{travel_speed}
+                G1 X{pin_park_x_loc} F{travel_speed}
+            {% else %}
+                G1 X{pin_park_x_loc} Y{pin_park_y_loc} F{travel_speed}
+            {% endif %}
+        {% endif %}
+    {% else %}
+        { action_raise_error("Invalid cut direction. Check the cut_direction in your AFC_Macro_Vars.cfg file!") }
+    {% endif %}
 #--=================================================================================-
 #------- Helper macro for tip cutting -----------------------------------------------
 #--=================================================================================-
@@ -334,14 +334,14 @@ gcode:
         {% if full_cut_loc_x > x_max or full_cut_loc_x < x_min %}
             { action_raise_error("X Cut move is outside your printer bounds. Check the cut_move_dist in your AFC_Macro_Vars.cfg file!") }
         {% else %}
-        	G1 X{fast_slow_transition_loc_x} F{cut_fast_move_speed} # Fast move to initiate contact of the blade with filament
-    		G1 X{full_cut_loc_x} F{cut_slow_move_speed} # Do the cut in slow move
-    		G4 P{cut_dwell_time}
-    		{% if rip_length > 0 %}
-    			G1 E-{rip_length} F{rip_speed}
-    		{% endif %}
+            G1 X{fast_slow_transition_loc_x} F{cut_fast_move_speed} # Fast move to initiate contact of the blade with filament
+            G1 X{full_cut_loc_x} F{cut_slow_move_speed} # Do the cut in slow move
+            G4 P{cut_dwell_time}
+            {% if rip_length > 0 %}
+                G1 E-{rip_length} F{rip_speed}
+            {% endif %}
             G4 P200
-    		G1 X{pin_park_x_loc} F{evacuate_speed} # Evacuate
+            G1 X{pin_park_x_loc} F{evacuate_speed} # Evacuate
             G4 P200
         {% endif %}
     {% elif cut_direction == "front" or cut_direction == "back" %}
@@ -351,14 +351,14 @@ gcode:
         {% if full_cut_loc_y > y_max or full_cut_loc_y < y_min %}
             { action_raise_error("Y Cut move is outside your printer bounds. Check the cut_move_dist in your AFC_Macro_Vars.cfg file!") }
         {% else %}
-        	G1 Y{fast_slow_transition_loc_y} F{cut_fast_move_speed} # Fast move to initiate contact of the blade with filament
-    		G1 Y{full_cut_loc_y} F{cut_slow_move_speed} # Do the cut in slow move
-    		G4 P{cut_dwell_time}
-    		{% if rip_length > 0 %}
-    			G1 E-{rip_length} F{rip_speed}
-    		{% endif %}
+            G1 Y{fast_slow_transition_loc_y} F{cut_fast_move_speed} # Fast move to initiate contact of the blade with filament
+            G1 Y{full_cut_loc_y} F{cut_slow_move_speed} # Do the cut in slow move
+            G4 P{cut_dwell_time}
+            {% if rip_length > 0 %}
+                G1 E-{rip_length} F{rip_speed}
+            {% endif %}
             G4 P200
-    		G1 Y{pin_park_y_loc} F{evacuate_speed} # Evacuate
+            G1 Y{pin_park_y_loc} F{evacuate_speed} # Evacuate
             G4 P200
         {% endif %}
     {% else %}
@@ -398,20 +398,20 @@ gcode:
     {% set vars = printer['gcode_macro _AFC_CUT_TIP_VARS'] %}
     {% set cut_direction = vars['cut_direction']|default('')|lower %}
     {% set act_x = printer.toolhead.position.x|float %}
-	{% set act_y = printer.toolhead.position.y|float %}
+    {% set act_y = printer.toolhead.position.y|float %}
     {% set max_x = printer.toolhead.axis_maximum.x|float %}
-	{% set max_y = printer.toolhead.axis_maximum.y|float %}
+    {% set max_y = printer.toolhead.axis_maximum.y|float %}
     {% set safe_margin_x, safe_margin_y = vars.safe_margin_xy|map('float') %}
 
     # Make traveling to cutter safer overall
-	{% if cut_direction == "front" or cut_direction == "back" or cut_direction == "left" or cut_direction == "right" %}
-		#assume left side pin
-		{% if (pin_park_x_loc) < (max_x/2) %}
-			G1 X{pin_park_x_loc+safe_margin_x} F{travel_speed}
-		#assume right side pin
-		{% elif (pin_park_x_loc) > (max_x/2) %}
-			G1 X{pin_park_x_loc-safe_margin_x} F{travel_speed}
-		{% endif %}
-	{% else %}
-		{ action_raise_error("Invalid cut direction. Check the cut_direction in your AFC_Macro_Vars.cfg file!") }
-	{% endif %}
+    {% if cut_direction == "front" or cut_direction == "back" or cut_direction == "left" or cut_direction == "right" %}
+        #assume left side pin
+        {% if (pin_park_x_loc) < (max_x/2) %}
+            G1 X{pin_park_x_loc+safe_margin_x} F{travel_speed}
+        #assume right side pin
+        {% elif (pin_park_x_loc) > (max_x/2) %}
+            G1 X{pin_park_x_loc-safe_margin_x} F{travel_speed}
+        {% endif %}
+    {% else %}
+        { action_raise_error("Invalid cut direction. Check the cut_direction in your AFC_Macro_Vars.cfg file!") }
+    {% endif %}

--- a/config/macros/Cut.cfg
+++ b/config/macros/Cut.cfg
@@ -254,8 +254,11 @@ gcode:
     {% set max_y = printer.toolhead.axis_maximum.y|float %}
     {% set safe_margin_x, safe_margin_y = vars.safe_margin_xy|map('float') %}
 
-    # Make traveling to cutter safer overall
+    # Make traveling to cutter pin safer overall
     {% if cut_direction == "front" or cut_direction == "back" or cut_direction == "left" or cut_direction == "right"%}
+        {% if verbose > 1 %}
+          RESPOND TYPE=command MSG='AFC_Cut: Moving to cutter pin'
+        {% endif %}
         #assume left side pin
         {% if (pin_park_x_loc) < (max_x/2) %}
             {% if act_x <= safe_margin_x+pin_park_x_loc %}
@@ -403,8 +406,11 @@ gcode:
     {% set max_y = printer.toolhead.axis_maximum.y|float %}
     {% set safe_margin_x, safe_margin_y = vars.safe_margin_xy|map('float') %}
 
-    # Make traveling to cutter safer overall
+    # Make moving away from cutter pin safer overall
     {% if cut_direction == "front" or cut_direction == "back" or cut_direction == "left" or cut_direction == "right" %}
+        {% if verbose > 1 %}
+          RESPOND TYPE=command MSG='AFC_Cut: Clearing cutter pin'
+        {% endif %}
         #assume left side pin
         {% if (pin_park_x_loc) < (max_x/2) %}
             G1 X{pin_park_x_loc+safe_margin_x} F{travel_speed}

--- a/config/macros/Cut.cfg
+++ b/config/macros/Cut.cfg
@@ -78,6 +78,11 @@ gcode:
     G90  # Absolute positioning
     M83  # Relative extrusion
     G92 E0
+    _MOVE_TO_CUTTER_PIN PIN_PARK_X_LOC={pin_park_x_loc} PIN_PARK_Y_LOC={pin_park_y_loc}
+    
+    G90  # Absolute positioning
+    M83  # Relative extrusion
+    G92 E0
     {% if retract_length > 0 %}
 
         {% if verbose > 1 %}
@@ -100,8 +105,6 @@ gcode:
     {% if verbose > 1 %}
           RESPOND TYPE=command MSG='AFC_Cut: Move to Cut Pin Location'
     {% endif %}
-    _MOVE_TO_CUTTER_PIN PIN_PARK_X_LOC={pin_park_x_loc} PIN_PARK_Y_LOC={pin_park_y_loc}
-
     # Extend servo if enabled
     {% if tool_servo_enable %}
         {% if verbose > 1 %}
@@ -226,7 +229,7 @@ gcode:
 
     # Reset acceleration values to what it was before
     SET_VELOCITY_LIMIT ACCEL={saved_accel}
-
+	_CLEAR_PIN PIN_PARK_X_LOC={pin_park_x_loc} PIN_PARK_Y_LOC={pin_park_y_loc}
     AFC_ENABLE_SKEW
 
     # Restore state and optionally position
@@ -245,24 +248,34 @@ gcode:
     {% set travel_speed = gVars['travel_speed'] * 60|float %}
     {% set vars = printer['gcode_macro _AFC_CUT_TIP_VARS'] %}
     {% set cut_direction = vars['cut_direction']|default('')|lower %}
+    {% set act_x = printer.toolhead.position.x|float %}
+	{% set act_y = printer.toolhead.position.y|float %}
+    {% set max_x = printer.toolhead.axis_maximum.x|float %}
+	{% set max_y = printer.toolhead.axis_maximum.y|float %}
     {% set safe_margin_x, safe_margin_y = vars.safe_margin_xy|map('float') %}
 
-    {% if ((printer.gcode_move.gcode_position.x - pin_park_x_loc)|abs < safe_margin_x) or ((printer.gcode_move.gcode_position.y - pin_park_y_loc)|abs < safe_margin_y) %}
-        # Make a safe but slower travel move
-        {% if cut_direction == "left" or cut_direction == "right" %}
-            G1 X{pin_park_x_loc} F{travel_speed}
-            G1 Y{pin_park_y_loc} F{travel_speed}
-        {% elif cut_direction == "front" or cut_direction == "back" %}
-            G1 Y{pin_park_y_loc} F{travel_speed}
-            G1 X{pin_park_x_loc} F{travel_speed}
-        {% else %}
-            { action_raise_error("Invalid cut direction. Check the cut_direction in your AFC_Macro_Vars.cfg file!") }
-        {% endif %}
-    {% else %}
-        G1 X{pin_park_x_loc} Y{pin_park_y_loc} F{travel_speed}
-    {% endif %}
-
-
+    # Make traveling to cutter safer overall
+	{% if cut_direction == "front" or cut_direction == "back" or cut_direction == "left" or cut_direction == "right"%}
+		#assume left side pin
+		{% if (pin_park_x_loc) < (max_x/2) %}
+			{% if act_x <= safe_margin_x+pin_park_x_loc %}
+				G1 X{safe_margin_x+pin_park_x_loc} Y{pin_park_y_loc} F{travel_speed}
+				G1 X{pin_park_x_loc} F{travel_speed}
+			{% else %}
+				G1 X{pin_park_x_loc} Y{pin_park_y_loc} F{travel_speed}
+			{% endif %}
+		#assume right side pin
+		{% elif (pin_park_x_loc) > (max_x/2) %}
+			{% if act_x >= pin_park_x_loc-safe_margin_x %}
+				G1 X{pin_park_x_loc-safe_margin_x} Y{pin_park_y_loc} F{travel_speed}
+				G1 X{pin_park_x_loc} F{travel_speed}
+			{% else %}
+				G1 X{pin_park_x_loc} Y{pin_park_y_loc} F{travel_speed}
+			{% endif %}
+		{% endif %}
+	{% else %}
+		{ action_raise_error("Invalid cut direction. Check the cut_direction in your AFC_Macro_Vars.cfg file!") }
+	{% endif %}
 #--=================================================================================-
 #------- Helper macro for tip cutting -----------------------------------------------
 #--=================================================================================-
@@ -371,3 +384,34 @@ gcode:
     {action_respond_info("Cutter Servo: provide POS=[in|out]")}
   {% endif %}
   SET_SERVO SERVO={c1.tool_servo_name} WIDTH=0
+
+#--=================================================================================-
+#------- Helper macro for tip cutting -----------------------------------------------
+#--=================================================================================-
+[gcode_macro _CLEAR_PIN]
+description: Helper to move the toolhead to the target pin in either safe or faster way, depending on toolhead clearance
+gcode:
+    {% set pin_park_x_loc = params.PIN_PARK_X_LOC|float %}
+    {% set pin_park_y_loc = params.PIN_PARK_Y_LOC|float %}
+    {% set gVars = printer['gcode_macro _AFC_GLOBAL_VARS'] %}
+    {% set travel_speed = gVars['travel_speed'] * 60|float %}
+    {% set vars = printer['gcode_macro _AFC_CUT_TIP_VARS'] %}
+    {% set cut_direction = vars['cut_direction']|default('')|lower %}
+    {% set act_x = printer.toolhead.position.x|float %}
+	{% set act_y = printer.toolhead.position.y|float %}
+    {% set max_x = printer.toolhead.axis_maximum.x|float %}
+	{% set max_y = printer.toolhead.axis_maximum.y|float %}
+    {% set safe_margin_x, safe_margin_y = vars.safe_margin_xy|map('float') %}
+
+    # Make traveling to cutter safer overall
+	{% if cut_direction == "front" or cut_direction == "back" or cut_direction == "left" or cut_direction == "right" %}
+		#assume left side pin
+		{% if (pin_park_x_loc) < (max_x/2) %}
+			G1 X{pin_park_x_loc+safe_margin_x} F{travel_speed}
+		#assume right side pin
+		{% elif (pin_park_x_loc) > (max_x/2) %}
+			G1 X{pin_park_x_loc-safe_margin_x} F{travel_speed}
+		{% endif %}
+	{% else %}
+		{ action_raise_error("Invalid cut direction. Check the cut_direction in your AFC_Macro_Vars.cfg file!") }
+	{% endif %}


### PR DESCRIPTION
## Major Changes in this PR
- Updated AFC_CUT macro to move to pin first before doing filament retraction.
- Updated AFC_CUT macro so that is more safe for toolheads with cutters that move in the forwards/backwards movement. 
- Updated AFC_CUT macro to clear pin once cutting is done so that is safer for toolheads with forward/backward cutters.

## Notes to Code Reviewers

## How the changes in this PR are tested
verified on personal printers to not be an issue
## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [ ] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.