### PR TITLE
[Enhancement] Adding ability to set toolhead led for status, and print leds based on mapping and extruder name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 - Added AFC_SET_TOOLHEAD_LED macro which sets print leds based off passed in mapping
 - Added ability to set toolhead leds directly with AFC_SET_EXTRUDER_LED macro
-- Updated multiple function to set toolhead led status based off current state
+- Updated multiple functions to set toolhead led status based off current state
 - New variables(led_name, status_led_idx) were added to support setting toolhead leds
 - Updating message during PREP to print out if toolhead is detected on shuttle
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2026-01-02]
 ## Added
 - Added AFC_SET_TOOLHEAD_LED macro which sets print leds based off passed in mapping
+- Added ability to set toolhead leds directly with AFC_SET_EXTRUDER_LED macro
 - Updated multiple function to set toolhead led status based off current state
 - New variables(led_name, status_led_idx) were added to support setting toolhead leds
 - Updating message during PREP to print out if toolhead is detected on shuttle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-01-02]
+## Added
+- Added AFC_SET_TOOLHEAD_LED macro which sets print leds based off passed in mapping
+- Updated multiple function to set toolhead led status based off current state
+- New variables(led_name, status_led_idx) were added to support setting toolhead leds
+- Updating message during PREP to print out if toolhead is detected on shuttle
+
 ## [2025-12-14]
 ## Added
 - Ability to use TD-1 device on direct load lanes

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -145,13 +145,14 @@ class afc:
         self.led_name               = config.get('led_name',None)
         self.led_off                = "0,0,0,0"
         self.led_fault              = config.get('led_fault','1,0,0,0')                # LED color to set when faults occur in lane
-        self.led_ready              = config.get('led_ready','1,1,1,1')                # LED color to set when lane is ready
-        self.led_not_ready          = config.get('led_not_ready','1,1,0,0')            # LED color to set when lane not ready
-        self.led_loading            = config.get('led_loading','1,0,0,0')              # LED color to set when lane is loading
-        self.led_prep_loaded        = config.get('led_loading','1,1,0,0')              # LED color to set when lane is loaded
+        self.led_ready              = config.get('led_ready','0,0.8,0,0')                # LED color to set when lane is ready
+        self.led_not_ready          = config.get('led_not_ready','1,0,0,0')            # LED color to set when lane not ready
+        self.led_loading            = config.get('led_loading','1,1,1,0')              # LED color to set when lane is loading
+        self.led_prep_loaded        = config.get('led_loading','1,1,1,0')              # LED color to set when lane is loaded
         self.led_unloading          = config.get('led_unloading','1,1,.5,0')           # LED color to set when lane is unloading
-        self.led_tool_loaded        = config.get('led_tool_loaded','1,1,0,0')          # LED color to set when lane is loaded into tool
+        self.led_tool_loaded        = config.get('led_tool_loaded','0,0,1,0')          # LED color to set when lane is loaded into tool
         self.led_tool_loaded_idle   = config.get('led_tool_loaded_idle','0.4,0.4,0,0') # LED color to set when lane is loaded into tool and idle
+        self.led_tool_unloaded      = config.get('led_tool_unloaded', '1,0,0,0')       # LED color to set when lanes extruder is unloaded
         self.led_advancing          = config.get('led_buffer_advancing','0,0,1,0')     # LED color to set when buffer is advancing
         self.led_trailing           = config.get('led_buffer_trailing','0,1,0,0')      # LED color to set when buffer is trailing
         self.led_buffer_disabled    = config.get('led_buffer_disable', '0,0,0,0.25')   # LED color to set when buffer is disabled
@@ -1019,7 +1020,7 @@ class afc:
             # Removing spool from vars since it was ejected
             self.spool.set_spoolID(cur_lane, "")
             self.logger.info("LANE {} eject done".format(cur_lane.name))
-            self.function.afc_led(cur_lane.led_not_ready, cur_lane.led_index)
+            cur_lane.unit_obj.lane_not_ready(cur_lane)
         elif cur_lane.extruder_obj.no_lanes and cur_lane.extruder_obj.lane_loaded:
             cur_lane.status = AFCLaneState.EJECTING
             cur_lane.extruder_obj.load_unload_sequence(cur_lane.extruder_obj.tool_stn_unload*-1)
@@ -1469,7 +1470,7 @@ class afc:
             cur_lane.disable_buffer()
 
             # Activate LED indicator for unloading.
-            self.function.afc_led(cur_lane.led_unloading, cur_lane.led_index)
+            cur_lane.unit_obj.lane_unloading(cur_lane)
 
             # Synchronize the extruder stepper with the lane.
             cur_lane.sync_to_extruder()

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -81,13 +81,17 @@ class afcBoxTurtle(afcUnit):
             else:
                 cur_lane.status = AFCLaneState.LOADED
                 msg +="<span class=success--text> AND LOADED</span>"
-                cur_lane.unit_obj.lane_illuminate_spool(cur_lane)
+                self.lane_illuminate_spool(cur_lane)
 
                 if cur_lane.tool_loaded:
                     if cur_lane.get_toolhead_pre_sensor_state() == True or cur_lane.extruder_obj.tool_start == "buffer" or cur_lane.extruder_obj.tool_end_state:
                         if cur_lane.extruder_obj.lane_loaded == cur_lane.name:
                             cur_lane.sync_to_extruder()
-                            msg +="<span class=primary--text> in ToolHead</span>"
+                            on_shuttle = ""
+                            if (cur_lane.extruder_obj.tool_obj
+                                and cur_lane.extruder_obj.tc_unit_name):
+                                on_shuttle = " and toolhead on shuttle" if cur_lane.extruder_obj.on_shuttle() else ""
+                            msg += f"<span class=primary--text> in ToolHead{on_shuttle}</span>"
                             if cur_lane.extruder_obj.tool_start == "buffer":
                                 msg += "<span class=warning--text>\n Ram sensor enabled, confirm tool is loaded</span>"
 

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -62,26 +62,26 @@ class afcBoxTurtle(afcUnit):
 
         if not cur_lane.prep_state:
             if not cur_lane.load_state:
