### PR TITLE
Adding debugging messages to print out toolhead unloading movements for tool_stn_unload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-01-12]
+### Added:
+- Added debugging messages when doing unloading filament from toolhead for tool_stn_unload movements
+
 ## [2026-01-10]
 ### Added:
 - Check to verify user's macros positions are set correctly and not left as default values. Changed default values to -99,-99 etc, just in case someone does truly have their positions at -1,-1.

--- a/config/AFC_Macro_Vars.cfg
+++ b/config/AFC_Macro_Vars.cfg
@@ -90,7 +90,7 @@ variable_pushback_dwell_time      : 20        # Time to dwell between the pushba
 # we make a safer but longer move if we are closer to the pin than this
 # specified margin. Usually setting these to the size of the toolhead
 # (plus a small margin) should be good enough 
-variable_safe_margin_xy           : 30, 30
+variable_safe_margin_xy           : 60, 60
 
 # Some printers may need a boost of power to complete the cut without skipping steps.
 # One option is to increase the current for the steppers in printer.cfg. Another

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1447,12 +1447,12 @@ class afc:
             # if ramming is enabled, AFC will retract to collapse buffer before unloading
             cur_lane.unsync_to_extruder()
             while not cur_lane.get_trailing() and self.tool_max_unload_attempts > 0:
+                num_tries += 1
                 self.afcDeltaTime.log_with_time(
                     f'TOOL_UNLOAD: Retracting Buffer, Try:{num_tries}'
                 )
                 # attempt to return buffer to trailing pin
                 cur_lane.move_advanced(cur_lane.short_move_dis * -1, SpeedMode.SHORT)
-                num_tries += 1
                 self.reactor.pause(self.reactor.monotonic() + 0.1)
                 if num_tries > self.tool_max_unload_attempts:
                     msg = ''
@@ -1473,7 +1473,7 @@ class afc:
             # we only need to do this if we need to move off the extruder gears
             if cur_extruder.tool_stn_unload > 0:
                 self.afcDeltaTime.log_with_time(
-                    f'TOOL_UNLOAD: Buffer-Unloading from toolhead(tool_stn_unload), Try:{num_tries}'
+                    'TOOL_UNLOAD: Buffer-Unloading from toolhead(tool_stn_unload)'
                 )
                 with cur_lane.assist_move(cur_extruder.tool_unload_speed, True, cur_lane.assisted_unload):
                     self.move_e_pos( cur_extruder.tool_stn_unload * -1, cur_extruder.tool_unload_speed, "Buffer Move")
@@ -1484,12 +1484,12 @@ class afc:
             if cur_extruder.tool_stn_unload == 0:
                 cur_lane.unsync_to_extruder()
                 while cur_lane.get_toolhead_pre_sensor_state():
+                    num_tries += 1
                     self.afcDeltaTime.log_with_time(
-                        f'TOOL_UNLOAD: Sensor-Unloading from toolhead(tool_stn_unload), Try:{num_tries}'
+                        f'TOOL_UNLOAD: Sensor-Unloading from toolhead(tool_stn_unload==0), Try:{num_tries}'
                     )
                     # attempt to move filament back from sensor without moving extruder
                     cur_lane.move_advanced(cur_lane.short_move_dis * -1, SpeedMode.SHORT)
-                    num_tries += 1
                     if num_tries > self.tool_max_unload_attempts:
                         # note that this will break out of the loop and immediately fall into the error
                         # condition of the next loop for messaging to the user

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1447,6 +1447,9 @@ class afc:
             # if ramming is enabled, AFC will retract to collapse buffer before unloading
             cur_lane.unsync_to_extruder()
             while not cur_lane.get_trailing() and self.tool_max_unload_attempts > 0:
+                self.afcDeltaTime.log_with_time(
+                    f'TOOL_UNLOAD: Retracting Buffer, Try:{num_tries}'
+                )
                 # attempt to return buffer to trailing pin
                 cur_lane.move_advanced(cur_lane.short_move_dis * -1, SpeedMode.SHORT)
                 num_tries += 1
@@ -1469,6 +1472,9 @@ class afc:
             cur_lane.sync_to_extruder(False)
             # we only need to do this if we need to move off the extruder gears
             if cur_extruder.tool_stn_unload > 0:
+                self.afcDeltaTime.log_with_time(
+                    f'TOOL_UNLOAD: Buffer-Unloading from toolhead(tool_stn_unload), Try:{num_tries}'
+                )
                 with cur_lane.assist_move(cur_extruder.tool_unload_speed, True, cur_lane.assisted_unload):
                     self.move_e_pos( cur_extruder.tool_stn_unload * -1, cur_extruder.tool_unload_speed, "Buffer Move")
 
@@ -1478,6 +1484,9 @@ class afc:
             if cur_extruder.tool_stn_unload == 0:
                 cur_lane.unsync_to_extruder()
                 while cur_lane.get_toolhead_pre_sensor_state():
+                    self.afcDeltaTime.log_with_time(
+                        f'TOOL_UNLOAD: Sensor-Unloading from toolhead(tool_stn_unload), Try:{num_tries}'
+                    )
                     # attempt to move filament back from sensor without moving extruder
                     cur_lane.move_advanced(cur_lane.short_move_dis * -1, SpeedMode.SHORT)
                     num_tries += 1
@@ -1503,6 +1512,10 @@ class afc:
                                 message += "\nOnce lane is loaded click resume to continue printing"
                     self.error.handle_lane_failure(cur_lane, message)
                     return False
+
+                self.afcDeltaTime.log_with_time(
+                    f'TOOL_UNLOAD: Sensor-Unloading from toolhead(tool_stn_unload), Try:{num_tries}'
+                )
                 cur_lane.sync_to_extruder()
 
                 with cur_lane.assist_move(cur_extruder.tool_unload_speed, True, cur_lane.assisted_unload):


### PR DESCRIPTION
## Major Changes in this PR
Adding debugging messages to print out toolhead unloading movements for tool_stn_unload

Resolved #581

## Notes to Code Reviewers

## How the changes in this PR are tested
Tested on toolchanger that has sensor and buffer setup on different toolheads

Toolhead with ramming setup:
<img width="963" height="299" alt="image" src="https://github.com/user-attachments/assets/6efd27c0-2ce8-4e84-8092-e02d94556b3e" />

Toolhead with sensor:
<img width="1007" height="302" alt="image" src="https://github.com/user-attachments/assets/3c51a59c-6354-4b54-9ccd-0a355ed39782" />

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.