### PR TITLE
[Enhancement] Updating how stats are tracked and stored in database for multiple extruders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-01-09]
+### Changed:
+- Restructured how extruder load/unload counts are stored in moonraker database to work better for toolchangers.
+- Added ability to track cuts per toolhead for toolchangers.
+- Changed how average times are calculated. Use `AFC_RESET_STATS EXTRUDER=all` to use new `total_time/count` calculation.
+- Merged normal and skinny AFC_STATS printout into one function and changed printout format to work better with toolchangers.
+
 ## [2025-12-26]
 ### Changed:
 - Updated AFC_CUT macro to move to pin first before doing filament retraction.

--- a/config/macros/Cut.cfg
+++ b/config/macros/Cut.cfg
@@ -253,6 +253,7 @@ gcode:
     {% set max_x = printer.toolhead.axis_maximum.x|float %}
     {% set max_y = printer.toolhead.axis_maximum.y|float %}
     {% set safe_margin_x, safe_margin_y = vars.safe_margin_xy|map('float') %}
+    {% set verbose = gVars['verbose']              |default(1)     | int %}
 
     # Make traveling to cutter pin safer overall
     {% if cut_direction == "front" or cut_direction == "back" or cut_direction == "left" or cut_direction == "right"%}
@@ -405,6 +406,7 @@ gcode:
     {% set max_x = printer.toolhead.axis_maximum.x|float %}
     {% set max_y = printer.toolhead.axis_maximum.y|float %}
     {% set safe_margin_x, safe_margin_y = vars.safe_margin_xy|map('float') %}
+    {% set verbose = gVars['verbose']              |default(1)     | int %}
 
     # Make moving away from cutter pin safer overall
     {% if cut_direction == "front" or cut_direction == "back" or cut_direction == "left" or cut_direction == "right" %}

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1937,7 +1937,7 @@ class afc:
 
         def reset_extruder(extruder: AFCExtruder):
             extruder.estats.reset_stats()
-            self.logger.info(f'Extruder stats reset for {extruder}')
+            self.logger.info(f'Extruder stats reset for {extruder.name}')
 
         if extruder or lane:
             if not self.db_backup:

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2024 Armored Turtle
 #
+from __future__ import annotations
 
 import json
 import re
@@ -9,6 +10,13 @@ import traceback
 from configfile import error
 from typing import Any
 
+from typing import Dict, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from gcode import GCodeCommand
+    from extras.AFC_lane import AFCLane
+    from extras.AFC_extruder import AFCExtruder
+    from extras.AFC_functions import afcFunction
 
 ERROR_STR = "Error trying to import {import_lib}, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper\n\n{trace}"
 
@@ -27,7 +35,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 try: from extras.AFC_stats import AFCStats
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
 
-AFC_VERSION="1.0.33"
+AFC_VERSION="1.0.34"
 
 # Class for holding different states so its clear what all valid states are
 class State:
@@ -54,7 +62,7 @@ class afc:
 
         self.spool      = self.printer.load_object(config, 'AFC_spool')
         self.error      = self.printer.load_object(config, 'AFC_error')
-        self.function   = self.printer.load_object(config, 'AFC_functions')
+        self.function: afcFunction   = self.printer.load_object(config, 'AFC_functions')
         self.function.afc = self
         self.gcode      = self.printer.load_object(config, 'gcode')
 
@@ -78,11 +86,12 @@ class afc:
         self.lane_data_enabled  = False
         self.prep_done          = False         # Variable used to hold of save_vars function from saving too early and overriding save before prep can be ran
         self.in_print_timer     = None
+        self.db_backup          = False
 
         # Objects for everything configured for AFC
         self.units      = {}
-        self.tools      = {}
-        self.lanes      = {}
+        self.tools: Dict[str, AFCExtruder] = {}
+        self.lanes: Dict[str, AFCLane]     = {}
         self.hubs       = {}
         self.buffers    = {}
         self.tool_cmds  = {}
@@ -248,6 +257,8 @@ class afc:
                                         self.cmd_AFC_TOGGLE_MACRO_help, self.cmd_AFC_TOGGLE_MACRO_options)
         self.function.register_commands(self.show_macros, 'UNSET_LANE_LOADED', self.cmd_UNSET_LANE_LOADED,
                                         self.cmd_UNSET_LANE_LOADED_help)
+        self.function.register_commands(self.show_macros, 'AFC_RESET_STATS', self.cmd_AFC_RESET_STATS,
+                                        self.cmd_AFC_RESET_STATS_help, self.cmd_AFC_RESET_STATS_options)
 
     def _remove_after_last(self, string, char):
         last_index = string.rfind(char)
@@ -308,7 +319,7 @@ class afc:
             self.moonraker.delete_lane_data()
             self.spoolman = self.moonraker.get_spoolman_server()
             self.td1_defined, self._td1_present, self.lane_data_enabled = self.moonraker.check_for_td1()
-            self.afc_stats = AFCStats(self.moonraker, self.logger, self.tool_cut_threshold)
+            self.afc_stats = AFCStats(self.moonraker, self.logger, len(self.tools) > 1)
 
             self.printer.send_event("afc:moonraker_connect")
         except Exception as e:
@@ -1215,7 +1226,7 @@ class afc:
             self.afc_stats.average_tool_load_time.average_time(load_time)
 
             # Increment stat counts
-            self.afc_stats.tc_tool_load.increase_count()
+            cur_lane.extruder_obj.estats.tc_tool_load.increase_count()
             cur_lane.lane_load_count.increase_count()
             cur_lane.espooler.stats.update_database()
 
