### PR TITLE
[feature] Allow root installation for SAF K1 environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-01-22]
+### Changed:
+- The install-afc.sh script will now allow users to install as root if it detects the user is running a SAF K1 environment.
+
 ## [2026-01-15]
 ### Added:
 - The afc-debug.sh script will now upload the AFC statistics from moonraker for easier troubleshooting.

--- a/include/check_commands.sh
+++ b/include/check_commands.sh
@@ -24,6 +24,11 @@ check_root() {
   # If the script is run as root, it prints an error message and exits with status 1.
   # This is to ensure the script is run by a normal user for security reasons.
 
+  check_for_k1
+  if [ "$is_k1_os" == "True" ]; then
+    print_msg WARNING "K1 OS detected, skipping root user check."
+    return
+  fi
   if [ "$EUID" -eq 0 ]; then
     print_msg ERROR "  Do not run as root, use a normal user"
     exit 1

--- a/include/check_commands.sh
+++ b/include/check_commands.sh
@@ -25,7 +25,8 @@ check_root() {
   # This is to ensure the script is run by a normal user for security reasons.
 
   check_for_k1
-  if [ "$is_k1_os" == "True" ]; then
+  # On K1 OS, allow running as root but warn the user instead of exiting.
+  if [ "$is_k1_os" == "True" ] && [ "$EUID" -eq 0 ]; then
     print_msg WARNING "K1 OS detected, skipping root user check."
     return
   fi

--- a/include/constants.sh
+++ b/include/constants.sh
@@ -37,6 +37,7 @@ installation_options=("BoxTurtle (4-Lane)" "BoxTurtle (8-Lane)" "NightOwl" "HTLF
 invalid_name="False"
 minimum_python_major="3"
 minimum_python_minor="8"
+is_k1_os="False"
 
 # AFC default configs
 park_macro="True"

--- a/include/utils.sh
+++ b/include/utils.sh
@@ -220,3 +220,9 @@ del_var_file() {
   fi
   export unit_message
 }
+
+check_for_k1() {
+  if grep -Fqs "ID=buildroot" /etc/os-release; then
+    is_k1_os="True"
+  fi
+}

--- a/install-afc.sh
+++ b/install-afc.sh
@@ -60,13 +60,12 @@ main() {
   moonraker_config_file="${printer_config_dir}/moonraker.conf"
   afc_path="$HOME/AFC-Klipper-Add-On"
 
-
   # Make sure necessary directories exist
-  echo "Ensuring we are not running as root.."
+  echo "Ensuring we are not running as root..."
   check_root
-  echo "Ensuring no conflicting software is present.."
+  echo "Ensuring no conflicting software is present..."
   check_for_hh
-  echo "Checking to ensure crudini and jq are present.."
+  echo "Checking to ensure crudini and jq are present..."
   check_for_prereqs
   if [ "$test_mode" == "False" ]; then
     check_python_version

--- a/install-afc.sh
+++ b/install-afc.sh
@@ -61,7 +61,7 @@ main() {
   afc_path="$HOME/AFC-Klipper-Add-On"
 
   # Make sure necessary directories exist
-  echo "Ensuring we are not running as root..."
+  echo "Ensuring we are not running as root (except on K1 OS)..."
   check_root
   echo "Ensuring no conflicting software is present..."
   check_for_hh


### PR DESCRIPTION
## Major Changes in this PR

This pull request updates the installation scripts to better support SAF K1 environments by allowing root user installation when the K1 OS is detected. It introduces a detection mechanism for K1 OS, updates the root user check logic, and ensures the relevant state is tracked across scripts.

**Support for SAF K1 Environment:**

* Added a new function `check_for_k1()` in `include/utils.sh` to detect K1 OS by checking for `ID=buildroot` in `/etc/os-release`, and sets the `is_k1_os` variable accordingly.
* Introduced an `is_k1_os` variable in `include/constants.sh` to track whether the K1 OS is detected.

**Root User Check Logic:**

* Modified the `check_root()` function in `include/check_commands.sh` to allow running as root if K1 OS is detected, skipping the usual root user restriction and printing a warning.

**Install Script Messaging:**

* Updated messaging in `install-afc.sh` to clarify root user checks and other installation steps.

**Documentation:**

* Added a changelog entry in `CHANGELOG.md` describing the new behavior for root user installation on SAF K1 environments.

## Notes to Code Reviewers

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.