### PR TITLE
[Update] Adding extruder stats for toolchangers, fixing afcDeltaTime start time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-01-24]
+## Added
+- Support for tracking selecting/unselecting toolheads for toolchangers
+
 ## [2026-01-23]
 ## Added
 - Support for using tool_probe instead of detection pin in Klipper-Toolchanger so AFC can properly detect which tool is loaded

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1141,7 +1141,6 @@ class afc:
         TOOL_LOAD LANE=lane1 PURGE_LENGTH=80
         ```
         """
-        self.afcDeltaTime.set_start_time()
         lane = gcmd.get('LANE', None)
         if lane not in self.lanes:
             self.logger.info('{} Unknown'.format(lane))
@@ -1156,7 +1155,7 @@ class afc:
 
         self.TOOL_LOAD(cur_lane, purge_length)
 
-    def TOOL_LOAD(self, cur_lane: AFCLane, purge_length: int=None):
+    def TOOL_LOAD(self, cur_lane: AFCLane, purge_length: int=None, set_start_time=False):
         """
         This function handles the loading of a specified lane into the tool. It performs
         several checks and movements to ensure the lane is properly loaded.
@@ -1168,6 +1167,9 @@ class afc:
         """
         if not self.function.check_homed():
             return False
+
+        if set_start_time:
+            self.afcDeltaTime.set_start_time()
 
         error_str = self.verify_macro_positions()
         if error_str:
@@ -1432,7 +1434,6 @@ class afc:
         TOOL_UNLOAD LANE=lane1
         ```
         """
-        self.afcDeltaTime.set_start_time()
         # TODO figure this out if moving to cur_lane.extruder_obj.lane_loaded structure, maybe get current extruder from toolhead?
         # How would you deal with multiple extruders....
 
@@ -1451,7 +1452,7 @@ class afc:
         # User manually unloaded spool from toolhead, remove spool from active status
         self.spool.set_active_spool(None)
 
-    def TOOL_UNLOAD(self, cur_lane: AFCLane):
+    def TOOL_UNLOAD(self, cur_lane: AFCLane, set_start_time=True):
         """
         This function handles the unloading of a specified lane from the tool. It performs
         several checks and movements to ensure the lane is properly unloaded.
@@ -1462,6 +1463,9 @@ class afc:
         """
         # Check if the bypass filament sensor detects filament; if so unload filament and abort the tool load.
         if self._check_bypass(unload=True): return False
+
+        if set_start_time:
+            self.afcDeltaTime.set_start_time()
 
         if not self.function.check_homed():
             return False
@@ -1890,7 +1894,7 @@ class afc:
                     if self.current not in self.lanes:
                         self.error.AFC_error('{} Unknown'.format(self.current))
                         return
-                    if not self.TOOL_UNLOAD(self.lanes[self.current]):
+                    if not self.TOOL_UNLOAD(self.lanes[self.current], set_start_time=False):
                         # Abort if the unloading process fails.
                         msg = (' UNLOAD ERROR NOT CLEARED')
                         self.error.fix(msg, self.lanes[self.current])  #send to error handling
@@ -1903,7 +1907,7 @@ class afc:
                 self.logger.info("{} heated and ready to print".format(infinite_extruder.name))
 
             # Load the new lane and restore the toolhead position if successful.
-            if self.TOOL_LOAD(cur_lane, purge_length) and not self.error_state:
+            if self.TOOL_LOAD(cur_lane, purge_length, set_start_time=False) and not self.error_state:
                 if restore_pos:
                     self.restore_pos()
                 total_time = self.afcDeltaTime.log_total_time("Total change time:")

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1162,6 +1162,7 @@ class afc:
 
         :param cur_lane: The lane object to be loaded into the tool.
         :param purge_length: Amount of filament to poop (optional).
+        :param set_start_time: Set true to set a starting time for afcDeltaTime.
 
         :return bool: True if load was successful, False if an error occurred.
         """
@@ -1458,6 +1459,7 @@ class afc:
         several checks and movements to ensure the lane is properly unloaded.
 
         :param cur_lane: The lane object to be unloaded from the tool.