@@ -1269,7 +1280,7 @@ class afc:
         # User manually unloaded spool from toolhead, remove spool from active status
         self.spool.set_active_spool(None)
 
-    def TOOL_UNLOAD(self, cur_lane):
+    def TOOL_UNLOAD(self, cur_lane: AFCLane):
         """
         This function handles the unloading of a specified lane from the tool. It performs
         several checks and movements to ensure the lane is properly unloaded.
@@ -1328,7 +1339,7 @@ class afc:
 
         # Perform filament cutting and parking if specified.
         if self.tool_cut:
-            self.afc_stats.increase_cut_total()
+            cur_lane.extruder_obj.estats.increase_cut_total()
             self.gcode.run_script_from_command(self.tool_cut_cmd)
             self.afcDeltaTime.log_with_time("TOOL_UNLOAD: After cut")
             self.function.log_toolhead_pos()
@@ -1507,7 +1518,7 @@ class afc:
         cur_lane.do_enable(False)
         cur_lane.unit_obj.return_to_home()
 
-        self.afc_stats.tc_tool_unload.increase_count()
+        cur_lane.extruder_obj.estats.tc_tool_unload.increase_count()
         cur_lane.espooler.stats.update_database()
 
         self.save_vars()
@@ -1575,7 +1586,7 @@ class afc:
 
         self.CHANGE_TOOL(self.lanes[self.tool_cmds[Tcmd]], purge_length)
 
-    def CHANGE_TOOL(self, cur_lane, purge_length=None, restore_pos=True):
+    def CHANGE_TOOL(self, cur_lane: AFCLane, purge_length=None, restore_pos=True):
         self.afcDeltaTime.set_start_time()
         # Check if the bypass filament sensor detects filament; if so, abort the tool change.
         if self._check_bypass(unload=False): return
@@ -1618,7 +1629,7 @@ class afc:
                 self.in_toolchange = False
                 # Setting next lane load as none since toolchange was successful
                 self.next_lane_load = None
-                self.afc_stats.increase_toolcount_change()
+                cur_lane.extruder_obj.estats.increase_toolcount_change()
             else:
                 # Error happened, reset toolchanges without error count
                 if not self.testing:
@@ -1863,24 +1874,103 @@ class afc:
         self.afc_stats.print_stats(afc_obj=self, short=short)
 
     cmd_AFC_CHANGE_BLADE_help = "Sets cutter blade changed date and resets total count since blade was changed"
-    def cmd_AFC_CHANGE_BLADE(self, gcmd):
+    def cmd_AFC_CHANGE_BLADE(self, gcmd: GCodeCommand):
         """
         This macro handles resetting cut total since blade was last changed and updates the data
         the blade was last changed to current date time when this macro was run.
 
+        Extruder variable is optional and will default to 'extruder'
+
         Usage
         -----
-        `AFC_CHANGE_BLADE`
+        `AFC_CHANGE_BLADE EXTRUDER=<extruder>`
 
         Example
         -----
         ```
-        AFC_CHANGE_BLADE
+        AFC_CHANGE_BLADE EXTRUDER=extruder1
         ```
         """
-        self.afc_stats.last_blade_changed.set_current_time()
-        self.afc_stats.cut_total_since_changed.reset_count()
-        self.logger.info("Cutter blade stats reset")
+        extruder: str = gcmd.get("EXTRUDER", "extruder")
+        extruder_obj = self.tools.get(extruder, None)
+        if extruder_obj:
+            extruder_obj.estats.last_blade_changed.set_current_time()
+            extruder_obj.estats.cut_total_since_changed.reset_count()
+            self.logger.info(f"Cutter blade stats reset for {extruder}")
+        else:
+            self.logger.error(f"{extruder} is not a valid extruder name")
+
+    cmd_AFC_RESET_STATS_help ="Resets stats for a given extruder or lane"
+    cmd_AFC_RESET_STATS_options = {"EXTRUDER": {"type": "string", "default":''},
+                                   "LANE": {"type":"string", "default": ''}}
+    def cmd_AFC_RESET_STATS(self, gcmd: GCodeCommand):
+        """
+        This macro handles resetting extruder(s) and lane(s) change total's. You can reset
+        each extruder or lane one by one or use `all`. When using the command,
+        moonrakers database will be backedup just incase you want to restore the old data.
+
+        When using `all` for extruders, this will trigger AFC will to start using a different
+        calculation when printing lane change times. AFC will now keep track of the total
+        times and divide by the number of changes.
+
+        For example the following will reset extruder change times/counts and start using the
+        new calculation.
+
+        `AFC_RESET_STATS EXTRUDER=all`
+
+        Usage
+        -----
+        `AFC_RESET_STATS EXTRUDER=<extruder_name> LANE=<lane_name>`
+
+        Example
+        -----
+        ```
+        AFC_RESET_STATS EXTRUDER=extruder LANE=lane1
+        ```
+        """
+        extruder: str = gcmd.get('EXTRUDER', None)
+        lane: str = gcmd.get("LANE", None)
+
+        def reset_lane(lane: AFCLane):
+            lane.lane_load_count.reset_count()
+            self.logger.info(f'Lane stats reset for {lane.name}')
+
+        def reset_extruder(extruder: AFCExtruder):
+            extruder.estats.reset_stats()
+            self.logger.info(f'Extruder stats reset for {extruder}')
+
+        if extruder or lane:
+            if not self.db_backup:
+                error = self.moonraker.trigger_db_backup()
+                if error: return
+                self.db_backup = True
+
+        if extruder:
+            if "all" in extruder.lower():
+                for extruder_obj in self.tools.values():
+                    reset_extruder(extruder_obj)
+                self.afc_stats.average_tool_load_time.reset_count()
+                self.afc_stats.reset_average_times()
+            else:
+                extruder_obj: AFCExtruder = self.tools.get(extruder, None)
+                if extruder_obj:
+                    reset_extruder(extruder_obj)
+                else:
+                    self.logger.error(f"{extruder} is not a valid extruder name")
+
+        if lane:
+            if "all" in lane.lower():
+                for lane_obj in self.lanes.values():
+                    reset_lane(lane_obj)
+            else:
+                lane_obj: AFCLane = self.lanes.get(lane, None)
+                if lane_obj:
+                    reset_lane(lane_obj)
+                else:
+                    self.logger.error(f"{lane} is not a valid lane name")
+
+        if extruder is None and lane is None:
+            self.logger.info("A valid EXTRUDER or LANE needs to be specified to reset")
 
     cmd_AFC_CLEAR_MESSAGE_help = "Macro to clear error and warning message from AFC message queue"
     def cmd_AFC_CLEAR_MESSAGE(self, gcmd):

--- a/extras/AFC_assist.py
+++ b/extras/AFC_assist.py
@@ -10,6 +10,11 @@ from __future__ import annotations
 import math
 import traceback
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from extras.AFC import afc
+
 from configfile import error
 try: from extras.AFC_utils import ERROR_STR
 except: raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".format(trace=traceback.format_exc()))
@@ -113,7 +118,7 @@ class AFCEspoolerStats:
     espooler_obj:
         Espooler object to easily get access to logger and moonraker objects
     """
