### PR TITLE
Update Cut Macro to support kalico-bleeding-edgev2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-02-01]
+### Added:
+- Update Cut Macro to support kalico-bleeding-edge-v2 nonlinear pressure advance
+
 ## [2026-01-31]
 ### Added:
 - Added ability to remember last ejected spool via new `SET_REMEMBER_SPOOL` macro.

--- a/config/macros/Cut.cfg
+++ b/config/macros/Cut.cfg
@@ -70,7 +70,7 @@ gcode:
 
     SET_VELOCITY_LIMIT ACCEL={selected_accel}
 
-    {% set prev_pa = printer.extruder.linear_advance|default(printer.extruder.pressure_advance) %}  # Save current PA  # Save current PA
+    {% set prev_pa = printer.extruder.linear_advance|default(printer.extruder.pressure_advance) %}  # Save current PA
     SET_PRESSURE_ADVANCE ADVANCE=0  # Temporarily disable PA
 
     AFC_DISABLE_SKEW

--- a/config/macros/Cut.cfg
+++ b/config/macros/Cut.cfg
@@ -70,7 +70,7 @@ gcode:
 
     SET_VELOCITY_LIMIT ACCEL={selected_accel}
 
-    {% set prev_pa = printer.extruder.pressure_advance %}  # Save current PA
+    {% set prev_pa = printer.extruder.linear_advance|default(printer.extruder.pressure_advance) %}  # Save current PA  # Save current PA
     SET_PRESSURE_ADVANCE ADVANCE=0  # Temporarily disable PA
 
     AFC_DISABLE_SKEW


### PR DESCRIPTION
Addresses #586

## Major Changes in this PR
No major changes. Modifies the cut macro to prevent erroring on kalio-bleeding-edgev2 when linear advance is enabled. See #586 
    Changes ```{% set prev_pa = printer.extruder.pressure_advance %}  # Save current PA```
    To ```{% set prev_pa = printer.extruder.linear_advance|default(printer.extruder.pressure_advance) %}  # Save current PA```

## Notes to Code Reviewers

## How the changes in this PR are tested
Tested on latest kalico-bleeding-edgev2 with latest updated AFC with latest macros. However, _I haven't personally tested on standard klipper with normal pressure advance_.
## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [ ] Tested on standard klipper
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.