### PR TITLE
[fix] Changing to use klippers stepper enable logic to help prevent crashes when calibrating HTLF devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-01-14]
+### Fix:
+- Implemented some fixes to prevent klipper crashing when calibrating HTLF units
+
 ## [2026-01-12]
 ### Added:
 - Added debugging messages when doing unloading filament from toolhead for tool_stn_unload movements

--- a/extras/AFC_HTLF.py
+++ b/extras/AFC_HTLF.py
@@ -156,9 +156,7 @@ class AFC_HTLF(afcBoxTurtle):
         Moves lobe selector to specified lane based off lanes index
 
         :param lane: Lane object to move selector to
-        :return boolean: Returns True if movement of selector succeeded
         """
-        self.failed_to_home = False
         if self.current_selected_lane != lane:
             self.logger.debug("HTLF: {} Homing to endstop.".format(self.name))
             if self.return_to_home( disable_selector=False ):
@@ -166,7 +164,7 @@ class AFC_HTLF(afcBoxTurtle):
                 self.logger.debug("HTLF: {} selected".format(lane))
                 self.current_selected_lane = lane
             else:
-                return False
+                self.logger.error(f"HTLF: failed to home when selecting {lane.name}")
 
     def check_runout(self, cur_lane):
         """

--- a/extras/AFC_HTLF.py
+++ b/extras/AFC_HTLF.py
@@ -81,7 +81,7 @@ class AFC_HTLF(afcBoxTurtle):
     def system_Test(self, cur_lane, delay, assignTcmd, enable_movement):
         cur_lane.prep_state = cur_lane.load_state
         if not self.prep_homed:
-            self.return_to_home( prep = True)
+            self.return_to_home( prep = True, disable_selector=False)
         status = super().system_Test( cur_lane, delay, assignTcmd, enable_movement)
         self.return_to_home()
 
@@ -109,7 +109,7 @@ class AFC_HTLF(afcBoxTurtle):
         """
         self.return_to_home()
 
-    def return_to_home(self, prep=False):
+    def return_to_home(self, prep=False, disable_selector=True):
         """
         Moves lobes to home position, if a current lane was selected this function moves back that amount and then performs smaller
         moves until home switch is triggered
@@ -134,8 +134,9 @@ class AFC_HTLF(afcBoxTurtle):
         self.prep_homed = True
         # Adding delay or disabling stepper motor will crash klipper with newest
         # motion queuing changes
-        self.afc.reactor.pause(self.afc.reactor.monotonic() + 0.1)
-        self.selector_stepper_obj.do_enable(False)
+        # self.afc.reactor.pause(self.afc.reactor.monotonic() + 0.1)
+        if disable_selector:
+            self.selector_stepper_obj.do_enable(False)
         self.current_selected_lane = None
         return True
 
@@ -160,7 +161,7 @@ class AFC_HTLF(afcBoxTurtle):
         self.failed_to_home = False
         if self.current_selected_lane != lane:
             self.logger.debug("HTLF: {} Homing to endstop.".format(self.name))
-            if self.return_to_home():
+            if self.return_to_home( disable_selector=False ):
                 self.selector_stepper_obj.move(self.calculate_lobe_movement( lane.index ), 50, 50, False)
                 self.logger.debug("HTLF: {} selected".format(lane))
                 self.current_selected_lane = lane

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -24,6 +24,7 @@ class AFCExtruderStepper(AFCLane):
         super().__init__(config)
 
         self.extruder_stepper   = extruder.ExtruderStepper(config)
+        self.stepper_enable     = self.printer.lookup_object('stepper_enable')
 
         # Check for Klipper new motion queuing update
         try:
@@ -141,14 +142,12 @@ class AFCExtruderStepper(AFCLane):
 
         :param enable: Enables/disables stepper motor
         """
-        self.sync_print_time()
-        stepper_enable = self.printer.lookup_object('stepper_enable')
-        se = stepper_enable.lookup_enable('AFC_stepper {}'.format(self.name))
-        if enable:
-            se.motor_enable(self.next_cmd_time)
+        if hasattr(self.stepper_enable, "set_motors_enable"):
+            # New klipper enable function
+            self.stepper_enable.set_motors_enable([f"AFC_stepper {self.name}"], enable)
         else:
-            se.motor_disable(self.next_cmd_time)
-        self.sync_print_time()
+            # Old klipper and kalico enable function
+            self.stepper_enable.motor_debug_enable(f"AFC_stepper {self.name}", enable)
 
     def sync_print_time(self):
         """


### PR DESCRIPTION
## Major Changes in this PR
Some people were running into issues when calibrating their HTLF with the newest klipper at the time. This updated solves this problem by using klippers enable/disable stepper logic. Also this update introduces logic to no disable HTLF selector motor when selecting different lanes

## Notes to Code Reviewers

## How the changes in this PR are tested
I was not able to replicate the crashes, but David from Armor3d Printing had this issue and was able to test the fixes and verified that he was able to calibrate on his HTLF with klipper.

Verifed that new stepper enable/disable logic still worked with BoxTurtle units.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.