-    def __init__(self, espooler_name:str, espooler_obj:object):
+    def __init__(self, espooler_name: str, espooler_obj: Espooler):
         self.espooler_name = espooler_name
         self.espooler_obj = espooler_obj
         self._n20_runtime_fwd   = 0
@@ -132,11 +137,7 @@ class AFCEspoolerStats:
         enough time to start before AFC tries to connect. This fixes a race condition that can
         happen between klipper and moonraker when first starting up.
         """
-        afc_stats = self.espooler_obj.afc.moonraker.get_afc_stats()
-        if afc_stats is not None:
-            values = afc_stats["value"]
-        else:
-            values = None
+        values = self.espooler_obj.afc.moonraker.get_afc_stats()
 
         self._n20_runtime_fwd   = AFCStats_var(self.espooler_name, "n20_runtime_fwd", values, self.espooler_obj.afc.moonraker)
         self._n20_runtime_rwd   = AFCStats_var(self.espooler_name, "n20_runtime_rwd", values, self.espooler_obj.afc.moonraker)
@@ -421,7 +422,7 @@ class Espooler:
     def __init__(self, name, config):
         self.name                   = name
         self.printer                = config.get_printer()
-        self.afc                    = self.printer.load_object(config, "AFC")
+        self.afc: afc               = self.printer.load_object(config, "AFC")
         self.logger                 = self.afc.logger
         self.reactor                = self.printer.get_reactor()
         self.callback_timer         = self.reactor.register_timer( self.timer_callback )    # Defaults to never trigger

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -260,7 +260,7 @@ class AFCLane:
         happen between klipper and moonraker when first starting up.
         """
         if self.unit_obj.type != "HTLF" or (self.unit_obj.type == "HTLF" and "AFC_lane" in self.fullname):
-            values = self.afc.moonraker.afc_stats["value"]
+            values = self.afc.moonraker.get_afc_stats()
             self.lane_load_count = AFCStats_var(self.name, "load_count", values, self.afc.moonraker)
             self.espooler.handle_moonraker_connect()
 

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2024 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import annotations
 
 import math
 import traceback
@@ -11,6 +12,10 @@ from contextlib import contextmanager
 from configfile import error
 from datetime import datetime
 from enum import Enum
+
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from extras.AFC import afc
 
 try: from extras.AFC_utils import ERROR_STR, add_filament_switch
 except: raise error("Error when trying to import AFC_utils.ERROR_STR, add_filament_switch\n{trace}".format(trace=traceback.format_exc()))
@@ -50,7 +55,7 @@ class AFCLane:
     UPDATE_WEIGHT_DELAY = 10.0
     def __init__(self, config):
         self.printer            = config.get_printer()
-        self.afc                = self.printer.load_object(config, 'AFC')
+        self.afc: afc           = self.printer.load_object(config, 'AFC')
         self.gcode              = self.printer.load_object(config, 'gcode')
         self.reactor            = self.printer.get_reactor()
         self.extruder_stepper   = None
@@ -255,9 +260,7 @@ class AFCLane:
         happen between klipper and moonraker when first starting up.
         """
         if self.unit_obj.type != "HTLF" or (self.unit_obj.type == "HTLF" and "AFC_lane" in self.fullname):
-            values = None
-            if self.afc.moonraker.afc_stats is not None:
-                values = self.afc.moonraker.afc_stats["value"]
+            values = self.afc.moonraker.afc_stats["value"]
             self.lane_load_count = AFCStats_var(self.name, "load_count", values, self.afc.moonraker)
             self.espooler.handle_moonraker_connect()
 

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -239,7 +239,8 @@ class afcPrep:
         if self.afc.bypass.filament_present:
             self.logger.raw(f"<span class=warning--text>{bypass_name} enabled</span>")
 
-        self.afc.afc_stats.check_cut_threshold()
+        for extruder in self.afc.tools.values():
+            extruder.estats.check_cut_threshold()
 
         # Defaulting to no active spool, putting at end so endpoint has time to register
         if self.afc.current is None:

--- a/extras/AFC_stats.py
+++ b/extras/AFC_stats.py
@@ -3,12 +3,20 @@
 # Copyright (C) 2024 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import annotations
+
 import traceback
 
 from configparser import Error as error
+from typing import TYPE_CHECKING, Any, Optional
 
 try: from extras.AFC_utils import check_and_return
 except: raise error("Error when trying to import AFC_utils.check_and_return\n{trace}".format(trace=traceback.format_exc()))
+
+if TYPE_CHECKING:
+    from extras.AFC_utils import AFC_moonraker
+    from extras.AFC_logger import AFC_logger
+    from extras.AFC import afc
 
 class AFCStats_var:
     """