-                self.afc.function.afc_led(cur_lane.led_not_ready, cur_lane.led_index)
+                self.lane_not_ready(cur_lane)
                 msg += 'EMPTY READY FOR SPOOL'
             else:
-                self.afc.function.afc_led(cur_lane.led_fault, cur_lane.led_index)
+                self.lane_fault(cur_lane)
                 msg +="<span class=error--text> NOT READY</span>"
                 cur_lane.do_enable(False)
                 msg = '<span class=error--text>CHECK FILAMENT Prep: False - Load: True</span>'
                 succeeded = False
 
         else:
-            self.afc.function.afc_led(cur_lane.led_ready, cur_lane.led_index)
+            self.lane_loaded(cur_lane)
             msg +="<span class=success--text>LOCKED</span>"
             if not cur_lane.load_state:
                 msg +="<span class=error--text> NOT LOADED</span>"
-                self.afc.function.afc_led(cur_lane.led_not_ready, cur_lane.led_index)
+                self.lane_not_ready(cur_lane)
                 succeeded = False
             else:
                 cur_lane.status = AFCLaneState.LOADED
                 msg +="<span class=success--text> AND LOADED</span>"
-                self.afc.function.afc_led(cur_lane.led_spool_illum, cur_lane.led_spool_index)
+                cur_lane.unit_obj.lane_illuminate_spool(cur_lane)
 
                 if cur_lane.tool_loaded:
                     if cur_lane.get_toolhead_pre_sensor_state() == True or cur_lane.extruder_obj.tool_start == "buffer" or cur_lane.extruder_obj.tool_end_state:
@@ -93,8 +93,10 @@ class afcBoxTurtle(afcUnit):
 
                             if self.afc.current == cur_lane.name:
                                 self.afc.spool.set_active_spool(cur_lane.spool_id)
-                                self.afc.function.afc_led(cur_lane.led_tool_loaded, cur_lane.led_index)
+                                self.lane_tool_loaded(cur_lane)
                                 cur_lane.status = AFCLaneState.TOOLED
+                            else:
+                                self.lane_tool_loaded_idle(cur_lane)
 
                             cur_lane.enable_buffer()
                         else:

--- a/extras/AFC_HTLF.py
+++ b/extras/AFC_HTLF.py
@@ -147,11 +147,12 @@ class AFC_HTLF(afcBoxTurtle):
         self.logger.debug("HTLF: Lobe Movement angle : {}".format(angle_movement))
         return (self.mm_move_per_rotation/360)*angle_movement
 
-    def select_lane( self, lane ):
+    def select_lane( self, lane, disable_selector: bool=False ):
         """
         Moves lobe selector to specified lane based off lanes index
 
         :param lane: Lane object to move selector to
+        :param disable_selector: When True disables selectors motor after selecting a lane
         :return boolean: Returns True if movement of selector succeeded
         """
         self.failed_to_home = False
@@ -163,6 +164,9 @@ class AFC_HTLF(afcBoxTurtle):
                 self.current_selected_lane = lane
             else:
                 return False
+
+        if disable_selector:
+            self.selector_stepper_obj.do_enable(False)
 
     def check_runout(self, cur_lane):
         """

--- a/extras/AFC_OpenAMS.py
+++ b/extras/AFC_OpenAMS.py
@@ -858,7 +858,11 @@ class afcAMS(afcUnit):
                     )
                     if tool_ready and cur_lane.extruder_obj.lane_loaded == cur_lane.name:
                         cur_lane.sync_to_extruder()
-                        msg += '<span class=primary--text> in ToolHead</span>'
+                        on_shuttle = ""
+                        if (cur_lane.extruder_obj.tool_obj
+                                and cur_lane.extruder_obj.tc_unit_name):
+                                on_shuttle = " and toolhead on shuttle" if cur_lane.extruder_obj.on_shuttle() else ""
+                        msg += f"<span class=primary--text> in ToolHead{on_shuttle}</span>"
                         if cur_lane.extruder_obj.tool_start == "buffer":
                             msg += (
                                 '<span class=warning--text>'

--- a/extras/AFC_OpenAMS.py
+++ b/extras/AFC_OpenAMS.py
@@ -860,8 +860,8 @@ class afcAMS(afcUnit):
                         cur_lane.sync_to_extruder()
                         on_shuttle = ""
                         if (cur_lane.extruder_obj.tool_obj
-                                and cur_lane.extruder_obj.tc_unit_name):
-                                on_shuttle = " and toolhead on shuttle" if cur_lane.extruder_obj.on_shuttle() else ""
+                            and cur_lane.extruder_obj.tc_unit_name):
+                            on_shuttle = " and toolhead on shuttle" if cur_lane.extruder_obj.on_shuttle() else ""
                         msg += f"<span class=primary--text> in ToolHead{on_shuttle}</span>"
                         if cur_lane.extruder_obj.tool_start == "buffer":
                             msg += (

--- a/extras/AFC_OpenAMS.py
+++ b/extras/AFC_OpenAMS.py
@@ -830,25 +830,25 @@ class afcAMS(afcUnit):
 
         if not cur_lane.prep_state:
             if not cur_lane.load_state:
-                self.afc.function.afc_led(cur_lane.led_not_ready, cur_lane.led_index)
+                self.lane_not_ready(cur_lane)
                 msg += '<span class=success--text>EMPTY READY FOR SPOOL</span>'
             else:
-                self.afc.function.afc_led(cur_lane.led_fault, cur_lane.led_index)
+                self.lane_fault(cur_lane)
                 msg += '<span class=error--text> NOT READY</span>'
                 cur_lane.do_enable(False)
                 msg = '<span class=error--text>CHECK FILAMENT Prep: False - Load: True</span>'
                 succeeded = False
         else:
-            self.afc.function.afc_led(cur_lane.led_ready, cur_lane.led_index)
+            self.lane_loaded(cur_lane)
             msg += '<span class=success--text>LOCKED</span>'
             if not cur_lane.load_state:
                 msg += '<span class=error--text> NOT LOADED</span>'
-                self.afc.function.afc_led(cur_lane.led_not_ready, cur_lane.led_index)
+                self.lane_not_ready(cur_lane)
                 succeeded = False
             else:
                 cur_lane.status = AFCLaneState.LOADED
                 msg += '<span class=success--text> AND LOADED</span>'
-                self.afc.function.afc_led(cur_lane.led_spool_illum, cur_lane.led_spool_index)
+                self.lane_illuminate_spool(cur_lane)
 
                 if cur_lane.tool_loaded:
                     tool_ready = (
@@ -866,8 +866,10 @@ class afcAMS(afcUnit):
                             )
                         if self.afc.function.get_current_lane() == cur_lane.name:
                             self.afc.spool.set_active_spool(cur_lane.spool_id)
-                            cur_lane.unit_obj.lane_tool_loaded(cur_lane)
+                            self.lane_tool_loaded(cur_lane)
                             cur_lane.status = AFCLaneState.TOOLED
+                        else:
+                            self.lane_tool_loaded_idle(cur_lane)
                         cur_lane.enable_buffer()
                     elif tool_ready:
                         msg += (

--- a/extras/AFC_Toolchanger.py
+++ b/extras/AFC_Toolchanger.py
@@ -108,7 +108,15 @@ class AfcToolchanger(afcUnit):
         self.afc.gcode.run_script_from_command("UNSELECT_TOOL")
         lane_obj = self.afc.function.get_current_lane_obj()
         if lane_obj:
-            lane_obj.extruder_obj.set_status_led(lane_obj.led_tool_loaded_idle)
+            if (lane_obj.prep_state
+                and lane_obj.load_state):
+                if lane_obj.tool_loaded:
+                    lane_obj.unit_obj.lane_tool_loaded_idle(lane_obj)
+                else:
+                    lane_obj.unit_obj.lane_tool_unloaded(lane_obj)
+            else:
+                lane_obj.extruder_obj.set_status_led(lane_obj.led_tool_unloaded)
+
         self.afc.spool.set_active_spool('')
 
     def tool_swap(self, lane):

--- a/extras/AFC_Toolchanger.py
+++ b/extras/AFC_Toolchanger.py
@@ -166,9 +166,11 @@ class AfcToolchanger(afcUnit):
     }
     def cmd_AFC_SET_TOOLHEAD_LED(self, gcmd: GCodeCommand):
         """
