### PR TITLE
Option to disable infinite spool eject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-01-30]
+### Added
+- `eject_on_infinite_swap` configuration added to disable eject after an infinite spool lane swap.
 
 ## [2026-01-24]
 ### Fixed

--- a/config/AFC.cfg
+++ b/config/AFC.cfg
@@ -26,6 +26,7 @@ load_to_hub: True               # Fast loads filament to hub when inserted, set 
 assisted_unload: True           # If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool. This is a global setting and can be overridden at the unit and stepper level.
 #pause_when_bypass_active: True  # When True AFC pauses print when change tool is called and bypass is loaded
 #unload_on_runout: True          # When True AFC will unload lane and then pause when runout is triggered and spool to swap to is not set(infinite spool)
+#eject_on_infinite_swap: True    # When False, AFC will not eject the remaining filament from the empty lane after an infinite spool swap
 #print_short_stats: True          # Set to true to print AFC_STATS in short form instead of wide form, printing short form is better for consoles that are small in width
 #debug: True                     # Setting to True turns on more debugging to show on console
 

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -208,6 +208,7 @@ class afc:
         self.assisted_unload        = config.getboolean("assisted_unload", True)    # If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool
         self.bypass_pause           = config.getboolean("pause_when_bypass_active", False) # When true AFC pauses print when change tool is called and bypass is loaded
         self.unload_on_runout       = config.getboolean("unload_on_runout", False)  # When True AFC will unload lane and then pause when runout is triggered and spool to swap to is not set(infinite spool)
+        self.eject_on_infinite_swap = config.getboolean("eject_on_infinite_swap", True) # When false AFC will not eject remaining filament after infinite spool swaps to a new lane
         self.short_stats            = config.getboolean("print_short_stats", False) # Set to true to print AFC_STATS in short form instead of wide form, printing short form is better for smaller in width consoles
         # Setting to True enables espooler assist while printing
         self.enable_assist          = config.getboolean("enable_assist",        True)

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -554,7 +554,8 @@ class AFCLane:
             return
 
         # Eject spool before loading next lane
-        self.gcode.run_script_from_command('LANE_UNLOAD LANE={}'.format(empty_lane.name))
+        if self.afc.eject_on_infinite_swap:
+            self.gcode.run_script_from_command('LANE_UNLOAD LANE={}'.format(empty_lane.name))
 
         self.afc.TOOL_LOAD(change_lane)
         # Change Mapping


### PR DESCRIPTION
## Major Changes in this PR

Adds "eject_on_infinite_swap" option to AFC section (default true). When using infinite spool and eject_on_infinite_swap is false, a lane that runs out will unload the filament as usual, but not automatically perform the final lane eject.

## Notes to Code Reviewers

## How the changes in this PR are tested

Ran a print and forced a lane to run out.  Verified the print continued without ejecting the previous lane.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [X] I have performed a self-review of my code
- [X] CHANGELOG.md is updated (if end-user facing)
- [X] Documentation updated in AT-Documentation repository
- [X] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.