@@ -30,23 +38,33 @@ class AFCStats_var:
     moonraker : AFC_moonraker
         AFC_moonraker class to easily post values to moonraker
     """
-    def __init__(self, parent_name:str, name:str, data:dict, moonraker:object):
+    def __init__(self, parent_name: str, name: str, data: dict, moonraker: AFC_moonraker,
+                 new_parent_name: str='', new_average: bool=False):
         self.parent_name = parent_name
         self.name        = name
         self.moonraker   = moonraker
+        self.new_average = new_average
+        self._value: Any
 
-        if data is not None and self.parent_name in data:
-            value = check_and_return( self.name, data[self.parent_name])
-            try:
-                self._value = int(value)
-            except ValueError:
-                try :
-                    self._value = float(value)
-                except:
-                    self._value = value
-        else:
-            self.moonraker.logger.debug("No data in database for {}.{}:{}".format( self.parent_name, name, bool(data is not None)))
-            self._value = 0
+        multi_parent = self.parent_name.split('.')
+        new_multi_parent = new_parent_name.split('.')
+        if data is not None:
+            if len(new_multi_parent) > 0 and new_multi_parent[0] in data:
+                self._get_value(data, new_multi_parent)
+            elif multi_parent[0] in data:
+                self._get_value(data, multi_parent)
+            else:
+                self.moonraker.logger.debug("No data in database for {}.{}:{}".format( self.parent_name, name, bool(data is not None)))
+                self._value = 0
+
+        # Check if new parent name has been passed in. If new parent override old parent
+        # name and delete key from database if its present.
+        if new_parent_name:
+            self.parent_name = new_parent_name
+            if multi_parent[0] in data:
+                self.update_database()
+                multi_parent.append(name)
+                self.moonraker.remove_database_entry(self.moonraker.afc_stats_key, '.'.join(multi_parent))
 
     def __str__(self):
         return str(self._value)
@@ -58,19 +76,63 @@ class AFCStats_var:
     def value(self, value):
         self._value = value
 
-    def average_time(self, value:float):
+    def _get_value(self, data: dict, parent_name: list):
+        """
+        Helper function to get correct data from dictionary based off parents name
+
+        :param parent_name: List in correct order of parent key name in database.
+                            ex. extruder.cut -> ['extruder', 'cut']
+        """
+        if len(parent_name) == 1:
+            value = check_and_return( self.name, data[parent_name[0]])
+        elif len(parent_name) == 2:
+            if parent_name[1] in data[parent_name[0]]:
+                value = check_and_return( self.name, data[parent_name[0]][parent_name[1]])
+            else:
+                self.moonraker.logger.debug("No data in database for {}.{}:{}".format( '.'.join(parent_name), self.name, bool(data is not None)))
+                value = 0
+        else:
+            self.moonraker.logger.error("Cannot have more than two parent names for stats")
+        try:
+            self._value = int(value)
+        except ValueError:
+            try :
+                self._value = float(value)
+            except:
+                self._value = value
+
+    def average_time(self, value: float):
         """
         Helper function for averaging time, moonrakers database is updated after
-        averaging numbers
+        averaging numbers. If AFC is using new average calculation, then values are just
+        totaled up. Calculating averages will happen when printing out stats.
 
-        :param value: Float value to average into current value
+        :param value: Float value to average or sum into current value
         """
         if self._value > 0:
             self._value += value
-            self._value /= 2
+            if not self.new_average:
+                self._value /= 2
         else:
             self._value = value
+
         self.update_database()
+
+    def get_average(self, total: int) -> float:
+        """
+        Helper function for returning average. If AFC is using new calculation, average
+        is calculated and returned.
+
+        :param total: Total number of loads, only used with new AFC calculations
+        :return float: Average value
+        """
+        if int(self.new_average):
+            if total > 0:
+                return self._value/total
+            else:
+                return self._value
+        else:
+            return self._value
 
     def increase_count(self):
         """
@@ -85,6 +147,7 @@ class AFCStats_var:
         """
         self._value = 0
         self.update_database()
+        self.new_average = True
 
     def update_database(self):
         """
@@ -117,95 +180,50 @@ class AFCStats:
         AFC_moonraker class is passed into AFCStats_var class for easily updating values in database
     logger: AFC_logger
         AFC_logger class for logging and printing to console