-        Macro call to set print led in toolhead based on lane/tool mapping. Led config name needs to be
+        Macro call to set nozzle led in toolhead based on lane/tool mapping. Led config name needs to be
         set to AFC_extruder `led_name` variable. Status led in toolhead will not be affected if `status_led_idx`
-        is set in AFC_extruder config.
+        is set in AFC_extruder config. If `nozzle_led_idx` is set in AFC_extruder configuration then just
+        those leds will be turned on. If `nozzle_led_inx` is not provided then all leds not in defined in
+        `status_led_idx` will be turned on.
 
         `MAP` - is the mapped toolhead to set. ex(T0,T1,etc)
 

--- a/extras/AFC_Toolchanger.py
+++ b/extras/AFC_Toolchanger.py
@@ -46,6 +46,11 @@ class AfcToolchanger(afcUnit):
         self.functions.register_commands(self.afc.show_macros, "AFC_UNSELECT_TOOL",
                                          self.cmd_AFC_UNSELECT_TOOL, self.cmd_AFC_UNSELECT_TOOL_help)
 
+        self.functions.register_commands(self.afc.show_macros, "AFC_SET_TOOLHEAD_LED",
+                                         self.cmd_AFC_SET_TOOLHEAD_LED,
+                                         self.cmd_AFC_SET_TOOLHEAD_LED_help,
+                                         self.cmd_AFC_SET_TOOLHEAD_LED_options)
+
     def system_Test(self, cur_lane: AFCLane, delay: float, assignTcmd: str, enable_movement: bool):
         if assignTcmd: self.afc.function.TcmdAssign(cur_lane)
         # Now that a T command is assigned, send lane data to moonraker
@@ -58,7 +63,7 @@ class AfcToolchanger(afcUnit):
     cmd_AFC_SELECT_TOOL_options = {
         "TOOL": {"type": "string", "default": "extruder"}
     }
-    def cmd_AFC_SELECT_TOOL(self, gcmd:GCodeCommand):
+    def cmd_AFC_SELECT_TOOL(self, gcmd: GCodeCommand):
         """
         Select's tool based off passed in extruder name
 
@@ -84,7 +89,7 @@ class AfcToolchanger(afcUnit):
             self.logger.error(f"Key:{tool_key} invalid for TOOL")
 
     cmd_AFC_UNSELECT_TOOL_help = "Unselects and docks current tool on shuttle"
-    def cmd_AFC_UNSELECT_TOOL(self, gcmd:GCodeCommand):
+    def cmd_AFC_UNSELECT_TOOL(self, gcmd: GCodeCommand):
         """
         Unselects current tool loaded in shuttle by calling klipper-toolchanger UNSELECT_TOOL
 
