### PR TITLE
Added check to verify that AFC macro positions have been updated in AFC_Macro_Vars file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-01-10]
+### Added:
+- Check to verify to users macros positions are set correctly and not left as default values. Changed default values to -99,-99 etc, just in case someone does truly have their positions at -1,-1.
+
 ## [2026-01-09]
 ### Changed:
 - Restructured how extruder load/unload counts are stored in moonraker database to work better for toolchangers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2026-01-10]
 ### Added:
-- Check to verify to users macros positions are set correctly and not left as default values. Changed default values to -99,-99 etc, just in case someone does truly have their positions at -1,-1.
+- Check to verify user's macros positions are set correctly and not left as default values. Changed default values to -99,-99 etc, just in case someone does truly have their positions at -1,-1.
 
 ## [2026-01-09]
 ### Changed:

--- a/config/AFC_Macro_Vars.cfg
+++ b/config/AFC_Macro_Vars.cfg
@@ -29,7 +29,7 @@ gcode: # Leave empty
 
 # This should be the position of the toolhead where the cutter arm just
 # lightly touches the depressor pin
-variable_pin_loc_xy               : -1, -1    # x,y coordinates of depressor pin
+variable_pin_loc_xy               : -99, -99    # x,y coordinates of depressor pin
 
 # Accel during cut. This will overwrite the global accel for this macro. Set to 0 to use global accel
 variable_cut_accel                : 0
@@ -126,7 +126,7 @@ description: Poop macro configuration variables
 gcode: # Leave empty
 
 
-variable_purge_loc_xy             : -1, -1    # (x,y) Location of where to purge
+variable_purge_loc_xy             : -99, -99    # (x,y) Location of where to purge
 variable_purge_spd                : 6.5       # Speed, in mm/s, of the purge.
 variable_z_purge_move             : True      # Set to False to not move in Z during poop
 
@@ -191,7 +191,7 @@ variable_purge_z: 0
 description: Kick macro configuration variables
 gcode: # Leave empty
 
-variable_kick_start_loc           : -1,-1,5  # Location to move before kick
+variable_kick_start_loc           : -99,-99,5  # Location to move before kick
 variable_kick_z                   : 1.5       # Height to drop to for kick move
 variable_kick_speed               : 150       # Speed of kick movement
 variable_kick_accel               : 0         # Accel of kick moves. This will overwrite the global accel for this macro. Set to 0 to use global accel
@@ -208,7 +208,7 @@ description: Brush macro configuration variables
 gcode: # Leave empty
 
 
-variable_brush_loc                : -1,-1,-1  # Position of the center of the brush (Set z to -1 if you dont want a z move)
+variable_brush_loc                : -99,-99,-1  # Position of the center of the brush (Set z to -1 if you dont want a z move)
 variable_brush_clean_speed        : 150       # Speed of cleaning moves when brushing
 # Accel of cleaning moves when brushing. This will overwrite the global accel for this macro. Set to 0 to use global accel
 variable_brush_clean_accel        : 0
@@ -234,7 +234,7 @@ variable_z_move                   : -1
 description: Park macro configuration variables
 gcode: # Leave empty
 
-variable_park_loc_xy              : -1, -1    # Position to park the toolhead
+variable_park_loc_xy              : -99, -99    # Position to park the toolhead
 # If you want z_hop during toolchanges please set the value in the AFC.cfg
 variable_z_hop                    : 0         # Height to raise Z when moving to park. Leave 0 to disable
 variable_park_z                   : 0         # Absolute height to lower to after park move.  Leave 0 to disable

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -372,6 +372,62 @@ class afc:
 
         self.logger.info(string, console_only)
 
