### PR TITLE
Resolve cumulative z height with AFC_TEST_LANES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2026-01-24]
-## Fixed
+### Fixed
 - Resolved bug where when running `AFC_TEST_LANES` on a single lane, the z axis would not reset correctly, resulting in a constantly increasing z height.
 ## [2026-01-22]
 ### Changed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-01-24]
+## Fixed
+- Resolved bug where when running `AFC_TEST_LANES` on a single lane, the z axis would not reset correctly, resulting in a constantly increasing z height.
 ## [2026-01-22]
 ### Changed:
 - The install-afc.sh script will now allow users to install as root if it detects the user is running a SAF K1 environment.

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -694,7 +694,7 @@ class afcFunction:
     def cmd_AFC_TEST_LANES(self, gcmd):
         """
         Run load/unload tests on specified lanes. This command allows users to test the loading and unloading
-        mechanisms to serve as a stress test / diagnostic tool for the AFC syst mem with an interactive prompt.
+        mechanisms to serve as a stress test / diagnostic tool for the AFC system with an interactive prompt.
 
         Usage
         -----

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -694,7 +694,7 @@ class afcFunction:
     def cmd_AFC_TEST_LANES(self, gcmd):
         """
         Run load/unload tests on specified lanes. This command allows users to test the loading and unloading
-        mechanisms to serve as a stress test / diagnostic tool for the AFC system with an interactive prompt.
+        mechanisms to serve as a stress test / diagnostic tool for the AFC syst mem with an interactive prompt.
 
         Usage
         -----
@@ -787,22 +787,28 @@ class afcFunction:
             lane_obj = self.afc.lanes.get(lane)
             if lane != 'all':
                 self.afc.logger.info('Running {} iterations for lane: {}'.format(iterations, lane))
-                for _ in range(iterations):
+                for i in range(iterations):
+                    self.afc.save_pos()
                     self.afc.logger.info('Loading lane: {}'.format(lane))
                     self.afc.CHANGE_TOOL(lane_obj)
+
                     if not self.afc.error_state:
-                        self.afc.logger.info("Lane {} loaded successfully".format(lane))
+                        self.afc.logger.info("Lane {} loaded successfully (Iteration {})".format(lane, i + 1))
                     else:
-                        self.afc.logger.error("Failed to load lane {}".format(lane))
+                        self.afc.logger.error("Failed to load lane {} on iteration {}".format(lane, i + 1))
                         self.afc.error.reset_failure()
                         break
+
                     self._safe_extrude(self.afc.test_extrude_amt)
                     self.logger.info("Unloading lane {}".format(lane))
                     self.afc.TOOL_UNLOAD(lane_obj)
+
                     if not self.afc.error_state:
-                        self.afc.logger.info("Lane {} unloaded successfully".format(lane))
+                        self.afc.logger.info(
+                            "Lane {} unloaded successfully for iteration {}/{}".format(lane, i + 1, iterations))
+                        self.afc.restore_pos()
                     else:
-                        self.afc.logger.error("Failed to unload lane {}".format(lane))
+                        self.afc.logger.error("Failed to unload lane {} at iteration {}".format(lane, i + 1))
                         self.afc.error.reset_failure()
                         return
 


### PR DESCRIPTION
## Major Changes in this PR

Closes #585 

This pull request addresses a bug with the z-axis reset during AFC lane testing and improves the logging and position handling in the lane test command. The main focus is to ensure that when running tests on a single lane, the z-axis is properly reset between iterations, and that the process is better logged and more robust in the face of errors.

Bug fix and improved lane testing:

* Fixed an issue where running `AFC_TEST_LANES` on a single lane did not reset the z axis, causing the z height to increase continuously.
* In `cmd_TEST_LANE` (`extras/AFC_functions.py`), added calls to `save_pos()` before loading a lane and `restore_pos()` after successful unloading, ensuring the printer's position (including z) is reset between iterations.
* Enhanced logging in `cmd_TEST_LANE` to include iteration numbers and more detailed success/failure messages, improving diagnosability of test runs.

Documentation:

* Updated the changelog to reflect the z-axis reset bug fix.

## Notes to Code Reviewers

Added some helpful text to show what iteration it is on also. `Lane lane7 unloaded successfully for iteration 3/3`. etc.
## How the changes in this PR are tested

Run macro with a single lane and multiple iterations and ensure z height is reset appropriately.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.