### PR TITLE
macros: poop: fix querying fan speed for toolchangers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for using tool_probe instead of detection pin in Klipper-Toolchanger so AFC can properly detect which tool is loaded
 ## Fixed
 - Fixed `spoolman_set_active_spool` error during PREP
+- Fixed default poop macro for toolchangers with per-tool fans defined
 
 ## [2026-01-02]
 ## Added

--- a/config/macros/Poop.cfg
+++ b/config/macros/Poop.cfg
@@ -36,7 +36,19 @@ gcode:
     {% if verbose > 1 %}
       RESPOND TYPE=command MSG='AFC_Poop: Set Cooling Fan to Full Speed'
     {% endif %}
-    {% set backup_fan_speed = printer.fan.speed %}
+    {% if printer.toolchanger is defined and printer.toolchanger.tool is not none %}
+      {% set tool = printer[printer.toolchanger.tool] %}
+      {% if tool.fan %}
+        {% set tool_fan = printer['fan_generic ' + tool.fan] %}
+        {% set backup_fan_speed = tool_fan.speed | float %}
+      {% else %}
+        {% set backup_fan_speed = 0 %}
+      {% endif %}
+    {% elif printer.fan is defined %}
+      {% set backup_fan_speed = printer.fan.speed | float %}
+    {% else %}
+      {% set backup_fan_speed = 0 %}
+    {% endif %}
     M106 S{(part_cooling_fan_speed * 255)|int}
   {% endif %}
   


### PR DESCRIPTION
The global fan object is no longer available if a fan_generic fan gets associated with a particular tool.

This change checks if a toolchanger setup is available, and if it is, will query the current fan speed from a loaded tool, if available. If not available, it will fall back on the global fan object, first checking if it exists, and then otherwise the fan is assumed to be off.