-    cut_threshold: integer
-        cut threshold set by user in AFC config
     """
-    def __init__(self, moonraker, logger, cut_threshold):
+    def __init__(self, moonraker: AFC_moonraker, logger: AFC_logger, multiple_tools: bool=False):
         self.moonraker  = moonraker
         self.logger     = logger
-        afc_stats       = self.moonraker.get_afc_stats()
+        self.multiple_tools = multiple_tools
+        values       = self.moonraker.get_afc_stats()
 
-        if afc_stats is not None:
-            values = afc_stats["value"]
-        else:
-            values = None
+        self.tc_without_error   = AFCStats_var("toolchange_count", "changes_without_error", values,
+                                               self.moonraker, "error_stats")
+        self.tc_last_load_error = AFCStats_var("toolchange_count", "last_load_error", values,
+                                               self.moonraker, "error_stats")
 
-        self.tc_total           = AFCStats_var("toolchange_count", "total",                 values, self.moonraker)
-        self.tc_tool_unload     = AFCStats_var("toolchange_count", "tool_unload",           values, self.moonraker)
-        self.tc_tool_load       = AFCStats_var("toolchange_count", "tool_load",             values, self.moonraker)
-        self.tc_without_error   = AFCStats_var("toolchange_count", "changes_without_error", values, self.moonraker)
-        self.tc_last_load_error = AFCStats_var("toolchange_count", "last_load_error",       values, self.moonraker)
+        new_average_calc = 1
+        if "average_time" in values:
+            new_average_calc = 0
 
-        self.cut_total                  = AFCStats_var("cut", "cut_total",                  values, self.moonraker)
-        self.cut_total_since_changed    = AFCStats_var("cut", "cut_total_since_changed",    values, self.moonraker)
-        self.last_blade_changed         = AFCStats_var("cut", "last_blade_changed",         values, self.moonraker)
-        self.cut_threshold_for_warning  = cut_threshold
-        self.threshold_warning_sent     = False
-        self.threshold_error_sent       = False
+        self.new_average_calc           = AFCStats_var("average_time", "new_average_calc", values,
+                                                       self.moonraker)
+        if self.new_average_calc.value == 0:
+            self.new_average_calc.value = new_average_calc
+            self.new_average_calc.update_database()
 
-        self.average_toolchange_time    = AFCStats_var("average_time", "tool_change", values, self.moonraker)
-        self.average_tool_unload_time   = AFCStats_var("average_time", "tool_unload", values, self.moonraker)
-        self.average_tool_load_time     = AFCStats_var("average_time", "tool_load",   values, self.moonraker)
+        self.average_toolchange_time    = AFCStats_var("average_time", "tool_change", values,
+                                                       self.moonraker, new_average=self.new_average_calc.value)
+        self.average_tool_unload_time   = AFCStats_var("average_time", "tool_unload", values,
+                                                       self.moonraker, new_average=self.new_average_calc.value)
+        self.average_tool_load_time     = AFCStats_var("average_time", "tool_load",   values,
+                                                       self.moonraker, new_average=self.new_average_calc.value)
+
 
         if self.tc_last_load_error.value == 0:
             self.tc_last_load_error.value = "N/A"
             self.tc_last_load_error.update_database()
 
-        if self.last_blade_changed.value == 0:
-            self.last_blade_changed.value = "N/A"
-            self.last_blade_changed.update_database()
+        self.average_tool_swap_time: Optional[AFCStats_var]     = None
+        if self.multiple_tools:
+            self.logger.debug("Multiple tools detected for stats")
+            self.average_tool_swap_time     = AFCStats_var("average_time", "tool_swap",   values,
+                                                           self.moonraker, new_average=self.new_average_calc.value)
 
-    def check_cut_threshold(self):
+    def increase_toolchange_wo_error(self):
         """
-        Function checks current cut value against users threshold value, outputs warning when cut is within
-        1k cuts of threshold. Outputs errors once number of cuts exceed threshold
+        Common function to increase toolchange total value when errors do not occur.
         """
-        send_message = False
-        message_type = None
-        blade_changed_date_string = self.last_blade_changed
-        span_start = "<span class=warning--text>"
-        if 0 == self.last_blade_changed.value:
-            blade_changed_date_string = "N/A"
-
-        if self.cut_total_since_changed.value >= self.cut_threshold_for_warning:
-            warning_msg_time        = "Time"
-            warning_msg_threshold   = "have exceeded"
-            span_start              = "<span class=error--text>"
-            message_type            = "error"
-            if not self.threshold_error_sent:
-                self.threshold_error_sent = send_message = True
-
-        elif self.cut_total_since_changed.value >= (self.cut_threshold_for_warning - 1000):
-            warning_msg_time        = "Almost time"
-            warning_msg_threshold   = "is about to exceeded"
-            span_start              = "<span class=warning--text>"
-            message_type            = "warning"
-            if not self.threshold_warning_sent:
-                self.threshold_warning_sent = send_message = True
-        else:
-            return
-
-        warning_msg = f"{warning_msg_time} to change cutting blade as your blade has performed {self.cut_total_since_changed} cuts\n"
-        warning_msg += f"since changed on {blade_changed_date_string}. Number of cuts {warning_msg_threshold} set threshold of {self.cut_threshold_for_warning}.\n"
-        warning_msg +=  "Once blade is changed, execute AFC_CHANGE_BLADE macro to reset count and date changed.\n"
-        if send_message:
-            self.logger.raw( f"{span_start}{warning_msg}</span>")
-            self.logger.afc.message_queue.append((warning_msg, message_type))
-
-    def increase_cut_total(self):
-        """
-        Helper function for increasing all cut counts
-        """
-        self.cut_total.increase_count()
-        self.cut_total_since_changed.increase_count()
-        self.check_cut_threshold()
-
-    def increase_toolcount_change(self):
-        """
-        Helper function for increasing total toolchange count and number of toolchanges with
-        error count.
-        """
-        self.tc_total.increase_count()
         self.tc_without_error.increase_count()
 
     def reset_toolchange_wo_error(self):
@@ -216,105 +234,169 @@ class AFCStats:
         self.tc_without_error.reset_count()
         self.tc_last_load_error.set_current_time()
 
-    def print_stats(self, afc_obj, short:bool=False):
+    def reset_average_times(self):
+        """
+        Common function to easily reset all change times. Once resetting AFC will start
+        using new calculation function when tracking and printing stats.
+        """
+        self.average_toolchange_time.reset_count()
+        self.average_tool_unload_time.reset_count()
+        self.average_tool_load_time.reset_count()
+        if self.average_tool_swap_time:
+            self.average_tool_swap_time.reset_count()
+        self.new_average_calc.value = 1
+        self.new_average_calc.update_database()
+
+    def print_stats(self, afc_obj: afc, short: bool=False):
         """
         Prints all stat to console
 
         :param afc_obj: AFC class that hold lane information so lanes stats can also be printed out
