### PR TITLE
Add AFC_POST_PREP macro call for user-configurable actions after spool load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-02-05]
+### Added:
+- If an AFC_POST_PREP macro is present in the user's config, it is now called when a spool is loaded into the MMU, allowing user-configurable automation after filament swap.
+
 ## [2026-01-22]
 ### Changed:
 - The install-afc.sh script will now allow users to install as root if it detects the user is running a SAF K1 environment.

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -717,6 +717,7 @@ class AFCLane:
                         self.status = AFCLaneState.LOADED
                         self.unit_obj.lane_loaded(self)
                         self.afc.spool._set_values(self)
+                        self._post_prep_user_macro()
                         # Check if user wants to get TD-1 data when loading
                         # TODO: When implementing multi-extruder this could still happen if a lane is loaded for a
                         # different extruder/hub
@@ -1439,7 +1440,10 @@ class AFCLane:
             response['td1_scan_time']   = self.td1_data['scan_time'] if "scan_time" in self.td1_data else ''
         return response
 
-
+    def _post_prep_user_macro(self):
+        if self.afc.function.check_macro_present("AFC_POST_PREP"):
+            cmd = f"AFC_POST_PREP LANE={self.name}"
+            self.gcode.run_script_from_command(cmd)
 
 def load_config_prefix(config):
     return AFCLane(config)


### PR DESCRIPTION
## Major Changes in this PR

Adds a hook for a user-configurable gcode macro, AFC_POST_PREP, to run after a spool is loaded.

## Notes to Code Reviewers

This PR addresses issue #631 which I opened recently. I have discussed the proposed functionality with members of the team on Discord.

## How the changes in this PR are tested

Tested with my own MMU and AFC_POST_PREP macro, which is running successfully on filament loads.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [ x ] I have performed a self-review of my code
- [ x ] CHANGELOG.md is updated (if end-user facing)
- [ x ] Documentation updated in AT-Documentation repository
- [ x ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ x ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.