### PR TITLE
Option to disable using spoolman extruder temperature for filament

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2026-02-02]
+### Added:
+- `ignore_spoolman_material_temps` configuration option added to ignore extruder temperature set in spoolman and instead fallback to default material temps when switching filament
+
 ## [2026-01-24]
 ### Fixed
 - Resolved bug where when running `AFC_TEST_LANES` on a single lane, the z axis would not reset correctly, resulting in a constantly increasing z height.

--- a/config/AFC.cfg
+++ b/config/AFC.cfg
@@ -17,7 +17,7 @@ enable_sensors_in_gui: True     # Uncomment to show all sensor switches as filam
 default_material_temps: default: 235, PLA:210, PETG:235, ABS:235, ASA:235 # Default temperature to set extruder when loading/unloading lanes.
                                                   # Material needs to be either manually set or uses material from spoolman if extruder temp is not
                                                   # set in spoolman. Follow current format to add more
-#ignore_spoolman_material_temps: False  # When True, AFC will ignore temperatures set in SpoolManager and use default_material_temps instead.
+#ignore_spoolman_material_temps: False  # When True, AFC will ignore temperatures set in Spoolman and use default_material_temps instead.
 common_density_values: PLA:1.24, PETG:1.23, ABS:1.04, ASA:1.07 # Generic default density values.  Follow current format to add more
 #default_material_type: PLA      # Default material type to assign to a spool once loaded into a lane
 

--- a/config/AFC.cfg
+++ b/config/AFC.cfg
@@ -17,6 +17,7 @@ enable_sensors_in_gui: True     # Uncomment to show all sensor switches as filam
 default_material_temps: default: 235, PLA:210, PETG:235, ABS:235, ASA:235 # Default temperature to set extruder when loading/unloading lanes.
                                                   # Material needs to be either manually set or uses material from spoolman if extruder temp is not
                                                   # set in spoolman. Follow current format to add more
+#ignore_spoolman_material_temps: False  # When True, AFC will ignore temperatures set in SpoolManager and use default_material_temps instead.
 common_density_values: PLA:1.24, PETG:1.23, ABS:1.04, ASA:1.07 # Generic default density values.  Follow current format to add more
 #default_material_type: PLA      # Default material type to assign to a spool once loaded into a lane
 

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -204,6 +204,7 @@ class afc:
         self.spool_ratio            = config.getfloat("spool_ratio",2)              # gear ratio for printed gearbox between N20 and spooler wheels
         self.full_weight            = config.getfloat("full_weight",1000, minval=1)           # full weight of filament spool (not counting spool itself)
         self.enable_sensors_in_gui  = config.getboolean("enable_sensors_in_gui", False) # Set to True to show all sensor switches as filament sensors in mainsail/fluidd gui
+        self.ignore_spoolman_material_temps = config.getboolean("ignore_spoolman_material_temps", False)  # When True, AFC will ignore temperatures set in SpoolManager and use default_material_temps instead.
         self.load_to_hub            = config.getboolean("load_to_hub", True)        # Fast loads filament to hub when inserted, set to False to disable. This is a global setting and can be overridden at AFC_stepper
         self.assisted_unload        = config.getboolean("assisted_unload", True)    # If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool
         self.bypass_pause           = config.getboolean("pause_when_bypass_active", False) # When true AFC pauses print when change tool is called and bypass is loaded

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -204,7 +204,7 @@ class afc:
         self.spool_ratio            = config.getfloat("spool_ratio",2)              # gear ratio for printed gearbox between N20 and spooler wheels
         self.full_weight            = config.getfloat("full_weight",1000, minval=1)           # full weight of filament spool (not counting spool itself)
         self.enable_sensors_in_gui  = config.getboolean("enable_sensors_in_gui", False) # Set to True to show all sensor switches as filament sensors in mainsail/fluidd gui
-        self.ignore_spoolman_material_temps = config.getboolean("ignore_spoolman_material_temps", False)  # When True, AFC will ignore temperatures set in SpoolManager and use default_material_temps instead.
+        self.ignore_spoolman_material_temps = config.getboolean("ignore_spoolman_material_temps", False)  # When True, AFC will ignore temperatures set in Spoolman and use default_material_temps instead.
         self.load_to_hub            = config.getboolean("load_to_hub", True)        # Fast loads filament to hub when inserted, set to False to disable. This is a global setting and can be overridden at AFC_stepper
         self.assisted_unload        = config.getboolean("assisted_unload", True)    # If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool
         self.bypass_pause           = config.getboolean("pause_when_bypass_active", False) # When true AFC pauses print when change tool is called and bypass is loaded

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -311,7 +311,8 @@ class AFCSpool:
                     cur_lane.spool_id = SpoolID
 
                     cur_lane.material           = self._get_filament_values(result['filament'], 'material')
-                    cur_lane.extruder_temp      = self._get_filament_values(result['filament'], 'settings_extruder_temp')
+                    if not self.afc.ignore_spoolman_material_temps:
+                        cur_lane.extruder_temp      = self._get_filament_values(result['filament'], 'settings_extruder_temp')
                     cur_lane.bed_temp           = self._get_filament_values(result['filament'], 'settings_bed_temp')
                     cur_lane.filament_density   = self._get_filament_values(result['filament'], 'density')
                     cur_lane.filament_diameter  = self._get_filament_values(result['filament'], 'diameter')


### PR DESCRIPTION
## Major Changes in this PR
`ignore_spoolman_material_temps` configuration option added to ignore extruder temperature set in spoolman and instead fallback to default material temps when switching filament.

## Notes to Code Reviewers

## How the changes in this PR are tested
Tested with option enabled - during filament swap the default material temp is used
Test with option disabled - during filament swap the spoolman extruder temp is used
## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.