@@ -101,6 +106,10 @@ class AfcToolchanger(afcUnit):
         ```
         """
         self.afc.gcode.run_script_from_command("UNSELECT_TOOL")
+        lane_obj = self.afc.function.get_current_lane_obj()
+        if lane_obj:
+            lane_obj.extruder_obj.set_status_led(lane_obj.led_tool_loaded_idle)
+        self.afc.spool.set_active_spool('')
 
     def tool_swap(self, lane):
         """
@@ -141,6 +150,46 @@ class AfcToolchanger(afcUnit):
             self.afc.last_gcode_position[i] += self.afc.gcode_move.base_position[i]
 
         self.afc.function.log_toolhead_pos("After toolswap: ")
+
+    cmd_AFC_SET_TOOLHEAD_LED_help = "Turns on leds for toolhead specified by mapping, does not affect status led if status_led_idx variable is provided"
+    cmd_AFC_SET_TOOLHEAD_LED_options = {
+        "MAP": {"type": "string", "default": "T0"},
+        "TURN_ON": {"type": "int", "default": 1}
+    }
+    def cmd_AFC_SET_TOOLHEAD_LED(self, gcmd: GCodeCommand):
+        """
+        Macro call to set print led in toolhead based on lane/tool mapping. Led config name needs to be
+        set to AFC_extruder `led_name` variable. Status led in toolhead will not be affected if `status_led_idx`
+        is set in AFC_extruder config.
+
+        `MAP` - is the mapped toolhead to set. ex(T0,T1,etc)
+
+        `TURN_ON` - set to 1 to turn on leds, set to 0 to turn off leds. If not supplied, defaults to 1
+
+        Usage
+        -----
+        `AFC_SET_TOOLHEAD_LED MAP=<T(n) mapping> TURN_ON=<0/1>`
+
+        Example
+        -----
+        ```
+        AFC_SET_TOOLHEAD_LED MAP=T2 TURN_ON=1
+        ```
+
+        """
+        mapping = gcmd.get("MAP")
+        state = gcmd.get_int("TURN_ON", 1)
+
+        lane_obj = self.afc.function.get_lane_by_map(mapping)
+        if lane_obj is None:
+            error_string = f"{mapping} mapping not found when trying to set toolhead led"
+            self.logger.error(error_string)
+            raise gcmd.error(error_string)
+
+        success, error_string = lane_obj.extruder_obj.set_print_leds(state)
+
+        if not success:
+            raise gcmd.error(error_string)
 
 def load_config_prefix(config: ConfigWrapper):
     return AfcToolchanger(config)

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -61,7 +61,7 @@ class afcError:
         else:
             self.PauseUserIntervention(problem)
         if not error_handled:
-            self.afc.function.afc_led(self.afc.led_fault, LANE.led_index)
+            LANE.unit_obj.lane_fault(LANE)
 
         return error_handled
 
@@ -256,4 +256,4 @@ class afcError:
         cur_lane.status = AFCLaneState.ERROR
         msg = "{} {}".format(cur_lane.name, message)
         self.AFC_error(msg, pause, level=2)
-        self.afc.function.afc_led(self.afc.led_fault, cur_lane.led_index)
+        cur_lane.unit_obj.lane_fault(cur_lane)

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -84,7 +84,8 @@ class AFCExtruder:
         self.check_transmit_status_fn   = None
         self.status_led_count:int       = 0
 
-        self.toolhead_status_index      = self.afc.function._get_led_indexes(self.toolhead_status_index)
+        if self.toolhead_status_index:
+            self.toolhead_status_index      = self.afc.function._get_led_indexes(self.toolhead_status_index)
 
         self.tc_unit_name: Optional[str] = config.get("toolchanger_unit", None)
         self.tc_unit_obj: Optional[AfcToolchanger|None] = None

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from reactor import PollReactor, SelectReactor
     from configfile import ConfigWrapper
     from kinematics.extruder import PrinterExtruder
+    from gcode import GCodeCommand
     from toolhead import ToolHead
     from extras.heaters import Heater
     from extras.AFC import afc
@@ -158,6 +159,10 @@ class AFCExtruder:
         self.function.register_mux_command(self.show_macros, 'SAVE_EXTRUDER_VALUES', "EXTRUDER", self.name,
                                            self.cmd_SAVE_EXTRUDER_VALUES, self.cmd_SAVE_EXTRUDER_VALUES_help,
                                            self.cmd_SAVE_EXTRUDER_VALUES_options)
+        if self.toolhead_leds:
+            self.function.register_mux_command(self.show_macros, 'AFC_SET_EXTRUDER_LED', "EXTRUDER", self.name,
+                                            self.cmd_AFC_SET_EXTRUDER_LED, self.cmd_AFC_SET_EXTRUDER_LED_help,
+                                            self.cmd_AFC_SET_EXTRUDER_LED_options)
 
     def __str__(self):
         return self.name
@@ -643,6 +648,39 @@ class AFCExtruder:
         self.afc.function.ConfigRewrite(self.fullname, 'tool_stn', self.tool_stn, '')
         self.afc.function.ConfigRewrite(self.fullname, 'tool_stn_unload', self.tool_stn_unload, '')
         self.afc.function.ConfigRewrite(self.fullname, 'tool_sensor_after_extruder', self.tool_sensor_after_extruder, '')
+
+    cmd_AFC_SET_EXTRUDER_LED_help = "Turns on toolhead leds for specified extruder name, does not affect status led if status_led_idx variable is provided"
+    cmd_AFC_SET_EXTRUDER_LED_options = {
+        "EXTRUDER": {"type": "string", "default": "extruder"},
+        "TURN_ON": {"type": "int", "default": 1}
+    }
+    def cmd_AFC_SET_EXTRUDER_LED(self, gcmd: GCodeCommand):
+        """
+        Macro call to set print led in toolhead based on extruder name. Led config name needs to be
+        set to AFC_extruder `led_name` variable. Status led in toolhead will not be affected if `status_led_idx`
+        is set in AFC_extruder config. Macro only is enabled per toolhead if `led_name` variable is provided.
+
+        `EXTRUDER` - AFC_extruder config name to print leds. If single toolhead, this will always be `extruder`
+
+        `TURN_ON` - set to 1 to turn on leds, set to 0 to turn off leds. If not supplied, defaults to 1
+
+        Usage
+        -----
+        `AFC_SET_TOOLHEAD_LED EXTRUDER=<extruder name> TURN_ON=<0/1>`
+
+        Example
+        -----
+        ```
+        AFC_SET_TOOLHEAD_LED EXTRUDER=extruder TURN_ON=1
+        ```
+
+        """
+        state = gcmd.get_int("TURN_ON", 1)
+
+        success, error_string = self.set_print_leds(state)
+
+        if not success:
+            raise gcmd.error(error_string)
 
     def get_status(self, eventtime=None):
         self.response = {}

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -525,7 +525,7 @@ class AFCExtruder:
         """
         if self.toolhead_led_obj is None:
             return
-        
+
         if (self.set_status_color_fn is None
             or self.check_transmit_status_fn is None):
             return
@@ -533,7 +533,7 @@ class AFCExtruder:
         color = tuple(map(float, color.split(',')))
         for idx in self.toolhead_status_index:
             self.set_status_color_fn(idx, color)
-        
+
         self.check_transmit_status_fn(None)
 
     def set_print_leds(self, state: int=1):
@@ -547,7 +547,7 @@ class AFCExtruder:
             error_string = f"led_name variable not set in [{self.fullname}] config section"
             self.logger.error(error_string)
             return False, error_string
-        
+
         if (self.set_status_color_fn is None
             or self.check_transmit_status_fn is None):
             error_string = "Cannot set print leds as status or check_transmit function are None"
@@ -564,7 +564,7 @@ class AFCExtruder:
 
     def on_shuttle(self):
         """
-        Helper function to easily detect if a toolhead is on the shuttle or not. This function is 
+        Helper function to easily detect if a toolhead is on the shuttle or not. This function is
         for toolchangers and will return True for single toolhead printers.
 
         :return bool: True if toolheads optotap sensor is triggered. Always returns True for single

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -667,12 +667,12 @@ class AFCExtruder:
 
         Usage
         -----
-        `AFC_SET_TOOLHEAD_LED EXTRUDER=<extruder name> TURN_ON=<0/1>`
+        `AFC_SET_EXTRUDER_LED EXTRUDER=<extruder name> TURN_ON=<0/1>`
 
         Example
         -----
         ```