+        :param set_start_time: Set true to set a starting time for afcDeltaTime.
 
         :return bool: True if unloading was successful, False if an error occurred.
         """

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -18,6 +18,9 @@ if TYPE_CHECKING:
     from extras.AFC_lane import AFCLane
     from extras.AFC_extruder import AFCExtruder
     from extras.AFC_functions import afcFunction
+    from extras.AFC_hub import afc_hub
+    from extras.AFC_spool import AFCSpool
+    from extras.AFC_error import afcError
 
 ERROR_STR = "Error trying to import {import_lib}, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper\n\n{trace}"
 
@@ -62,8 +65,9 @@ class afc:
         self.printer.register_event_handler("klippy:connect",self.handle_connect)
         self.logger  = AFC_logger(self.printer, self)
 
-        self.spool      = self.printer.load_object(config, 'AFC_spool')
-        self.error      = self.printer.load_object(config, 'AFC_error')
+        self.spool: AFCSpool = self.printer.load_object(config, 'AFC_spool')
+        self.error: afcError = self.printer.load_object(config, 'AFC_error')
+
         self.function: afcFunction   = self.printer.load_object(config, 'AFC_functions')
         self.function.afc = self
         self.gcode: GCodeDispatch = self.printer.load_object(config, 'gcode')
@@ -1278,7 +1282,7 @@ class afc:
                     return False
         return True
 
-    def load_sequence(self, cur_lane, cur_hub, cur_extruder):
+    def load_sequence(self, cur_lane: AFCLane, cur_hub: afc_hub, cur_extruder: AFCExtruder):
         """
         This function controls the loading sequence and allows for custom gcode commands to be executed
         during the loading process.
@@ -1545,7 +1549,7 @@ class afc:
         self.current_state = State.IDLE
         return True
 
-    def unload_sequence(self, cur_lane, cur_hub, cur_extruder):
+    def unload_sequence(self, cur_lane: AFCLane, cur_hub: afc_hub, cur_extruder: AFCExtruder):
         """
         This function controls the unloading sequence and allows for custom gcode commands to be executed
         during the loading process.

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1548,8 +1548,8 @@ class afc:
             if not self.unload_sequence(cur_lane, cur_hub, cur_extruder):
                 return False
 
-        unload_time = self.afcDeltaTime.log_major_delta("Lane {} unload done".format(cur_lane.name if cur_lane is not None else "None"))
-        self.afc_stats.average_tool_unload_time.average_time(unload_time)
+            unload_time = self.afcDeltaTime.log_major_delta("Lane {} unload done".format(cur_lane.name if cur_lane is not None else "None"))
+            self.afc_stats.average_tool_unload_time.average_time(unload_time)
         self.current_state = State.IDLE
         return True
 

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -3,10 +3,16 @@
 # Copyright (C) 2024 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import annotations
+
 import traceback
 
 from configparser import Error as error
 from datetime import datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from extras.AFC_lane import AFCLane
 
 try: from extras.AFC_utils import ERROR_STR
 except: raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".format(trace=traceback.format_exc()))
@@ -47,7 +53,7 @@ class afcBoxTurtle(afcUnit):
         self.logo_error+='! \_________/ |___|</span>\n'
         self.logo_error+= '  ' + self.name + '\n'
 
-    def system_Test(self, cur_lane, delay, assignTcmd, enable_movement):
+    def system_Test(self, cur_lane: AFCLane, delay, assignTcmd, enable_movement):
         msg = ''
         succeeded = True
 

--- a/extras/AFC_Toolchanger.py
+++ b/extras/AFC_Toolchanger.py
@@ -141,6 +141,7 @@ class AfcToolchanger(afcUnit):
         to switch to the correct extruder. This is primarily used in multi-extruder/toolchanger setups.
 
         :param lane: The lane object whose extruder/toolhead should be activated.
+        :param set_start_time: Set true to set a starting time for afcDeltaTime.
 
         :return: None
         """

