### PR TITLE
[update] Add descriptions to AFC macros for improved clarity

### DIFF
--- a/config/macros/AFC_macros.cfg
+++ b/config/macros/AFC_macros.cfg
@@ -61,6 +61,7 @@ gcode:
   PREP
 
 [gcode_macro AFC_DISABLE_SKEW]
+description: Disable skew correction temporarily
 gcode:
   {% set gVars = printer['gcode_macro _AFC_GLOBAL_VARS'] %}
   {% set verbose = gVars['verbose']|int %}
@@ -79,6 +80,7 @@ gcode:
   {% endif %}
 
 [gcode_macro AFC_ENABLE_SKEW]
+description: Re-enable skew correction if it was previously disabled
 variable_skew_profile: "my_skew_profile" # Widely used as documented in Klipper docs.
 gcode:
   {% set gVars = printer['gcode_macro _AFC_GLOBAL_VARS'] %}

--- a/config/macros/Kick.cfg
+++ b/config/macros/Kick.cfg
@@ -1,4 +1,5 @@
 [gcode_macro AFC_KICK]
+description: Perform a kick movement to remove purged filament from bed
 gcode:
   {% set gVars              = printer['gcode_macro _AFC_GLOBAL_VARS'] %}
   {% set accel              = gVars['accel']            | default(2000)     | float %}

--- a/config/macros/Park.cfg
+++ b/config/macros/Park.cfg
@@ -1,4 +1,5 @@
 [gcode_macro AFC_PARK]
+description: Parks the toolhead at a specified XY location with optional Z hop
 gcode:
   {% set gVars          = printer['gcode_macro _AFC_GLOBAL_VARS'] %}
   {% set travel_speed   = gVars['travel_speed']     | default(120)*60   | float %}

--- a/config/macros/Poop.cfg
+++ b/config/macros/Poop.cfg
@@ -1,6 +1,6 @@
 
 [gcode_macro AFC_POOP]
-
+description: Purges filament by extruding while raising Z in small increments at a specified location
 gcode:
   {% set gVars                  = printer['gcode_macro _AFC_GLOBAL_VARS'] %}
   {% set travel_speed           = gVars['travel_speed']     | default(120)*60   | float %}


### PR DESCRIPTION
## Major Changes in this PR

This pull request adds helpful descriptions to several G-code macros to improve documentation and usability. These descriptions clarify the purpose and behavior of each macro, making it easier for users to understand and maintain the configuration.

Documentation improvements:

* Added a description to `AFC_DISABLE_SKEW` macro explaining it temporarily disables skew correction.
* Added a description to `AFC_ENABLE_SKEW` macro stating it re-enables skew correction if previously disabled.
* Added a description to `AFC_KICK` macro indicating it performs a kick movement to remove purged filament from the bed.
* Added a description to `AFC_PARK` macro specifying it parks the toolhead at a given XY location with optional Z hop.
* Added a description to `AFC_POOP` macro describing its function to purge filament by extruding while raising Z.

## Notes to Code Reviewers

Didn't do a changelog, since it is a minor change. 

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.