-        AFC_SET_TOOLHEAD_LED EXTRUDER=extruder TURN_ON=1
+        AFC_SET_EXTRUDER_LED EXTRUDER=extruder TURN_ON=1
         ```
 
         """

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import traceback
 import chelper
 from extras.force_move import calc_move_time
+import configfile
 
 try:
     from printer import message_ready as READY # type: ignore
@@ -74,6 +75,15 @@ class AFCExtruder:
         self.enable_runout              = config.getboolean("enable_tool_runout",       self.afc.enable_tool_runout)
         self.debounce_delay             = config.getfloat("debounce_delay",             self.afc.debounce_delay)
         self.deadband                   = config.getfloat("deadband", 2)                                                # Deadband for extruder heater, default is 2 degrees Celsius
+
+        self.toolhead_leds              = config.get('led_name', None)
+        self.toolhead_status_index      = config.get('status_led_idx', None)
+        self.toolhead_led_obj           = None
+        self.set_status_color_fn        = None
+        self.check_transmit_status_fn   = None
+        self.status_led_count:int       = 0
+
+        self.toolhead_status_index      = self.afc.function._get_led_indexes(self.toolhead_status_index)
 
         self.tc_unit_name: Optional[str] = config.get("toolchanger_unit", None)
         self.tc_unit_obj: Optional[AfcToolchanger|None] = None
@@ -194,7 +204,7 @@ class AFCExtruder:
             if self.tool:
                 self.tool_obj = self.printer.lookup_object(self.tool)
         except:
-            raise error(f'[{self.tool}] not found in config file for {self.name}')
+            raise error(f'[{self.tool}] not found in config file for {self.fullname}')
 
         try:
             if self.tc_unit_name:
@@ -205,7 +215,31 @@ class AFCExtruder:
 
         except:
             raise error(
-                f'AFC_Toolchanger {self.tc_unit_name} not found in config file for {self.name}'
+                f'AFC_Toolchanger {self.tc_unit_name} not found in config file for {self.fullname}'
+            )
+
+        try:
+            # Looking up led object if user supplied variable
+            if self.toolhead_leds:
+                self.toolhead_led_obj = self.printer.lookup_object(
+                    f"{self.toolhead_leds}"
+                )
+                # Setting led_count, status_color function and check_transmit function since
+                # these functions are named differently depending on klipper/kalico versions
+                if hasattr(self.toolhead_led_obj, "led_helper"):
+                    led_helper = self.toolhead_led_obj.led_helper
+                    self.status_led_count = led_helper.led_count
+                    if hasattr(led_helper, "_set_color"):
+                        self.set_status_color_fn = led_helper._set_color
+                        self.check_transmit_status_fn = led_helper._check_transmit
+                    else:
+                        self.set_status_color_fn = led_helper.set_color
+                        self.check_transmit_status_fn = led_helper.check_transmit
+
+        except configfile.error:
+            raise error(
+                f"{self.toolhead_leds} not found in config file for led_name variable in " \
+                f"{self.fullname} config section"
             )
 
     def _handle_toolhead_sensor_runout(self, state, sensor_name):
@@ -482,6 +516,66 @@ class AFCExtruder:
             self.logger.info(msg)
         else:
             self.logger.error("tool_sensor_after_extruder length should be greater than zero")
+
+    def set_status_led(self, color):
+        """
+        Function to set status led indexes on toolhead if user defines `status_led_idx`
+
+        :param color: Color to set led indexes
+        """
+        if self.toolhead_led_obj is None:
+            return
+        
+        if (self.set_status_color_fn is None
+            or self.check_transmit_status_fn is None):
+            return
+
+        color = tuple(map(float, color.split(',')))
+        for idx in self.toolhead_status_index:
+            self.set_status_color_fn(idx, color)
+        
+        self.check_transmit_status_fn(None)
+
+    def set_print_leds(self, state: int=1):
+        """
+        Function to set toolhead part led's, currently will set leds in `led_name` objects chain count
+        to white. Does not set led's that defined in `status_led_idx`.
+
+        :param state: Set to 1 to turn on the leds, set to 0 to turn off leds
+        """
+        if self.toolhead_led_obj is None:
+            error_string = f"led_name variable not set in [{self.fullname}] config section"
+            self.logger.error(error_string)
+            return False, error_string
+        
+        if (self.set_status_color_fn is None
+            or self.check_transmit_status_fn is None):
+            error_string = "Cannot set print leds as status or check_transmit function are None"
+            self.logger.error(error_string)
+            return False, error_string
+
+        for idx in range(1, self.status_led_count+1):
+            if idx not in self.toolhead_status_index:
+                self.set_status_color_fn(idx, (state,)*4)
+
+        self.check_transmit_status_fn(None)
+
+        return True, ""
+
+    def on_shuttle(self):
+        """
+        Helper function to easily detect if a toolhead is on the shuttle or not. This function is 
+        for toolchangers and will return True for single toolhead printers.
+
+        :return bool: True if toolheads optotap sensor is triggered. Always returns True for single
+                      toolhead printers.
+        """
+        # Return true if both are not set as this would be for single toolhead
+        # setups
+        if self.tool_obj is None and self.tc_unit_name is None:
+            return True
+
+        return self.tool_obj.detect_state
 
     cmd_UPDATE_TOOLHEAD_SENSORS_help = "Gives ability to update tool_stn, tool_stn_unload, tool_sensor_after_extruder values without restarting klipper"
     cmd_UPDATE_TOOLHEAD_SENSORS_options = {

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -357,7 +357,7 @@ class afcFunction:
         :return AFCLane: Lane object if found, None if not found
         """
         lane_obj: Optional[AFCLane] = None
-        lane_name: str = self.afc.tool_cmds.get(map_name, None)
+        lane_name: Optional[str] = self.afc.tool_cmds.get(map_name, None)
 
         if lane_name is None:
             self.logger.info("Lane map {} not found".format(map_name))
@@ -407,7 +407,7 @@ class afcFunction:
         :return string: Name of current extruder/tool, None if no extruder/tool
         """
         current_extruder: str = self.afc.toolhead.get_extruder().name
-        tool_obj: AFCExtruder = self.afc.tools.get(current_extruder, None)
+        tool_obj: Optional[AFCExtruder] = self.afc.tools.get(current_extruder, None)
         if tool_obj:
             return current_extruder if tool_obj.on_shuttle() else None
         else:
@@ -495,8 +495,8 @@ class afcFunction:
             if cur_lane_loaded is None or key != cur_lane_loaded.name:
                 obj.do_enable(False)
                 obj.disable_buffer()
-                if cur_lane_loaded is None \
-                    or (obj.unit_obj.name != cur_lane_loaded.unit_obj.name):
+                if (cur_lane_loaded is None
+                    or (obj.unit_obj.name != cur_lane_loaded.unit_obj.name)):
                     obj.unit_obj.return_to_home()
                 obj.unsync_to_extruder()
                 if obj.prep_state and obj.load_state:

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -8,6 +8,7 @@
 # Originally authored by Félix Boisselier and licensed under the GNU General Public License v3.0.
 #
 # Full license text available at: https://www.gnu.org/licenses/gpl-3.0.html
+from __future__ import annotations
 
 import os
 import random
@@ -18,6 +19,12 @@ import configparser
 from configfile import error
 from datetime import datetime
 from pathlib import Path
+
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from extras.AFC_lane import AFCLane
+    from extras.AFC_extruder import AFCExtruder
 
 try: from extras.AFC_utils import ERROR_STR
 except: raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".format(trace=traceback.format_exc()))
@@ -342,21 +349,21 @@ class afcFunction:
         pause_resume = self.printer.lookup_object("pause_resume")
         return bool(pause_resume.get_status(eventtime)["is_paused"])
 
-    def get_lane_by_map(self, map_name):
+    def get_lane_by_map(self, map_name) -> Optional[AFCLane]:
         """
         Helper function to lookup lane by map name
 
         :param map_name: Name of lane map to lookup
-        :return object: Lane object if found, None if not found
+        :return AFCLane: Lane object if found, None if not found
         """
-        lane_name = None
-        for lane in self.afc.lanes:
-            lane_obj = self.afc.lanes[lane]
-            if lane_obj.map == map_name:
-                lane_name = lane_obj
+        lane_obj: Optional[AFCLane] = None
+        lane_name: str = self.afc.tool_cmds.get(map_name, None)
+    
         if lane_name is None:
             self.logger.info("Lane map {} not found".format(map_name))
-        return lane_name
+        else:
+            lane_obj = self.afc.lanes.get(lane_name, None)
+        return lane_obj
 
     def get_current_lane(self):
         """
@@ -382,7 +389,7 @@ class afcFunction:
             curr_lane_obj = self.afc.lanes[curr_lane]
         return curr_lane_obj
 
-    def get_current_extruder_obj(self):
+    def get_current_extruder_obj(self) -> Optional[AFCExtruder]:
         """
         Helper function to lookup current extruder object loaded into active toolhead
 
@@ -390,20 +397,19 @@ class afcFunction:
         """
         extruder_name = self.get_current_extruder()
         if extruder_name:
-            return self.afc.tools[extruder_name]
+            return self.afc.tools.get(extruder_name, None)
         return None
 
-    def get_current_extruder(self):
+    def get_current_extruder(self) -> Optional[str]:
         """
         Helper function to lookup current extruder name loaded into active toolhead
 
         :return string: Name of current extruder/tool, None if no extruder/tool
         """
-        current_extruder = self.afc.toolhead.get_extruder().name
-        if current_extruder in self.afc.tools:
-            tool_obj = self.afc.tools[current_extruder].tool_obj
-            detected_state = tool_obj.detect_state if hasattr(tool_obj, "detect_state") else 1
-            return current_extruder if detected_state else None
+        current_extruder: str = self.afc.toolhead.get_extruder().name
+        tool_obj: AFCExtruder = self.afc.tools.get(current_extruder, None)
+        if tool_obj:
+            return current_extruder if tool_obj.on_shuttle() else None
         else:
             return None
 
@@ -483,25 +489,27 @@ class afcFunction:
         cur_lane_loaded = self.get_current_lane_obj()
         self.logger.debug("Activating extruder lane: {}".format(cur_lane_loaded.name if cur_lane_loaded else "None"))
 
+        self.afc.spool.set_active_spool('')
         # Disable extruder steppers for non active lanes
         for key, obj in self.afc.lanes.items():
             if cur_lane_loaded is None or key != cur_lane_loaded.name:
                 obj.do_enable(False)
                 obj.disable_buffer()
-                obj.unit_obj.return_to_home()
+                if cur_lane_loaded is None \
+                    or (obj.unit_obj.name != cur_lane_loaded.unit_obj.name):
+                    obj.unit_obj.return_to_home()
                 obj.unsync_to_extruder()
                 if obj.prep_state and obj.load_state:
                     if obj.tool_loaded:
                         # If tool is loaded, set led to tool loaded color
-                        self.afc_led(obj.led_tool_loaded_idle, obj.led_index)
+                        obj.unit_obj.lane_tool_loaded_idle(obj)
                     else:
-                        self.afc_led(obj.led_ready, obj.led_index)
+                        obj.unit_obj.lane_loaded(obj)
                 else:
-                    self.afc_led(obj.led_not_ready, obj.led_index)
+                    obj.unit_obj.lane_unloaded(obj)
 
         # Exit early if lane is None
         if cur_lane_loaded is None:
-            self.afc.spool.set_active_spool('')
             return
 
         # Switch spoolman ID

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -358,7 +358,7 @@ class afcFunction:
         """
         lane_obj: Optional[AFCLane] = None
         lane_name: str = self.afc.tool_cmds.get(map_name, None)
-    
+
         if lane_name is None:
             self.logger.info("Lane map {} not found".format(map_name))
         else:

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -127,6 +127,7 @@ class AFCLane:
         self.led_unloading        = config.get('led_unloading',None)                    # LED color to set when lane is unloading
         self.led_tool_loaded      = config.get('led_tool_loaded',None)                  # LED color to set when lane is loaded into tool
         self.led_tool_loaded_idle = config.get('led_tool_loaded_idle',None)             # LED color to set when lane is loaded into tool and idle
+        self.led_tool_unloaded    = config.get('led_tool_unloaded', None)               # LED color to set when lanes extruder is unloaded
         self.led_spool_index      = config.get('led_spool_index', None)                 # LED index to illuminate under spool
         self.led_spool_illum      = config.get('led_spool_illuminate', None)            # LED color to illuminate under spool
 
@@ -389,6 +390,7 @@ class AFCLane:
         if self.led_unloading        is None: self.led_unloading        = self.unit_obj.led_unloading
         if self.led_tool_loaded      is None: self.led_tool_loaded      = self.unit_obj.led_tool_loaded
         if self.led_tool_loaded_idle is None: self.led_tool_loaded_idle = self.unit_obj.led_tool_loaded_idle
+        if self.led_tool_unloaded    is None: self.led_tool_unloaded    = self.unit_obj.led_tool_unloaded
         if self.led_spool_illum      is None: self.led_spool_illum      = self.unit_obj.led_spool_illum
 
         if self.rev_long_moves_speed_factor is None: self.rev_long_moves_speed_factor  = self.unit_obj.rev_long_moves_speed_factor
@@ -569,7 +571,7 @@ class AFCLane:
             - Once changeover is successful print is automatically resumed
         """
         self.status = AFCLaneState.NONE
-        self.afc.function.afc_led(self.afc.led_not_ready, self.led_index)
+        self.unit_obj.lane_not_ready(self)
         self.logger.info("Infinite Spool triggered for {}".format(self.name))
         empty_lane = self.afc.lanes[self.afc.current]
         change_lane = self.afc.lanes[self.runout_lane]
@@ -592,7 +594,7 @@ class AFCLane:
             # Resume with manual issued command
             self.afc.error.pause_resume.send_resume_command()
             # Set LED to not ready
-            self.afc.function.afc_led(self.led_not_ready, self.led_index)
+            self.unit_obj.lane_not_ready(self)
 
     def _perform_pause_runout(self):
         """
@@ -611,7 +613,7 @@ class AFCLane:
         self.status = AFCLaneState.NONE
         msg = "Runout triggered for lane {} and runout lane is not setup to switch to another lane".format(self.name)
         msg += "\nPlease manually load next spool into toolhead and then hit resume to continue"
-        self.afc.function.afc_led(self.afc.led_not_ready, self.led_index)
+        self.unit_obj.lane_not_ready(self)
         self.afc.error.AFC_error(msg)
 
     def _prep_capture_td1(self):
@@ -727,7 +729,7 @@ class AFCLane:
                         if x> 40:
                             msg = ' FAILED TO LOAD, CHECK FILAMENT AT TRIGGER\n||==>--||----||------||\nTRG   LOAD   HUB    TOOL'
                             self.afc.error.AFC_error(msg, False)
-                            self.afc.function.afc_led(self.afc.led_fault, self.led_index)
+                            self.unit_obj.lane_fault(self)
                             self.status = AFCLaneState.NONE
                             break
                     self.status = AFCLaneState.NONE

--- a/extras/AFC_led.py
+++ b/extras/AFC_led.py
@@ -5,7 +5,7 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
 import logging
-from . import led
+from extras import led
 BACKGROUND_PRIORITY_CLOCK = 0x7fffffff00000000
 BIT_MAX_TIME = .000004
 RESET_MIN_TIME = .000050

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -116,14 +116,20 @@ class afcPrep:
 
         # check if Lane is supposed to be loaded in tool head from saved file
         for extruder in self.afc.tools.keys():
-            PrinterObject=self.afc.tools[extruder]
-            self.afc.tools[PrinterObject.name]=PrinterObject
+            extruder_obj=self.afc.tools[extruder]
+            extruder_obj.set_status_led( self.afc.led_tool_unloaded )
+            if extruder_obj.on_shuttle():
+                # Calls ACTIVATE_EXTRUDER if current toolhead on shuttle is not the active extruder
+                if self.afc.function.get_current_extruder() != extruder_obj.name:
+                    self.afc.gcode.run_script_from_command(
+                        f"ACTIVATE_EXTRUDER EXTRUDER={extruder_obj.name}"
+                    )
             if 'system' in units and "extruders" in units["system"]:
                 # Check to see if lane_loaded is in dictionary and its not an empty string
-                if PrinterObject.name in units["system"]["extruders"] and \
-                  'lane_loaded' in units["system"]["extruders"][PrinterObject.name] and \
-                  units["system"]["extruders"][PrinterObject.name]['lane_loaded']:
-                    PrinterObject.lane_loaded = units["system"]["extruders"][PrinterObject.name]['lane_loaded']
+                if extruder_obj.name in units["system"]["extruders"] and \
+                  'lane_loaded' in units["system"]["extruders"][extruder_obj.name] and \
+                  units["system"]["extruders"][extruder_obj.name]['lane_loaded']:
+                    extruder_obj.lane_loaded = units["system"]["extruders"][extruder_obj.name]['lane_loaded']
 
 
         for lane in self.afc.lanes.keys():
@@ -211,7 +217,7 @@ class afcPrep:
         # have selectors to make sure the selector is on the correct lane
         current_lane = self.afc.function.get_current_lane_obj()
         if current_lane is not None:
-            current_lane.unit_obj.select_lane(current_lane)
+            current_lane.unit_obj.select_lane(current_lane, True)
             current_lane.sync_to_extruder()
 
         # Restore previous bypass state if virtual bypass is active

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -63,6 +63,7 @@ class afcUnit:
         self.led_unloading               = config.get('led_unloading', self.afc.led_unloading)               # LED color to set when lane is unloading
         self.led_tool_loaded             = config.get('led_tool_loaded', self.afc.led_tool_loaded)           # LED color to set when lane is loaded into tool
         self.led_tool_loaded_idle        = config.get('led_tool_loaded_idle', self.afc.led_tool_loaded_idle) # LED color to set when lane is loaded into tool and idle
+        self.led_tool_unloaded           = config.get('led_tool_unloaded', self.afc.led_tool_unloaded)       # LED color to set when lanes extruder is unloaded
         self.led_spool_illum             = config.get('led_spool_illuminate', self.afc.led_spool_illum)      # LED color to illuminate under spool
         self.led_logo_index              = config.get('led_logo_index', None)                                # LED Logo index
         self.led_logo_color              = self.afc.function.HexConvert(config.get('led_logo_color', '0,0,0,0'))# Default logo color when nothing is loaded
@@ -394,6 +395,14 @@ class afcUnit:
             led_color = self.afc.function.HexToLedString(color.replace("#", ""))
             self.afc.function.afc_led( led_color, self.led_logo_index )
 
+    def lane_not_ready(self, lane):
+        """
+        Common function for setting a lanes led when a lane is not ready
+
+        :param lane: Lane object to set led
+        """
+        self.afc.function.afc_led(lane.led_not_ready, lane.led_index)
+
     def lane_loaded(self, lane):
         """
         Common function for setting a lanes led when lane is loaded
@@ -401,6 +410,14 @@ class afcUnit:
         :param lane: Lane object to set led
         """
         self.afc.function.afc_led(lane.led_ready, lane.led_index)
+    
+    def lane_unloading(self, lane):
+        """
+        Common function for setting a lanes led when lane is unloading
+
+        :param lane: Lane object to set led
+        """
+        self.afc.function.afc_led(lane.led_unloading, lane.led_index)
 
     def lane_unloaded(self, lane):
         """
@@ -408,7 +425,7 @@ class afcUnit:
 
         :param lane: Lane object to set led
         """
-        self.afc.function.afc_led(lane.led_not_ready, lane.led_index)
+        self.lane_not_ready(lane)
 
     def lane_loading(self, lane):
         """
@@ -420,22 +437,52 @@ class afcUnit:
 
     def lane_tool_loaded(self, lane):
         """
-        Common function for setting a lanes led when lane is tool loaded
+        Common function for setting a lanes led when lane is tool loaded,
+        also sets toolheads led status color
 
         :param lane: Lane object to set led
         """
         self.afc.function.afc_led(lane.led_tool_loaded, lane.led_index)
+        lane.extruder_obj.set_status_led(lane.led_tool_loaded)
 
     def lane_tool_unloaded(self, lane):
         """
-        Common function for setting a lanes led when lane is tool unloaded
+        Common function for setting a lanes led when lane is tool unloaded,
+        also sets toolheads led status color
 
         :param lane: Lane object to set led
         """
         self.afc.function.afc_led(lane.led_ready, lane.led_index)
-        return
+        lane.extruder_obj.set_status_led(lane.led_tool_unloaded)
 
-    def select_lane( self, lane ):
+    def lane_tool_loaded_idle(self, lane):
+        """
+        Common function for setting a lanes led when its loaded into a tool
+        and tool is docked(for toolchangers). Function also sets toolheads led
+        status color.
+
+        :param lane: Lane object to set led
+        """
+        self.afc.function.afc_led(lane.led_tool_loaded_idle, lane.led_index)
+        lane.extruder_obj.set_status_led(lane.led_tool_loaded_idle)
+    
+    def lane_illuminate_spool(self, lane):
+        """
+        Common function for setting lane illumination leds
+
+        :param lane: Lane object to set led
+        """
+        self.afc.function.afc_led(lane.led_spool_illum, lane.led_spool_index)
+
+    def lane_fault(self, lane):
+        """
+        Common function for setting a lanes led when a fault happens
+
+        :param lane: Lane object to set led
+        """
+        self.afc.function.afc_led(lane.led_fault, lane.led_index)
+
+    def select_lane( self, lane, disable_selector: bool=False ):
         """
         Function to select lane
         """

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -410,7 +410,7 @@ class afcUnit:
         :param lane: Lane object to set led
         """
         self.afc.function.afc_led(lane.led_ready, lane.led_index)
-    
+
     def lane_unloading(self, lane):
         """
         Common function for setting a lanes led when lane is unloading
@@ -465,7 +465,7 @@ class afcUnit:
         """
         self.afc.function.afc_led(lane.led_tool_loaded_idle, lane.led_index)
         lane.extruder_obj.set_status_led(lane.led_tool_loaded_idle)
-    
+
     def lane_illuminate_spool(self, lane):
         """
         Common function for setting lane illumination leds

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ruff==0.6.9
 configfile
+mypy==1.5.1
 pip~=24.3.1


### PR DESCRIPTION
## Major Changes in this PR
- Added AFC_SET_TOOLHEAD_LED macro which sets print leds based off passed in mapping
- Added ability to set toolhead leds directly with AFC_SET_EXTRUDER_LED macro
- Updated multiple function to set toolhead led status based off current state
- New variables(led_name, status_led_idx) were added to support setting toolhead leds
- Updating message during PREP to print out if toolhead is detected on shuttle

@weemantella 
## Notes to Code Reviewers

## How the changes in this PR are tested
Tested on toolchanger and printer with single toolhead

Multiple toolheads showing status:
![PXL_20260101_234107189](https://github.com/user-attachments/assets/67b7eb2f-264c-4437-8562-8e94fdbc1870)

Toolhead changing status when docking toolhead:

https://github.com/user-attachments/assets/eb0a94f3-dd4e-4964-91e6-bed42fc95deb


Detecting tool on shuttle during PREP:
<img width="1001" height="527" alt="image" src="https://github.com/user-attachments/assets/565983db-7fad-4331-90fa-dd7b77abbfdf" />


## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.