+    def verify_macro_positions(self) -> str:
+        """
+        Verifies that cut, park, poop, kick, wipe positions are set correctly if these
+        macros have been enabled in AFC.cfg file.
+
+        :return str: If an position has not been updated error string is returned with
+                     text informing the user they need to update their positions
+        """
+        error_str = ""
+        tool_cut_obj = self.printer.lookup_object('gcode_macro _AFC_CUT_TIP_VARS', None)
+        if (self.tool_cut
+            and self.tool_cut_cmd == "AFC_CUT"
+            and tool_cut_obj):
+            pin_loc_xy = tool_cut_obj.variables.get('pin_loc_xy', None)
+            if pin_loc_xy and pin_loc_xy == (-99,-99):
+                error_str += 'tool_cut is set to True and variable_pin_loc_xy has not been updated.\n'
+                error_str += 'Please update variable_pin_loc_xy in AFC\AFC_Macro_Vars.cfg file.\n\n'
+
+        park_obj = self.printer.lookup_object('gcode_macro _AFC_PARK_VARS', None)
+        if (self.park
+            and self.park_cmd == "AFC_PARK"
+            and park_obj):
+            park_loc_xy = park_obj.variables.get('park_loc_xy', None)
+            if park_loc_xy and park_loc_xy == (-99,-99):
+                error_str += 'park is set to True and variable_park_loc_xy has not been updated.\n'
+                error_str += 'Please update variable_park_loc_xy in AFC\AFC_Macro_Vars.cfg file.\n\n'
+
+        poop_obj = self.printer.lookup_object('gcode_macro _AFC_POOP_VARS', None)
+        if (self.poop
+            and self.poop_cmd == "AFC_POOP"
+            and poop_obj):
+            purge_loc_xy = poop_obj.variables.get('purge_loc_xy', None)
+            if purge_loc_xy and purge_loc_xy == (-99,-99):
+                error_str += 'poop is set to True and variable_purge_loc_xy has not been updated.\n'
+                error_str += 'Please update variable_purge_loc_xy in AFC\AFC_Macro_Vars.cfg file.\n\n'
+
+        kick_obj = self.printer.lookup_object('gcode_macro _AFC_KICK_VARS', None)
+        if (self.kick
+            and self.kick_cmd == "AFC_KICK"
+            and kick_obj):
+            kick_start_loc = kick_obj.variables.get('kick_start_loc', None)
+            if kick_start_loc and kick_start_loc == (-99,-99,5):
+                error_str += 'kick is set to True and variable_kick_start_loc has not been updated.\n'
+                error_str += 'Please update variable_kick_start_loc in AFC\AFC_Macro_Vars.cfg file.\n\n'
+
+        wipe_obj = self.printer.lookup_object('gcode_macro _AFC_BRUSH_VARS', None)
+        if (self.wipe
+            and self.wipe_cmd == "AFC_BRUSH"
+            and wipe_obj):
+            brush_loc = wipe_obj.variables.get('brush_loc', None)
+            if brush_loc and brush_loc == (-99,-99,-1):
+                error_str += 'wipe is set to True and variable_brush_loc has not been updated.\n'
+                error_str += 'Please update variable_brush_loc in AFC\AFC_Macro_Vars.cfg file.\n\n'
+
+        return error_str
+
     @property
     def td1_present(self):
         present = self._td1_present
@@ -1058,8 +1114,17 @@ class afc:
         if not self.function.check_homed():
             return False
 
+        error_str = self.verify_macro_positions()
+        if error_str:
+            self.error.AFC_error(
+                f"Error occurred when verifying macro postions, TOOL_LOAD aborted.\n{error_str}",
+                pause=self.function.in_print()
+            )
+            return False
+
         if cur_lane is None:
-            self.error.AFC_error("No lane provided to load, not loading any lane.", pause=self.function.in_print())
+            self.error.AFC_error("No lane provided to load, not loading any lane.",
+                                 pause=self.function.in_print())
             # Exit early if no lane is provided.
             return False
 
@@ -1295,9 +1360,18 @@ class afc:
         if not self.function.check_homed():
             return False
 
+        error_str = self.verify_macro_positions()
+        if error_str:
+            self.error.AFC_error(
+                f"Error occurred when verifying macro postions, TOOL_UNLOAD aborted.\n{error_str}",
+                pause=self.function.in_print()
+            )
+            return False
+
         if cur_lane is None:
             # If no lane is provided, exit the function early with a failure.
-            self.error.AFC_error("No lane is currently loaded, nothing to unload", pause=self.function.in_print())
+            self.error.AFC_error("No lane is currently loaded, nothing to unload",
+                                 pause=self.function.in_print())
             return False
 
         self.current_state  = State.UNLOADING

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -377,7 +377,7 @@ class afc:
         Verifies that cut, park, poop, kick, wipe positions are set correctly if these
         macros have been enabled in AFC.cfg file.
 
-        :return str: If an position has not been updated error string is returned with
+        :return str: If a position has not been updated error string is returned with
                      text informing the user they need to update their positions
         """
         error_str = ""
@@ -1117,7 +1117,7 @@ class afc:
         error_str = self.verify_macro_positions()
         if error_str:
             self.error.AFC_error(
-                f"Error occurred when verifying macro postions, TOOL_LOAD aborted.\n{error_str}",
+                f"Error occurred when verifying macro positions, TOOL_LOAD aborted.\n{error_str}",
                 pause=self.function.in_print()
             )
             return False
@@ -1363,7 +1363,7 @@ class afc:
         error_str = self.verify_macro_positions()
         if error_str:
             self.error.AFC_error(
-                f"Error occurred when verifying macro postions, TOOL_UNLOAD aborted.\n{error_str}",
+                f"Error occurred when verifying macro positions, TOOL_UNLOAD aborted.\n{error_str}",
                 pause=self.function.in_print()
             )
             return False

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -258,6 +258,11 @@ class afcPrep:
                                     "switches are triggered on Buffer {}. "
                                     "Please check your buffer switches or configuration.</span>".format(buffer_name))
 
+        # Verifying that user has macro positions set correctly for enabled park, cut, etc macros
+        error_str = self.afc.verify_macro_positions()
+        if error_str:
+            self.logger.error(error_str)
+
 def load_config(config):
     return afcPrep(config)
 


### PR DESCRIPTION
## Major Changes in this PR
- Checks added and prints during PREP, check also happens during load/unload and aborts if user has ignored PREP message but still tried to do a load/unload.
- Updated default positions to -99,-99 for x/y

## How the changes in this PR are tested
Prep printout:
<img width="662" height="515" alt="image" src="https://github.com/user-attachments/assets/6c0aec0d-5b30-4dec-81f3-a6d471714745" />

Load/Unload printouts:
<img width="665" height="807" alt="image" src="https://github.com/user-attachments/assets/04991cd1-2cb4-4738-a712-f14c33bb27d1" />

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.