--- a/extras/AFC_Toolchanger.py
+++ b/extras/AFC_Toolchanger.py
@@ -59,6 +59,14 @@ class AfcToolchanger(afcUnit):
         cur_lane.set_afc_prep_done()
         return True
 
+    def _increase_unselect(self):
+        """
+        Helper function to lookup current selected extruder and increase tool unselected count
+        """
+        current_extruder = self.afc.function.get_current_extruder_obj()
+        if current_extruder:
+            current_extruder.estats.tool_unselected.increase_count()
+
     cmd_AFC_SELECT_TOOL_help = "Select specified tool"
     cmd_AFC_SELECT_TOOL_options = {
         "TOOL": {"type": "string", "default": "extruder"}
@@ -82,6 +90,7 @@ class AfcToolchanger(afcUnit):
 
         if tool:
             if hasattr(tool, 'tc_lane') and tool.tc_lane is not None:
+                self.afc.afcDeltaTime.set_start_time()
                 self.tool_swap(tool.tc_lane)
             else:
                 self.logger.error(f"Tool '{tool_key}' does not have a valid 'tc_lane' attribute.")
@@ -105,6 +114,8 @@ class AfcToolchanger(afcUnit):
         AFC_UNSELECT_TOOL
         ```
         """
+        self._increase_unselect()
+
         self.afc.gcode.run_script_from_command("UNSELECT_TOOL")
         lane_obj = self.afc.function.get_current_lane_obj()
         if lane_obj:
@@ -119,7 +130,7 @@ class AfcToolchanger(afcUnit):
 
         self.afc.spool.set_active_spool('')
 
-    def tool_swap(self, lane):
+    def tool_swap(self, lane: AFCLane):
         """
         Perform a tool swap operation for the specified lane.
 
@@ -132,6 +143,7 @@ class AfcToolchanger(afcUnit):
         :return: None
         """
         self.afc.current_state = State.TOOL_SWAP
+        self._increase_unselect()
         self.afc.function.log_toolhead_pos("Before toolswap: ")
         # Save the current position before switching tools and subtract offsets
         for i in range(0, 3):
@@ -145,10 +157,13 @@ class AfcToolchanger(afcUnit):
         # Switching toolhead extruders, this is mainly for setups with multiple extruders
         lane.activate_toolhead_extruder()
         # Need to call again since KTC activate callback happens before switching to new extruder
-        # Take double call out once transitioned away from KTC
+        # TODO: Take double call out once transitioned away from KTC
         self.afc.function._handle_activate_extruder(0)
 
+        self.afc.toolhead.wait_moves()
         self.afc.afcDeltaTime.log_with_time("Tool swap done")
+        if self.afc.afc_stats.average_tool_swap_time:
+            self.afc.afc_stats.average_tool_swap_time.average_time(self.afc.afcDeltaTime.delta_time)
         self.afc.current_state = State.IDLE
         # Update the base position and homing position after the tool swap.
         self.afc.base_position   = list(self.afc.gcode_move.base_position)
@@ -158,6 +173,7 @@ class AfcToolchanger(afcUnit):
             self.afc.last_gcode_position[i] += self.afc.gcode_move.base_position[i]
 
         self.afc.function.log_toolhead_pos("After toolswap: ")
+        lane.extruder_obj.estats.tool_selected.increase_count()
 
     cmd_AFC_SET_TOOLHEAD_LED_help = "Turns on leds for toolhead specified by mapping, does not affect status led if status_led_idx variable is provided"
     cmd_AFC_SET_TOOLHEAD_LED_options = {

--- a/extras/AFC_Toolchanger.py
+++ b/extras/AFC_Toolchanger.py
@@ -93,7 +93,6 @@ class AfcToolchanger(afcUnit):
 
         if tool:
             if hasattr(tool, 'tc_lane') and tool.tc_lane is not None:
-                self.afc.afcDeltaTime.set_start_time()
                 self.tool_swap(tool.tc_lane)
             else:
                 self.logger.error(f"Tool '{tool_key}' does not have a valid 'tc_lane' attribute.")
@@ -133,7 +132,7 @@ class AfcToolchanger(afcUnit):
 
         self.afc.spool.set_active_spool('')
 
-    def tool_swap(self, lane: AFCLane):
+    def tool_swap(self, lane: AFCLane, set_start_time=True):
         """
         Perform a tool swap operation for the specified lane.
 
@@ -145,6 +144,9 @@ class AfcToolchanger(afcUnit):
 
         :return: None
         """
+        if set_start_time:
+            self.afc.afcDeltaTime.set_start_time()
+
         self.afc.current_state = State.TOOL_SWAP
         self._increase_unselect()
         self.afc.function.log_toolhead_pos("Before toolswap: ")
@@ -164,7 +166,7 @@ class AfcToolchanger(afcUnit):
         self.afc.function._handle_activate_extruder(0)
 
         self.afc.toolhead.wait_moves()
-        self.afc.afcDeltaTime.log_with_time("Tool swap done")
+        self.afc.afcDeltaTime.log_with_time("Tool swap done", debug=False)
         if self.afc.afc_stats.average_tool_swap_time:
             self.afc.afc_stats.average_tool_swap_time.average_time(self.afc.afcDeltaTime.delta_time)
         self.afc.current_state = State.IDLE

--- a/extras/AFC_Toolchanger.py
+++ b/extras/AFC_Toolchanger.py
@@ -55,7 +55,10 @@ class AfcToolchanger(afcUnit):
         if assignTcmd: self.afc.function.TcmdAssign(cur_lane)
         # Now that a T command is assigned, send lane data to moonraker
         cur_lane.send_lane_data()
-        self.logger.info( '{lane_name} tool cmd: {tcmd:3} {msg}'.format(lane_name=cur_lane.name, tcmd=cur_lane.map, msg=""))
+        msg = ""
+        if( cur_lane.prep_state and cur_lane.load_state ):
+            msg = "<span class=success--text>LOADED</span> <span class=primary--text>in ToolHead</span>"
+        self.logger.raw( '{lane_name} tool cmd: {tcmd:3} {msg}'.format(lane_name=cur_lane.name, tcmd=cur_lane.map, msg=msg))
         cur_lane.set_afc_prep_done()
         return True
 

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -356,6 +356,9 @@ class AFCExtruder:
         if self.name in self.lanes:
             self.no_lanes = True
             self.logger.info(f"{self.name} no lanes")
+            # Due to race conditions at startup, these variables might not be set correctly,
+            #  set to current tool start state
+            self.tc_lane.load_state = self.tc_lane.prep_state = self.tool_start_state
 
             if self.tool_start == "buffer":
                 raise error(

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -270,6 +270,7 @@ class AFCExtruder:
         self.estats = AFCExtruderStats(self.name, self, self.afc.tool_cut_threshold)
 
         self.tool_start_state = False
+        # TODO: add a check here as pin_tool_start should always be required, or let klipper take care of it by not passing in None
         if self.tool_start is not None:
             if "unknown" == self.tool_start.lower():
                 raise error(f"Unknown is not valid for pin_tool_start in [{self.fullname}] config.")

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -23,6 +23,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
+    from extras.AFC import afc
+    from AFC_logger import AFC_logger
     from extras.AFC_lane import AFCLane
     from extras.AFC_extruder import AFCExtruder
 
@@ -49,8 +51,8 @@ class afcFunction:
         self.auto_var_file = None
         self.errorLog = {}
         self.pause    = False
-        self.afc      = None
-        self.logger   = None
+        self.afc: afc
+        self.logger: AFC_logger
         self.mcu      = None
         self.next_cmd_time = 0.
 
@@ -1789,6 +1791,7 @@ class afcDeltaTime:
         self.logger = afc.logger
         self.start_time = None
         self.last_time  = None
+        self.delta_time = 0
 
     def set_start_time(self):
         self.major_delta_time = self.last_time = self.start_time = datetime.now()
@@ -1796,9 +1799,9 @@ class afcDeltaTime:
     def log_with_time(self, msg, debug=True):
         try:
             curr_time = datetime.now()
-            delta_time = (curr_time - self.last_time ).total_seconds()
+            self.delta_time = (curr_time - self.last_time ).total_seconds()
             total_time = (curr_time - self.start_time).total_seconds()
-            msg = "{} (Δt:{:.3f}s, t:{:.3f})".format( msg, delta_time, total_time )
+            msg = "{} (Δt:{:.3f}s, t:{:.3f})".format( msg, self.delta_time, total_time )
             if debug:
                 self.logger.debug( msg )
             else:
@@ -1808,17 +1811,17 @@ class afcDeltaTime:
             self.logger.debug("Error in log_with_time function {}".format(e))
 
     def log_major_delta(self, msg, debug=True):
-        delta_time = 0
+        self.delta_time = 0
         try:
             curr_time = datetime.now()
-            delta_time = (curr_time - self.major_delta_time ).total_seconds()
-            msg = "{} t:{:.3f}".format( msg, delta_time )
+            self.delta_time = (curr_time - self.major_delta_time ).total_seconds()
+            msg = "{} t:{:.3f}".format( msg, self.delta_time )
             self.logger.info( msg )
             self.major_delta_time = curr_time
         except Exception as e:
             self.logger.debug("Error in log_major_delta function {}".format(e))
 
-        return delta_time
+        return self.delta_time
 
     def log_total_time(self, msg):
         total_time = 0

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -17,11 +17,11 @@ from typing import Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from configfile import ConfigWrapper
+    from extras.AFC import afc
     from extras.AFC_extruder import AFCExtruder
     from extras.AFC_hub import afc_hub
     from extras.AFC_buffer import AFCTrigger
     from extras.AFC_unit import afcUnit
-    from extras.AFC import afc
 
 try: from extras.AFC_utils import ERROR_STR, add_filament_switch
 except: raise error("Error when trying to import AFC_utils.ERROR_STR, add_filament_switch\n{trace}".format(trace=traceback.format_exc()))

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -679,7 +679,6 @@ class AFCLane:
                     if self.afc.function.is_printing(check_movement=True):
                         self.afc.error.AFC_error("Cannot load spool to toolhead while printer is actively moving or homing", False)
                     else:
-                        self.afc.afcDeltaTime.set_start_time()
                         self.afc.TOOL_LOAD(self)
             else:
                 # Don't run if user disabled sensor in gui
@@ -751,7 +750,6 @@ class AFCLane:
                     #   This is only really a issue when using direct_load and still using load sensor
                     if self.hub == 'direct_load' and self.prep_state:
                         self.logger.debug(f"Prep: direct load logic-{self.name}-{self.hub}")
-                        self.afc.afcDeltaTime.set_start_time()
                         self.afc.TOOL_LOAD(self)
                         self.afc.spool._set_values(self)
                         self.logger.debug(f"Prep: direct load logic done-{self.name}-{self.hub}")
@@ -1147,7 +1145,7 @@ class AFCLane:
         Helper function for calling extruder's tool_swap function
         """
         if self.extruder_obj.tc_unit_obj is not None:
-            self.extruder_obj.tc_unit_obj.tool_swap(self)
+            self.extruder_obj.tc_unit_obj.tool_swap(self, set_start_time=False)
 
 
     def send_lane_data(self):

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -3,9 +3,15 @@
 # Copyright (C) 2024 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import annotations
 
 import os
 import json
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from extras.AFC import afc
 
 class afcPrep:
     def __init__(self, config):
@@ -27,7 +33,7 @@ class afcPrep:
         This function is called when the printer connects. It looks up AFC info
         and assigns it to the instance variable `self.AFC`.
         """
-        self.afc = self.printer.lookup_object('AFC')
+        self.afc: afc = self.printer.lookup_object('AFC')
         self.afc.gcode.register_command('PREP', self.PREP, desc=None)
         self.logger = self.afc.logger
 


### PR DESCRIPTION
## Major Changes in this PR
- Adding toolchange select/unselect counts for toolchangers
- Fixing when afcDeltaTime start time happens so its easier in the future for others
- Fixing adding up delta time when just doing tool swaps with T macros
- Added more typing

## Notes to Code Reviewers

## How the changes in this PR are tested
- Tested on my toolchanger

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.