### PR TITLE
Adding support for tool_probe detection and fixed spoolman_set_active_spool error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-01-23]
+## Added
+- Support for using tool_probe instead of detection pin in Klipper-Toolchanger so AFC can properly detect which tool is loaded
+## Fixed
+- Fixed `spoolman_set_active_spool` error during PREP
+
 ## [2026-01-02]
 ## Added
 - Added AFC_SET_TOOLHEAD_LED macro which sets print leds based off passed in mapping

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -329,6 +329,14 @@ class afc:
             # stale lane data is not in database
             self.moonraker.delete_lane_data()
             self.spoolman = self.moonraker.get_spoolman_server()
+            if self.spoolman is not None:
+                # Wait for remote method to be registered
+                for i in range(0, 30):
+                    if self.spool.SPOOLMAN_REMOTE_METHOD in self.webhooks._remote_methods:
+                        self.logger.debug(f"{self.spool.SPOOLMAN_REMOTE_METHOD} registered after {i}s")
+                        break
+
+                    self.toolhead.dwell(1)
             self.td1_defined, self._td1_present, self.lane_data_enabled = self.moonraker.check_for_td1()
             self.afc_stats = AFCStats(self.moonraker, self.logger, self.tool_cut_threshold)
 

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -606,7 +606,13 @@ class AFCExtruder:
         if self.tool_obj is None and self.tc_unit_name is None:
             return True
 
-        return self.tool_obj.detect_state
+        if hasattr(self.tool_obj, "detect_state"):
+            return (
+                self.tool_obj.detect_state == 1 or
+                self.tool_obj.main_toolchanger.get_selected_tool() == self.tool_obj
+            )
+        else:
+            return False
 
     cmd_UPDATE_TOOLHEAD_SENSORS_help = "Gives ability to update tool_stn, tool_stn_unload, tool_sensor_after_extruder values without restarting klipper"
     cmd_UPDATE_TOOLHEAD_SENSORS_options = {
@@ -724,6 +730,7 @@ class AFCExtruder:
         self.response['tool_end'] = self.tool_end
         self.response['tool_end_status'] = bool(self.tool_end_state)
         self.response['lanes'] = [lane.name for lane in self.lanes.values()]
+        self.response['on_shuttle'] = self.on_shuttle()
         return self.response
 
 def load_config_prefix(config):

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -9,6 +9,7 @@ class AFCSpool:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.printer.register_event_handler("klippy:connect", self.handle_connect)
+        self.SPOOLMAN_REMOTE_METHOD = 'spoolman_set_active_spool'
 
         # Temporary status variables
         self.next_spool_id      = ''
@@ -211,7 +212,7 @@ class AFCSpool:
 
             args = {'spool_id' : id }
             try:
-                webhooks.call_remote_method("spoolman_set_active_spool", **args)
+                webhooks.call_remote_method(self.SPOOLMAN_REMOTE_METHOD, **args)
             except self.printer.command_error as e:
                 self.logger.error("Error trying to set active spool \n{}".format(e))
 


### PR DESCRIPTION
## Major Changes in this PR
- Added detection support for users using `tool_probe` in KTC
- Fixed `spoolman_set_active_spool ` that happens during PREP

## Notes to Code Reviewers

## How the changes in this PR are tested
Added `tool_probe` to test, also verified by Rob(lameandboard) in discord

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.