### PR TITLE
[fix] Updates to help with false clog/feed detections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added:
 - The afc-debug.sh script will now upload the AFC statistics from moonraker for easier troubleshooting.
 
+## Fixed
+- Updates to help with false clog/feed detections
+- Resetting filament position for clog detection when starting a new print
+
 ## [2026-01-14]
 ### Fix:
 - Implemented some fixes to prevent klipper crashing when calibrating HTLF units

--- a/config/macros/Brush.cfg
+++ b/config/macros/Brush.cfg
@@ -144,6 +144,7 @@ gcode:
     SET_VELOCITY_LIMIT ACCEL={saved_accel}
 
     AFC_ENABLE_SKEW
+    M400
 
 #--=================================================================================-
 #------- Helper macro for brush servo -----------------------------------------------

--- a/config/macros/Kick.cfg
+++ b/config/macros/Kick.cfg
@@ -13,7 +13,8 @@ gcode:
   {% set z_after_kick       = vars['z_after_kick']      | default(10)       | float %}
   {% set kick_speed         = vars['kick_speed']        | default(150)*60   | float %}
   {% set kick_accel         = vars['kick_accel']        | default(0)        | float %}
-
+  
+  M400
   # Get printer bounds to make sure none of our kick moves fall outside of them
   # Check for IDEX
   {% if printer.dual_carriage is defined %}

--- a/config/macros/Poop.cfg
+++ b/config/macros/Poop.cfg
@@ -24,7 +24,8 @@ gcode:
   {% set iteration_z_change     = vars['iteration_z_change']| default(0.6)      | float %}
   {% set max_iterations_per_blob= vars['max_iterations_per_blob'] | default(3) | int %}
   {% set purge_z                = vars['purge_z']           | default(0)        | float %}
-
+  
+  M400
   {% if verbose > 0 %}
     RESPOND TYPE=command MSG='AFC_Poop: Starting poop'
   {% endif %}

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -35,7 +35,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 try: from extras.AFC_stats import AFCStats
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
 
-AFC_VERSION="1.0.34"
+AFC_VERSION="1.0.35"
 
 # Class for holding different states so its clear what all valid states are
 class State:

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -469,6 +469,13 @@ class afc:
             self.current_toolchange     = -1 # Reset
             self.logger.info("Total number of toolchanges set to {}".format(self.number_of_toolchanges))
 
+            # Get current lane and update position to reset fault detection as sometimes
+            # purging in PRINT_START can lead to false positive detections
+            current_lane = self.function.get_current_lane_obj()
+            if current_lane:
+                if current_lane.buffer_obj is not None:
+                    current_lane.buffer_obj.update_filament_error_pos()
+
         return self.reactor.NEVER
 
     def _get_default_material_temps(self, cur_lane):
@@ -1251,7 +1258,9 @@ class afc:
                 cur_lane.sync_to_extruder()
             # Update tool and lane status.
             cur_lane.set_loaded()
-            cur_lane.enable_buffer()
+            # Setting disable_fault so that fault detection is turned off for users
+            # that utilize poop
+            cur_lane.enable_buffer(disable_fault=True)
             self.save_vars()
 
             # Activate the tool-loaded LED and handle filament operations if enabled.
@@ -1280,6 +1289,8 @@ class afc:
                 self.gcode.run_script_from_command(self.wipe_cmd)
                 self.afcDeltaTime.log_with_time("TOOL_LOAD: After second wipe")
                 self.function.log_toolhead_pos()
+
+            cur_lane.enable_fault_detection()
 
             # Update lane and extruder state for tracking.
             cur_extruder.lane_loaded = cur_lane.name

--- a/extras/AFC_buffer.py
+++ b/extras/AFC_buffer.py
@@ -132,6 +132,13 @@ class AFCTrigger:
         else:
             return 0
 
+    def restore_fault_sensitivity(self):
+        """
+        Helper function to easily set fault sensitivity back based off passed in
+        filament_error_sensitivity variable
+        """
+        self.fault_sensitivity = self.get_fault_sensitivity(self.error_sensitivity)
+
     def setup_fault_timer(self):
         """
         Set up the fault detection timer and initialize error position tracking.
@@ -165,7 +172,7 @@ class AFCTrigger:
 
         :return boolean: True if printer is printing with movement and sensitivity > 0
         """
-        if self.error_sensitivity > 0:
+        if self.fault_sensitivity > 0:
             return True
         else:
             return False

--- a/extras/AFC_buffer.py
+++ b/extras/AFC_buffer.py
@@ -132,9 +132,15 @@ class AFCTrigger:
         else:
             return 0
 
+    def disable_fault_sensitivity(self):
+        """
+        Helper function to easily disable fault detection
+        """
+        self.fault_sensitivity = 0
+
     def restore_fault_sensitivity(self):
         """
-        Helper function to easily set fault sensitivity back based off passed in
+        Helper function to easily set fault sensitivity back based on passed in
         filament_error_sensitivity variable
         """
         self.fault_sensitivity = self.get_fault_sensitivity(self.error_sensitivity)

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -947,10 +947,10 @@ class AFCLane:
         Enable the buffer if `buffer_name` is set.
         Retrieves the buffer object and calls its `enable_buffer()` method to activate it.
 
-        :param disable_fault: Set to turn to disable fault detection when enabling buffer
+        :param disable_fault: Set to True to disable fault detection when enabling buffer
         """
         if self.buffer_obj is not None:
-            if disable_fault: self.buffer_obj.fault_sensitivity = 0
+            if disable_fault: self.buffer_obj.disable_fault_sensitivity()
             self.buffer_obj.enable_buffer()
         self.espooler.enable_timer()
         self.enable_weight_timer()

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -942,15 +942,27 @@ class AFCLane:
         self.afc.spool.set_active_spool(None)
         self.unit_obj.lane_tool_unloaded(self)
 
-    def enable_buffer(self):
+    def enable_buffer(self, disable_fault: bool=False):
         """
         Enable the buffer if `buffer_name` is set.
         Retrieves the buffer object and calls its `enable_buffer()` method to activate it.
+
+        :param disable_fault: Set to turn to disable fault detection when enabling buffer
         """
         if self.buffer_obj is not None:
+            if disable_fault: self.buffer_obj.fault_sensitivity = 0
             self.buffer_obj.enable_buffer()
         self.espooler.enable_timer()
         self.enable_weight_timer()
+
+    def enable_fault_detection(self):
+        """
+        Helper function to restore fault sensitivity and enables buffer to reactivate
+        fault timer and multiplier.
+        """
+        if self.buffer_obj is not None:
+            self.buffer_obj.restore_fault_sensitivity()
+            self.buffer_obj.enable_buffer()
 
     def disable_buffer(self):
         """


### PR DESCRIPTION
## Major Changes in this PR
- Resetting filament position when starting a new print
- During loading fault detection is turned off before pooping, once done fault detection is re-enabled to help with false detection during poop macro.

@weemantella

## Notes to Code Reviewers

## How the changes in this PR are tested
Multiple users tested, I also tested when starting new prints to verify clog detection is not triggered during purge line

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.