### PR TITLE
[Enhancement] Add Configurable Post‑Prep Macro Hook for Automatic Actions After Spool Load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-02-05]
+### Added:
+- User can now set an AFC_POST_PREP macro which will automatically run immediately after a new spool is loaded into a lane.
+
 ## [2026-02-01]
 ### Added:
 - Update Cut Macro to support kalico-bleeding-edge-v2 nonlinear pressure advance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2026-02-05]
 ### Added:
-- User can now set an AFC_POST_PREP macro which will automatically run immediately after a new spool is loaded into a lane.
+- User can now set an AFC_POST_PREP macro which will automatically run immediately after a new spool is loaded into a lane. Macro is also configurable by adding a `post_prep_macro` variable to AFC_stepper/AFC_lane or in AFC Units(AFC_BoxTurtle, AFC_HTLF, etc).
 
 ## [2026-02-01]
 ### Added:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2026-02-05]
 ### Added:
-- User can now set an AFC_POST_PREP macro which will automatically run immediately after a new spool is loaded into a lane. Macro is also configurable by adding a `post_prep_macro` variable to AFC_stepper/AFC_lane or in AFC Units(AFC_BoxTurtle, AFC_HTLF, etc).
+- User can now set an AFC_POST_PREP macro which will automatically run immediately after a new spool is loaded into a lane. Macro is also configurable by adding a `post_prep_macro` variable to AFC_stepper/AFC_lane or in AFC Units (AFC_BoxTurtle, AFC_HTLF, etc).
 
 ## [2026-02-01]
 ### Added:

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -724,6 +724,7 @@ class AFCLane:
                         self.status = AFCLaneState.LOADED
                         self.unit_obj.lane_loaded(self)
                         self.afc.spool._set_values(self)
+                        self._post_prep_user_macro()
                         # Check if user wants to get TD-1 data when loading
                         # TODO: When implementing multi-extruder this could still happen if a lane is loaded for a
                         # different extruder/hub
@@ -1485,7 +1486,10 @@ class AFCLane:
             response['td1_scan_time']   = self.td1_data['scan_time'] if "scan_time" in self.td1_data else ''
         return response
 
-
+    def _post_prep_user_macro(self):
+        if self.afc.function.check_macro_present("AFC_POST_PREP"):
+            cmd = f"AFC_POST_PREP LANE={self.name}"
+            self.gcode.run_script_from_command(cmd)
 
 def load_config_prefix(config):
     return AFCLane(config)

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -386,7 +386,7 @@ class AFCLane:
         if self.max_move_dis                is None: self.max_move_dis      = self.unit_obj.max_move_dis
         if self.td1_when_loaded             is None: self.td1_when_loaded   = self.unit_obj.td1_when_loaded
         if self.td1_device_id               is None: self.td1_device_id     = self.unit_obj.td1_device_id
-        if self.post_prep_macro             is None: self.post_prep_macro   = self.unit_obj.self.post_prep_macro
+        if self.post_prep_macro             is None: self.post_prep_macro   = self.unit_obj.post_prep_macro
 
         if self.rev_long_moves_speed_factor < 0.5: self.rev_long_moves_speed_factor = 0.5
         if self.rev_long_moves_speed_factor > 1.2: self.rev_long_moves_speed_factor = 1.2

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -142,6 +142,8 @@ class AFCLane:
         self.td1_when_loaded    = config.getboolean("capture_td1_when_loaded", None)
         self.td1_device_id      = config.get("td1_device_id", None)
 
+        self.post_prep_macro    = config.get("post_prep_macro", None)  # Macro to call after loading filament during prep callback
+
 
         self.printer.register_event_handler("AFC_unit_{}:connect".format(self.unit),self.handle_unit_connect)
 
@@ -384,6 +386,7 @@ class AFCLane:
         if self.max_move_dis                is None: self.max_move_dis      = self.unit_obj.max_move_dis
         if self.td1_when_loaded             is None: self.td1_when_loaded   = self.unit_obj.td1_when_loaded
         if self.td1_device_id               is None: self.td1_device_id     = self.unit_obj.td1_device_id
+        if self.self.post_prep_macro        is None: self.self.post_prep_macro = self.unit_obj.self.post_prep_macro
 
         if self.rev_long_moves_speed_factor < 0.5: self.rev_long_moves_speed_factor = 0.5
         if self.rev_long_moves_speed_factor > 1.2: self.rev_long_moves_speed_factor = 1.2
@@ -776,6 +779,14 @@ class AFCLane:
                 self.unit_obj.lane_unloaded(self)
 
         self.afc.save_vars()
+
+    def _post_prep_user_macro(self):
+        """
+        Function to call macro once filament has successfully been loaded during prep callback
+        """
+        if self.afc.function.check_macro_present(self.post_prep_macro):
+            cmd = f"{self.post_prep_macro} LANE={self.name}"
+            self.gcode.run_script_from_command(cmd)
 
     def do_enable(self, enable):
         if self.drive_stepper is not None:
@@ -1485,11 +1496,6 @@ class AFCLane:
             response['td1_color']       = self.td1_data['color'] if "color" in self.td1_data else ''
             response['td1_scan_time']   = self.td1_data['scan_time'] if "scan_time" in self.td1_data else ''
         return response
-
-    def _post_prep_user_macro(self):
-        if self.afc.function.check_macro_present("AFC_POST_PREP"):
-            cmd = f"AFC_POST_PREP LANE={self.name}"
-            self.gcode.run_script_from_command(cmd)
 
 def load_config_prefix(config):
     return AFCLane(config)

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -386,7 +386,7 @@ class AFCLane:
         if self.max_move_dis                is None: self.max_move_dis      = self.unit_obj.max_move_dis
         if self.td1_when_loaded             is None: self.td1_when_loaded   = self.unit_obj.td1_when_loaded
         if self.td1_device_id               is None: self.td1_device_id     = self.unit_obj.td1_device_id
-        if self.self.post_prep_macro        is None: self.self.post_prep_macro = self.unit_obj.self.post_prep_macro
+        if self.post_prep_macro             is None: self.post_prep_macro   = self.unit_obj.self.post_prep_macro
 
         if self.rev_long_moves_speed_factor < 0.5: self.rev_long_moves_speed_factor = 0.5
         if self.rev_long_moves_speed_factor > 1.2: self.rev_long_moves_speed_factor = 1.2

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -643,6 +643,7 @@ class AFCLane:
                 # Check if user wants to get TD-1 data when loading
                 if not self.tool_loaded:
                     self._prep_capture_td1()
+                self._post_prep_user_macro()
             else:
                 # Don't run if user disabled sensor in gui
                 if not self.fila_load.runout_helper.sensor_enabled and self.afc.function.is_printing():

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -90,6 +90,8 @@ class afcUnit:
         self.td1_when_loaded    = config.getboolean("capture_td1_when_loaded", self.afc.td1_when_loaded)
         self.td1_device_id      = config.get("td1_device_id", None)
 
+        self.post_prep_macro    = config.get("post_prep_macro", "AFC_POST_PREP")  # Macro to call after loading filament during prep callback
+
     def __str__(self):
         return self.name
 


### PR DESCRIPTION
## Major Changes in this PR

Rebased to DEV branch after closing earlier PR. This PR adds the feature I recently requested in issue #631 by checking whether an AFC_POST_PREP macro exists, and if it does, calling it once a lane is loaded.

## Notes to Code Reviewers

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.