-        :param short: When set to True calls print_stats_skinny function.
+        :param short: When set to True print out skinner version.
         """
         MAX_WIDTH = 87
+        SECTIONAL_LENGTH = 42
+        MAX_SPAN = SECTIONAL_LENGTH*2+1
+        END = "|\n"
+        total_selected = 0
+        total_unselected = 0
+        total_changes = 0
+        total_unload = 0
+        total_load = 0
 
         def end_string():
             nonlocal print_str, temp_str
             print_str += f"{temp_str:{' '}<{86}}|\n"
             temp_str = ""
 
+        def add_end():
+            nonlocal short
+            if short:
+                return END
+            else:
+                return ''
+
+        max_lane_name_size = 0
+        for k in afc_obj.lanes.keys():
+            max_lane_name_size = max(max_lane_name_size, len(k))
+
         if short:
-            return self.print_stats_skinny(afc_obj)
+            MAX_WIDTH = 44
+            MAX_SPAN = MAX_WIDTH - 2
 
-        avg_tool_load   = f"Avg Tool Load: {self.average_tool_load_time.value:4.2f}s"
-        avg_tool_unload = f"Avg Tool Unload: {self.average_tool_unload_time.value:4.2f}s"
-        avg_tool_change = f"Avg Tool Change: {self.average_toolchange_time.value:4.2f}s"
+        overall_str  = f"{'':{'-'}<{MAX_WIDTH}}\n"
+        overall_str += f"|{'Overall Stats':{' '}^{MAX_WIDTH-2}}|\n"
+        overall_str += f"|{'Changes without error':{' '}>22} : {self.tc_without_error.value:{' '}<17}"
+        overall_str += add_end()
+        overall_str += f"|{'Last error date':{' '}>22} : {self.tc_last_load_error.value:{' '}<17}|\n"
 
-        cuts_since_change = f"{self.cut_total_since_changed.value}/{self.cut_threshold_for_warning}"
 
-        print_str  = f"{'':{'-'}<{MAX_WIDTH}}\n"
-        print_str += f"|{'Toolchanges':{' '}^42}|{'Cut':{' '}^42}|\n"
+        print_str = ""
         print_str += f"|{'':{'-'}<{MAX_WIDTH-2}}|\n"
-        print_str += f"|{'Total':{' '}>22} : {self.tc_total.value:{' '}<17}|{'Total':{' '}>22} : {self.cut_total.value:{''}<17}|\n"
-        print_str += f"|{'Tool Unload':{' '}>22} : {self.tc_tool_unload.value:{' '}<17}|{'Total since changed':{' '}>22} : {cuts_since_change:{''}<17}|\n"
-        print_str += f"|{'Tool Load':{' '}>22} : {self.tc_tool_load.value:{' '}<17}|{'Blade last changed':{' '}>22} : {self.last_blade_changed.value:{''}<17}|\n"
-        print_str += f"|{'Changes without error':{' '}>22} : {self.tc_without_error.value:{' '}<17}|{'':{''}<42}|\n"
-        print_str += f"|{'Last error date':{' '}>22} : {self.tc_last_load_error.value:{' '}<17}|{'':{''}<42}|\n"
-        print_str += f"{'':{'-'}<{MAX_WIDTH}}\n"
-        print_str += f"|{avg_tool_load:{' '}^28}|{avg_tool_unload:{' '}^27}|{avg_tool_change:{' '}^28}|\n"
-        print_str += f"{'':{'-'}<{MAX_WIDTH}}\n"
+        if not short:
+            print_str += f"|{'Toolchanges':{' '}^{SECTIONAL_LENGTH}}"
+            print_str += f"|{'Cut':{' '}^{SECTIONAL_LENGTH}}|\n"
+            print_str += f"|{'':{'-'}<{MAX_WIDTH-2}}|\n"
+
+        for extruder in afc_obj.tools.values():
+            cut_str = f"{extruder.name} Cut"
+            cut_str = f"|{cut_str:{' '}^{MAX_SPAN}}|\n"
+            stats = extruder.estats
+            cuts_since_change = f"{stats.cut_total_since_changed.value}/{stats.cut_threshold_for_warning}"
+
+            total_changes += stats.tc_total.value
+            total_unload += stats.tc_tool_unload.value
+            total_load += stats.tc_tool_load.value
+            extruder_lbl = f"{extruder.name} Toolchanges" if short else f"{extruder.name}"
+            print_str += f"|{extruder_lbl:{' '}^{MAX_SPAN}}|\n"
+
+            print_str += f"|{'Successful Changes':{' '}>22} : {stats.tc_total.value:{' '}<17}"
+            print_str += add_end()
+            string = f"|{'Total':{' '}>22} : {stats.cut_total.value:{''}<17}|\n"
+            if short: cut_str += string
+            else: print_str += string
+
+            print_str += f"|{'Tool Unload':{' '}>22} : {stats.tc_tool_unload.value:{' '}<17}"
+            print_str += add_end()
+            string = f"|{'Total since changed':{' '}>22} : {cuts_since_change:{''}<17}|\n"
+            if short: cut_str += string
+            else: print_str += string
+
+            print_str += f"|{'Tool Load':{' '}>22} : {stats.tc_tool_load.value:{' '}<17}"
+            print_str += add_end()
+            string = f"|{'Blade last changed':{' '}>22} : {stats.last_blade_changed.value:{''}<17}|\n"
+            if short: cut_str += string
+            else: print_str += string
+
+            if self.multiple_tools:
+                total_selected += stats.tool_selected.value
+                total_unselected += stats.tool_unselected.value
+                print_str += f"|{'Tool Unselected':{' '}>22} : {stats.tool_unselected.value:{' '}<17}"
+                if not short: print_str += f"|{' ':{' '}^{SECTIONAL_LENGTH}}|\n"
+                else: print_str += add_end()
+                print_str += f"|{'Tool Selected':{' '}>22} : {stats.tool_selected.value:{' '}<17}"
+                if not short: print_str += f"|{' ':{' '}^{SECTIONAL_LENGTH}}|\n"
+                else: print_str += add_end()
+
+            if short:
+                print_str += f"|{'':{'-'}<{MAX_WIDTH-2}}|\n"
+                print_str += cut_str
+
+            print_str += f"|{'':{'-'}<{MAX_WIDTH-2}}|\n"
+
+        avg_tool_load   = f"{'Avg Tool Load':{' '}>22} : {self.average_tool_load_time.get_average(total_load):4.2f}s"
+        avg_tool_unload = f"{'Avg Tool Unload':{' '}>22} : {self.average_tool_unload_time.get_average(total_unload):4.2f}s"
+        avg_tool_change = f"{'Avg Tool Change':{' '}>22} : {self.average_toolchange_time.get_average(total_changes):4.2f}s"
+        if self.average_tool_swap_time:
+            avg_tool_swap = f"{'Avg Tool Swap':{' '}>22} : {self.average_tool_swap_time.get_average(total_selected):4.2f}s"
+        else:
+            avg_tool_swap = ""
+
+
+        avg_str = f"|{avg_tool_load:{' '}<{SECTIONAL_LENGTH}}"
+        avg_str += add_end()
+        avg_str += f"|{avg_tool_unload:{' '}<{SECTIONAL_LENGTH}}|\n"
+        avg_str += f"|{avg_tool_change:{' '}<{SECTIONAL_LENGTH}}"
+        avg_str += add_end()
+        if (not short
+            or short and avg_tool_swap):
+            avg_str += f"|{avg_tool_swap:{' '}<{SECTIONAL_LENGTH}}|\n"
+
+        if self.multiple_tools:
+            avg_str += f"|{'Total Load':{' '}>22} : {total_load:{' '}<{17}}"
+            avg_str += add_end()
+            avg_str += f"|{'Total Unload':{' '}>{22}} : {total_unload:{' '}<17}|\n"
+            avg_str += f"|{'Total Selected':{' '}>22} : {total_selected:{' '}<17}"
+            avg_str += add_end()
+            avg_str += f"|{'Total Unselected':{' '}>{22}} : {total_unselected:{' '}<17}|\n"
+
+
+        print_str = overall_str + avg_str + print_str
 
         strings = []
         for lane in afc_obj.lanes.values():
-            espooler_stats = lane.espooler.get_spooler_stats()
-            string = f"{lane.name:{' '}>7} : Lane change count: {lane.lane_load_count.value:{' '}>7}"
+            espooler_stats = lane.espooler.get_spooler_stats(short)
+            string = f"{lane.name:{' '}>{max(max_lane_name_size,7)}} : Lane change count: {lane.lane_load_count.value:{' '}>7}"
+            if short: string = f"|{string:{' '}^{MAX_SPAN}}|\n"
             if len(espooler_stats) > 0:
-                string += f"    {espooler_stats}"
+                if short: string += f"|{espooler_stats:{' '}^{MAX_WIDTH}}|\n"
+                else: string += f"    {espooler_stats}"
             strings.append(string)
 
-        temp_str = ""
-        for i, s in enumerate(strings):
-            if len(temp_str) > 60:
-                end_string()
+        if short:
+            print_str += "".join(strings)
+        else:
+            temp_str = ""
+            for i, s in enumerate(strings):
+                if len(temp_str) > 60: end_string()
 
-            if len(s) > 60:
-                if len(temp_str) > 0:
-                    end_string()
-                print_str += f"|{s}{'|':{' '}>4}\n"
-            else:
-                temp_str += f"|{s:{' '}<42}"
-        if len(temp_str) > 0:
-            end_string()
+                if len(s) > 60:
+                    if len(temp_str) > 0: end_string()
+
+                    print_str += f"|{s}{'|':{' '}>4}\n"
+                else:
+                    temp_str += f"|{s:{' '}^{SECTIONAL_LENGTH}}"
+            if len(temp_str) > 0: end_string()
 
         print_str += f"{'':{'-'}<{MAX_WIDTH}}\n"
-        self.logger.raw(print_str)
-
-    def print_stats_skinny(self, afc_obj):
-        """
-        Prints all stats to console, this is different as its skinner so its easier to view on phones, Klipperscreen, etc.
-
-        :param afc_obj: AFC class that hold lane information so lanes stats can also be printed out
-        """
-        MAX_WIDTH = 42
-
-        avg_tool_load   = f"{'Avg Tool Load':{' '}>22} : {self.average_tool_load_time.value:4.2f}s"
-        avg_tool_unload = f"{'Avg Tool Unload':{' '}>22} : {self.average_tool_unload_time.value:4.2f}s"
-        avg_tool_change = f"{'Avg Tool Change':{' '}>22} : {self.average_toolchange_time.value:4.2f}s"
-
-        cuts_since_change = f"{self.cut_total_since_changed.value}/{self.cut_threshold_for_warning}"
-
-        print_str  = f"{'':{'-'}<{MAX_WIDTH+2}}\n"
-        print_str += f"|{'Toolchanges':{' '}^42}|\n"
-        print_str += f"|{'':{'-'}<{MAX_WIDTH}}|\n"
-        print_str += f"|{'Total':{' '}>22} : {self.tc_total.value:{' '}<17}|\n"
-        print_str += f"|{'Tool Unload':{' '}>22} : {self.tc_tool_unload.value:{' '}<17}|\n"
-        print_str += f"|{'Tool Load':{' '}>22} : {self.tc_tool_load.value:{' '}<17}|\n"
-        print_str += f"|{'Changes without error':{' '}>22} : {self.tc_without_error.value:{' '}<17}|\n"
-        print_str += f"|{'Last error date':{' '}>22} : {self.tc_last_load_error.value:{' '}<17}|\n"
-        print_str += f"|{'':{'-'}<{MAX_WIDTH}}|\n"
-        print_str += f"|{'Cut':{' '}^42}|\n"
-        print_str += f"|{'':{'-'}<{MAX_WIDTH}}|\n"
-        print_str += f"|{'Total':{' '}>22} : {self.cut_total.value:{''}<17}|\n"
-        print_str += f"|{'Total since changed':{' '}>22} : {cuts_since_change:{''}<17}|\n"
-        print_str += f"|{'Blade last changed':{' '}>22} : {self.last_blade_changed.value:{''}<17}|\n"
-        print_str += f"|{'':{'-'}<{MAX_WIDTH}}|\n"
-        print_str += f"|{avg_tool_load:{' '}<42}|\n|{avg_tool_unload:{' '}<42}|\n|{avg_tool_change:{' '}<42}|\n"
-        print_str += f"|{'':{'-'}<{MAX_WIDTH}}|\n"
-
-        for lane in afc_obj.lanes.values():
-            espooler_stats = lane.espooler.get_spooler_stats(short=True)
-            str = f"{lane.name:{' '}>7} : Lane change count: {lane.lane_load_count.value:{' '}>7}"
-            str = f"|{str:{' '}^{MAX_WIDTH}}|\n"
-            if len(espooler_stats) > 0:
-                str += f"|{espooler_stats:{' '}^{MAX_WIDTH}}|\n"
-            print_str += str
-
-        print_str += f"{'':{'-'}<{MAX_WIDTH+2}}\n"
         self.logger.raw(print_str)

--- a/extras/AFC_stats.py
+++ b/extras/AFC_stats.py
@@ -44,7 +44,7 @@ class AFCStats_var:
         self.name        = name
         self.moonraker   = moonraker
         self.new_average = new_average
-        self._value: Any
+        self._value: Any = 0
 
         multi_parent = self.parent_name.split('.')
         new_multi_parent = new_parent_name.split('.')
@@ -61,7 +61,7 @@ class AFCStats_var:
         # name and delete key from database if its present.
         if new_parent_name:
             self.parent_name = new_parent_name
-            if multi_parent[0] in data:
+            if data is not None and multi_parent[0] in data:
                 self.update_database()
                 multi_parent.append(name)
                 self.moonraker.remove_database_entry(self.moonraker.afc_stats_key, '.'.join(multi_parent))
@@ -93,6 +93,7 @@ class AFCStats_var:
                 value = 0
         else:
             self.moonraker.logger.error("Cannot have more than two parent names for stats")
+            value = 0
         try:
             self._value = int(value)
         except ValueError:
@@ -193,7 +194,7 @@ class AFCStats:
                                                self.moonraker, "error_stats")
 
         new_average_calc = 1
-        if "average_time" in values:
+        if values is not None and "average_time" in values:
             new_average_calc = 0
 
         self.new_average_calc           = AFCStats_var("average_time", "new_average_calc", values,


### PR DESCRIPTION
## Major Changes in this PR
- Restructured how extruder load/unload counts are stored in moonraker database to work better for toolchangers.
- Added ability to track cuts per toolhead for toolchangers.
- Changed how average times are calculated. Use `AFC_RESET_STATS EXTRUDER=all` to use new `total_time/count` calculation.
- Merged normal and skinny AFC_STATS printout into one function and changed printout format to work better with toolchangers.

AT-documentation PR - https://github.com/ArmoredTurtle/AT-Documentation/pull/145

## Notes to Code Reviewers

## How the changes in this PR are tested
Reset stats and did lane changes to verify that new averaging worked correctly. Also verified that old averaging still worked correctly until a reset happens

Changed code to look at `afc_stats_testing` to verify that namespace is still created without killing klipper

New stat printing formatting:
<img width="801" height="552" alt="afc_stats_wide" src="https://github.com/user-attachments/assets/6eacc3b4-72d0-4086-88be-64b577b63af2" />
<img width="365" height="948" alt="afc_stats_short" src="https://github.com/user-attachments/assets/0d832e10-1dc0-4d03-881c-50599a19ad2f" />


## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.