### PR TITLE
[Enhancement] Adding homing-aware movements when loading/unloading/ejecting filament

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-02-06]
+### Added:
+- Adds homing-aware filament movement (new config flags homing_enabled, home_to_hub, home_to_tool); replaces many move/move_advanced calls with move_to (endstop-aware moves), updates calibration, load/unload and hub/tool flows, and adds type hints and small error/logging tweaks. Default homing behavior is enabled.
+
 ## [2026-02-05]
 ### Added:
 - User can now set an AFC_POST_PREP macro which will automatically run immediately after a new spool is loaded into a lane. Macro is also configurable by adding a `post_prep_macro` variable to AFC_stepper/AFC_lane or in AFC Units (AFC_BoxTurtle, AFC_HTLF, etc).

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1615,7 +1615,7 @@ class afc:
         # Ensure filament is fully cleared from the hub.
         num_tries = 0
         while cur_hub.state:
-            cur_lane.move_to(cur_lane.afc_bowden_length * -1, SpeedMode.SHORT,
+            cur_lane.move_to(cur_hub.afc_unload_bowden_length * -1, SpeedMode.SHORT,
                              assist_active=AssistActive.YES,
                              endstop=AFCHomingPoints.HUB,
                              use_homing=self.homing_enabled)

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1238,7 +1238,7 @@ class afc:
                 while not cur_lane.get_toolhead_pre_sensor_state():
                     tool_attempts += 1
                     # TODO: change this to short moves when not using homing, same for unload
-                    cur_lane.move_to(cur_lane.afc_bowden_length, SpeedMode.SHORT,
+                    cur_lane.move_to(cur_hub.afc_bowden_length, SpeedMode.SHORT,
                                         endstop=cur_lane.get_toolhead_endstop(),
                                         use_homing=self.homing_enabled)
                     if tool_attempts > int(self.tool_homing_distance/cur_lane.short_move_dis):
@@ -1286,9 +1286,7 @@ class afc:
                 cur_lane.unsync_to_extruder()
                 load_checks = 0
                 while cur_lane.get_toolhead_pre_sensor_state():
-                    cur_lane.move_to(cur_lane.short_move_dis * -1, SpeedMode.SHORT,
-                                     endstop=AFCHomingPoints.BUFFER_TRAIL,
-                                     use_homing=self.homing_enabled)
+                    cur_lane.move_advanced(cur_lane.short_move_dis * -1, SpeedMode.SHORT)
                     load_checks += 1
                     self.reactor.pause(self.reactor.monotonic() + 0.1)
                     if load_checks > self.tool_max_load_checks:

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1053,11 +1053,13 @@ class afc:
             cur_lane.status = AFCLaneState.EJECTING
             self.save_vars()
             if cur_lane.loaded_to_hub:
-                cur_lane.move_advanced(cur_lane.dist_hub * -1, SpeedMode.HUB, assist_active = AssistActive.DYNAMIC)
+                # cur_lane.move_advanced(cur_lane.dist_hub * -1, SpeedMode.HUB, assist_active = AssistActive.DYNAMIC)
+                cur_lane.home_to("load", (cur_lane.dist_hub+100) * -1, SpeedMode.HUB, triggered=False,
+                                 assist_active=AssistActive.DYNAMIC)
             cur_lane.loaded_to_hub = False
             while cur_lane.load_state:
                 cur_lane.move_advanced(cur_hub.move_dis * -1, SpeedMode.SHORT, assist_active = AssistActive.YES)
-            cur_lane.move_advanced(cur_hub.move_dis * -5, SpeedMode.SHORT)
+            cur_lane.move_advanced(-50, SpeedMode.SHORT)
             cur_lane.do_enable(False)
             cur_lane.status = AFCLaneState.NONE
             cur_lane.unit_obj.return_to_home()

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -187,6 +187,8 @@ class afc:
         self.tool_homing_distance   = config.getfloat("tool_homing_distance", 200)  # Distance over which toolhead homing is to be attempted.
         self.max_move_dis           = config.getfloat("max_move_dis", 999999)       # Maximum distance to move filament. AFC breaks filament moves over this number into multiple moves. Useful to lower this number if running into timer too close errors when doing long filament moves.
         self.n20_break_delay_time   = config.getfloat("n20_break_delay_time", 0.200)# Time to wait between breaking n20 motors(nSleep/FWD/RWD all 1) and then releasing the break to allow coasting.
+        self.auto_home_to_hub       = config.getboolean("auto_home_to_hub", False)  # Global setting to auto-home to hub during moves
+        self.auto_home_to_tool      = config.getboolean("auto_home_to_tool", False) # Global setting to auto-home to tool during moves  
 
         self.tool_max_unload_attempts= config.getint('tool_max_unload_attempts', 4) # Max number of attempts to unload filament from toolhead when using buffer as ramming sensor
         self.tool_max_load_checks   = config.getint('tool_max_load_checks', 4)      # Max number of attempts to check to make sure filament is loaded into toolhead extruder when using buffer as ramming sensor
@@ -1170,43 +1172,55 @@ class afc:
 
             cur_lane.loaded_to_hub = True
             hub_attempts = 0
+            homed_to_hub = False
+
+            if cur_lane.hub != 'direct' and not cur_hub.state:
+                if not cur_lane.auto_home_to_hub:
+                    cur_lane.move_advanced(cur_hub.move_dis, SpeedMode.SHORT)
+                    hub_attempts += 1
+                else:
+                    homed_to_hub = cur_lane.home_to('hub', cur_hub.move_dis, SpeedMode.HUB, True, True)
+                    hub_attempts += 1
 
             # Ensure filament moves past the hub.
-            while not cur_hub.state and cur_lane.hub != 'direct':
-                if hub_attempts == 0:
-                    cur_lane.move_advanced(cur_hub.move_dis, SpeedMode.SHORT)
-                else:
+            if not homed_to_hub:
+                while not cur_hub.state and cur_lane.hub != 'direct':
                     cur_lane.move_advanced(cur_lane.short_move_dis, SpeedMode.SHORT)
-                hub_attempts += 1
-                if hub_attempts > 20:
-                    message = 'filament did not trigger hub sensor, CHECK FILAMENT PATH\n||=====||==>--||-----||\nTRG   LOAD   HUB   TOOL.'
-                    if self.function.in_print():
-                        message += '\nOnce issue is resolved please manually load {} with {} macro and click resume to continue printing.'.format(cur_lane.name, cur_lane.map)
-                        message += '\nIf you have to retract filament back, use LANE_MOVE macro for {}.'.format(cur_lane.name)
-                    self.error.handle_lane_failure(cur_lane, message)
-                    return False
+                    hub_attempts += 1
+                    if hub_attempts > 20:
+                        message = 'filament did not trigger hub sensor, CHECK FILAMENT PATH\n||=====||==>--||-----||\nTRG   LOAD   HUB   TOOL.'
+                        if self.function.in_print():
+                            message += '\nOnce issue is resolved please manually load {} with {} macro and click resume to continue printing.'.format(cur_lane.name, cur_lane.map)
+                            message += '\nIf you have to retract filament back, use LANE_MOVE macro for {}.'.format(cur_lane.name)
+                        self.error.handle_lane_failure(cur_lane, message)
+                        return False
 
             self.afcDeltaTime.log_with_time("Filament loaded to hub")
 
             # Move filament towards the toolhead.
+            homed_to_tool = False
             if cur_lane.hub != 'direct':
-                cur_lane.move_advanced(cur_hub.afc_bowden_length, SpeedMode.LONG, assist_active = AssistActive.YES)
+                if not cur_lane.auto_home_to_tool:
+                    cur_lane.move_advanced(cur_hub.afc_bowden_length, SpeedMode.LONG, assist_active = AssistActive.YES)
+                else:
+                    homed_to_tool = cur_lane.home_to('tool', cur_hub.afc_bowden_length + 25, SpeedMode.LONG, True, True)
 
-            # Ensure filament reaches the toolhead.
-            tool_attempts = 0
-            if cur_extruder.tool_start:
-                while not cur_lane.get_toolhead_pre_sensor_state():
-                    tool_attempts += 1
-                    cur_lane.move(cur_lane.short_move_dis, cur_extruder.tool_load_speed, cur_lane.long_moves_accel)
-                    if tool_attempts > int(self.tool_homing_distance/cur_lane.short_move_dis):
-                        message = 'filament failed to trigger pre extruder gear toolhead sensor, CHECK FILAMENT PATH\n||=====||====||==>--||\nTRG   LOAD   HUB   TOOL'
-                        message += '\nTo resolve set lane loaded with `SET_LANE_LOADED LANE={}` macro.'.format(cur_lane.name)
-                        message += '\nManually move filament with LANE_MOVE macro for {} until filament is right before toolhead extruder gears,'.format(cur_lane.name)
-                        message += '\n then load into extruder gears with extrude button in your gui of choice until the color fully changes'
-                        if self.function.in_print():
-                            message += '\nOnce filament is fully loaded click resume to continue printing'
-                        self.error.handle_lane_failure(cur_lane, message)
-                        return False
+            if not homed_to_tool:
+                # Ensure filament reaches the toolhead.
+                tool_attempts = 0
+                if cur_extruder.tool_start:
+                    while not cur_lane.get_toolhead_pre_sensor_state():
+                        tool_attempts += 1
+                        cur_lane.move(cur_lane.short_move_dis, cur_extruder.tool_load_speed, cur_lane.long_moves_accel)
+                        if tool_attempts > int(self.tool_homing_distance/cur_lane.short_move_dis):
+                            message = 'filament failed to trigger pre extruder gear toolhead sensor, CHECK FILAMENT PATH\n||=====||====||==>--||\nTRG   LOAD   HUB   TOOL'
+                            message += '\nTo resolve set lane loaded with `SET_LANE_LOADED LANE={}` macro.'.format(cur_lane.name)
+                            message += '\nManually move filament with LANE_MOVE macro for {} until filament is right before toolhead extruder gears,'.format(cur_lane.name)
+                            message += '\n then load into extruder gears with extrude button in your gui of choice until the color fully changes'
+                            if self.function.in_print():
+                                message += '\nOnce filament is fully loaded click resume to continue printing'
+                            self.error.handle_lane_failure(cur_lane, message)
+                            return False
 
             self.afcDeltaTime.log_with_time("Filament loaded to pre-sensor")
 
@@ -1266,6 +1280,7 @@ class afc:
 
             # Activate the tool-loaded LED and handle filament operations if enabled.
             cur_lane.unit_obj.lane_tool_loaded( cur_lane )
+            cur_lane.espooler.do_assist_move()
             if self.poop:
                 if purge_length is not None:
                     self.gcode.run_script_from_command("%s %s=%s" % (self.poop_cmd, 'PURGE_LENGTH', purge_length))
@@ -1548,7 +1563,11 @@ class afc:
         # Synchronize and move filament out of the hub.
         cur_lane.unsync_to_extruder()
         if cur_lane.hub != 'direct':
-            cur_lane.move_advanced(cur_hub.afc_unload_bowden_length * -1, SpeedMode.LONG, assist_active = AssistActive.YES)
+            if not cur_lane.auto_home_to_hub:
+                homed_to_hub = False
+                cur_lane.move_advanced(cur_hub.afc_bowden_length * -1, SpeedMode.LONG, assist_active = AssistActive.YES)
+            else:
+                homed_to_hub = cur_lane.home_to('hub', cur_hub.afc_bowden_length * -1, SpeedMode.LONG, False, False)
         else:
             cur_lane.move_advanced(cur_lane.dist_hub * -1, SpeedMode.HUB, assist_active = AssistActive.DYNAMIC)
 
@@ -1561,7 +1580,7 @@ class afc:
 
         # Ensure filament is fully cleared from the hub.
         num_tries = 0
-        while cur_hub.state:
+        while cur_hub.state and homed_to_hub == False:
             cur_lane.move_advanced(cur_lane.short_move_dis * -1, SpeedMode.SHORT, assist_active = AssistActive.YES)
             num_tries += 1
             if num_tries > (cur_hub.afc_unload_bowden_length / cur_lane.short_move_dis):

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1595,7 +1595,7 @@ class afc:
         # Synchronize and move filament out of the hub.
         cur_lane.unsync_to_extruder()
         if cur_lane.hub != 'direct':
-            cur_lane.move_to(cur_hub.afc_unload_bowden_length * -1, SpeedMode.HUB,
+            cur_lane.move_to(cur_hub.afc_unload_bowden_length * -1, SpeedMode.LONG,
                              assist_active=AssistActive.YES,
                              endstop=AFCHomingPoints.HUB,
                              use_homing=self.homing_enabled)

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1243,13 +1243,15 @@ class afc:
                 while not cur_lane.get_toolhead_pre_sensor_state():
                     tool_attempts += 1
                     move_distance = cur_lane.short_move_dis
+                    max_attempts = int(self.tool_homing_distance/cur_lane.short_move_dis)
                     if (self.homing_enabled
                         and self.home_to_tool):
                         move_distance = cur_hub.afc_bowden_length
+                        max_attempts = 2
                     cur_lane.move_to(move_distance, SpeedMode.SHORT,
                                      endstop=cur_lane.get_toolhead_endstop(),
                                      use_homing=self.homing_enabled and self.home_to_tool)
-                    if tool_attempts > int(self.tool_homing_distance/cur_lane.short_move_dis):
+                    if tool_attempts >= max_attempts:
                         message = 'filament failed to trigger pre extruder gear toolhead sensor, CHECK FILAMENT PATH\n||=====||====||==>--||\nTRG   LOAD   HUB   TOOL'
                         message += '\nTo resolve set lane loaded with `SET_LANE_LOADED LANE={}` macro.'.format(cur_lane.name)
                         message += '\nManually move filament with LANE_MOVE macro for {} until filament is right before toolhead extruder gears,'.format(cur_lane.name)
@@ -1621,12 +1623,17 @@ class afc:
         # Ensure filament is fully cleared from the hub.
         num_tries = 0
         while cur_hub.state:
-            cur_lane.move_to(cur_hub.afc_unload_bowden_length * -1, SpeedMode.SHORT,
+            max_attempts = (cur_hub.afc_unload_bowden_length / cur_lane.short_move_dis)
+            move_dist = cur_lane.short_move_dis
+            if self.homing_enabled:
+                max_attempts = 2
+                move_dist = cur_hub.afc_unload_bowden_length
+            cur_lane.move_to(move_dist * -1, SpeedMode.SHORT,
                              assist_active=AssistActive.YES,
                              endstop=AFCHomingPoints.HUB,
                              use_homing=self.homing_enabled)
             num_tries += 1
-            if num_tries > (cur_hub.afc_unload_bowden_length / cur_lane.short_move_dis):
+            if num_tries >= max_attempts:
                 # Handle failure if the filament doesn't clear the hub.
                 message = 'Hub is not clearing, filament may be stuck in hub'
                 message += '\nPlease check to make sure filament has not broken off and caused the sensor to stay stuck'
@@ -1660,7 +1667,6 @@ class afc:
                     cur_lane.move_advanced(cur_lane.short_move_dis * -1, SpeedMode.SHORT,
                                            assist_active=AssistActive.YES)
                     num_tries += 1
-                    # TODO: Figure out max number of tries
                     if num_tries > (cur_hub.afc_unload_bowden_length / cur_lane.short_move_dis):
                         message = 'HUB NOT CLEARING after hub cut\n'
                         self.error.handle_lane_failure(cur_lane, message)

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -394,7 +394,7 @@ class afc:
             pin_loc_xy = tool_cut_obj.variables.get('pin_loc_xy', None)
             if pin_loc_xy and pin_loc_xy == (-99,-99):
                 error_str += 'tool_cut is set to True and variable_pin_loc_xy has not been updated.\n'
-                error_str += 'Please update variable_pin_loc_xy in AFC\AFC_Macro_Vars.cfg file.\n\n'
+                error_str += 'Please update variable_pin_loc_xy in AFC\\AFC_Macro_Vars.cfg file.\n\n'
 
         park_obj = self.printer.lookup_object('gcode_macro _AFC_PARK_VARS', None)
         if (self.park
@@ -403,7 +403,7 @@ class afc:
             park_loc_xy = park_obj.variables.get('park_loc_xy', None)
             if park_loc_xy and park_loc_xy == (-99,-99):
                 error_str += 'park is set to True and variable_park_loc_xy has not been updated.\n'
-                error_str += 'Please update variable_park_loc_xy in AFC\AFC_Macro_Vars.cfg file.\n\n'
+                error_str += 'Please update variable_park_loc_xy in AFC\\AFC_Macro_Vars.cfg file.\n\n'
 
         poop_obj = self.printer.lookup_object('gcode_macro _AFC_POOP_VARS', None)
         if (self.poop
@@ -412,7 +412,7 @@ class afc:
             purge_loc_xy = poop_obj.variables.get('purge_loc_xy', None)
             if purge_loc_xy and purge_loc_xy == (-99,-99):
                 error_str += 'poop is set to True and variable_purge_loc_xy has not been updated.\n'
-                error_str += 'Please update variable_purge_loc_xy in AFC\AFC_Macro_Vars.cfg file.\n\n'
+                error_str += 'Please update variable_purge_loc_xy in AFC\\AFC_Macro_Vars.cfg file.\n\n'
 
         kick_obj = self.printer.lookup_object('gcode_macro _AFC_KICK_VARS', None)
         if (self.kick
@@ -421,7 +421,7 @@ class afc:
             kick_start_loc = kick_obj.variables.get('kick_start_loc', None)
             if kick_start_loc and kick_start_loc == (-99,-99,5):
                 error_str += 'kick is set to True and variable_kick_start_loc has not been updated.\n'
-                error_str += 'Please update variable_kick_start_loc in AFC\AFC_Macro_Vars.cfg file.\n\n'
+                error_str += 'Please update variable_kick_start_loc in AFC\\AFC_Macro_Vars.cfg file.\n\n'
 
         wipe_obj = self.printer.lookup_object('gcode_macro _AFC_BRUSH_VARS', None)
         if (self.wipe
@@ -430,7 +430,7 @@ class afc:
             brush_loc = wipe_obj.variables.get('brush_loc', None)
             if brush_loc and brush_loc == (-99,-99,-1):
                 error_str += 'wipe is set to True and variable_brush_loc has not been updated.\n'
-                error_str += 'Please update variable_brush_loc in AFC\AFC_Macro_Vars.cfg file.\n\n'
+                error_str += 'Please update variable_brush_loc in AFC\\AFC_Macro_Vars.cfg file.\n\n'
 
         return error_str
 

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1004,7 +1004,7 @@ class afc:
                 # TODO: add timout routine here
                 cur_lane.move_to(cur_hub.move_dis, SpeedMode.SHORT,
                                  endstop=AFCHomingPoints.LOAD,
-                                 active_assist=AssistActive.DYNAMIC,
+                                 assist_active=AssistActive.DYNAMIC,
                                  use_homing=self.homing_enabled)
         if not cur_lane.loaded_to_hub:
             dist_to_hub = cur_lane.dist_hub

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -187,8 +187,8 @@ class afc:
         self.tool_homing_distance   = config.getfloat("tool_homing_distance", 200)  # Distance over which toolhead homing is to be attempted.
         self.max_move_dis           = config.getfloat("max_move_dis", 999999)       # Maximum distance to move filament. AFC breaks filament moves over this number into multiple moves. Useful to lower this number if running into timer too close errors when doing long filament moves.
         self.n20_break_delay_time   = config.getfloat("n20_break_delay_time", 0.200)# Time to wait between breaking n20 motors(nSleep/FWD/RWD all 1) and then releasing the break to allow coasting.
-        self.auto_home_to_hub       = config.getboolean("auto_home_to_hub", False)  # Global setting to auto-home to hub during moves
-        self.auto_home_to_tool      = config.getboolean("auto_home_to_tool", False) # Global setting to auto-home to tool during moves  
+        self.home_to_hub            = config.getboolean("home_to_hub", True)  # Global setting to auto-home to hub during moves
+        self.home_to_tool           = config.getboolean("home_to_tool", True) # Global setting to auto-home to tool during moves  
         self.homing_enabled         = config.getboolean("homing_enabled", True)
 
         self.tool_max_unload_attempts= config.getint('tool_max_unload_attempts', 4) # Max number of attempts to unload filament from toolhead when using buffer as ramming sensor
@@ -1200,7 +1200,6 @@ class afc:
 
             cur_lane.loaded_to_hub = True
             hub_attempts = 0
-            homed_to_hub = False
 
             if cur_lane.hub != 'direct' and not cur_hub.state:
                 cur_lane.move_to(cur_hub.move_dis, SpeedMode.SHORT,
@@ -1212,7 +1211,7 @@ class afc:
             while not cur_hub.state and cur_lane.hub != 'direct':
                 cur_lane.move_to(cur_hub.move_dis, SpeedMode.SHORT,
                                  endstop=AFCHomingPoints.HUB,
-                                 use_homing=self.homing_enabled)
+                                 use_homing=self.homing_enabled and self.home_to_hub)
                 hub_attempts += 1
                 if hub_attempts > 20:
                     message = 'filament did not trigger hub sensor, CHECK FILAMENT PATH\n||=====||==>--||-----||\nTRG   LOAD   HUB   TOOL.'
@@ -1230,17 +1229,20 @@ class afc:
                                  SpeedMode.LONG,
                                  assist_active=AssistActive.YES,
                                  endstop=cur_lane.get_toolhead_endstop(),
-                                 use_homing=self.homing_enabled)
+                                 use_homing=self.homing_enabled and self.home_to_tool)
 
             # Ensure filament reaches the toolhead.
             tool_attempts = 0
             if cur_extruder.tool_start:
                 while not cur_lane.get_toolhead_pre_sensor_state():
                     tool_attempts += 1
-                    # TODO: change this to short moves when not using homing, same for unload
-                    cur_lane.move_to(cur_hub.afc_bowden_length, SpeedMode.SHORT,
-                                        endstop=cur_lane.get_toolhead_endstop(),
-                                        use_homing=self.homing_enabled)
+                    move_distance = cur_lane.short_move_dis
+                    if (self.homing_enabled
+                        and self.home_to_tool):
+                        move_distance = cur_hub.afc_bowden_length
+                    cur_lane.move_to(move_distance, SpeedMode.SHORT,
+                                     endstop=cur_lane.get_toolhead_endstop(),
+                                     use_homing=self.homing_enabled and self.home_to_tool)
                     if tool_attempts > int(self.tool_homing_distance/cur_lane.short_move_dis):
                         message = 'filament failed to trigger pre extruder gear toolhead sensor, CHECK FILAMENT PATH\n||=====||====||==>--||\nTRG   LOAD   HUB   TOOL'
                         message += '\nTo resolve set lane loaded with `SET_LANE_LOADED LANE={}` macro.'.format(cur_lane.name)
@@ -1509,9 +1511,7 @@ class afc:
                     f'TOOL_UNLOAD: Retracting Buffer, Try:{num_tries}'
                 )
                 # attempt to return buffer to trailing pin
-                cur_lane.move_to(cur_lane.short_move_dis * -1, SpeedMode.SHORT,
-                                 endstop=AFCHomingPoints.BUFFER_TRAIL,
-                                 use_homing=self.homing_enabled)
+                cur_lane.move_advanced(cur_lane.short_move_dis * -1, SpeedMode.SHORT)
                 self.reactor.pause(self.reactor.monotonic() + 0.1)
                 if num_tries > self.tool_max_unload_attempts:
                     msg = ''
@@ -1595,12 +1595,12 @@ class afc:
         # Synchronize and move filament out of the hub.
         cur_lane.unsync_to_extruder()
         if cur_lane.hub != 'direct':
-            cur_lane.move_to(cur_hub.afc_bowden_length * -1, SpeedMode.LONG,
+            cur_lane.move_to(cur_hub.afc_unload_bowden_length * -1, SpeedMode.HUB,
                              assist_active=AssistActive.YES,
                              endstop=AFCHomingPoints.HUB,
                              use_homing=self.homing_enabled)
         else:
-            cur_lane.move_to(cur_lane.dist_hub * -1, SpeedMode.HUB,
+            cur_lane.move_to(cur_lane.dist_hub * -1, SpeedMode.LONG,
                              assist_active = AssistActive.DYNAMIC,
                              endstop=AFCHomingPoints.LOAD,
                              use_homing=self.homing_enabled)

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -10,13 +10,15 @@ import traceback
 from configfile import error
 from typing import Any
 
-from typing import Dict, TYPE_CHECKING
+from typing import Dict, TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
     from gcode import GCodeCommand
     from extras.AFC_lane import AFCLane
     from extras.AFC_extruder import AFCExtruder
     from extras.AFC_functions import afcFunction
+    from extras.AFC_error import afcError
+    from extras.AFC_stepper import AFCExtruderStepper
 
 ERROR_STR = "Error trying to import {import_lib}, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper\n\n{trace}"
 
@@ -61,7 +63,7 @@ class afc:
         self.logger  = AFC_logger(self.printer, self)
 
         self.spool      = self.printer.load_object(config, 'AFC_spool')
-        self.error      = self.printer.load_object(config, 'AFC_error')
+        self.error: afcError = self.printer.load_object(config, 'AFC_error')
         self.function: afcFunction   = self.printer.load_object(config, 'AFC_functions')
         self.function.afc = self
         self.gcode      = self.printer.load_object(config, 'gcode')
@@ -91,7 +93,7 @@ class afc:
         # Objects for everything configured for AFC
         self.units      = {}
         self.tools: Dict[str, AFCExtruder] = {}
-        self.lanes: Dict[str, AFCLane]     = {}
+        self.lanes: Dict[str, Union[AFCLane, AFCExtruderStepper]] = {}
         self.hubs       = {}
         self.buffers    = {}
         self.tool_cmds  = {}
@@ -187,8 +189,8 @@ class afc:
         self.tool_homing_distance   = config.getfloat("tool_homing_distance", 200)  # Distance over which toolhead homing is to be attempted.
         self.max_move_dis           = config.getfloat("max_move_dis", 999999)       # Maximum distance to move filament. AFC breaks filament moves over this number into multiple moves. Useful to lower this number if running into timer too close errors when doing long filament moves.
         self.n20_break_delay_time   = config.getfloat("n20_break_delay_time", 0.200)# Time to wait between breaking n20 motors(nSleep/FWD/RWD all 1) and then releasing the break to allow coasting.
-        self.home_to_hub            = config.getboolean("home_to_hub", True)  # Global setting to auto-home to hub during moves
-        self.home_to_tool           = config.getboolean("home_to_tool", True) # Global setting to auto-home to tool during moves  
+        self.home_to_hub            = config.getboolean("home_to_hub", True)        # Global setting to auto-home to hub during moves
+        self.home_to_tool           = config.getboolean("home_to_tool", True)       # Global setting to auto-home to tool during moves
         self.homing_enabled         = config.getboolean("homing_enabled", True)
 
         self.tool_max_unload_attempts= config.getint('tool_max_unload_attempts', 4) # Max number of attempts to unload filament from toolhead when using buffer as ramming sensor
@@ -783,7 +785,7 @@ class afc:
         if abs(distance) >= 200: speed_mode = SpeedMode.LONG
 
         cur_lane.set_load_current() # Making current is set correctly when doing lane moves
-        cur_lane.move_advanced(distance, speed_mode, assist_active = AssistActive.YES)      # Checked
+        cur_lane.move_advanced(distance, speed_mode, assist_active = AssistActive.YES)
         cur_lane.do_enable(False)
         self.current_state = State.IDLE
         cur_lane.unit_obj.return_to_home()
@@ -1016,7 +1018,7 @@ class afc:
                              endstop=AFCHomingPoints.HUB, use_homing=self.homing_enabled)
         while cur_hub.state:
             # TODO: add timout routine here
-            cur_lane.move_advanced(cur_hub.move_dis * -1, SpeedMode.SHORT) # Checked
+            cur_lane.move_advanced(cur_hub.move_dis * -1, SpeedMode.SHORT)
         cur_lane.status = AFCLaneState.NONE
         cur_lane.do_enable(False)
         cur_lane.loaded_to_hub = True
@@ -1074,8 +1076,9 @@ class afc:
             cur_lane.loaded_to_hub = False
             while cur_lane.load_state:
                 # TODO: add timout routine here
-                cur_lane.move_advanced(cur_hub.move_dis * -1, SpeedMode.SHORT, assist_active = AssistActive.YES) # Checked
-            cur_lane.move_advanced(-50, SpeedMode.SHORT) # Checked
+                cur_lane.move_advanced(cur_hub.move_dis * -1, SpeedMode.SHORT,
+                                       assist_active = AssistActive.YES)
+            cur_lane.move_advanced(cur_lane.extruder_clear_dis * -1, SpeedMode.SHORT)
             cur_lane.do_enable(False)
             cur_lane.status = AFCLaneState.NONE
             cur_lane.unit_obj.return_to_home()
@@ -1186,13 +1189,16 @@ class afc:
             # Move filament to the hub if it's not already loaded there.
             if not cur_lane.loaded_to_hub or cur_lane.hub == 'direct':
                 dist_to_hub = cur_lane.dist_hub
-                if self.homing_enabled and cur_lane.hub != 'direct':
+                if (self.homing_enabled
+                    and cur_lane.hub != 'direct'):
                     dist_to_hub += cur_hub.move_dis
+
                 home_endstop = AFCHomingPoints.HUB
                 if cur_lane.hub == 'direct':
                     home_endstop= cur_lane.get_toolhead_endstop()
 
-                cur_lane.move_to(dist_to_hub, SpeedMode.HUB, assist_active=AssistActive.DYNAMIC,
+                cur_lane.move_to(dist_to_hub, SpeedMode.HUB,
+                                 assist_active=AssistActive.DYNAMIC,
                                  endstop=home_endstop, use_homing=self.homing_enabled)
                 self.afcDeltaTime.log_with_time(
                     f"Loaded to {'hub' if cur_lane.hub != 'direct' else 'toolhead'}"
@@ -1548,7 +1554,7 @@ class afc:
                         f'TOOL_UNLOAD: Sensor-Unloading from toolhead(tool_stn_unload==0), Try:{num_tries}'
                     )
                     # attempt to move filament back from sensor without moving extruder
-                    cur_lane.move_advanced(cur_lane.short_move_dis * -1, SpeedMode.SHORT) # Checked, not sure if this should use move_to
+                    cur_lane.move_advanced(cur_lane.short_move_dis * -1, SpeedMode.SHORT)
                     if num_tries > self.tool_max_unload_attempts:
                         # note that this will break out of the loop and immediately fall into the error
                         # condition of the next loop for messaging to the user
@@ -1640,7 +1646,7 @@ class afc:
         #Move to make sure hub path is clear based on the move_clear_dis var
         if cur_lane.hub != 'direct':
             cur_lane.move_advanced(cur_hub.hub_clear_move_dis * -1, SpeedMode.SHORT,
-                                   assist_active=AssistActive.YES) # Checked
+                                   assist_active=AssistActive.YES)
 
             # Cut filament at the hub, if configured.
             if cur_hub.cut:
@@ -1652,7 +1658,7 @@ class afc:
                 # Confirm the hub is clear after the cut.
                 while cur_hub.state:
                     cur_lane.move_advanced(cur_lane.short_move_dis * -1, SpeedMode.SHORT,
-                                           assist_active=AssistActive.YES) # Checked
+                                           assist_active=AssistActive.YES)
                     num_tries += 1
                     # TODO: Figure out max number of tries
                     if num_tries > (cur_hub.afc_unload_bowden_length / cur_lane.short_move_dis):
@@ -1671,7 +1677,7 @@ class afc:
             while cur_lane.load_state:
                 cur_lane.move_advanced(cur_lane.short_move_dis * -1, SpeedMode.SHORT,
                                        assist_active=AssistActive.YES)
-            cur_lane.move_advanced(cur_lane.short_move_dis * -5, SpeedMode.SHORT) # Checked both
+            cur_lane.move_advanced(cur_lane.short_move_dis * -5, SpeedMode.SHORT)
 
         cur_lane.do_enable(False)
         cur_lane.unit_obj.return_to_home()

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 ERROR_STR = "Error trying to import {import_lib}, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper\n\n{trace}"
 
-try: from extras.AFC_lane import AFCLaneState, SpeedMode, AssistActive
+try: from extras.AFC_lane import AFCLaneState, SpeedMode, AssistActive, AFCHomingPoints
 except: raise error(ERROR_STR.format(import_lib="AFC_logger", trace=traceback.format_exc()))
 
 try: from extras.AFC_logger import AFC_logger
@@ -189,6 +189,7 @@ class afc:
         self.n20_break_delay_time   = config.getfloat("n20_break_delay_time", 0.200)# Time to wait between breaking n20 motors(nSleep/FWD/RWD all 1) and then releasing the break to allow coasting.
         self.auto_home_to_hub       = config.getboolean("auto_home_to_hub", False)  # Global setting to auto-home to hub during moves
         self.auto_home_to_tool      = config.getboolean("auto_home_to_tool", False) # Global setting to auto-home to tool during moves  
+        self.homing_enabled         = config.getboolean("homing_enabled", True)
 
         self.tool_max_unload_attempts= config.getint('tool_max_unload_attempts', 4) # Max number of attempts to unload filament from toolhead when using buffer as ramming sensor
         self.tool_max_load_checks   = config.getint('tool_max_load_checks', 4)      # Max number of attempts to check to make sure filament is loaded into toolhead extruder when using buffer as ramming sensor
@@ -782,7 +783,7 @@ class afc:
         if abs(distance) >= 200: speed_mode = SpeedMode.LONG
 
         cur_lane.set_load_current() # Making current is set correctly when doing lane moves
-        cur_lane.move_advanced(distance, speed_mode, assist_active = AssistActive.YES)
+        cur_lane.move_advanced(distance, speed_mode, assist_active = AssistActive.YES)      # Checked
         cur_lane.do_enable(False)
         self.current_state = State.IDLE
         cur_lane.unit_obj.return_to_home()
@@ -998,13 +999,24 @@ class afc:
         cur_lane.status = AFCLaneState.HUB_LOADING
         if not cur_lane.load_state:
             while not cur_lane.load_state:
-                cur_lane.move_advanced( cur_hub.move_dis, SpeedMode.SHORT)
+                # TODO: add timout routine here
+                cur_lane.move_to(cur_hub.move_dis, SpeedMode.SHORT,
+                                 endstop=AFCHomingPoints.LOAD,
+                                 active_assist=AssistActive.DYNAMIC,
+                                 use_homing=self.homing_enabled)
         if not cur_lane.loaded_to_hub:
-            cur_lane.move_advanced(cur_lane.dist_hub, SpeedMode.HUB, assist_active = AssistActive.DYNAMIC)
+            dist_to_hub = cur_lane.dist_hub
+            if self.homing_enabled:
+                dist_to_hub = cur_lane.dist_hub + cur_hub.move_dis
+            cur_lane.move_to(dist_to_hub, SpeedMode.HUB, assist_active=AssistActive.DYNAMIC,
+                             endstop=AFCHomingPoints.HUB, use_homing=self.homing_enabled)
         while not cur_hub.state:
-            cur_lane.move_advanced(cur_hub.move_dis, SpeedMode.SHORT)
+            # TODO: add timout routine here
+            cur_lane.move_to(cur_hub.move_dis, SpeedMode.SHORT, assist_active=AssistActive.NO,
+                             endstop=AFCHomingPoints.HUB, use_homing=self.homing_enabled)
         while cur_hub.state:
-            cur_lane.move_advanced(cur_hub.move_dis * -1, SpeedMode.SHORT)
+            # TODO: add timout routine here
+            cur_lane.move_advanced(cur_hub.move_dis * -1, SpeedMode.SHORT) # Checked
         cur_lane.status = AFCLaneState.NONE
         cur_lane.do_enable(False)
         cur_lane.loaded_to_hub = True
@@ -1042,6 +1054,8 @@ class afc:
         self.LANE_UNLOAD( cur_lane )
 
     def LANE_UNLOAD(self, cur_lane):
+        # TODO: update this to unload from toolhead and move all the way back to load
+        # when homing is enabled
         cur_hub = cur_lane.hub_obj
 
         self.current_state = State.EJECTING_LANE
@@ -1053,13 +1067,15 @@ class afc:
             cur_lane.status = AFCLaneState.EJECTING
             self.save_vars()
             if cur_lane.loaded_to_hub:
-                # cur_lane.move_advanced(cur_lane.dist_hub * -1, SpeedMode.HUB, assist_active = AssistActive.DYNAMIC)
-                cur_lane.home_to("load", (cur_lane.dist_hub+100) * -1, SpeedMode.HUB, triggered=False,
-                                 assist_active=AssistActive.DYNAMIC)
+                cur_lane.move_to( cur_lane.dist_hub * -1, SpeedMode.HUB,
+                                  endstop=AFCHomingPoints.LOAD,
+                                  assist_active=AssistActive.DYNAMIC,
+                                  use_homing=self.homing_enabled)
             cur_lane.loaded_to_hub = False
             while cur_lane.load_state:
-                cur_lane.move_advanced(cur_hub.move_dis * -1, SpeedMode.SHORT, assist_active = AssistActive.YES)
-            cur_lane.move_advanced(-50, SpeedMode.SHORT)
+                # TODO: add timout routine here
+                cur_lane.move_advanced(cur_hub.move_dis * -1, SpeedMode.SHORT, assist_active = AssistActive.YES) # Checked
+            cur_lane.move_advanced(-50, SpeedMode.SHORT) # Checked
             cur_lane.do_enable(False)
             cur_lane.status = AFCLaneState.NONE
             cur_lane.unit_obj.return_to_home()
@@ -1169,60 +1185,71 @@ class afc:
 
             # Move filament to the hub if it's not already loaded there.
             if not cur_lane.loaded_to_hub or cur_lane.hub == 'direct':
-                cur_lane.move_advanced(cur_lane.dist_hub, SpeedMode.HUB, assist_active = AssistActive.DYNAMIC)
-                self.afcDeltaTime.log_with_time("Loaded to hub")
+                dist_to_hub = cur_lane.dist_hub
+                if self.homing_enabled and cur_lane.hub != 'direct':
+                    dist_to_hub += cur_hub.move_dis
+                home_endstop = AFCHomingPoints.HUB
+                if cur_lane.hub == 'direct':
+                    home_endstop= cur_lane.get_toolhead_endstop()
+
+                cur_lane.move_to(dist_to_hub, SpeedMode.HUB, assist_active=AssistActive.DYNAMIC,
+                                 endstop=home_endstop, use_homing=self.homing_enabled)
+                self.afcDeltaTime.log_with_time(
+                    f"Loaded to {'hub' if cur_lane.hub != 'direct' else 'toolhead'}"
+                )
 
             cur_lane.loaded_to_hub = True
             hub_attempts = 0
             homed_to_hub = False
 
             if cur_lane.hub != 'direct' and not cur_hub.state:
-                if not cur_lane.auto_home_to_hub:
-                    cur_lane.move_advanced(cur_hub.move_dis, SpeedMode.SHORT)
-                    hub_attempts += 1
-                else:
-                    homed_to_hub = cur_lane.home_to('hub', cur_hub.move_dis, SpeedMode.HUB, True, True)
-                    hub_attempts += 1
+                cur_lane.move_to(cur_hub.move_dis, SpeedMode.SHORT,
+                                 endstop=AFCHomingPoints.HUB,
+                                 use_homing=self.homing_enabled)
+                hub_attempts += 1
 
             # Ensure filament moves past the hub.
-            if not homed_to_hub:
-                while not cur_hub.state and cur_lane.hub != 'direct':
-                    cur_lane.move_advanced(cur_lane.short_move_dis, SpeedMode.SHORT)
-                    hub_attempts += 1
-                    if hub_attempts > 20:
-                        message = 'filament did not trigger hub sensor, CHECK FILAMENT PATH\n||=====||==>--||-----||\nTRG   LOAD   HUB   TOOL.'
-                        if self.function.in_print():
-                            message += '\nOnce issue is resolved please manually load {} with {} macro and click resume to continue printing.'.format(cur_lane.name, cur_lane.map)
-                            message += '\nIf you have to retract filament back, use LANE_MOVE macro for {}.'.format(cur_lane.name)
-                        self.error.handle_lane_failure(cur_lane, message)
-                        return False
+            while not cur_hub.state and cur_lane.hub != 'direct':
+                cur_lane.move_to(cur_hub.move_dis, SpeedMode.SHORT,
+                                 endstop=AFCHomingPoints.HUB,
+                                 use_homing=self.homing_enabled)
+                hub_attempts += 1
+                if hub_attempts > 20:
+                    message = 'filament did not trigger hub sensor, CHECK FILAMENT PATH\n||=====||==>--||-----||\nTRG   LOAD   HUB   TOOL.'
+                    if self.function.in_print():
+                        message += '\nOnce issue is resolved please manually load {} with {} macro and click resume to continue printing.'.format(cur_lane.name, cur_lane.map)
+                        message += '\nIf you have to retract filament back, use LANE_MOVE macro for {}.'.format(cur_lane.name)
+                    self.error.handle_lane_failure(cur_lane, message)
+                    return False
 
             self.afcDeltaTime.log_with_time("Filament loaded to hub")
 
             # Move filament towards the toolhead.
-            homed_to_tool = False
             if cur_lane.hub != 'direct':
-                if not cur_lane.auto_home_to_tool:
-                    cur_lane.move_advanced(cur_hub.afc_bowden_length, SpeedMode.LONG, assist_active = AssistActive.YES)
-                else:
-                    homed_to_tool = cur_lane.home_to('tool', cur_hub.afc_bowden_length + 25, SpeedMode.LONG, True, True)
+                cur_lane.move_to(cur_hub.afc_bowden_length,
+                                 SpeedMode.LONG,
+                                 assist_active=AssistActive.YES,
+                                 endstop=cur_lane.get_toolhead_endstop(),
+                                 use_homing=self.homing_enabled)
 
-            if not homed_to_tool:
-                # Ensure filament reaches the toolhead.
-                tool_attempts = 0
-                if cur_extruder.tool_start:
-                    while not cur_lane.get_toolhead_pre_sensor_state():
-                        tool_attempts += 1
-                        cur_lane.move(cur_lane.short_move_dis, cur_extruder.tool_load_speed, cur_lane.long_moves_accel)
-                        if tool_attempts > int(self.tool_homing_distance/cur_lane.short_move_dis):
-                            message = 'filament failed to trigger pre extruder gear toolhead sensor, CHECK FILAMENT PATH\n||=====||====||==>--||\nTRG   LOAD   HUB   TOOL'
-                            message += '\nTo resolve set lane loaded with `SET_LANE_LOADED LANE={}` macro.'.format(cur_lane.name)
-                            message += '\nManually move filament with LANE_MOVE macro for {} until filament is right before toolhead extruder gears,'.format(cur_lane.name)
-                            message += '\n then load into extruder gears with extrude button in your gui of choice until the color fully changes'
-                            if self.function.in_print():
-                                message += '\nOnce filament is fully loaded click resume to continue printing'
-                            self.error.handle_lane_failure(cur_lane, message)
-                            return False
+            # Ensure filament reaches the toolhead.
+            tool_attempts = 0
+            if cur_extruder.tool_start:
+                while not cur_lane.get_toolhead_pre_sensor_state():
+                    tool_attempts += 1
+                    # TODO: change this to short moves when not using homing, same for unload
+                    cur_lane.move_to(cur_lane.afc_bowden_length, SpeedMode.SHORT,
+                                        endstop=cur_lane.get_toolhead_endstop(),
+                                        use_homing=self.homing_enabled)
+                    if tool_attempts > int(self.tool_homing_distance/cur_lane.short_move_dis):
+                        message = 'filament failed to trigger pre extruder gear toolhead sensor, CHECK FILAMENT PATH\n||=====||====||==>--||\nTRG   LOAD   HUB   TOOL'
+                        message += '\nTo resolve set lane loaded with `SET_LANE_LOADED LANE={}` macro.'.format(cur_lane.name)
+                        message += '\nManually move filament with LANE_MOVE macro for {} until filament is right before toolhead extruder gears,'.format(cur_lane.name)
+                        message += '\n then load into extruder gears with extrude button in your gui of choice until the color fully changes'
+                        if self.function.in_print():
+                            message += '\nOnce filament is fully loaded click resume to continue printing'
+                        self.error.handle_lane_failure(cur_lane, message)
+                        return False
 
             self.afcDeltaTime.log_with_time("Filament loaded to pre-sensor")
 
@@ -1234,7 +1261,8 @@ class afc:
             if cur_extruder.tool_end:
                 while not cur_extruder.tool_end_state:
                     tool_attempts += 1
-                    self.move_e_pos( cur_lane.short_move_dis, cur_extruder.tool_load_speed, "Tool end", wait_tool=True )
+                    self.move_e_pos(cur_lane.short_move_dis, cur_extruder.tool_load_speed,
+                                    "Tool end", wait_tool=True )
                     if tool_attempts > 20:
                         message = 'filament failed to trigger post extruder gear toolhead sensor, CHECK FILAMENT PATH\n||=====||====||==>--||\nTRG   LOAD   HUB   TOOL'
                         message += '\nTo resolve set lane loaded with `SET_LANE_LOADED LANE={}` macro.'.format(cur_lane.name)
@@ -1258,7 +1286,9 @@ class afc:
                 cur_lane.unsync_to_extruder()
                 load_checks = 0
                 while cur_lane.get_toolhead_pre_sensor_state():
-                    cur_lane.move_advanced(cur_lane.short_move_dis * -1, SpeedMode.SHORT)
+                    cur_lane.move_to(cur_lane.short_move_dis * -1, SpeedMode.SHORT,
+                                     endstop=AFCHomingPoints.BUFFER_TRAIL,
+                                     use_homing=self.homing_enabled)
                     load_checks += 1
                     self.reactor.pause(self.reactor.monotonic() + 0.1)
                     if load_checks > self.tool_max_load_checks:
@@ -1481,7 +1511,9 @@ class afc:
                     f'TOOL_UNLOAD: Retracting Buffer, Try:{num_tries}'
                 )
                 # attempt to return buffer to trailing pin
-                cur_lane.move_advanced(cur_lane.short_move_dis * -1, SpeedMode.SHORT)
+                cur_lane.move_to(cur_lane.short_move_dis * -1, SpeedMode.SHORT,
+                                 endstop=AFCHomingPoints.BUFFER_TRAIL,
+                                 use_homing=self.homing_enabled)
                 self.reactor.pause(self.reactor.monotonic() + 0.1)
                 if num_tries > self.tool_max_unload_attempts:
                     msg = ''
@@ -1518,7 +1550,7 @@ class afc:
                         f'TOOL_UNLOAD: Sensor-Unloading from toolhead(tool_stn_unload==0), Try:{num_tries}'
                     )
                     # attempt to move filament back from sensor without moving extruder
-                    cur_lane.move_advanced(cur_lane.short_move_dis * -1, SpeedMode.SHORT)
+                    cur_lane.move_advanced(cur_lane.short_move_dis * -1, SpeedMode.SHORT) # Checked, not sure if this should use move_to
                     if num_tries > self.tool_max_unload_attempts:
                         # note that this will break out of the loop and immediately fall into the error
                         # condition of the next loop for messaging to the user
@@ -1565,13 +1597,15 @@ class afc:
         # Synchronize and move filament out of the hub.
         cur_lane.unsync_to_extruder()
         if cur_lane.hub != 'direct':
-            if not cur_lane.auto_home_to_hub:
-                homed_to_hub = False
-                cur_lane.move_advanced(cur_hub.afc_bowden_length * -1, SpeedMode.LONG, assist_active = AssistActive.YES)
-            else:
-                homed_to_hub = cur_lane.home_to('hub', cur_hub.afc_bowden_length * -1, SpeedMode.LONG, False, False)
+            cur_lane.move_to(cur_hub.afc_bowden_length * -1, SpeedMode.LONG,
+                             assist_active=AssistActive.YES,
+                             endstop=AFCHomingPoints.HUB,
+                             use_homing=self.homing_enabled)
         else:
-            cur_lane.move_advanced(cur_lane.dist_hub * -1, SpeedMode.HUB, assist_active = AssistActive.DYNAMIC)
+            cur_lane.move_to(cur_lane.dist_hub * -1, SpeedMode.HUB,
+                             assist_active = AssistActive.DYNAMIC,
+                             endstop=AFCHomingPoints.LOAD,
+                             use_homing=self.homing_enabled)
 
         self.afcDeltaTime.log_with_time("Long retract done")
 
@@ -1582,8 +1616,11 @@ class afc:
 
         # Ensure filament is fully cleared from the hub.
         num_tries = 0
-        while cur_hub.state and homed_to_hub == False:
-            cur_lane.move_advanced(cur_lane.short_move_dis * -1, SpeedMode.SHORT, assist_active = AssistActive.YES)
+        while cur_hub.state:
+            cur_lane.move_to(cur_lane.afc_bowden_length * -1, SpeedMode.SHORT,
+                             assist_active=AssistActive.YES,
+                             endstop=AFCHomingPoints.HUB,
+                             use_homing=self.homing_enabled)
             num_tries += 1
             if num_tries > (cur_hub.afc_unload_bowden_length / cur_lane.short_move_dis):
                 # Handle failure if the filament doesn't clear the hub.
@@ -1604,7 +1641,8 @@ class afc:
 
         #Move to make sure hub path is clear based on the move_clear_dis var
         if cur_lane.hub != 'direct':
-            cur_lane.move_advanced(cur_hub.hub_clear_move_dis * -1, SpeedMode.SHORT, assist_active = AssistActive.YES)
+            cur_lane.move_advanced(cur_hub.hub_clear_move_dis * -1, SpeedMode.SHORT,
+                                   assist_active=AssistActive.YES) # Checked
 
             # Cut filament at the hub, if configured.
             if cur_hub.cut:
@@ -1615,7 +1653,8 @@ class afc:
 
                 # Confirm the hub is clear after the cut.
                 while cur_hub.state:
-                    cur_lane.move_advanced(cur_lane.short_move_dis * -1, SpeedMode.SHORT, assist_active = AssistActive.YES)
+                    cur_lane.move_advanced(cur_lane.short_move_dis * -1, SpeedMode.SHORT,
+                                           assist_active=AssistActive.YES) # Checked
                     num_tries += 1
                     # TODO: Figure out max number of tries
                     if num_tries > (cur_hub.afc_unload_bowden_length / cur_lane.short_move_dis):
@@ -1632,8 +1671,9 @@ class afc:
 
         if cur_lane.hub == 'direct':
             while cur_lane.load_state:
-                cur_lane.move_advanced(cur_lane.short_move_dis * -1, SpeedMode.SHORT, assist_active = AssistActive.YES)
-            cur_lane.move_advanced(cur_lane.short_move_dis * -5, SpeedMode.SHORT)
+                cur_lane.move_advanced(cur_lane.short_move_dis * -1, SpeedMode.SHORT,
+                                       assist_active=AssistActive.YES)
+            cur_lane.move_advanced(cur_lane.short_move_dis * -5, SpeedMode.SHORT) # Checked both
 
         cur_lane.do_enable(False)
         cur_lane.unit_obj.return_to_home()

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -401,9 +401,10 @@ class afcBoxTurtle(afcUnit):
         self.logger.info('Calibrating {}'.format(cur_lane.name))
         cur_lane.status = AFCLaneState.CALIBRATING
         # reset to extruder
+        move_dis = cur_lane.dist_hub+100
         if self.afc.homing_enabled:
             checkpoint = "retract to extruder"
-            success, pos = cur_lane.move_to(distance=(cur_lane.dist_hub+100)*-1,
+            success, pos = cur_lane.move_to(distance=move_dis*-1,
                                             speed_mode=SpeedMode.CALIBRATION,
                                             endstop=AFCHomingPoints.LOAD,
                                             assist_active=AssistActive.YES)
@@ -411,19 +412,17 @@ class afcBoxTurtle(afcUnit):
             pos, checkpoint, success = self.calc_position(cur_lane,
                                                           lambda: cur_lane.load_state, 0,
                                                           cur_lane.short_move_dis,
-                                                          tol, cur_lane.dist_hub + 100,
+                                                          tol, move_dis,
                                                           "retract to extruder")
 
         if not success:
             if checkpoint == "retract to extruder":
-                msg = (
-                    """\n{} failed during calibration after {}mm. Check position of filament and
-                    reset filament using BT_LANE_MOVE macro if necessary. If filament is between
-                    the extruder and the hub, and is moving smoothly, you may need to increase the
-                    dist_hub value. Once adjusted, please try again. This can be adjusted by
-                    using the SET_HUB_DIST LANE=<lane> LENGTH=<+/- distance> macro. Once you are
-                    satisfied, you can save the values with SAVE_HUB_DIST LANE=<lane> macro.\n""".format(cur_lane.name, pos)
-                )
+                msg = f"{cur_lane.name} failed during calibration after {round(pos,2)}mm. Check position of filament and " \
+                    "reset filament using BT_LANE_MOVE macro if necessary. If filament is between " \
+                    "the extruder and the hub, and is moving smoothly, you may need to increase the " \
+                    "dist_hub value. Once adjusted, please try again. This can be adjusted by " \
+                    "using the SET_HUB_DIST LANE=<lane> LENGTH=<+/- distance> macro. Once you are " \
+                    "satisfied, you can save the values with SAVE_HUB_DIST LANE=<lane> macro.\n"
             else:
                 msg = 'Lane failed to calibrate {} after {}mm'.format(checkpoint, pos)
             cur_lane.status = AFCLaneState.NONE
@@ -432,11 +431,11 @@ class afcBoxTurtle(afcUnit):
 
         else:
             if self.afc.homing_enabled:
-                success, hub_pos = cur_lane.move_to(distance=cur_lane.dist_hub+100,
+                success, hub_pos = cur_lane.move_to(distance=move_dis,
                                             speed_mode=SpeedMode.CALIBRATION,
                                             endstop=AFCHomingPoints.HUB,
                                             assist_active=AssistActive.NO)
-                message = 'failed hub calibration {cur_lane.name} after {hub_pos}mm'
+                message = f'Failed hub calibration {cur_lane.name} after {round(hub_pos, 2)}mm'
             else:
                 success, message, hub_pos = self.calibrate_hub(cur_lane, tol)
 
@@ -448,7 +447,7 @@ class afcBoxTurtle(afcUnit):
             # Always run hub clear
             cur_lane.move(cur_hub.hub_clear_move_dis * -1, cur_lane.short_moves_speed, cur_lane.short_moves_accel, True)
 
-            cal_dist = hub_pos - cur_hub.hub_clear_move_dis
+            cal_dist = round(hub_pos - cur_hub.hub_clear_move_dis, 2)
             cal_msg = "\n{} dist_hub: New: {} Old: {}".format(cur_lane.name, cal_dist, cur_lane.dist_hub)
             cur_lane.loaded_to_hub  = True
             cur_lane.do_enable(False)

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -184,11 +184,9 @@ class afcBoxTurtle(afcUnit):
                 if not success:
                     return False, message, hub_dis
 
-            if cur_hub.state or self.afc.homing_enabled:
-                # reset at hub
-                cur_lane.move(cur_hub.hub_clear_move_dis * -1,
-                              cur_lane.short_moves_speed, cur_lane.short_moves_accel,
-                              True)
+            # Always run hub clear move
+            cur_lane.move(cur_hub.hub_clear_move_dis * -1, cur_lane.short_moves_speed,
+                          cur_lane.short_moves_accel, True)
 
             bowden_dist = round(bow_pos, 2)
             if not self.afc.homing_enabled:
@@ -274,11 +272,14 @@ class afcBoxTurtle(afcUnit):
             cur_lane.move(dis, self.short_moves_speed, self.short_moves_accel)
             self.afc.reactor.pause(self.afc.reactor.monotonic() + 5)
 
-        cur_lane.move(bow_pos * -1, cur_lane.long_moves_speed, cur_lane.long_moves_accel, True)
+        cur_lane.move_to(distance=bow_pos*-1, SpeedMode=SpeedMode.LONG,
+                         endstop=AFCHomingPoints.HUB, assist_active=AssistActive.YES,
+                         use_homing=self.afc.homing_enabled)
 
         # Reset to hub
-        self.calc_position(cur_lane, lambda: cur_lane.hub_obj.state, 0,
-                           cur_lane.short_move_dis, tol, 200, checkpoint)
+        if not self.afc.homing_enabled:
+            self.calc_position(cur_lane, lambda: cur_lane.hub_obj.state, 0,
+                            cur_lane.short_move_dis, tol, 200, checkpoint)
 
         cur_lane.move(cur_hub.hub_clear_move_dis * -1, cur_lane.short_moves_speed, cur_lane.short_moves_accel, True)
 
@@ -400,8 +401,18 @@ class afcBoxTurtle(afcUnit):
         self.logger.info('Calibrating {}'.format(cur_lane.name))
         cur_lane.status = AFCLaneState.CALIBRATING
         # reset to extruder
-        pos, checkpoint, success = self.calc_position(cur_lane, lambda: cur_lane.load_state, 0, cur_lane.short_move_dis,
-                                                      tol, cur_lane.dist_hub + 100, "retract to extruder")
+        if self.afc.homing_enabled:
+            checkpoint = "retract to extruder"
+            success, pos = cur_lane.move_to(distance=(cur_lane.dist_hub+100)*-1,
+                                            speed_mode=SpeedMode.CALIBRATION,
+                                            endstop=AFCHomingPoints.LOAD,
+                                            assist_active=AssistActive.YES)
+        else:
+            pos, checkpoint, success = self.calc_position(cur_lane,
+                                                          lambda: cur_lane.load_state, 0,
+                                                          cur_lane.short_move_dis,
+                                                          tol, cur_lane.dist_hub + 100,
+                                                          "retract to extruder")
 
         if not success:
             if checkpoint == "retract to extruder":
@@ -420,15 +431,22 @@ class afcBoxTurtle(afcUnit):
             return False, msg, 0
 
         else:
-            success, message, hub_pos = self.calibrate_hub(cur_lane, tol)
+            if self.afc.homing_enabled:
+                success, hub_pos = cur_lane.move_to(distance=cur_lane.dist_hub+100,
+                                            speed_mode=SpeedMode.CALIBRATION,
+                                            endstop=AFCHomingPoints.HUB,
+                                            assist_active=AssistActive.NO)
+                message = 'failed hub calibration {cur_lane.name} after {hub_pos}mm'
+            else:
+                success, message, hub_pos = self.calibrate_hub(cur_lane, tol)
 
             if not success:
                 cur_lane.status = AFCLaneState.NONE
                 cur_lane.unit_obj.return_to_home()
                 return False, message, hub_pos
 
-            if cur_hub.state:
-                cur_lane.move(cur_hub.move_dis * -1, cur_lane.short_moves_speed, cur_lane.short_moves_accel, True)
+            # Always run hub clear
+            cur_lane.move(cur_hub.hub_clear_move_dis * -1, cur_lane.short_moves_speed, cur_lane.short_moves_accel, True)
 
             cal_dist = hub_pos - cur_hub.hub_clear_move_dis
             cal_msg = "\n{} dist_hub: New: {} Old: {}".format(cur_lane.name, cal_dist, cur_lane.dist_hub)

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -162,7 +162,7 @@ class afcBoxTurtle(afcUnit):
                     return False, msg, bow_pos
 
             if (cur_extruder.tool_start != 'buffer'
-                and not self.homing_enabled):
+                and not self.afc.homing_enabled):
                 # is using ramming, only use first trigger of sensor
                 bow_pos, checkpoint, success = self.calc_position(cur_lane, lambda: cur_lane.get_toolhead_pre_sensor_state(), bow_pos,
                                                                   cur_lane.short_move_dis, tol, 100, "retract from toolhead sensor")
@@ -272,7 +272,7 @@ class afcBoxTurtle(afcUnit):
             cur_lane.move(dis, self.short_moves_speed, self.short_moves_accel)
             self.afc.reactor.pause(self.afc.reactor.monotonic() + 5)
 
-        cur_lane.move_to(distance=bow_pos*-1, SpeedMode=SpeedMode.LONG,
+        cur_lane.move_to(distance=bow_pos*-1, speed_mode=SpeedMode.LONG,
                          endstop=AFCHomingPoints.HUB, assist_active=AssistActive.YES,
                          use_homing=self.afc.homing_enabled)
 

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -125,10 +125,10 @@ class afcBoxTurtle(afcUnit):
         # move to hub and retrieve that distance, the checkpoint returned and if successful
         if not self.afc.homing_enabled:
             hub_pos, checkpoint, success = self.move_until_state(cur_lane, lambda: cur_hub.state,
-                                                                cur_hub.move_dis, tol,
-                                                                cur_lane.short_move_dis,
-                                                                0, cur_lane.dist_hub + 200,
-                                                                "Moving to hub")
+                                                                 cur_hub.move_dis, tol,
+                                                                 cur_lane.short_move_dis,
+                                                                 0, cur_lane.dist_hub + 200,
+                                                                 "Moving to hub")
         else:
             success, hub_pos = cur_lane.move_to(distance=cur_lane.dist_hub+200,
                                                 speed_mode=SpeedMode.CALIBRATION,
@@ -418,11 +418,11 @@ class afcBoxTurtle(afcUnit):
         if not success:
             if checkpoint == "retract to extruder":
                 msg = f"{cur_lane.name} failed during calibration after {round(pos,2)}mm. Check position of filament and " \
-                    "reset filament using BT_LANE_MOVE macro if necessary. If filament is between " \
-                    "the extruder and the hub, and is moving smoothly, you may need to increase the " \
-                    "dist_hub value. Once adjusted, please try again. This can be adjusted by " \
-                    "using the SET_HUB_DIST LANE=<lane> LENGTH=<+/- distance> macro. Once you are " \
-                    "satisfied, you can save the values with SAVE_HUB_DIST LANE=<lane> macro.\n"
+                      "reset filament using BT_LANE_MOVE macro if necessary. If filament is between " \
+                      "the extruder and the hub, and is moving smoothly, you may need to increase the " \
+                      "dist_hub value. Once adjusted, please try again. This can be adjusted by " \
+                      "using the SET_HUB_DIST LANE=<lane> LENGTH=<+/- distance> macro. Once you are " \
+                      "satisfied, you can save the values with SAVE_HUB_DIST LANE=<lane> macro.\n"
             else:
                 msg = 'Lane failed to calibrate {} after {}mm'.format(checkpoint, pos)
             cur_lane.status = AFCLaneState.NONE

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -11,7 +11,7 @@ from datetime import datetime
 try: from extras.AFC_utils import ERROR_STR
 except: raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".format(trace=traceback.format_exc()))
 
-try: from extras.AFC_lane import AFCLaneState
+try: from extras.AFC_lane import AFCLaneState, SpeedMode, AFCHomingPoints, AssistActive
 except: raise error(ERROR_STR.format(import_lib="AFC_lane", trace=traceback.format_exc()))
 
 try: from extras.AFC_unit import afcUnit
@@ -123,8 +123,17 @@ class afcBoxTurtle(afcUnit):
         cur_hub = cur_lane.hub_obj
         self.logger.raw('Calibrating Bowden Length with {}'.format(cur_lane.name))
         # move to hub and retrieve that distance, the checkpoint returned and if successful
-        hub_pos, checkpoint, success = self.move_until_state(cur_lane, lambda: cur_hub.state, cur_hub.move_dis, tol,
-                                                             cur_lane.short_move_dis, 0, cur_lane.dist_hub + 200, "Moving to hub")
+        if not self.afc.homing_enabled:
+            hub_pos, checkpoint, success = self.move_until_state(cur_lane, lambda: cur_hub.state,
+                                                                cur_hub.move_dis, tol,
+                                                                cur_lane.short_move_dis,
+                                                                0, cur_lane.dist_hub + 200,
+                                                                "Moving to hub")
+        else:
+            success, hub_pos = cur_lane.move_to(distance=cur_lane.dist_hub+200,
+                                                speed_mode=SpeedMode.CALIBRATION,
+                                                endstop=AFCHomingPoints.HUB,
+                                                use_homing=self.afc.homing_enabled)
 
         if not success:
             # if movement does not succeed fault and return values to calibration macro
@@ -136,8 +145,13 @@ class afcBoxTurtle(afcUnit):
             # if tool_start is defined move and confirm distance
             while not cur_lane.get_toolhead_pre_sensor_state():
                 fault_dis = cur_hub.afc_bowden_length + 500
-                cur_lane.move(dis, self.short_moves_speed, self.short_moves_accel)
-                bow_pos += dis
+                if self.afc.homing_enabled:
+                    dis = fault_dis
+                homed, distance = cur_lane.move_to(distance=dis,
+                                                   speed_mode=SpeedMode.CALIBRATION,
+                                                   endstop=cur_lane.get_toolhead_endstop(),
+                                                   use_homing=self.afc.homing_enabled)
+                bow_pos += distance
                 self.afc.reactor.pause(self.afc.reactor.monotonic() + 0.1)
                 if bow_pos >= fault_dis:
                     # fault if move to bowden length does not reach toolhead sensor return to calibration macro
@@ -147,7 +161,8 @@ class afcBoxTurtle(afcUnit):
                     msg += '\n SET_BOWDEN_LENGTH HUB={} LENGTH=+(distance the filament was short from the toolhead)'.format(cur_hub.name)
                     return False, msg, bow_pos
 
-            if cur_extruder.tool_start != 'buffer':
+            if (cur_extruder.tool_start != 'buffer'
+                and not self.homing_enabled):
                 # is using ramming, only use first trigger of sensor
                 bow_pos, checkpoint, success = self.calc_position(cur_lane, lambda: cur_lane.get_toolhead_pre_sensor_state(), bow_pos,
                                                                   cur_lane.short_move_dis, tol, 100, "retract from toolhead sensor")
@@ -157,22 +172,30 @@ class afcBoxTurtle(afcUnit):
                 msg = 'Failed {} after {}mm'.format(checkpoint, bow_pos)
                 return False, msg, bow_pos
 
-            cur_lane.move(bow_pos * -1, cur_lane.long_moves_speed, cur_lane.long_moves_accel, True)
-
-            success, message, hub_dis = self.calibrate_hub(cur_lane, tol)
-
+            success, _ = cur_lane.move_to(bow_pos * -1, speed_mode=SpeedMode.LONG,
+                             endstop=AFCHomingPoints.HUB, assist_active=AssistActive.YES,
+                             use_homing=self.afc.homing_enabled)
             if not success:
-                return False, message, hub_dis
+                return False, "Failed to home filament back to hub", 0
 
-            if cur_hub.state:
+            if not self.afc.homing_enabled:
+                success, message, hub_dis = self.calibrate_hub(cur_lane, tol)
+
+                if not success:
+                    return False, message, hub_dis
+
+            if cur_hub.state or self.afc.homing_enabled:
                 # reset at hub
-                cur_lane.move(cur_hub.move_dis * -1, cur_lane.short_moves_speed, cur_lane.short_moves_accel, True)
+                cur_lane.move(cur_hub.hub_clear_move_dis * -1,
+                              cur_lane.short_moves_speed, cur_lane.short_moves_accel,
+                              True)
 
-            bowden_dist = 0
-            if cur_extruder.tool_start == 'buffer':
-                bowden_dist = bow_pos - (cur_lane.short_move_dis * 2)
-            else:
-                bowden_dist = bow_pos - cur_lane.short_move_dis
+            bowden_dist = round(bow_pos, 2)
+            if not self.afc.homing_enabled:
+                if cur_extruder.tool_start == 'buffer':
+                    bowden_dist = round(bow_pos - (cur_lane.short_move_dis * 2), 2)
+                else:
+                    bowden_dist = round(bow_pos - cur_lane.short_move_dis, 2)
 
             unload_dist = bowden_dist
 

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -77,6 +77,7 @@ class afcError:
 
         else: #toolhead empty
             if cur_lane.load_state: #Lane has filament
+                # TODO: Update this to use better logic
                 while cur_lane.load_state:  # slowly back filament up to lane extruder
                     cur_lane.move(-5, self.afc.short_moves_speed, self.afc.short_moves_accel, True)
                 while not cur_lane.load_state:  # reload lane extruder

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -29,7 +29,7 @@ try: from extras.AFC_respond import AFCprompt
 except: raise error(ERROR_STR.format(import_lib="AFC_respond", trace=traceback.format_exc()))
 
 try: from extras.AFC_lane import SpeedMode, AssistActive, AFCHomingPoints
-except: raise error(ERROR_STR.format(import_lib="AFC_logger", trace=traceback.format_exc()))
+except: raise error(ERROR_STR.format(import_lib="AFC_lane", trace=traceback.format_exc()))
 
 if TYPE_CHECKING:
     from extras.AFC import afc

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -1309,7 +1309,7 @@ class afcFunction:
         fail_state_msg = "'{}' failed to reset to hub, {} switch became false during reset"
 
         if long_dis is not None:
-            cur_lane.move_to(distance=CUR_HUB.afc_bowden_length,
+            cur_lane.move_to(distance=float(long_dis) *-1,
                              speed_mode=SpeedMode.SHORT,
                              endstop=AFCHomingPoints.HUB,
                              assist_active=AssistActive.YES,

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -8,6 +8,7 @@
 # Originally authored by Félix Boisselier and licensed under the GNU General Public License v3.0.
 #
 # Full license text available at: https://www.gnu.org/licenses/gpl-3.0.html
+from __future__ import annotations
 
 import os
 import random
@@ -19,11 +20,22 @@ from configfile import error
 from datetime import datetime
 from pathlib import Path
 
+from typing import TYPE_CHECKING, Union
+
 try: from extras.AFC_utils import ERROR_STR
 except: raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".format(trace=traceback.format_exc()))
 
 try: from extras.AFC_respond import AFCprompt
 except: raise error(ERROR_STR.format(import_lib="AFC_respond", trace=traceback.format_exc()))
+
+try: from extras.AFC_lane import SpeedMode, AssistActive, AFCHomingPoints
+except: raise error(ERROR_STR.format(import_lib="AFC_logger", trace=traceback.format_exc()))
+
+if TYPE_CHECKING:
+    from extras.AFC import afc
+    from extras.AFC_lane import AFCLane
+    from extras.AFC_stepper import AFCExtruderStepper
+    from extras.AFC_hub import afc_hub
 
 def load_config(config):
     return afcFunction(config)
@@ -39,7 +51,7 @@ class afcFunction:
         self.auto_var_file = None
         self.errorLog = {}
         self.pause    = False
-        self.afc      = None
+        self.afc: afc
         self.logger   = None
         self.mcu      = None
 
@@ -1234,7 +1246,7 @@ class afcFunction:
                                   "LANE": {"default": "lane1", "type": "string"}}
     def cmd_AFC_LANE_RESET(self, gcmd):
         """
-        This function resets a specified lane to the hub position in the AFC system. It checks for various error conditions,
+        This macro resets a specified lane to the hub position in the AFC system. It checks for various error conditions,
         such as whether the toolhead is loaded or whether the hub is already clear. The function moves the lane back to the
         hub based on the specified or default distances, ensuring the lane's correct state before completing the reset.
 
@@ -1256,7 +1268,7 @@ class afcFunction:
 
         prompt = AFCprompt(gcmd, self.logger)
         lane = gcmd.get('LANE', None)
-        long_dis = gcmd.get('DISTANCE', None)
+        long_dis = gcmd.get('DISTANCE', 50)
 
         if not lane:
             prompt.p_end()
@@ -1278,8 +1290,8 @@ class afcFunction:
                 self.afc.error.AFC_error("DISTANCE must be a valid number.", pause=False)
                 return
 
-        cur_lane = self.afc.lanes[lane]
-        CUR_HUB = cur_lane.hub_obj
+        cur_lane: Union[AFCLane, AFCExtruderStepper] = self.afc.lanes[lane]
+        CUR_HUB: afc_hub = cur_lane.hub_obj
         short_move = cur_lane.short_move_dis * 2
 
         if not CUR_HUB.state:
@@ -1297,7 +1309,11 @@ class afcFunction:
         fail_state_msg = "'{}' failed to reset to hub, {} switch became false during reset"
 
         if long_dis is not None:
-            cur_lane.move(float(long_dis) * -1, cur_lane.long_moves_speed, cur_lane.long_moves_accel, True)
+            cur_lane.move_to(distance=CUR_HUB.afc_bowden_length,
+                             speed_mode=SpeedMode.SHORT,
+                             endstop=AFCHomingPoints.HUB,
+                             assist_active=AssistActive.YES,
+                             use_homing=self.afc.homing_enabled)
 
         while CUR_HUB.state:
             cur_lane.move(short_move * -1, cur_lane.short_moves_speed, cur_lane.short_moves_accel, True)
@@ -1315,7 +1331,7 @@ class afcFunction:
                 self.afc.error.AFC_error("'{}' failed to reset to hub".format(cur_lane), pause=False)
                 return
 
-        cur_lane.move(CUR_HUB.move_dis * -1, cur_lane.short_moves_speed, cur_lane.short_moves_accel, True)
+        cur_lane.move(CUR_HUB.hub_clear_move_dis * -1, cur_lane.short_moves_speed, cur_lane.short_moves_accel, True)
         cur_lane.loaded_to_hub = True
         cur_lane.do_enable(False)
 

--- a/extras/AFC_hub.py
+++ b/extras/AFC_hub.py
@@ -55,13 +55,11 @@ class afc_hub:
         self.enable_runout          = config.getboolean("enable_hub_runout",        self.afc.enable_hub_runout)
 
         buttons = self.printer.load_object(config, "buttons")
-        if self.switch_pin is not None:
-            self.state = False
-            buttons.register_buttons([self.switch_pin], self.switch_pin_callback)
-
         self.fila, self.debounce_button = add_filament_switch( f"{self.name}_Hub", self.switch_pin, self.printer,
                                                                 self.enable_sensors_in_gui, self.handle_runout, self.enable_runout,
                                                                 self.debounce_delay)
+        self.state = False
+        buttons.register_buttons([self.switch_pin], self.switch_pin_callback)
 
         # Adding self to AFC hubs
         self.afc.hubs[self.name]=self

--- a/extras/AFC_hub.py
+++ b/extras/AFC_hub.py
@@ -30,12 +30,12 @@ class afc_hub:
         # HUB Cut variables
         # Next two variables are used in AFC
         self.switch_pin             = config.get('switch_pin')                      # Pin hub sensor it connected to
-        self.hub_clear_move_dis     = config.getfloat("hub_clear_move_dis", 25)     # How far to move filament so that it's not block the hub exit
+        self.hub_clear_move_dis     = config.getfloat("hub_clear_move_dis", 65)     # How far to move filament so that it's not block the hub exit
         self.afc_bowden_length      = config.getfloat("afc_bowden_length", 900)     # Length of the Bowden tube from the hub to the toolhead sensor in mm.
         self.td1_bowden_length      = config.getfloat("td1_bowden_length", self.afc_bowden_length-50)     # Length of the Bowden tube from the hub to a TD-1 device in mm.
         self.afc_unload_bowden_length= config.getfloat("afc_unload_bowden_length", self.afc_bowden_length) # Length to unload when retracting back from toolhead to hub in mm. Defaults to afc_bowden_length
         self.assisted_retract       = config.getboolean("assisted_retract", False)  # if True, retracts are assisted to prevent loose windings on the spool
-        self.move_dis               = config.getfloat("move_dis", 50)               # Distance to move the filament within the hub in mm.
+        self.move_dis               = config.getfloat("move_dis", 75)               # Distance to move the filament within the hub in mm.
         # Servo settings
         self.cut                    = config.getboolean("cut", False)               # Set True if Hub cutter installed (e.g. Snappy)
         self.cut_cmd                = config.get('cut_cmd', None)                   # Macro to use for cut.

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -13,7 +13,7 @@ from configfile import error
 from datetime import datetime
 from enum import Enum
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from extras.AFC import afc
     from AFC_stepper import AFCExtruderStepper
@@ -26,6 +26,9 @@ except: raise error(ERROR_STR.format(import_lib="AFC_assist", trace=traceback.fo
 
 try: from extras.AFC_stats import AFCStats_var
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
+
+if TYPE_CHECKING:
+    from extras.AFC_hub import afc_hub
 
 # Class for holding different states so its clear what all valid states are
 
@@ -77,7 +80,7 @@ class AFCLane:
         self.cb_update_weight   = self.reactor.register_timer( self.update_weight_callback )
 
         self.unit_obj           = None
-        self.hub_obj            = None
+        self.hub_obj: afc_hub   = None
         self.buffer_obj         = None
         self.extruder_obj       = None
 
@@ -139,6 +142,7 @@ class AFCLane:
         self.max_move_dis       = config.getfloat("max_move_dis", None)                 # Maximum distance to move filament. AFC breaks filament moves over this number into multiple moves. Useful to lower this number if running into timer too close errors when doing long filament moves. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
         self.n20_break_delay_time= config.getfloat("n20_break_delay_time", None)        # Time to wait between breaking n20 motors(nSleep/FWD/RWD all 1) and then releasing the break to allow coasting. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
         self.homing_overshoot   = config.getfloat("homing_overshoot", None)             # Amount to add to homing distance so that distance is long enough to actually hit endstop
+        self.extruder_clear_dis = config.getfloat("extruder_clear_dis", None)
 
         self.rev_long_moves_speed_factor = config.getfloat("rev_long_moves_speed_factor", None)     # scalar speed factor when reversing filamentalist
 
@@ -400,6 +404,7 @@ class AFCLane:
         if self.homing_overshoot            is None: self.homing_overshoot  = self.unit_obj.homing_overshoot
         if self.td1_when_loaded             is None: self.td1_when_loaded   = self.unit_obj.td1_when_loaded
         if self.td1_device_id               is None: self.td1_device_id     = self.unit_obj.td1_device_id
+        if self.extruder_clear_dis          is None: self.extruder_clear_dis= self.unit_obj.extruder_clear_dis
         if self.post_prep_macro             is None: self.post_prep_macro   = self.unit_obj.post_prep_macro
 
         if self.rev_long_moves_speed_factor < 0.5: self.rev_long_moves_speed_factor = 0.5
@@ -508,6 +513,21 @@ class AFCLane:
             else:
                 return self.short_moves_speed, self.short_moves_accel
 
+    def get_active_assist(self, distance, assist_active:AssistActive) -> bool:
+        """
+        Helper method to return boolean based off `AssistActive` enum and distance
+
+        :param distance: Distance to move stepper, used to determine assist if using Dynamic assist mode
+        :param assist_active: `AssistActive` enum to determine if assist will be active or not
+        :return bool: Returns True if `AssistActive.YES` or `AssistActive.DYNAMIC` and distance > 200
+        """
+        assist = False
+        if assist_active == AssistActive.YES:
+            assist = True
+        elif assist_active == AssistActive.DYNAMIC:
+            assist = abs(distance) > 200
+        return assist
+
     def move(self, distance, speed, accel, assist_active=False):
         """
         Move the specified lane a given distance with specified speed and acceleration.
@@ -522,10 +542,22 @@ class AFCLane:
         with self.assist_move( speed, distance < 0, assist_active):
             if self.drive_stepper is not None:
                 self.drive_stepper.move(distance, speed, accel, assist_active)
-    
+
     def move_to(self, distance: float, speed_mode: SpeedMode,
                 endstop:AFCHomingPoints=AFCHomingPoints.NONE,
-                assist_active=AssistActive.NO, use_homing=True):
+                assist_active=AssistActive.NO, use_homing=True) -> tuple[bool, int]:
+        """
+        Helper function for calling stepper move_advance or home_to functions based
+        off use_homing parameter
+
+        :param distance: Distance to move stepper
+        :param speed_mode: SpeedMode type to use when moving stepper
+        :param endstop: When homing is enabled, used to specify which endstop to home to
+        :param assist_active: AssistActive type to enable/disable espoolers when moving stepper
+        :param use_homing: When enabled home_to logic is used, else move_advance logic is used
+        :return tuple: Returns if move was successful and distance moved. When homing is
+                       disabled, always returns True, 0.
+        """
         if (self.drive_stepper
             or hasattr(self, "extruder_stepper")):
             if use_homing:
@@ -538,8 +570,8 @@ class AFCLane:
                 if distance < 0:
                     new_distance = distance - self.homing_overshoot
 
-                return home_to(endstop, new_distance, speed_mode, 
-                        distance > 0, assist_active=assist_active==AssistActive.YES)
+                return home_to(endstop, new_distance, speed_mode,
+                        distance > 0, assist_active=self.get_active_assist(distance, assist_active))
             else:
                 self.move_advanced(distance, speed_mode, assist_active )
                 return True, 0
@@ -556,11 +588,7 @@ class AFCLane:
         """
         speed, accel = self.get_speed_accel(speed_mode)
 
-        assist = False
-        if assist_active == AssistActive.YES:
-            assist = True
-        elif assist_active == AssistActive.DYNAMIC:
-            assist = abs(distance) > 200
+        assist = self.get_active_assist(distance, assist_active)
 
         self.move(distance, speed, accel, assist)
 
@@ -736,14 +764,13 @@ class AFCLane:
                     if self.afc.function.is_printing(check_movement=True):
                         self.afc.error.AFC_error("Cannot load spools while printer is actively moving or homing", False)
                         break
-                    
-                    # TODO: Update this to work with drive_stepper, add try catch
+
                     if self.afc.homing_enabled:
                         self.move_to(10*40, SpeedMode.SHORT,
                                      assist_active=AssistActive.NO,
                                      endstop=AFCHomingPoints.LOAD,
                                      use_homing=True)
-                    
+
                     while not self.load_state and self.prep_state and self.load is not None:
                         x += 1
                         self.move(10,500,400)
@@ -1062,8 +1089,14 @@ class AFCLane:
             return self.buffer_obj.advance_state
         else:
             return self.extruder_obj.tool_start_state
-    
-    def get_toolhead_endstop(self):
+
+    def get_toolhead_endstop(self) ->AFCHomingPoints:
+        """
+        Helper method to lookup endstop type based on users config.
+
+        :return AFCHomingPoints: Returns `AFCHomingPoints.BUFFER` if users tool_start is set to buffer
+            else returns `AFCHomingPoints.TOOL`
+        """
         if self.extruder_obj.tool_start == "buffer":
             return AFCHomingPoints.BUFFER
         else:
@@ -1226,7 +1259,15 @@ class AFCLane:
 
         if not self.hub_obj.state:
             if not self.loaded_to_hub:
-                self.move_auto_speed(self.dist_hub)
+                move_dis = self.dist_hub
+                if self.afc.homing_enabled:
+                    move_dis += self.hub_obj.move_dis
+                self.move_to(distance=move_dis,
+                             speed_mode=SpeedMode.LONG,
+                             endstop=AFCHomingPoints.HUB,
+                             assist_active=AssistActive.YES,
+                             use_homing=self.afc.homing_enabled)
+                self.loaded_to_hub = True
 
             while not self.hub_obj.state:
                 if max_move_tries >= self.afc.max_move_tries:
@@ -1252,7 +1293,11 @@ class AFCLane:
                 self.afc.error.AFC_error(msg, pause=False)
                 status = False
 
-            self.move_auto_speed(self.hub_obj.td1_bowden_length * -1)
+            self.move_to(distance=self.hub_obj.td1_bowden_length * -1,
+                         speed_mode=SpeedMode.LONG,
+                         endstop=AFCHomingPoints.HUB,
+                         assist_active=AssistActive.YES,
+                         use_homing=self.afc.homing_enabled)
             if success:
                 self.send_lane_data()
 
@@ -1548,9 +1593,7 @@ class AFCLane:
             response['td1_td']          = self.td1_data['td'] if "td" in self.td1_data else ''
             response['td1_color']       = self.td1_data['color'] if "color" in self.td1_data else ''
             response['td1_scan_time']   = self.td1_data['scan_time'] if "scan_time" in self.td1_data else ''
-        
-        if hasattr(self, "_endstops"):
-            response['endstops'] = ",".join(self._endstops[key][1] for key in self._endstops)
+
         return response
 
 def load_config_prefix(config):

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -520,17 +520,17 @@ class AFCLane:
     def move_to(self, distance: float, speed_mode: SpeedMode,
                 endstop:AFCHomingPoints=AFCHomingPoints.NONE,
                 assist_active=AssistActive.NO, use_homing=True):
-        if (hasattr(self, "drive_stepper")
+        if (self.drive_stepper
             or hasattr(self, "extruder_stepper")):
             if use_homing:
-                if hasattr(self, "drive_stepper"):
+                if self.drive_stepper:
                     home_to = self.drive_stepper.home_to
                 else:
                     home_to = self.home_to
                 # Add extra distance to homing move to guarantee that endstop is hit
                 new_distance = distance + 50 if distance > 0 else distance - 50
                 return home_to(endstop, new_distance, speed_mode, 
-                        distance > 0, assist_active=assist_active)
+                        distance > 0, assist_active=assist_active==AssistActive.YES)
             else:
                 self.move_advanced(distance, speed_mode, assist_active )
                 return True
@@ -731,7 +731,8 @@ class AFCLane:
                     # TODO: Update this to work with drive_stepper, add try catch
                     if self.afc.homing_enabled:
                         self.move_to(10*40, SpeedMode.SHORT,
-                                     endstop=AFCHomingPoints.HUB,
+                                     assist_active=AssistActive.NO,
+                                     endstop=AFCHomingPoints.LOAD,
                                      use_homing=True)
                     
                     while not self.load_state and self.prep_state and self.load is not None:
@@ -1538,6 +1539,9 @@ class AFCLane:
             response['td1_td']          = self.td1_data['td'] if "td" in self.td1_data else ''
             response['td1_color']       = self.td1_data['color'] if "color" in self.td1_data else ''
             response['td1_scan_time']   = self.td1_data['scan_time'] if "scan_time" in self.td1_data else ''
+        
+        if hasattr(self, "_endstops"):
+            response['endstops'] = ",".join(self._endstops[key][1] for key in self._endstops)
         return response
 
 def load_config_prefix(config):

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -545,7 +545,7 @@ class AFCLane:
 
     def move_to(self, distance: float, speed_mode: SpeedMode,
                 endstop:AFCHomingPoints=AFCHomingPoints.NONE,
-                assist_active=AssistActive.NO, use_homing=True) -> tuple[bool, int]:
+                assist_active=AssistActive.NO, use_homing=True) -> tuple[bool, float|int]:
         """
         Helper function for calling stepper move_advance or home_to functions based
         off use_homing parameter

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -138,6 +138,7 @@ class AFCLane:
         self.short_move_dis     = config.getfloat("short_move_dis", None)               # Move distance in mm for failsafe moves. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
         self.max_move_dis       = config.getfloat("max_move_dis", None)                 # Maximum distance to move filament. AFC breaks filament moves over this number into multiple moves. Useful to lower this number if running into timer too close errors when doing long filament moves. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
         self.n20_break_delay_time= config.getfloat("n20_break_delay_time", None)        # Time to wait between breaking n20 motors(nSleep/FWD/RWD all 1) and then releasing the break to allow coasting. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
+        self.homing_overshoot   = config.getfloat("homing_overshoot", None)             # Amount to add to homing distance so that distance is long enough to actually hit endstop
 
         self.rev_long_moves_speed_factor = config.getfloat("rev_long_moves_speed_factor", None)     # scalar speed factor when reversing filamentalist
 
@@ -396,6 +397,7 @@ class AFCLane:
         if self.short_moves_accel           is None: self.short_moves_accel = self.unit_obj.short_moves_accel
         if self.short_move_dis              is None: self.short_move_dis    = self.unit_obj.short_move_dis
         if self.max_move_dis                is None: self.max_move_dis      = self.unit_obj.max_move_dis
+        if self.homing_overshoot            is None: self.homing_overshoot  = self.unit_obj.homing_overshoot
         if self.td1_when_loaded             is None: self.td1_when_loaded   = self.unit_obj.td1_when_loaded
         if self.td1_device_id               is None: self.td1_device_id     = self.unit_obj.td1_device_id
         if self.post_prep_macro             is None: self.post_prep_macro   = self.unit_obj.post_prep_macro
@@ -532,7 +534,10 @@ class AFCLane:
                 else:
                     home_to = self.home_to
                 # Add extra distance to homing move to guarantee that endstop is hit
-                new_distance = distance + 50 if distance > 0 else distance - 50
+                new_distance = distance + self.homing_overshoot
+                if distance > 0:
+                    new_distance = distance - self.homing_overshoot
+
                 return home_to(endstop, new_distance, speed_mode, 
                         distance > 0, assist_active=assist_active==AssistActive.YES)
             else:

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -54,6 +54,7 @@ class AFCLaneState:
 class AFCLane:
     UPDATE_WEIGHT_DELAY = 10.0
     def __init__(self, config):
+        self._config            = config
         self.printer            = config.get_printer()
         self.afc: afc           = self.printer.load_object(config, 'AFC')
         self.gcode              = self.printer.load_object(config, 'gcode')
@@ -684,9 +685,9 @@ class AFCLane:
         for i in range(1):
             # Hacky way for do{}while(0) loop, DO NOT return from this for loop, use break instead so that self.prep_state variable gets sets correctly
             #  before exiting function
-            if self.printer.state_message == 'Printer is ready' and True == self._afc_prep_done and self.status != AFCLaneState.TOOL_UNLOADING:
+            if self.printer.state_message == 'Printer is ready' and self._afc_prep_done and self.status != AFCLaneState.TOOL_UNLOADING:
                 # Only try to load when load state trigger is false
-                if self.prep_state == True and self.load_state == False:
+                if self.prep_state and not self.load_state:
                     x = 0
                     # Checking to make sure last time prep switch was activated was less than 1 second, returning to keep is printing message from spamming
                     # the console since it takes klipper some time to transition to idle when idle_resume=printing
@@ -697,8 +698,11 @@ class AFCLane:
                     if self.afc.function.is_printing(check_movement=True):
                         self.afc.error.AFC_error("Cannot load spools while printer is actively moving or homing", False)
                         break
-
-                    while self.load_state == False and self.prep_state == True and self.load is not None:
+                    
+                    # TODO: Update this to work with drive_stepper, add try catch
+                    self.home_to("load", 10*40, SpeedMode.SHORT, True, True, assist_active=False)
+                    
+                    while not self.load_state and self.prep_state and self.load is not None:
                         x += 1
                         self.move(10,500,400)
                         self.reactor.pause(self.reactor.monotonic() + 0.1)

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -13,9 +13,10 @@ from configfile import error
 from datetime import datetime
 from enum import Enum
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 if TYPE_CHECKING:
     from extras.AFC import afc
+    from AFC_stepper import AFCExtruderStepper
 
 try: from extras.AFC_utils import ERROR_STR, add_filament_switch
 except: raise error("Error when trying to import AFC_utils.ERROR_STR, add_filament_switch\n{trace}".format(trace=traceback.format_exc()))
@@ -50,6 +51,15 @@ class AFCLaneState:
     HUB_LOADING      = "HUB Loading"
     EJECTING         = "Ejecting"
     CALIBRATING      = "Calibrating"
+
+class AFCHomingPoints:
+    NONE        = None
+    HUB         = "hub"
+    LOAD        = "load"
+    TOOL        = "tool"
+    TOOL_START  = "tool_start"
+    BUFFER      = "buffer"
+    BUFFER_TRAIL= "buffer_trailing"
 
 class AFCLane:
     UPDATE_WEIGHT_DELAY = 10.0
@@ -90,7 +100,7 @@ class AFCLane:
         # END TODO
 
         self.multi_hubs_found   = False
-        self.drive_stepper      = None
+        self.drive_stepper: AFCExtruderStepper = None
         unit                    = config.get('unit')                                    # Unit name(AFC_BoxTurtle/NightOwl/etc) that belongs to this stepper.
         # Overrides buffers set at the unit level
         self.hub                = config.get('hub',None)                                # Hub name(AFC_hub) that belongs to this stepper, overrides hub that is set in unit(AFC_BoxTurtle/NightOwl/etc) section.
@@ -506,6 +516,25 @@ class AFCLane:
         with self.assist_move( speed, distance < 0, assist_active):
             if self.drive_stepper is not None:
                 self.drive_stepper.move(distance, speed, accel, assist_active)
+    
+    def move_to(self, distance: float, speed_mode: SpeedMode,
+                endstop:AFCHomingPoints=AFCHomingPoints.NONE,
+                assist_active=AssistActive.NO, use_homing=True):
+        if (hasattr(self, "drive_stepper")
+            or hasattr(self, "extruder_stepper")):
+            if use_homing:
+                if hasattr(self, "drive_stepper"):
+                    home_to = self.drive_stepper.home_to
+                else:
+                    home_to = self.home_to
+                # Add extra distance to homing move to guarantee that endstop is hit
+                new_distance = distance + 50 if distance > 0 else distance - 50
+                return home_to(endstop, new_distance, speed_mode, 
+                        distance > 0, assist_active=assist_active)
+            else:
+                self.move_advanced(distance, speed_mode, assist_active )
+                return True
+
 
     def move_advanced(self, distance, speed_mode: SpeedMode, assist_active: AssistActive = AssistActive.NO):
         """
@@ -700,7 +729,10 @@ class AFCLane:
                         break
                     
                     # TODO: Update this to work with drive_stepper, add try catch
-                    self.home_to("load", 10*40, SpeedMode.SHORT, True, True, assist_active=False)
+                    if self.afc.homing_enabled:
+                        self.move_to(10*40, SpeedMode.SHORT,
+                                     endstop=AFCHomingPoints.HUB,
+                                     use_homing=True)
                     
                     while not self.load_state and self.prep_state and self.load is not None:
                         x += 1
@@ -1020,6 +1052,12 @@ class AFCLane:
             return self.buffer_obj.advance_state
         else:
             return self.extruder_obj.tool_start_state
+    
+    def get_toolhead_endstop(self):
+        if self.extruder_obj.tool_start == "buffer":
+            return AFCHomingPoints.BUFFER
+        else:
+            return AFCHomingPoints.TOOL
 
     def get_trailing(self):
         """

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -535,7 +535,7 @@ class AFCLane:
                     home_to = self.home_to
                 # Add extra distance to homing move to guarantee that endstop is hit
                 new_distance = distance + self.homing_overshoot
-                if distance > 0:
+                if distance < 0:
                     new_distance = distance - self.homing_overshoot
 
                 return home_to(endstop, new_distance, speed_mode, 

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -763,7 +763,8 @@ class AFCLane:
                     # Check to see if the printer is printing or moving, as trying to load while printer is doing something will crash klipper
                     if self.afc.function.is_printing(check_movement=True):
                         self.afc.error.AFC_error("Cannot load spools while printer is actively moving or homing", False)
-                        break
+                        self.prep_active = False
+                        return
 
                     if self.afc.homing_enabled:
                         self.move_to(10*40, SpeedMode.SHORT,

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -39,6 +39,7 @@ class SpeedMode(Enum):
     SHORT = 2
     HUB = 3
     NIGHT = 4
+    CALIBRATION = 5
 
 class AFCLaneState:
     NONE             = "None"
@@ -497,10 +498,13 @@ class AFCLane:
                 return self.afc.quiet_moves_speed, self.short_moves_accel
             elif mode == SpeedMode.LONG:
                 return self.long_moves_speed, self.long_moves_accel
-            elif mode == SpeedMode.SHORT:
+            elif (mode == SpeedMode.SHORT
+                  or mode == SpeedMode.CALIBRATION):
                 return self.short_moves_speed, self.short_moves_accel
-            else:
+            elif mode == SpeedMode.HUB:
                 return self.dist_hub_move_speed, self.dist_hub_move_accel
+            else:
+                return self.short_moves_speed, self.short_moves_accel
 
     def move(self, distance, speed, accel, assist_active=False):
         """
@@ -533,7 +537,7 @@ class AFCLane:
                         distance > 0, assist_active=assist_active==AssistActive.YES)
             else:
                 self.move_advanced(distance, speed_mode, assist_active )
-                return True
+                return True, 0
 
 
     def move_advanced(self, distance, speed_mode: SpeedMode, assist_active: AssistActive = AssistActive.NO):

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -26,6 +26,31 @@ class AFCExtruderStepper(AFCLane):
         self.extruder_stepper   = extruder.ExtruderStepper(config)
         self.stepper_enable     = self.printer.lookup_object('stepper_enable')
 
+        # Homing-related configuration (optional)
+        # Choose which sensor to use by default when doing STOP_ON_ENDSTOP moves
+        # Allowed values: 'load', or a raw MCU pin string (e.g. '^AFC:TRG1')
+        self.default_homing_endstop = config.get('homing_endstop', 'load')
+        # Optional overrides similar to manual_stepper
+        self.homing_velocity = config.getfloat('homing_velocity', None)
+        self.homing_accel = config.getfloat('homing_accel', None)
+        self._manual_axis_pos = 0.0
+
+        # Optional explicit hub endstop pin override in stepper section
+        self.hub_endstop = config.get('hub_endstop', None)
+
+        # Optional: allow declaring extra raw endstop pins that should be
+        # created at config time (comma-separated list)
+        self._extra_homing_pins = set(config.getlist('homing_endstop_pins', default="", sep=','))
+        # Pre-create MCU endstops now so MCU config callbacks run before ready
+        self._endstops = {}
+        self._init_endstops()
+
+        # Register AFC_HOME mux command for this lane name
+        stepper_name = config.get_name().split()[-1]
+        self.gcode.register_mux_command('AFC_HOME', 'STEPPER',
+                                        stepper_name, self.cmd_AFC_HOME,
+                                        desc=self.cmd_AFC_HOME_help)
+
         # Check for Klipper new motion queuing update
         try:
             self.motion_queuing = self.printer.load_object(config, "motion_queuing")
@@ -47,6 +72,9 @@ class AFCExtruderStepper(AFCLane):
             self.trapq_finalize_moves   = ffi_lib.trapq_finalize_moves
 
         self.assist_activate=False
+        # Track last homing event for synchronization with lane logic
+        self._last_home_endstop = None
+        self._last_home_time = 0.0
 
         # Current to use while printing, set to a lower current to reduce stepper heat when printing.
         # Defaults to global_print_current, if not specified current is not changed.
@@ -214,6 +242,380 @@ class AFCExtruderStepper(AFCLane):
                           base rotation distance and dividing by multiplier.
         """
         self.extruder_stepper.stepper.set_rotation_distance( self.base_rotation_dist / multiplier )
+
+    # ------------------ ManualStepper compatibility shims ------------------
+    # These wrappers allow using Klipper's homing flow with our existing stepper
+    def flush_step_generation(self):
+        # Do not dwell the main toolhead waiting for our private time cursor.
+        # If our next_cmd_time is ahead of the toolhead's time, trim it instead
+        # of blocking. This prevents a post-trigger hesitation when homing
+        # stops early before the commanded full distance.
+        try:
+            toolhead = self.printer.lookup_object('toolhead')
+            th_time = toolhead.get_last_move_time()
+            if self.next_cmd_time > th_time:
+                self.next_cmd_time = th_time
+        except Exception:
+            # Fallback to previous behavior if toolhead is unavailable
+            self.sync_print_time()
+
+    def get_position(self):
+        # 1D position along filament path
+        return [self._manual_axis_pos, 0., 0., 0.]
+
+    def set_position(self, newpos, homing_axes=""):
+        # Set our internal commanded position (1D)
+        try:
+            self._manual_axis_pos = float(newpos[0])
+        except Exception:
+            self._manual_axis_pos = 0.0
+
+    def get_last_move_time(self):
+        self.sync_print_time()
+        return self.next_cmd_time
+
+    def dwell(self, delay):
+        # Advance internal time to satisfy homing scheduler
+        self.next_cmd_time += max(0., delay)
+
+    def drip_move(self, newpos, speed, drip_completion):
+        # Queue the homing move quickly; do not block or dwell here. Homing
+        # controller will wait for the endstop and handle final positioning.
+        target = float(newpos[0])
+        delta = target - self._manual_axis_pos
+        accel = self.homing_accel if self.homing_accel is not None else (self.short_moves_accel or 0.)
+        v = self.homing_velocity if self.homing_velocity is not None else speed
+
+        toolhead = self.printer.lookup_object('toolhead')
+
+        toolhead.flush_step_generation()
+        self.sync_print_time()
+        prev_sk = self.extruder_stepper.stepper.set_stepper_kinematics(self.stepper_kinematics)
+        prev_trapq = self.extruder_stepper.stepper.set_trapq(self.trapq)
+        try:
+            self.extruder_stepper.stepper.set_position((0., 0., 0.))
+            axis_r, accel_t, cruise_t, cruise_v = calc_move_time(delta, v, accel)
+            self.trapq_append(self.trapq, self.next_cmd_time, accel_t, cruise_t, accel_t,
+                              0., 0., 0., axis_r, 0., 0., 0., cruise_v, accel)
+            end_time = self.next_cmd_time + accel_t + cruise_t + accel_t
+            self.extruder_stepper.stepper.generate_steps(end_time)
+            # Finalize near end_time; no far-future finalize so host can trim
+            self.trapq_finalize_moves(self.trapq, end_time + 0.001, end_time + 0.001)
+            self.next_cmd_time = end_time
+            # toolhead.note_mcu_movequeue_activity(end_time)
+        finally:
+            self.extruder_stepper.stepper.set_trapq(prev_trapq)
+            self.extruder_stepper.stepper.set_stepper_kinematics(prev_sk)
+
+    def get_kinematics(self):
+        # Homing expects an object with kinematics-like API; we self-provide
+        return self
+
+    def get_steppers(self):
+        # Return underlying single stepper for homing code
+        return [self.extruder_stepper.stepper]
+
+    def calc_position(self, stepper_positions):
+        # Map stepper positions into kinematic position; unused for filament homing
+        return [stepper_positions[self.extruder_stepper.stepper.get_name()], 0., 0.]
+
+    # ------------------ Endstop plumbing ------------------
+    def _resolve_endstop_pin(self, endstop_spec):
+        """
+        Resolve an endstop spec into an MCU endstop and a human name.
+        - endstop_spec can be 'load', 'hub', 'tool'|'tool_start'|'tool_end',
+          'buffer'|'buffer_advance'|'buffer_trailing', or a raw MCU pin string.
+        """
+        # Normalize aliases
+        alias_map = {
+            'tool': 'tool_start',
+            'buffer': 'buffer_advance',
+        }
+        key = alias_map.get(endstop_spec, endstop_spec)
+        # Look up a pre-created endstop; do not create at runtime (MCU cb won't run)
+        mcu_endstop, name = self._endstops.get(key, (None, None))
+        if mcu_endstop is None:
+            raise error("Unknown ENDSTOP '{}' for lane '{}'. Declare it in [AFC_stepper {}] using 'homing_endstop_pins: {}' or use ENDSTOP=load/hub/tool/buffer".format(
+                endstop_spec, self.name, self.name, endstop_spec))
+        return (mcu_endstop, name)
+
+    def _init_endstops(self):
+        """Create and register endstops at config time so MCU callbacks run."""
+        printer = self.printer
+        ppins = printer.lookup_object('pins')
+        qes = printer.load_object(self._config, 'query_endstops')
+
+        # Keep handles for use in helper
+        self._ppins = ppins
+        self._qes = qes
+
+        # Built-ins from AFCLane config
+        self._add_endstop('load', self.load, 'load')
+        # Extra raw pins declared in config
+        for raw_pin in list(self._extra_homing_pins):
+            r = raw_pin.strip()
+            if not r:
+                continue
+            # Derive a suffix from the pin token for display; keep key as exact raw string
+            suffix = 'raw'
+            try:
+                token = r.split(':')[-1]
+                suffix = token.replace('/', '_').replace('^', '').replace('!', '')
+            except Exception:
+                pass
+            self._add_endstop(r, r, suffix)
+
+        # Hub endstop (register at config time so MCU setup is complete)
+        hub_pin = self.hub_endstop
+        if hub_pin is None:
+            hub_name = getattr(self, 'hub', None)
+            if not hub_name or hub_name == 'direct':
+                hub_name = self._inherit_from_unit('hub')
+            hub_pin = self._get_section_value('AFC_hub', hub_name, 'switch_pin')
+
+        # Toolhead endstops from AFC_extruder (tool_start/tool_end)
+        extruder_name = getattr(self, 'extruder_name', None) or self._inherit_from_unit('extruder')
+        tool_start_pin = self._get_section_value('AFC_extruder', extruder_name, 'pin_tool_start')
+        tool_end_pin   = self._get_section_value('AFC_extruder', extruder_name, 'pin_tool_end')
+
+        # Buffer endstops from AFC_buffer (advance/trailing), inherit from extruder or unit if needed
+        buffer_name = getattr(self, 'buffer_name', None)
+        if not buffer_name:
+            buffer_name = self._get_section_value('AFC_extruder', extruder_name, 'buffer') or self._inherit_from_unit('buffer')
+        buffer_adv_pin   = self._get_section_value('AFC_buffer', buffer_name, 'advance_pin')
+        buffer_trail_pin = self._get_section_value('AFC_buffer', buffer_name, 'trailing_pin')
+
+        self._add_endstop('hub', hub_pin, 'hub')
+        if tool_start_pin != 'buffer':
+            self._add_endstop('tool_start', tool_start_pin, 'tool_start')
+        else:
+            self._add_endstop('tool_start', buffer_adv_pin, 'tool_start')
+        self._add_endstop('tool_end', tool_end_pin, 'tool_end')
+        self._add_endstop('buffer_advance', buffer_adv_pin, 'buffer_adv')
+        self._add_endstop('buffer_trailing', buffer_trail_pin, 'buffer_trailing')
+
+    def _inherit_from_unit(self, target_key):
+        """Return value (e.g., 'hub', 'extruder', etc.) from the unit section matching this object's unit."""
+        unit = getattr(self, 'unit', None)
+        if not unit:
+            return None
+
+        ignore_prefixes = (
+            'AFC_hub ', 'AFC_extruder ', 'AFC_buffer ',
+            'AFC_stepper ', 'AFC_functions ', 'AFC_stats ', 'AFC_respond '
+        )
+
+        try:
+            for sec in self._config.fileconfig.sections():
+                if not sec.startswith('AFC_'):
+                    continue
+                if sec.startswith(ignore_prefixes):
+                    continue
+                # Match on final token == unit name
+                tokens = sec.split()
+                if tokens and tokens[-1] == unit:
+                    unit_cfg = self._config.getsection(sec)
+                    value = unit_cfg.get(target_key, None)
+                    if value is not None:
+                        logging.debug(f"Inherited '{target_key}'='{value}' from section '{sec}' for unit '{unit}'")
+                    return value
+        except Exception as e:
+            logging.debug(f"_inherit_from_unit({target_key}) failed: {e}", exc_info=True)
+
+        return None
+
+    def _get_section_value(self, section_prefix, name, key, default=None):
+        """Safely fetch a key from a named section like 'AFC_extruder my_extruder'."""
+        if not name:
+            return default
+        section = f"{section_prefix} {name}"
+        try:
+            cfg = self._config.getsection(section)
+            return cfg.get(key, default)
+        except Exception as e:
+            logging.debug(f"Missing or invalid section '{section}': {e}")
+            return default
+
+    def _add_endstop(self, key, pin, suffix):
+        """Helper to create/register an endstop and bind it to the drive stepper."""
+        if pin is None:
+            return
+        # Normalize and create endstop
+        try:
+            self._ppins.parse_pin(pin, True, True)
+            mcu_endstop = self._ppins.setup_pin('endstop', pin)
+        except Exception:
+            return
+        
+        single_key_aliases = {'hub', 'tool_start', 'tool_end', 'buffer_advance', 'buffer_trailing'}
+        if key in single_key_aliases:
+            name = '{}'.format(suffix)
+        else:
+            name = '{}_{}'.format(self.name, suffix)
+
+        try:
+            self._qes.register_endstop(mcu_endstop, name)
+        except Exception:
+            pass
+        try:
+            mcu_endstop.add_stepper(self.extruder_stepper.stepper)
+        except Exception:
+            pass
+        self._endstops[key] = (mcu_endstop, name)
+
+    def handle_unit_connect(self, unit_obj):
+        """Extend AFCLane hook. Hub endstop is already registered at config time."""
+        super().handle_unit_connect(unit_obj)
+
+    def do_homing_move(self, movepos, speed, accel, endstop_spec, triggered=True, check_trigger=True):
+        """Perform a homing-like move using the specified endstop.
+        movepos: target absolute position along the filament axis
+        speed/accel: motion params (fallbacks applied if None)
+        endstop_spec: 'load' | raw pin string
+        triggered/check_trigger: same semantics as manual_stepper
+        """
+        reactor = self.printer.get_reactor()
+        start_ts = reactor.monotonic()
+        try:
+            self.logger.debug(f"[AFC_stepper:{self.name}] Homing start endstop={endstop_spec} movepos={movepos} speed={speed} accel={accel}")
+        except Exception:
+            pass
+        if accel is None:
+            accel = self.homing_accel if self.homing_accel is not None else (self.short_moves_accel or 50.)
+        if speed is None:
+            speed = self.homing_velocity if self.homing_velocity is not None else (self.short_moves_speed or 50.)
+        # Avoid zero-distance drip sequences which can confuse stepcompress
+        if movepos == self._manual_axis_pos:
+            self.logger.debug(f"AFC stepper '{self.name}' homing target equals current position; skipping move")
+            return
+        pos = [movepos, 0., 0., 0.]
+
+        phoming = self.printer.lookup_object('homing')
+
+        # Try to get a real MCU-backed endstop
+        try:
+            endstop = self._resolve_endstop_pin(endstop_spec)
+        except Exception as e_resolve:
+            # TODO Fallback
+            self._info(f"ENDSTOP '{endstop_spec}' could not be resolved ({e_resolve}); using software homing.")
+            raise self.gcode.error(f"ENDSTOP '{endstop_spec}' could not be resolved ({e_resolve})")
+
+        # Try MCU-based homing first
+        # Start/stop assist exactly with homing lifetime
+        rewind = movepos < self._manual_axis_pos
+        try:
+            with self.assist_move(speed, rewind, assist_active=True):
+                phoming.manual_home(self, [endstop], pos, speed, triggered, check_trigger)
+            end_ts = reactor.monotonic()
+            self._last_home_endstop = endstop_spec
+            self._last_home_time = end_ts
+            # Log distance at trigger using homing trigger positions
+            try:
+                homing_mgr = self.printer.lookup_object('homing')
+                stepper_name = self.extruder_stepper.stepper.get_name()
+                trig_mcu_pos = homing_mgr.get_trigger_position(stepper_name)
+                start_mcu_pos = self.extruder_stepper.stepper.get_mcu_position()
+                # Distance in steps (commanded frame) is trig - start of homing move
+                # We don't have the start position directly; approximate via last commanded 0 with our local kinematics:
+                # Use delta from current commanded to trigger pos as step delta
+                step_dist = self.extruder_stepper.stepper.get_step_dist()
+                # In Klipper, get_mcu_position() returns at current commanded pos; we can't read 'start' cleanly here.
+                # However, the Homing manager's trigger_mcu_pos is absolute; compute delta from current mcu pos as a proxy for short homing moves.
+                steps_moved = trig_mcu_pos - start_mcu_pos
+                dist_mm = steps_moved * step_dist
+                self.logger.debug(f"AFC lane '{self.name}': endstop '{endstop_spec}' trigger after {dist_mm:.3f} mm (steps={steps_moved})")
+            except Exception:
+                pass
+            self.logger.debug(f"Homed lane '{self.name}' to ENDSTOP='{endstop_spec}' at position {self._manual_axis_pos:.2f}mm (dt={(end_ts-start_ts):.3f}s)")
+            return True
+        except Exception as e:
+            # TODO Fallback
+            msg = str(e).lower()
+            if "no trigger on" in msg:
+                if not self.printer.is_shutdown():
+                    try:
+                        self.logger.debug(f"[{self.name}] Homing: {e}; continuing because homing_ignore_no_trigger is enabled")
+                    except Exception:
+                        pass
+                    return False
+                raise self.gcode.error(str(e))
+            if ("communication timeout during homing" in msg) or ("endstop" in msg and "still triggered" in msg):
+                raise self.gcode.error(str(e))
+            # Other MCU homing issues: surface message and re-raise as gcode error
+            try:
+                self.logger.debug(f"MCU homing issue ({e}); not proceeding with homing move")
+            except Exception:
+                pass
+            raise self.gcode.error(str(e))
+
+    # ------------------ Convenience homing helpers ------------------
+    def home_to(self, endstop_spec, distance=None, speed_mode=SpeedMode, triggered=True, check_trigger=True):
+        """
+        Home towards an endstop relative to current position by distance (mm).
+        If 'distance' is None, callers should prefer the typed helpers which pick a
+        sensible default direction and magnitude for the chosen endstop.
+
+        Parameters:
+        endstop_spec (str): The target endstop to home to. Can be a raw pin identifier or a logical
+            name such as 'load', 'toolhead', etc.
+        distance (float, optional): Relative distance to move toward the endstop in millimeters.
+            Required unless using a helper method.
+        speed_mode (SpeedMode, optional): Enum or configuration selecting the speed and acceleration
+            profile to use for this move. Defaults to `SpeedMode`.
+        triggered (bool, optional): If True, movement stops when the endstop triggers. Defaults to True.
+        check_trigger (bool, optional): If True, verify that the endstop is actually triggered at the
+            end of the move. Defaults to True.
+        """
+        speed, accel = self.get_speed_accel(speed_mode)
+
+        if distance is None:
+            raise self.gcode.error("home_to requires an explicit distance; use home_to_hub/toolhead/buffer for sensible defaults")
+        # Compute an absolute target along our 1D axis
+        target = float(self._manual_axis_pos + float(distance))
+        self.logger.debug(f"Homing lane '{self.name}' to ENDSTOP='{endstop_spec}' at position {distance:.2f}mm")
+        homed = self.do_homing_move(target, speed, accel, endstop_spec,
+                            triggered=triggered, check_trigger=check_trigger)
+        self.sync_print_time()
+        return homed
+
+    # ------------------ Command shim (AFC_HOME) ------------------
+    cmd_AFC_HOME_help = "Command a manually controlled stepper (AFC shim)"
+    def cmd_AFC_HOME(self, gcmd):
+        """
+        Shim to mirror Klipper's AFC_HOME for AFC lanes, including STOP_ON_ENDSTOP.
+        Usage examples:
+          AFC_HOME STEPPER={name} ENABLE=1
+          AFC_HOME STEPPER={name} MOVE=10 SPEED=5
+          AFC_HOME STEPPER={name} STOP_ON_ENDSTOP=1 MOVE=200 SPEED=5 [ENDSTOP=load|^AFC:TRG1]
+        """
+        enable = gcmd.get_int('ENABLE', None)
+        if enable is not None:
+            self.do_enable(enable)
+        setpos = gcmd.get_float('SET_POSITION', None)
+        if setpos is not None:
+            self.set_position([setpos, 0., 0., 0.])
+        speed = gcmd.get_float('SPEED', self.short_moves_speed or 5., above=0.)
+        accel = gcmd.get_float('ACCEL', self.short_moves_accel or 0., minval=0.)
+        homing_move = gcmd.get_int('STOP_ON_ENDSTOP', 0)
+        if homing_move:
+            movepos = gcmd.get_float('MOVE')
+            endstop_spec = gcmd.get('ENDSTOP', self.default_homing_endstop)
+            self.do_homing_move(movepos, speed, accel,
+                                endstop_spec,
+                                triggered = homing_move > 0,
+                                check_trigger = abs(homing_move) == 1)
+        elif gcmd.get_float('MOVE', None) is not None:
+            movepos = gcmd.get_float('MOVE')
+            sync = gcmd.get_int('SYNC', 1)
+            # Implement simple absolute-position move using our pipeline
+            delta = movepos - self._manual_axis_pos
+            if delta:
+                self._move(delta, speed, accel, assist_active=True)
+                self._manual_axis_pos = movepos
+            if sync:
+                self.sync_print_time()
+        elif gcmd.get_int('SYNC', 0):
+            self.sync_print_time()
 
 def load_config_prefix(config):
     return AFCExtruderStepper(config)

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -11,13 +11,6 @@ import traceback
 from kinematics import extruder
 from configfile import error
 from extras.force_move import calc_move_time
-from toolhead import (
-    DripModeEndSignal,
-    DRIP_TIME,
-    STEPCOMPRESS_FLUSH_TIME,
-    BUFFER_TIME_HIGH,
-    DRIP_SEGMENT_TIME
-)
 
 from typing import Optional, TYPE_CHECKING
 
@@ -27,7 +20,13 @@ except: raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".f
 try: from extras.AFC_lane import AFCLane, SpeedMode, AFCHomingPoints
 except: raise error(ERROR_STR.format(import_lib="AFC_lane", trace=traceback.format_exc()))
 
+
 LARGE_TIME_OFFSET = 99999.9
+# Manually adding since these are in different files between klipper and kalico
+DRIP_TIME=0.100
+STEPCOMPRESS_FLUSH_TIME=0.050
+BUFFER_TIME_HIGH=1.0
+DRIP_SEGMENT_TIME=0.050
 
 class AFCExtruderStepper(AFCLane):
     def __init__(self, config):

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -335,6 +335,7 @@ class AFCExtruderStepper(AFCLane):
         self.logger.info(f"AFC_Stepper drip move {newpos} {speed} {self.next_cmd_time}")
         target = float(newpos[0])
         delta = target - self._manual_axis_pos
+        # TODO: figure out way to use accel passed into home_to function
         accel = self.homing_accel if self.homing_accel is not None else (self.short_moves_accel or 0.)
         v = self.homing_velocity if self.homing_velocity is not None else speed
 
@@ -474,7 +475,7 @@ class AFCExtruderStepper(AFCLane):
                     unit_cfg = self._config.getsection(sec)
                     value = unit_cfg.get(target_key, None)
                     if value is not None:
-                        self.logger.debug(f"Inherited '{target_key}'='{value}' from section '{sec}' for unit '{unit}'")
+                        self.logger.debug(f"Inherited '{target_key}'='{value}' from section '{sec}' for unit '{unit}' {self.name}")
                     return value
         except Exception as e:
             self.logger.debug(f"_inherit_from_unit({target_key}) failed: {e}", exc_info=True)
@@ -496,12 +497,16 @@ class AFCExtruderStepper(AFCLane):
     def _add_endstop(self, key, pin, suffix):
         """Helper to create/register an endstop and bind it to the drive stepper."""
         if pin is None:
+            self.logger.info(f"Pin for {key} is none for {self.name}")
             return
         # Normalize and create endstop
         try:
+            self._ppins.allow_multi_use_pin(pin.strip("!^"))
             self._ppins.parse_pin(pin, True, True)
             mcu_endstop = self._ppins.setup_pin('endstop', pin)
-        except Exception:
+        except Exception as e:
+            self.logger.info(f"Error parsing pin for {key} is none for {self.name}")
+            self.logger.info(f"{e}")
             return
         
         single_key_aliases = {'hub', 'tool_start', 'tool_end', 'buffer_advance', 'buffer_trailing'}
@@ -513,11 +518,14 @@ class AFCExtruderStepper(AFCLane):
         try:
             self._qes.register_endstop(mcu_endstop, name)
         except Exception:
+            self.logger.info(f"Error when registering {name} as endstop for {self.lane}")
             pass
         try:
             mcu_endstop.add_stepper(self.extruder_stepper.stepper)
         except Exception:
+            self.logger.info(f"Error when registering stepper {self.lane}")
             pass
+        self.logger.debug(f"{self.name} adding endstop {key}:{name}:{pin}") # TODO:remove once fully tested on toolchanger
         self._endstops[key] = (mcu_endstop, name)
 
     def handle_unit_connect(self, unit_obj):

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -614,7 +614,7 @@ class AFCExtruderStepper(AFCLane):
         try:
             endstop = self._resolve_endstop_pin(endstop_spec)
         except Exception as e_resolve:
-            self._info(f"ENDSTOP '{endstop_spec}' could not be resolved ({e_resolve}); using software homing.")
+            self.logger.debug(f"ENDSTOP '{endstop_spec}' could not be resolved ({e_resolve})")
             raise_string = f"ENDSTOP '{endstop_spec}' could not be resolved ({e_resolve})"
             raise self.gcode.error(raise_string)
 

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -704,7 +704,8 @@ class AFCExtruderStepper(AFCLane):
         return homed, move_distance
 
     cmd_AFC_STEPPER_HOME_help = "Command a manually home stepper to specified endstop"
-    cmd_AFC_STEPPER_HOME_options = {"ENABLE": {"type": "int", "default": 1},
+    cmd_AFC_STEPPER_HOME_options = {"STEPPER": {"type":"string", "default":"lane1"},
+                            "ENABLE": {"type": "int", "default": 1},
                             "SPEED": {"type": "float", "default": 100},
                             "ACCEL": {"type": "float", "default": 100},
                             "STOP_ON_ENDSTOP": {"type": "int", "default": 1},

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -598,7 +598,7 @@ class AFCExtruderStepper(AFCLane):
                 self.logger.debug(f"Exception {e}")
                 pass
             self.logger.debug(f"Homed lane '{self.name}' to ENDSTOP='{endstop_spec}' at position {self._manual_axis_pos:.2f}mm (dt={(end_ts-start_ts):.3f}s)")
-            return True
+            return True, dist_mm
         except Exception as e:
             # TODO Fallback
             msg = str(e).lower()
@@ -649,15 +649,18 @@ class AFCExtruderStepper(AFCLane):
         target = float(self._manual_axis_pos + float(distance))
         self.logger.debug(f"Homing lane '{self.name}' to ENDSTOP='{endstop_spec}' at position {distance:.2f}mm")
         homed = False
+        move_distance = 0
         try:
-            homed = self.do_homing_move(target, speed, accel, endstop_spec,
-                                triggered=triggered, check_trigger=check_trigger,
-                                assist_active=assist_active)
+            homed, move_distance = self.do_homing_move(target, speed, accel,
+                                                       endstop_spec,
+                                                       triggered=triggered,
+                                                       check_trigger=check_trigger,
+                                                       assist_active=assist_active)
         except Exception:
             # TODO: figure out what exceptions to catch here
             self.logger.info(f"{traceback.format_exc()}")
         self.sync_print_time()
-        return homed
+        return homed, move_distance
 
     # ------------------ Command shim (AFC_HOME) ------------------
     cmd_AFC_HOME_help = "Command a manually controlled stepper (AFC shim)"

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -266,19 +266,6 @@ class AFCExtruderStepper(AFCLane):
     # ------------------ ManualStepper compatibility shims ------------------
     # These wrappers allow using Klipper's homing flow with our existing stepper
     def flush_step_generation(self):
-        # Do not dwell the main toolhead waiting for our private time cursor.
-        # If our next_cmd_time is ahead of the toolhead's time, trim it instead
-        # of blocking. This prevents a post-trigger hesitation when homing
-        # stops early before the commanded full distance.
-        # try:
-        #     toolhead = self.printer.lookup_object('toolhead')
-        #     th_time = toolhead.get_last_move_time()
-        #     if self.next_cmd_time > th_time:
-        #         self.next_cmd_time = th_time
-        # except Exception:
-        #     # Fallback to previous behavior if toolhead is unavailable
-        # toolhead = self.printer.lookup_object('toolhead')
-        # toolhead.flush_step_generation()
         self.sync_print_time()
 
     def get_position(self):
@@ -286,10 +273,6 @@ class AFCExtruderStepper(AFCLane):
         return [self.extruder_stepper.stepper.get_commanded_position(), 0., 0., 0.]
 
     def set_position(self, newpos, homing_axes=""):
-        # Set our internal commanded position (1D)
-        # try:
-        #     self._manual_axis_pos = float(newpos[0])
-        # except Exception:
         self._manual_axis_pos = 0.0
 
     def get_last_move_time(self):
@@ -315,7 +298,6 @@ class AFCExtruderStepper(AFCLane):
 
         while toolhead.print_time < max_time:
             if drip_completion.test():
-                self.logger.info(f"Done {self.reactor.monotonic()}")
                 break
             curtime = self.reactor.monotonic()
             est_print_time = toolhead.mcu.estimated_print_time(curtime)
@@ -332,7 +314,6 @@ class AFCExtruderStepper(AFCLane):
         # Queue the homing move quickly; do not block or dwell here. Homing
         # controller will wait for the endstop and handle final positioning.
         self.sync_print_time()
-        self.logger.info(f"AFC_Stepper drip move {newpos} {speed} {self.next_cmd_time}")
         target = float(newpos[0])
         delta = target - self._manual_axis_pos
         v = self.homing_velocity if self.homing_velocity is not None else speed
@@ -544,7 +525,7 @@ class AFCExtruderStepper(AFCLane):
 
         try:
 
-            self.logger.debug(f"[AFC_stepper:{self.name}] Homing start endstop={endstop_spec} movepos={movepos} speed={speed} accel={accel} {self._manual_axis_pos} {self.extruder_stepper.stepper.get_commanded_position()}")
+            self.logger.debug(f"[AFC_stepper:{self.name}] Homing start endstop={endstop_spec} movepos={movepos} speed={speed} accel={accel}")
         except Exception:
             pass
         if accel is None:
@@ -582,8 +563,6 @@ class AFCExtruderStepper(AFCLane):
             self._last_home_time = end_ts
             # Log distance at trigger using homing trigger positions
             try:
-                homing_mgr = self.printer.lookup_object('homing')
-                stepper_name = self.extruder_stepper.stepper.get_name()
                 trig_mcu_pos = self.extruder_stepper.stepper.get_mcu_position()
                 # Distance in steps (commanded frame) is trig - start of homing move
                 # We don't have the start position directly; approximate via last commanded 0 with our local kinematics:
@@ -609,7 +588,7 @@ class AFCExtruderStepper(AFCLane):
                         self.logger.debug(f"[{self.name}] Homing: {e}; continuing because homing_ignore_no_trigger is enabled {ffi_lib.itersolve_get_commanded_pos(self.stepper_kinematics)}")
                     except Exception:
                         pass
-                    return False
+                    return False, movepos
                 raise self.gcode.error(str(e))
             if ("communication timeout during homing" in msg) or ("endstop" in msg and "still triggered" in msg):
                 self.logger.info(f"{e}")
@@ -683,7 +662,6 @@ class AFCExtruderStepper(AFCLane):
         homing_move = gcmd.get_int('STOP_ON_ENDSTOP', 0)
         if homing_move:
             movepos = gcmd.get_float('MOVE')
-            final_pos = float(self._manual_axis_pos) + float(movepos)
             endstop_spec = gcmd.get('ENDSTOP', self.default_homing_endstop)
             self.do_homing_move(movepos, speed, accel,
                                 endstop_spec,

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -41,7 +41,7 @@ class AFCExtruderStepper(AFCLane):
         self.stepper_enable     = self.printer.lookup_object('stepper_enable')
 
         # Homing-related configuration
-        self.default_homing_endstop = config.get('homing_endstop', 'load')
+        self.default_homing_endstop = config.get('default_homing_endstop', 'load')
         self._homing_accel          = self.short_moves_accel # Should only be updated in do_homing_move so accel can be used in drip_move callback
         self._manual_axis_pos       = 0.0
 
@@ -720,16 +720,15 @@ class AFCExtruderStepper(AFCLane):
 
         Optional Values
         ----
-        ENABLE: Use the ENABLE parameter to enable/disable the stepper.
-        SPEED: If SPEED is specified then the given value will be used instead of the default specified in the config file.
-        ACCEL: If SPEED is specified then the given value will be used instead of the default specified in the config file.
-        STOP_ON_ENDSTOP: If STOP_ON_ENDSTOP=1 is specified then the move will end early should the endstop report as
+        ENABLE - Use the ENABLE parameter to enable/disable the stepper.<br>
+        SPEED - If SPEED is specified then the given value will be used instead of the default specified in the config file.<br>
+        ACCEL - If SPEED is specified then the given value will be used instead of the default specified in the config file.<br>
+        STOP_ON_ENDSTOP - If STOP_ON_ENDSTOP=1 is specified then the move will end early should the endstop report as
         triggered (use STOP_ON_ENDSTOP=2 to complete the move without error even if the endstop does not trigger,
-        use -1 or -2 to stop when the endstop reports not triggered).
-        DIST: Distance to move stepper
-        ENDSTOP: Endstop to try and home to, default names to use are:
-            load, hub, tool_start, buffer_adv, buffer_trailing
-        SYNC: Only valid when not using STOP_ON_ENDSTOP, setting sync 0 will allow the stepper
+        use -1 or -2 to stop when the endstop reports not triggered).<br>
+        DIST - Distance to move stepper<br>
+        ENDSTOP - Endstop to try and home to, default names to use are: load, hub, tool_start, buffer_adv, buffer_trailing<br>
+        SYNC - Only valid when not using STOP_ON_ENDSTOP, setting sync 0 will allow the stepper
         to be moved in paralled with other stepper movement.
 
         Usage
@@ -739,9 +738,22 @@ class AFCExtruderStepper(AFCLane):
         Example
         ----
         ```
-        AFC_STEPPER_HOME STEPPER=lane1 ENABLE=1
+        AFC_STEPPER_HOME STEPPER=lane1 ENABLE=0
+        ```
+        Example
+        ----
+        ```
         AFC_STEPPER_HOME STEPPER=lane1 MOVE=10 SPEED=5
-        AFC_STEPPER_HOME STEPPER=lane1 STOP_ON_ENDSTOP=1 DIST=200 SPEED=5 ENDSTOP=hub]
+        ```
+        Example
+        ----
+        ```
+        AFC_STEPPER_HOME STEPPER=lane1 STOP_ON_ENDSTOP=1 DIST=200 SPEED=5 ENDSTOP=hub
+        ```
+        Example
+        ----
+        ```
+        AFC_STEPPER_HOME STEPPER=lane1 STOP_ON_ENDSTOP=-1 DIST=-200 SPEED=5 ENDSTOP=hub
         ```
         """
         enable = gcmd.get_int('ENABLE', None)

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -42,6 +42,7 @@ class AFCExtruderStepper(AFCLane):
         # Optional overrides similar to manual_stepper
         self.homing_velocity = config.getfloat('homing_velocity', None)
         self.homing_accel = config.getfloat('homing_accel', None)
+        self._homing_accel = self.homing_accel # Should only be updated in do_homing_move so accel can be used in drip_move callback
         self._manual_axis_pos = 0.0
 
         # Optional explicit hub endstop pin override in stepper section
@@ -334,8 +335,6 @@ class AFCExtruderStepper(AFCLane):
         self.logger.info(f"AFC_Stepper drip move {newpos} {speed} {self.next_cmd_time}")
         target = float(newpos[0])
         delta = target - self._manual_axis_pos
-        # TODO: figure out way to use accel passed into home_to function
-        accel = self.homing_accel if self.homing_accel is not None else (self.short_moves_accel or 0.)
         v = self.homing_velocity if self.homing_velocity is not None else speed
 
         start_time = self.next_cmd_time
@@ -343,11 +342,12 @@ class AFCExtruderStepper(AFCLane):
         prev_sk     = self.extruder_stepper.stepper.set_stepper_kinematics(self.stepper_kinematics)
         prev_trapq  = self.extruder_stepper.stepper.set_trapq(self.trapq)
 
-        dwell_time = self._submit_move( start_time, delta, v, accel)
+        dwell_time = self._submit_move( start_time, delta, v, self._homing_accel)
         max_time = start_time + dwell_time
 
         toolhead = self.printer.lookup_object('toolhead')
 
+        # TODO: add a check for toolhead.drip_update_time and test with https://github.com/KalicoCrew/kalico/pull/825 PR
         if self.motion_queuing is None:
             self._drip_update_time(toolhead, max_time, drip_completion)
             self.reactor.update_timer(toolhead.flush_timer, self.reactor.NOW)
@@ -547,10 +547,14 @@ class AFCExtruderStepper(AFCLane):
             self.logger.debug(f"[AFC_stepper:{self.name}] Homing start endstop={endstop_spec} movepos={movepos} speed={speed} accel={accel} {self._manual_axis_pos} {self.extruder_stepper.stepper.get_commanded_position()}")
         except Exception:
             pass
+        self._hom
         if accel is None:
-            accel = self.homing_accel if self.homing_accel is not None else (self.short_moves_accel or 50.)
+            accel = self.homing_accel if self.homing_accel else (self.short_moves_accel or 50.)
         if speed is None:
-            speed = self.homing_velocity if self.homing_velocity is not None else (self.short_moves_speed or 50.)
+            speed = self.homing_velocity if self.homing_velocity else (self.short_moves_speed or 50.)
+        
+         # Setting private variable so accel can be used in drip_move callback
+        self._homing_accel = accel
         # Avoid zero-distance drip sequences which can confuse stepcompress
         if movepos == self._manual_axis_pos:
             self.logger.debug(f"AFC stepper '{self.name}' homing target equals current position; skipping move")

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -24,7 +24,7 @@ from typing import Optional, TYPE_CHECKING
 try: from extras.AFC_utils import ERROR_STR
 except: raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".format(trace=traceback.format_exc()))
 
-try: from extras.AFC_lane import AFCLane, SpeedMode
+try: from extras.AFC_lane import AFCLane, SpeedMode, AFCHomingPoints
 except: raise error(ERROR_STR.format(import_lib="AFC_lane", trace=traceback.format_exc()))
 
 LARGE_TIME_OFFSET = 99999.9
@@ -175,6 +175,14 @@ class AFCExtruderStepper(AFCLane):
             move_value = move_value * direction
 
             self._move(move_value, speed, accel, assist_active)
+    
+    # def move_to(self, distance: float, speed_mode: SpeedMode, endstop:str,
+    #             assist_active=True, use_homing=True):
+    #     if use_homing:
+    #         self.home_to(endstop, distance, speed_mode,
+    #                                     distance > 0, assist_active=assist_active)
+    #     else:
+    #         self.move_advanced(distance, speed_mode, assist_active )
 
     def do_enable(self, enable):
         """
@@ -605,7 +613,7 @@ class AFCExtruderStepper(AFCLane):
             raise self.gcode.error(str(e))
 
     # ------------------ Convenience homing helpers ------------------
-    def home_to(self, endstop_spec:str, distance:Optional[int]=None, speed_mode:SpeedMode=SpeedMode,
+    def home_to(self, endstop_spec:AFCHomingPoints, distance:Optional[int], speed_mode: SpeedMode,
                 triggered=True, check_trigger=True, assist_active=True):
         """
         Home towards an endstop relative to current position by distance (mm).
@@ -630,9 +638,13 @@ class AFCExtruderStepper(AFCLane):
         # Compute an absolute target along our 1D axis
         target = float(self._manual_axis_pos + float(distance))
         self.logger.debug(f"Homing lane '{self.name}' to ENDSTOP='{endstop_spec}' at position {distance:.2f}mm")
-        homed = self.do_homing_move(target, speed, accel, endstop_spec,
-                            triggered=triggered, check_trigger=check_trigger,
-                            assist_active=assist_active)
+        try:
+            homed = self.do_homing_move(target, speed, accel, endstop_spec,
+                                triggered=triggered, check_trigger=check_trigger,
+                                assist_active=assist_active)
+        except Exception:
+            # TODO: figure out what exceptions to catch here
+            self.logger.info(f"{traceback.format_exc()}")
         self.sync_print_time()
         return homed
 

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2024-2026 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import annotations
 
 import chelper
 import traceback
@@ -10,11 +11,20 @@ import traceback
 from kinematics import extruder
 from configfile import error
 from extras.force_move import calc_move_time
+from toolhead import (
+    DripModeEndSignal,
+    DRIP_TIME,
+    STEPCOMPRESS_FLUSH_TIME,
+    BUFFER_TIME_HIGH,
+    DRIP_SEGMENT_TIME
+)
+
+from typing import Optional, TYPE_CHECKING
 
 try: from extras.AFC_utils import ERROR_STR
 except: raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".format(trace=traceback.format_exc()))
 
-try: from extras.AFC_lane import AFCLane
+try: from extras.AFC_lane import AFCLane, SpeedMode
 except: raise error(ERROR_STR.format(import_lib="AFC_lane", trace=traceback.format_exc()))
 
 LARGE_TIME_OFFSET = 99999.9
@@ -52,10 +62,7 @@ class AFCExtruderStepper(AFCLane):
                                         desc=self.cmd_AFC_HOME_help)
 
         # Check for Klipper new motion queuing update
-        try:
-            self.motion_queuing = self.printer.load_object(config, "motion_queuing")
-        except Exception:
-            self.motion_queuing = None
+        self.motion_queuing = self.printer.load_object(config, "motion_queuing", None)
 
         self.next_cmd_time = 0.
 
@@ -98,6 +105,13 @@ class AFCExtruderStepper(AFCLane):
             raise self.gcode.error(msg)
 
         self.tmc_load_current = self.tmc_driver.getfloat('run_current')
+    
+    def _submit_move( self, movetime, distance, speed, accel):
+        self.extruder_stepper.stepper.set_position((0., 0., 0.))
+        axis_r, accel_t, cruise_t, cruise_v = calc_move_time(distance, speed, accel)
+        self.trapq_append(self.trapq, movetime, accel_t, cruise_t, accel_t,
+                              0., 0., 0., axis_r, 0., 0., 0., cruise_v, accel)
+        return accel_t + cruise_t + accel_t
 
     def _move(self, distance, speed, accel, assist_active=False):
         """
@@ -109,7 +123,7 @@ class AFCExtruderStepper(AFCLane):
         speed (float): The speed of the movement.
         accel (float): The acceleration of the movement.
         """
-
+        self.sync_print_time()
 
         with self.assist_move(speed, distance < 0, assist_active):
             # Code based off force_move.py manual_move function
@@ -117,12 +131,10 @@ class AFCExtruderStepper(AFCLane):
             toolhead.flush_step_generation()
             prev_sk     = self.extruder_stepper.stepper.set_stepper_kinematics(self.stepper_kinematics)
             prev_trapq  = self.extruder_stepper.stepper.set_trapq(self.trapq)
-            self.extruder_stepper.stepper.set_position((0., 0., 0.))
-            axis_r, accel_t, cruise_t, cruise_v = calc_move_time(distance, speed, accel)
             print_time = toolhead.get_last_move_time()
-            self.trapq_append(self.trapq, print_time, accel_t, cruise_t, accel_t,
-                              0., 0., 0., axis_r, 0., 0., 0., cruise_v, accel)
-            print_time = print_time + accel_t + cruise_t + accel_t
+            
+            dwell_time = self._submit_move( print_time, distance, speed, accel)
+            print_time += dwell_time
 
             if self.motion_queuing is None:
                 self.extruder_stepper.stepper.generate_steps(print_time)
@@ -132,7 +144,7 @@ class AFCExtruderStepper(AFCLane):
             else:
                 self.motion_queuing.note_mcu_movequeue_activity(print_time)
 
-            toolhead.dwell(accel_t + cruise_t + accel_t)
+            toolhead.dwell( dwell_time )
             toolhead.flush_step_generation()
             self.extruder_stepper.stepper.set_trapq(prev_trapq)
             self.extruder_stepper.stepper.set_stepper_kinematics(prev_sk)
@@ -250,25 +262,27 @@ class AFCExtruderStepper(AFCLane):
         # If our next_cmd_time is ahead of the toolhead's time, trim it instead
         # of blocking. This prevents a post-trigger hesitation when homing
         # stops early before the commanded full distance.
-        try:
-            toolhead = self.printer.lookup_object('toolhead')
-            th_time = toolhead.get_last_move_time()
-            if self.next_cmd_time > th_time:
-                self.next_cmd_time = th_time
-        except Exception:
-            # Fallback to previous behavior if toolhead is unavailable
-            self.sync_print_time()
+        # try:
+        #     toolhead = self.printer.lookup_object('toolhead')
+        #     th_time = toolhead.get_last_move_time()
+        #     if self.next_cmd_time > th_time:
+        #         self.next_cmd_time = th_time
+        # except Exception:
+        #     # Fallback to previous behavior if toolhead is unavailable
+        # toolhead = self.printer.lookup_object('toolhead')
+        # toolhead.flush_step_generation()
+        self.sync_print_time()
 
     def get_position(self):
         # 1D position along filament path
-        return [self._manual_axis_pos, 0., 0., 0.]
+        return [self.extruder_stepper.stepper.get_commanded_position(), 0., 0., 0.]
 
     def set_position(self, newpos, homing_axes=""):
         # Set our internal commanded position (1D)
-        try:
-            self._manual_axis_pos = float(newpos[0])
-        except Exception:
-            self._manual_axis_pos = 0.0
+        # try:
+        #     self._manual_axis_pos = float(newpos[0])
+        # except Exception:
+        self._manual_axis_pos = 0.0
 
     def get_last_move_time(self):
         self.sync_print_time()
@@ -277,35 +291,70 @@ class AFCExtruderStepper(AFCLane):
     def dwell(self, delay):
         # Advance internal time to satisfy homing scheduler
         self.next_cmd_time += max(0., delay)
+    
+    def _drip_update_time(self, toolhead, max_time, drip_completion):
+        """
+        Same as mainline klipper that using motion queue, this is only called if motion
+        queue object is not found
+        """
+        toolhead.special_queuing_state = "Drip"
+        toolhead.need_check_pause = self.reactor.NEVER
+        self.reactor.update_timer(toolhead.flush_timer, self.reactor.NEVER)
+        toolhead.do_kick_flush_timer = False
+        toolhead.lookahead.set_flush_time(BUFFER_TIME_HIGH)
+        toolhead.check_stall_time = 0.
+        flush_delay = DRIP_TIME + STEPCOMPRESS_FLUSH_TIME + toolhead.kin_flush_delay
+
+        while toolhead.print_time < max_time:
+            if drip_completion.test():
+                self.logger.info(f"Done {self.reactor.monotonic()}")
+                break
+            curtime = self.reactor.monotonic()
+            est_print_time = toolhead.mcu.estimated_print_time(curtime)
+            wait_time = toolhead.print_time - est_print_time - flush_delay
+            if wait_time > 0.:
+                drip_completion.wait(curtime + wait_time)
+                continue
+            npt = min(toolhead.print_time + DRIP_SEGMENT_TIME, max_time)
+            toolhead.note_mcu_movequeue_activity(npt + toolhead.kin_flush_delay)
+            toolhead._advance_move_time(npt)
+        
 
     def drip_move(self, newpos, speed, drip_completion):
         # Queue the homing move quickly; do not block or dwell here. Homing
         # controller will wait for the endstop and handle final positioning.
+        self.sync_print_time()
+        self.logger.info(f"AFC_Stepper drip move {newpos} {speed} {self.next_cmd_time}")
         target = float(newpos[0])
         delta = target - self._manual_axis_pos
         accel = self.homing_accel if self.homing_accel is not None else (self.short_moves_accel or 0.)
         v = self.homing_velocity if self.homing_velocity is not None else speed
 
+        start_time = self.next_cmd_time
+
+        prev_sk     = self.extruder_stepper.stepper.set_stepper_kinematics(self.stepper_kinematics)
+        prev_trapq  = self.extruder_stepper.stepper.set_trapq(self.trapq)
+
+        dwell_time = self._submit_move( start_time, delta, v, accel)
+        max_time = start_time + dwell_time
+
         toolhead = self.printer.lookup_object('toolhead')
 
-        toolhead.flush_step_generation()
+        if self.motion_queuing is None:
+            self._drip_update_time(toolhead, max_time, drip_completion)
+            self.reactor.update_timer(toolhead.flush_timer, self.reactor.NOW)
+            toolhead.flush_step_generation()
+            self.trapq_finalize_moves(self.trapq, self.reactor.NEVER, 0)
+            self.extruder_stepper.stepper.set_position([delta, 0., 0.])
+        else:
+            self.motion_queuing.drip_update_time( start_time, max_time, drip_completion)
+
+        self.extruder_stepper.stepper.set_trapq(prev_trapq)
+        self.extruder_stepper.stepper.set_stepper_kinematics(prev_sk)
+        if self.motion_queuing is not None:
+            self.motion_queuing.wipe_trapq(self.trapq)
+
         self.sync_print_time()
-        prev_sk = self.extruder_stepper.stepper.set_stepper_kinematics(self.stepper_kinematics)
-        prev_trapq = self.extruder_stepper.stepper.set_trapq(self.trapq)
-        try:
-            self.extruder_stepper.stepper.set_position((0., 0., 0.))
-            axis_r, accel_t, cruise_t, cruise_v = calc_move_time(delta, v, accel)
-            self.trapq_append(self.trapq, self.next_cmd_time, accel_t, cruise_t, accel_t,
-                              0., 0., 0., axis_r, 0., 0., 0., cruise_v, accel)
-            end_time = self.next_cmd_time + accel_t + cruise_t + accel_t
-            self.extruder_stepper.stepper.generate_steps(end_time)
-            # Finalize near end_time; no far-future finalize so host can trim
-            self.trapq_finalize_moves(self.trapq, end_time + 0.001, end_time + 0.001)
-            self.next_cmd_time = end_time
-            # toolhead.note_mcu_movequeue_activity(end_time)
-        finally:
-            self.extruder_stepper.stepper.set_trapq(prev_trapq)
-            self.extruder_stepper.stepper.set_stepper_kinematics(prev_sk)
 
     def get_kinematics(self):
         # Homing expects an object with kinematics-like API; we self-provide
@@ -417,10 +466,10 @@ class AFCExtruderStepper(AFCLane):
                     unit_cfg = self._config.getsection(sec)
                     value = unit_cfg.get(target_key, None)
                     if value is not None:
-                        logging.debug(f"Inherited '{target_key}'='{value}' from section '{sec}' for unit '{unit}'")
+                        self.logger.debug(f"Inherited '{target_key}'='{value}' from section '{sec}' for unit '{unit}'")
                     return value
         except Exception as e:
-            logging.debug(f"_inherit_from_unit({target_key}) failed: {e}", exc_info=True)
+            self.logger.debug(f"_inherit_from_unit({target_key}) failed: {e}", exc_info=True)
 
         return None
 
@@ -433,7 +482,7 @@ class AFCExtruderStepper(AFCLane):
             cfg = self._config.getsection(section)
             return cfg.get(key, default)
         except Exception as e:
-            logging.debug(f"Missing or invalid section '{section}': {e}")
+            self.logger.debug(f"Missing or invalid section '{section}': {e}")
             return default
 
     def _add_endstop(self, key, pin, suffix):
@@ -467,7 +516,8 @@ class AFCExtruderStepper(AFCLane):
         """Extend AFCLane hook. Hub endstop is already registered at config time."""
         super().handle_unit_connect(unit_obj)
 
-    def do_homing_move(self, movepos, speed, accel, endstop_spec, triggered=True, check_trigger=True):
+    def do_homing_move(self, movepos: int, speed: int, accel: int, endstop_spec:str,
+                       triggered=True, check_trigger=True, assist_active=True):
         """Perform a homing-like move using the specified endstop.
         movepos: target absolute position along the filament axis
         speed/accel: motion params (fallbacks applied if None)
@@ -476,8 +526,10 @@ class AFCExtruderStepper(AFCLane):
         """
         reactor = self.printer.get_reactor()
         start_ts = reactor.monotonic()
+
         try:
-            self.logger.debug(f"[AFC_stepper:{self.name}] Homing start endstop={endstop_spec} movepos={movepos} speed={speed} accel={accel}")
+
+            self.logger.debug(f"[AFC_stepper:{self.name}] Homing start endstop={endstop_spec} movepos={movepos} speed={speed} accel={accel} {self._manual_axis_pos} {self.extruder_stepper.stepper.get_commanded_position()}")
         except Exception:
             pass
         if accel is None:
@@ -504,7 +556,8 @@ class AFCExtruderStepper(AFCLane):
         # Start/stop assist exactly with homing lifetime
         rewind = movepos < self._manual_axis_pos
         try:
-            with self.assist_move(speed, rewind, assist_active=True):
+            start_mcu_pos = self.extruder_stepper.stepper.get_mcu_position()
+            with self.assist_move(speed, rewind, assist_active=assist_active):
                 phoming.manual_home(self, [endstop], pos, speed, triggered, check_trigger)
             end_ts = reactor.monotonic()
             self._last_home_endstop = endstop_spec
@@ -513,18 +566,18 @@ class AFCExtruderStepper(AFCLane):
             try:
                 homing_mgr = self.printer.lookup_object('homing')
                 stepper_name = self.extruder_stepper.stepper.get_name()
-                trig_mcu_pos = homing_mgr.get_trigger_position(stepper_name)
-                start_mcu_pos = self.extruder_stepper.stepper.get_mcu_position()
+                trig_mcu_pos = self.extruder_stepper.stepper.get_mcu_position()
                 # Distance in steps (commanded frame) is trig - start of homing move
                 # We don't have the start position directly; approximate via last commanded 0 with our local kinematics:
                 # Use delta from current commanded to trigger pos as step delta
                 step_dist = self.extruder_stepper.stepper.get_step_dist()
                 # In Klipper, get_mcu_position() returns at current commanded pos; we can't read 'start' cleanly here.
                 # However, the Homing manager's trigger_mcu_pos is absolute; compute delta from current mcu pos as a proxy for short homing moves.
-                steps_moved = trig_mcu_pos - start_mcu_pos
+                steps_moved = abs(trig_mcu_pos - start_mcu_pos)
                 dist_mm = steps_moved * step_dist
                 self.logger.debug(f"AFC lane '{self.name}': endstop '{endstop_spec}' trigger after {dist_mm:.3f} mm (steps={steps_moved})")
-            except Exception:
+            except Exception as e:
+                self.logger.debug(f"Exception {e}")
                 pass
             self.logger.debug(f"Homed lane '{self.name}' to ENDSTOP='{endstop_spec}' at position {self._manual_axis_pos:.2f}mm (dt={(end_ts-start_ts):.3f}s)")
             return True
@@ -534,12 +587,15 @@ class AFCExtruderStepper(AFCLane):
             if "no trigger on" in msg:
                 if not self.printer.is_shutdown():
                     try:
-                        self.logger.debug(f"[{self.name}] Homing: {e}; continuing because homing_ignore_no_trigger is enabled")
+                        ffi_main, ffi_lib = chelper.get_ffi()
+                        self.logger.debug(f"[{self.name}] Homing: {e}; continuing because homing_ignore_no_trigger is enabled {ffi_lib.itersolve_get_commanded_pos(self.stepper_kinematics)}")
                     except Exception:
                         pass
                     return False
                 raise self.gcode.error(str(e))
             if ("communication timeout during homing" in msg) or ("endstop" in msg and "still triggered" in msg):
+                self.logger.info(f"{e}")
+                self.logger.info(f"{traceback.format_exc()}")
                 raise self.gcode.error(str(e))
             # Other MCU homing issues: surface message and re-raise as gcode error
             try:
@@ -549,7 +605,8 @@ class AFCExtruderStepper(AFCLane):
             raise self.gcode.error(str(e))
 
     # ------------------ Convenience homing helpers ------------------
-    def home_to(self, endstop_spec, distance=None, speed_mode=SpeedMode, triggered=True, check_trigger=True):
+    def home_to(self, endstop_spec:str, distance:Optional[int]=None, speed_mode:SpeedMode=SpeedMode,
+                triggered=True, check_trigger=True, assist_active=True):
         """
         Home towards an endstop relative to current position by distance (mm).
         If 'distance' is None, callers should prefer the typed helpers which pick a
@@ -574,7 +631,8 @@ class AFCExtruderStepper(AFCLane):
         target = float(self._manual_axis_pos + float(distance))
         self.logger.debug(f"Homing lane '{self.name}' to ENDSTOP='{endstop_spec}' at position {distance:.2f}mm")
         homed = self.do_homing_move(target, speed, accel, endstop_spec,
-                            triggered=triggered, check_trigger=check_trigger)
+                            triggered=triggered, check_trigger=check_trigger,
+                            assist_active=assist_active)
         self.sync_print_time()
         return homed
 
@@ -599,6 +657,7 @@ class AFCExtruderStepper(AFCLane):
         homing_move = gcmd.get_int('STOP_ON_ENDSTOP', 0)
         if homing_move:
             movepos = gcmd.get_float('MOVE')
+            final_pos = float(self._manual_axis_pos) + float(movepos)
             endstop_spec = gcmd.get('ENDSTOP', self.default_homing_endstop)
             self.do_homing_move(movepos, speed, accel,
                                 endstop_spec,

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -12,13 +12,18 @@ from kinematics import extruder
 from configfile import error
 from extras.force_move import calc_move_time
 
-from typing import Optional, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING, Dict
 
 try: from extras.AFC_utils import ERROR_STR
 except: raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".format(trace=traceback.format_exc()))
 
 try: from extras.AFC_lane import AFCLane, SpeedMode, AFCHomingPoints
 except: raise error(ERROR_STR.format(import_lib="AFC_lane", trace=traceback.format_exc()))
+
+if TYPE_CHECKING:
+    from toolhead import Toolhead
+    from stepper import PrinterStepper
+    from mcu import MCU_endstop
 
 
 LARGE_TIME_OFFSET = 99999.9
@@ -35,31 +40,25 @@ class AFCExtruderStepper(AFCLane):
         self.extruder_stepper   = extruder.ExtruderStepper(config)
         self.stepper_enable     = self.printer.lookup_object('stepper_enable')
 
-        # Homing-related configuration (optional)
-        # Choose which sensor to use by default when doing STOP_ON_ENDSTOP moves
-        # Allowed values: 'load', or a raw MCU pin string (e.g. '^AFC:TRG1')
+        # Homing-related configuration
         self.default_homing_endstop = config.get('homing_endstop', 'load')
-        # Optional overrides similar to manual_stepper
-        self.homing_velocity = config.getfloat('homing_velocity', None)
-        self.homing_accel = config.getfloat('homing_accel', None)
-        self._homing_accel = self.homing_accel # Should only be updated in do_homing_move so accel can be used in drip_move callback
-        self._manual_axis_pos = 0.0
+        self._homing_accel          = self.short_moves_accel # Should only be updated in do_homing_move so accel can be used in drip_move callback
+        self._manual_axis_pos       = 0.0
 
         # Optional explicit hub endstop pin override in stepper section
         self.hub_endstop = config.get('hub_endstop', None)
 
-        # Optional: allow declaring extra raw endstop pins that should be
-        # created at config time (comma-separated list)
-        self._extra_homing_pins = set(config.getlist('homing_endstop_pins', default="", sep=','))
+        self._extra_homing_pins = set(config.getlist('homing_endstop_pins', default="", sep=',')) # Additional homing endstops to add to stepper, comma-seperated list
         # Pre-create MCU endstops now so MCU config callbacks run before ready
-        self._endstops = {}
+        self._endstops: Dict[MCU_endstop,str] = {}
         self._init_endstops()
 
         # Register AFC_HOME mux command for this lane name
         stepper_name = config.get_name().split()[-1]
-        self.gcode.register_mux_command('AFC_HOME', 'STEPPER',
-                                        stepper_name, self.cmd_AFC_HOME,
-                                        desc=self.cmd_AFC_HOME_help)
+        self.function.register_mux_command(self.show_macros, "AFC_STEPPER_HOME", "STEPPER",
+                                           stepper_name, self.cmd_AFC_STEPPER_HOME,
+                                           description=self.cmd_AFC_STEPPER_HOME_help,
+                                           options=self.cmd_AFC_STEPPER_HOME_options)
 
         # Check for Klipper new motion queuing update
         self.motion_queuing = self.printer.load_object(config, "motion_queuing", None)
@@ -79,9 +78,6 @@ class AFCExtruderStepper(AFCLane):
             self.trapq_finalize_moves   = ffi_lib.trapq_finalize_moves
 
         self.assist_activate=False
-        # Track last homing event for synchronization with lane logic
-        self._last_home_endstop = None
-        self._last_home_time = 0.0
 
         # Current to use while printing, set to a lower current to reduce stepper heat when printing.
         # Defaults to global_print_current, if not specified current is not changed.
@@ -105,15 +101,26 @@ class AFCExtruderStepper(AFCLane):
             raise self.gcode.error(msg)
 
         self.tmc_load_current = self.tmc_driver.getfloat('run_current')
-    
-    def _submit_move( self, movetime, distance, speed, accel):
+
+    def _submit_move( self, movetime: float, distance: float, speed: float, accel: float) -> float:
+        """
+        Helper function for calculating moves and adding to trapq
+
+        :param movetime: Base time to start moves when adding to trapq
+        :param distance: Distance to move stepper
+        :param speed: Speed to use when calculating moves
+        :param accel: Acceleration to use when calculating moves
+
+        :return float: Returns total time move will take for specified distance at specified speed/accel
+        """
         self.extruder_stepper.stepper.set_position((0., 0., 0.))
         axis_r, accel_t, cruise_t, cruise_v = calc_move_time(distance, speed, accel)
         self.trapq_append(self.trapq, movetime, accel_t, cruise_t, accel_t,
                               0., 0., 0., axis_r, 0., 0., 0., cruise_v, accel)
         return accel_t + cruise_t + accel_t
 
-    def _move(self, distance, speed, accel, assist_active=False):
+    def _move(self, distance: float, speed: float, accel: float, assist_active: bool=False,
+              sync: bool=True):
         """
         Helper function to move the specified lane a given distance with specified speed and acceleration.
         This function calculates the movement parameters and commands the stepper motor
@@ -123,7 +130,7 @@ class AFCExtruderStepper(AFCLane):
         speed (float): The speed of the movement.
         accel (float): The acceleration of the movement.
         """
-        self.sync_print_time()
+        if sync: self.sync_print_time()
 
         with self.assist_move(speed, distance < 0, assist_active):
             # Code based off force_move.py manual_move function
@@ -132,7 +139,7 @@ class AFCExtruderStepper(AFCLane):
             prev_sk     = self.extruder_stepper.stepper.set_stepper_kinematics(self.stepper_kinematics)
             prev_trapq  = self.extruder_stepper.stepper.set_trapq(self.trapq)
             print_time = toolhead.get_last_move_time()
-            
+
             dwell_time = self._submit_move( print_time, distance, speed, accel)
             print_time += dwell_time
 
@@ -144,15 +151,16 @@ class AFCExtruderStepper(AFCLane):
             else:
                 self.motion_queuing.note_mcu_movequeue_activity(print_time)
 
-            toolhead.dwell( dwell_time )
-            toolhead.flush_step_generation()
+            if sync:
+                toolhead.dwell( dwell_time )
+                toolhead.flush_step_generation()
             self.extruder_stepper.stepper.set_trapq(prev_trapq)
             self.extruder_stepper.stepper.set_stepper_kinematics(prev_sk)
             if self.motion_queuing is not None:
                 self.motion_queuing.wipe_trapq(self.trapq)
-            toolhead.wait_moves()
+            if sync: toolhead.wait_moves()
 
-    def move(self, distance, speed, accel, assist_active=False):
+    def move(self, distance: float, speed: float, accel: float, assist_active=False):
         """
         Move the specified lane a given distance with specified speed and acceleration.
         This function calculates the movement parameters and commands the stepper motor
@@ -175,14 +183,6 @@ class AFCExtruderStepper(AFCLane):
             move_value = move_value * direction
 
             self._move(move_value, speed, accel, assist_active)
-    
-    # def move_to(self, distance: float, speed_mode: SpeedMode, endstop:str,
-    #             assist_active=True, use_homing=True):
-    #     if use_homing:
-    #         self.home_to(endstop, distance, speed_mode,
-    #                                     distance > 0, assist_active=assist_active)
-    #     else:
-    #         self.move_advanced(distance, speed_mode, assist_active )
 
     def do_enable(self, enable):
         """
@@ -266,27 +266,57 @@ class AFCExtruderStepper(AFCLane):
     # ------------------ ManualStepper compatibility shims ------------------
     # These wrappers allow using Klipper's homing flow with our existing stepper
     def flush_step_generation(self):
+        """
+        Only syncs print time, is needed for homing flow
+        """
         self.sync_print_time()
 
-    def get_position(self):
+    def get_position(self) -> list[float]:
+        """
+        Returns current steppers commanded position in xyze
+
+        :return list[float]: steppers commanded position, x index is steppers current position
+        """
         # 1D position along filament path
         return [self.extruder_stepper.stepper.get_commanded_position(), 0., 0., 0.]
 
-    def set_position(self, newpos, homing_axes=""):
+    def set_position(self, newpos=0, homing_axes=""):
+        """
+        Manually set current steppers position, always sets to zero regardless of whats
+        passed in. Needed for homing flow.
+
+        :param newpos: Position to set axis
+        :param homing_axis: Axis to set position
+        """
         self._manual_axis_pos = 0.0
 
-    def get_last_move_time(self):
+    def get_last_move_time(self) -> float:
+        """
+        Syncs print time and returns last commanded position time. Needed for homing flow.
+
+        :return float: Last commanded position time.
+        """
         self.sync_print_time()
         return self.next_cmd_time
 
     def dwell(self, delay):
+        """
+        Needed for homing flow, done in the same way as manual_stepper.py
+        """
         # Advance internal time to satisfy homing scheduler
         self.next_cmd_time += max(0., delay)
-    
-    def _drip_update_time(self, toolhead, max_time, drip_completion):
+
+    def _drip_update_time(self, toolhead: Toolhead, max_time: float, drip_completion) -> None:
         """
+        Helper function for mimicking how klipper toolhead does drip moves
+
         Same as mainline klipper that using motion queue, this is only called if motion
         queue object is not found
+
+        :param toolhead: Klipper toolhead object
+        :param max_time: Max time move should take to home to endstop, break out once
+                         this time is reached
+        :param drip_completion: Endstop callback to test if endstop has been reached or not
         """
         toolhead.special_queuing_state = "Drip"
         toolhead.need_check_pause = self.reactor.NEVER
@@ -294,39 +324,45 @@ class AFCExtruderStepper(AFCLane):
         toolhead.do_kick_flush_timer = False
         toolhead.lookahead.set_flush_time(BUFFER_TIME_HIGH)
         toolhead.check_stall_time = 0.
-        flush_delay = DRIP_TIME + STEPCOMPRESS_FLUSH_TIME + toolhead.kin_flush_delay
+        flush_delay: float = DRIP_TIME + STEPCOMPRESS_FLUSH_TIME + toolhead.kin_flush_delay
 
         while toolhead.print_time < max_time:
             if drip_completion.test():
                 break
-            curtime = self.reactor.monotonic()
-            est_print_time = toolhead.mcu.estimated_print_time(curtime)
-            wait_time = toolhead.print_time - est_print_time - flush_delay
+            curtime: float = self.reactor.monotonic()
+            est_print_time: float = toolhead.mcu.estimated_print_time(curtime)
+            wait_time: float = toolhead.print_time - est_print_time - flush_delay
             if wait_time > 0.:
                 drip_completion.wait(curtime + wait_time)
                 continue
             npt = min(toolhead.print_time + DRIP_SEGMENT_TIME, max_time)
             toolhead.note_mcu_movequeue_activity(npt + toolhead.kin_flush_delay)
             toolhead._advance_move_time(npt)
-        
 
-    def drip_move(self, newpos, speed, drip_completion):
+    def drip_move(self, newpos: float, speed: float, drip_completion):
+        """
+        Drip move callback, needed for homing flow. Creates and add moves to trapq then
+        waits for homing to complete or exits once max time is hit.
+
+        :param newpos: Position to move when homing to endstop
+        :param speed: Speed to move stepper
+        :pram drip_completion: Endstop callback to test if move has completed or not
+        """
         # Queue the homing move quickly; do not block or dwell here. Homing
         # controller will wait for the endstop and handle final positioning.
         self.sync_print_time()
         target = float(newpos[0])
         delta = target - self._manual_axis_pos
-        v = self.homing_velocity if self.homing_velocity is not None else speed
 
         start_time = self.next_cmd_time
 
         prev_sk     = self.extruder_stepper.stepper.set_stepper_kinematics(self.stepper_kinematics)
         prev_trapq  = self.extruder_stepper.stepper.set_trapq(self.trapq)
 
-        dwell_time = self._submit_move( start_time, delta, v, self._homing_accel)
+        dwell_time = self._submit_move( start_time, delta, speed, self._homing_accel)
         max_time = start_time + dwell_time
 
-        toolhead = self.printer.lookup_object('toolhead')
+        toolhead: Toolhead = self.printer.lookup_object('toolhead')
 
         # TODO: add a check for toolhead.drip_update_time and test with https://github.com/KalicoCrew/kalico/pull/825 PR
         if self.motion_queuing is None:
@@ -345,24 +381,27 @@ class AFCExtruderStepper(AFCLane):
 
         self.sync_print_time()
 
-    def get_kinematics(self):
+    def get_kinematics(self) -> AFCExtruderStepper:
         # Homing expects an object with kinematics-like API; we self-provide
         return self
 
-    def get_steppers(self):
+    def get_steppers(self) -> list[PrinterStepper]:
         # Return underlying single stepper for homing code
         return [self.extruder_stepper.stepper]
 
-    def calc_position(self, stepper_positions):
+    def calc_position(self, stepper_positions) -> list[float]:
         # Map stepper positions into kinematic position; unused for filament homing
         return [stepper_positions[self.extruder_stepper.stepper.get_name()], 0., 0.]
 
     # ------------------ Endstop plumbing ------------------
-    def _resolve_endstop_pin(self, endstop_spec):
+    def _resolve_endstop_pin(self, endstop_spec) -> tuple[MCU_endstop, str]:
         """
         Resolve an endstop spec into an MCU endstop and a human name.
         - endstop_spec can be 'load', 'hub', 'tool'|'tool_start'|'tool_end',
           'buffer'|'buffer_advance'|'buffer_trailing', or a raw MCU pin string.
+
+        :param endstop_spec: Name of endstop to search for in local mapping
+        :return tuple: Returns MCU_endstop and endstop name found in local dictionary
         """
         # Normalize aliases
         alias_map = {
@@ -378,7 +417,9 @@ class AFCExtruderStepper(AFCLane):
         return (mcu_endstop, name)
 
     def _init_endstops(self):
-        """Create and register endstops at config time so MCU callbacks run."""
+        """
+        Create and register endstops at config time so MCU callbacks run.
+        """
         printer = self.printer
         ppins = printer.lookup_object('pins')
         qes = printer.load_object(self._config, 'query_endstops')
@@ -432,8 +473,14 @@ class AFCExtruderStepper(AFCLane):
         self._add_endstop('buffer_advance', buffer_adv_pin, 'buffer_adv')
         self._add_endstop('buffer_trailing', buffer_trail_pin, 'buffer_trailing')
 
-    def _inherit_from_unit(self, target_key):
-        """Return value (e.g., 'hub', 'extruder', etc.) from the unit section matching this object's unit."""
+    def _inherit_from_unit(self, target_key: str) -> Optional[str]:
+        """
+        Lookup and return value (e.g., 'hub', 'extruder', etc.) from the unit section
+        matching this object's unit.
+
+        :param target_key: Key to lookup in unit config section
+        :return str: If key is found in unit, returns config value
+        """
         unit = getattr(self, 'unit', None)
         if not unit:
             return None
@@ -462,8 +509,16 @@ class AFCExtruderStepper(AFCLane):
 
         return None
 
-    def _get_section_value(self, section_prefix, name, key, default=None):
-        """Safely fetch a key from a named section like 'AFC_extruder my_extruder'."""
+    def _get_section_value(self, section_prefix: str, name: str, key: str, default=None) -> Optional[str]:
+        """
+        Safely fetch a variable key from a named section like 'AFC_extruder my_extruder'.
+
+        :param section_prefix: Config section prefix, eg. AFC_extruder, AFC_hub, etc
+        :param name: Config section name
+        :param key: Config section variable name
+        :param default: Default value to use if config variable is not found
+        :return str: If variable found in config section, returns variable value
+        """
         if not name:
             return default
         section = f"{section_prefix} {name}"
@@ -474,8 +529,14 @@ class AFCExtruderStepper(AFCLane):
             self.logger.debug(f"Missing or invalid section '{section}': {e}")
             return default
 
-    def _add_endstop(self, key, pin, suffix):
-        """Helper to create/register an endstop and bind it to the drive stepper."""
+    def _add_endstop(self, key: str, pin: str, suffix: str):
+        """
+        Helper to create/register an endstop and bind it to the drive stepper.
+
+        :param key: Endstop key name to register for stepper
+        :param pin: Pin to register as endstop for stepper
+        :param suffix: String to append at end of endstop key
+        """
         if pin is None:
             self.logger.info(f"Pin for {key} is none for {self.name}")
             return
@@ -488,7 +549,7 @@ class AFCExtruderStepper(AFCLane):
             self.logger.info(f"Error parsing pin for {key} is none for {self.name}")
             self.logger.info(f"{e}")
             return
-        
+
         single_key_aliases = {'hub', 'tool_start', 'tool_end', 'buffer_advance', 'buffer_trailing'}
         if key in single_key_aliases:
             name = '{}'.format(suffix)
@@ -508,17 +569,21 @@ class AFCExtruderStepper(AFCLane):
         self.logger.debug(f"{self.name} adding endstop {key}:{name}:{pin}") # TODO:remove once fully tested on toolchanger
         self._endstops[key] = (mcu_endstop, name)
 
-    def handle_unit_connect(self, unit_obj):
-        """Extend AFCLane hook. Hub endstop is already registered at config time."""
-        super().handle_unit_connect(unit_obj)
+    # def handle_unit_connect(self, unit_obj):
+    #     """Extend AFCLane hook. Hub endstop is already registered at config time."""
+    #     super().handle_unit_connect(unit_obj)
 
     def do_homing_move(self, movepos: int, speed: int, accel: int, endstop_spec:str,
-                       triggered=True, check_trigger=True, assist_active=True):
-        """Perform a homing-like move using the specified endstop.
-        movepos: target absolute position along the filament axis
-        speed/accel: motion params (fallbacks applied if None)
-        endstop_spec: 'load' | raw pin string
-        triggered/check_trigger: same semantics as manual_stepper
+                       triggered=True, check_trigger=True, assist_active=True) -> tuple[bool, float]:
+        """
+        Perform's a homing move using the specified endstop, speed/accel and distance.
+
+        :param movepos: target absolute position along the filament axis
+        :param speed/accel: motion params (fallbacks applied if None)
+        :param endstop_spec: 'load' | raw pin string
+        :param triggered/check_trigger: same semantics as manual_stepper
+        :return tuple: When homing is success returns True and distance moved.
+                       If homing failed returns False and move pos as distance moved.
         """
         reactor = self.printer.get_reactor()
         start_ts = reactor.monotonic()
@@ -528,17 +593,15 @@ class AFCExtruderStepper(AFCLane):
             self.logger.debug(f"[AFC_stepper:{self.name}] Homing start endstop={endstop_spec} movepos={movepos} speed={speed} accel={accel}")
         except Exception:
             pass
-        if accel is None:
-            accel = self.homing_accel if self.homing_accel else (self.short_moves_accel or 50.)
-        if speed is None:
-            speed = self.homing_velocity if self.homing_velocity else (self.short_moves_speed or 50.)
-        
-         # Setting private variable so accel can be used in drip_move callback
+        if accel is None: accel = self.short_moves_accel
+        if speed is None: speed = self.short_moves_speed
+
+        # Setting private variable so accel can be used in drip_move callback
         self._homing_accel = accel
         # Avoid zero-distance drip sequences which can confuse stepcompress
         if movepos == self._manual_axis_pos:
             self.logger.debug(f"AFC stepper '{self.name}' homing target equals current position; skipping move")
-            return
+            return False, 0.
         pos = [movepos, 0., 0., 0.]
 
         phoming = self.printer.lookup_object('homing')
@@ -547,7 +610,6 @@ class AFCExtruderStepper(AFCLane):
         try:
             endstop = self._resolve_endstop_pin(endstop_spec)
         except Exception as e_resolve:
-            # TODO Fallback
             self._info(f"ENDSTOP '{endstop_spec}' could not be resolved ({e_resolve}); using software homing.")
             raise self.gcode.error(f"ENDSTOP '{endstop_spec}' could not be resolved ({e_resolve})")
 
@@ -559,10 +621,8 @@ class AFCExtruderStepper(AFCLane):
             with self.assist_move(speed, rewind, assist_active=assist_active):
                 phoming.manual_home(self, [endstop], pos, speed, triggered, check_trigger)
             end_ts = reactor.monotonic()
-            self._last_home_endstop = endstop_spec
-            self._last_home_time = end_ts
-            # Log distance at trigger using homing trigger positions
             try:
+                # Log distance at trigger using homing trigger positions
                 trig_mcu_pos = self.extruder_stepper.stepper.get_mcu_position()
                 # Distance in steps (commanded frame) is trig - start of homing move
                 # We don't have the start position directly; approximate via last commanded 0 with our local kinematics:
@@ -579,12 +639,11 @@ class AFCExtruderStepper(AFCLane):
             self.logger.debug(f"Homed lane '{self.name}' to ENDSTOP='{endstop_spec}' at position {self._manual_axis_pos:.2f}mm (dt={(end_ts-start_ts):.3f}s)")
             return True, dist_mm
         except Exception as e:
-            # TODO Fallback
             msg = str(e).lower()
             if "no trigger on" in msg:
                 if not self.printer.is_shutdown():
                     try:
-                        ffi_main, ffi_lib = chelper.get_ffi()
+                        _, ffi_lib = chelper.get_ffi()
                         self.logger.debug(f"[{self.name}] Homing: {e}; continuing because homing_ignore_no_trigger is enabled {ffi_lib.itersolve_get_commanded_pos(self.stepper_kinematics)}")
                     except Exception:
                         pass
@@ -592,7 +651,7 @@ class AFCExtruderStepper(AFCLane):
                 raise self.gcode.error(str(e))
             if ("communication timeout during homing" in msg) or ("endstop" in msg and "still triggered" in msg):
                 self.logger.info(f"{e}")
-                self.logger.info(f"{traceback.format_exc()}")
+                self.logger.debug(f"{traceback.format_exc()}")
                 raise self.gcode.error(str(e))
             # Other MCU homing issues: surface message and re-raise as gcode error
             try:
@@ -602,23 +661,25 @@ class AFCExtruderStepper(AFCLane):
             raise self.gcode.error(str(e))
 
     # ------------------ Convenience homing helpers ------------------
-    def home_to(self, endstop_spec:AFCHomingPoints, distance:Optional[int], speed_mode: SpeedMode,
-                triggered=True, check_trigger=True, assist_active=True):
+    def home_to(self, endstop_spec:AFCHomingPoints, distance:Optional[float], speed_mode: SpeedMode,
+                triggered=True, check_trigger=True, assist_active=True) -> tuple[bool, float]:
         """
         Home towards an endstop relative to current position by distance (mm).
         If 'distance' is None, callers should prefer the typed helpers which pick a
         sensible default direction and magnitude for the chosen endstop.
 
-        Parameters:
-        endstop_spec (str): The target endstop to home to. Can be a raw pin identifier or a logical
-            name such as 'load', 'toolhead', etc.
-        distance (float, optional): Relative distance to move toward the endstop in millimeters.
-            Required unless using a helper method.
-        speed_mode (SpeedMode, optional): Enum or configuration selecting the speed and acceleration
-            profile to use for this move. Defaults to `SpeedMode`.
-        triggered (bool, optional): If True, movement stops when the endstop triggers. Defaults to True.
-        check_trigger (bool, optional): If True, verify that the endstop is actually triggered at the
-            end of the move. Defaults to True.
+        :param endstop_spec: The target endstop to home to. Can be a raw pin identifier
+                             or a logical name such as 'load', 'toolhead', etc.
+        :param distance: Relative distance to move toward the endstop in millimeters.
+                         Required unless using a helper method.
+        :param speed_mode: Enum or configuration selecting the speed and acceleration
+                           profile to use for this move. Defaults to `SpeedMode`.
+        :param triggered: If True, movement stops when the endstop triggers. Defaults to True.
+        :param check_trigger: If True, verify that the endstop is actually triggered at the
+                              end of the move. Defaults to True.
+        :return tuple: bool indicated if homing was successful or not, float indicated movement
+                       weather homing was successful or not. When not successful distance
+                       will equal max move distance.
         """
         speed, accel = self.get_speed_accel(speed_mode)
 
@@ -636,32 +697,60 @@ class AFCExtruderStepper(AFCLane):
                                                        check_trigger=check_trigger,
                                                        assist_active=assist_active)
         except Exception:
-            # TODO: figure out what exceptions to catch here
-            self.logger.info(f"{traceback.format_exc()}")
+            msg = f"Error occurred when trying to home to {endstop_spec}, PAUSING!"
+            self.afc.error.AFC_error(msg, self.afc.function.in_print())
+            self.logger.debug(f"{traceback.format_exc()}")
         self.sync_print_time()
         return homed, move_distance
 
-    # ------------------ Command shim (AFC_HOME) ------------------
-    cmd_AFC_HOME_help = "Command a manually controlled stepper (AFC shim)"
-    def cmd_AFC_HOME(self, gcmd):
+    cmd_AFC_STEPPER_HOME_help = "Command a manually home stepper to specified endstop"
+    cmd_AFC_STEPPER_HOME_options = {"ENABLE": {"type": "int", "default": 1},
+                            "SPEED": {"type": "float", "default": 100},
+                            "ACCEL": {"type": "float", "default": 100},
+                            "STOP_ON_ENDSTOP": {"type": "int", "default": 1},
+                            "DIST": {"type": "float", "default": 100},
+                            "ENDSTOP": {"type": "string", "default": "load"},
+                            "SYNC": {"type": "int", "default": 1}}
+    def cmd_AFC_STEPPER_HOME(self, gcmd):
         """
-        Shim to mirror Klipper's AFC_HOME for AFC lanes, including STOP_ON_ENDSTOP.
-        Usage examples:
-          AFC_HOME STEPPER={name} ENABLE=1
-          AFC_HOME STEPPER={name} MOVE=10 SPEED=5
-          AFC_HOME STEPPER={name} STOP_ON_ENDSTOP=1 MOVE=200 SPEED=5 [ENDSTOP=load|^AFC:TRG1]
+        Macro to manually home/move stepper to specified endstop, provided distance needs
+        to be large so that filament can reach specified endstop. If distance is not large enough
+        then stepped will only be moved by distance amount.
+
+        Optional Values
+        ----
+        ENABLE: Use the ENABLE parameter to enable/disable the stepper.
+        SPEED: If SPEED is specified then the given value will be used instead of the default specified in the config file.
+        ACCEL: If SPEED is specified then the given value will be used instead of the default specified in the config file.
+        STOP_ON_ENDSTOP: If STOP_ON_ENDSTOP=1 is specified then the move will end early should the endstop report as
+        triggered (use STOP_ON_ENDSTOP=2 to complete the move without error even if the endstop does not trigger,
+        use -1 or -2 to stop when the endstop reports not triggered).
+        DIST: Distance to move stepper
+        ENDSTOP: Endstop to try and home to, default names to use are:
+            load, hub, tool_start, buffer_adv, buffer_trailing
+        SYNC: Only valid when not using STOP_ON_ENDSTOP, setting sync 0 will allow the stepper
+        to be moved in paralled with other stepper movement.
+
+        Usage
+        ----
+        AFC_STEPPER_HOME STEPPER=<lane_name> DIST=<move distance> SPEED=<speed> ACCEL=<acceleration> STOP_ON_ENDSTOP=<-2,-1,0,1,2> ENDSTOP=<endstop name> SYNC=<0/1>
+
+        Example
+        ----
+        ```
+        AFC_STEPPER_HOME STEPPER=lane1 ENABLE=1
+        AFC_STEPPER_HOME STEPPER=lane1 MOVE=10 SPEED=5
+        AFC_STEPPER_HOME STEPPER=lane1 STOP_ON_ENDSTOP=1 DIST=200 SPEED=5 ENDSTOP=hub]
+        ```
         """
         enable = gcmd.get_int('ENABLE', None)
         if enable is not None:
             self.do_enable(enable)
-        setpos = gcmd.get_float('SET_POSITION', None)
-        if setpos is not None:
-            self.set_position([setpos, 0., 0., 0.])
         speed = gcmd.get_float('SPEED', self.short_moves_speed or 5., above=0.)
         accel = gcmd.get_float('ACCEL', self.short_moves_accel or 0., minval=0.)
         homing_move = gcmd.get_int('STOP_ON_ENDSTOP', 0)
         if homing_move:
-            movepos = gcmd.get_float('MOVE')
+            movepos = gcmd.get_float('DIST')
             endstop_spec = gcmd.get('ENDSTOP', self.default_homing_endstop)
             self.do_homing_move(movepos, speed, accel,
                                 endstop_spec,

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -547,7 +547,6 @@ class AFCExtruderStepper(AFCLane):
             self.logger.debug(f"[AFC_stepper:{self.name}] Homing start endstop={endstop_spec} movepos={movepos} speed={speed} accel={accel} {self._manual_axis_pos} {self.extruder_stepper.stepper.get_commanded_position()}")
         except Exception:
             pass
-        self._hom
         if accel is None:
             accel = self.homing_accel if self.homing_accel else (self.short_moves_accel or 50.)
         if speed is None:
@@ -649,6 +648,7 @@ class AFCExtruderStepper(AFCLane):
         # Compute an absolute target along our 1D axis
         target = float(self._manual_axis_pos + float(distance))
         self.logger.debug(f"Homing lane '{self.name}' to ENDSTOP='{endstop_spec}' at position {distance:.2f}mm")
+        homed = False
         try:
             homed = self.do_homing_move(target, speed, accel, endstop_spec,
                                 triggered=triggered, check_trigger=check_trigger,

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -15,7 +15,9 @@ from extras.force_move import calc_move_time
 from typing import Optional, TYPE_CHECKING, Dict
 
 try: from extras.AFC_utils import ERROR_STR
-except: raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".format(trace=traceback.format_exc()))
+except:
+    raise_string = "Error when trying to import AFC_utils.ERROR_STR\n{trace}".format(trace=traceback.format_exc())
+    raise error(raise_string)
 
 try: from extras.AFC_lane import AFCLane, SpeedMode, AFCHomingPoints
 except: raise error(ERROR_STR.format(import_lib="AFC_lane", trace=traceback.format_exc()))
@@ -50,7 +52,7 @@ class AFCExtruderStepper(AFCLane):
 
         self._extra_homing_pins = set(config.getlist('homing_endstop_pins', default="", sep=',')) # Additional homing endstops to add to stepper, comma-seperated list
         # Pre-create MCU endstops now so MCU config callbacks run before ready
-        self._endstops: Dict[MCU_endstop,str] = {}
+        self._endstops: Dict[str, tuple[MCU_endstop,str]] = {}
         self._init_endstops()
 
         # Register AFC_HOME mux command for this lane name
@@ -339,7 +341,7 @@ class AFCExtruderStepper(AFCLane):
             toolhead.note_mcu_movequeue_activity(npt + toolhead.kin_flush_delay)
             toolhead._advance_move_time(npt)
 
-    def drip_move(self, newpos: float, speed: float, drip_completion):
+    def drip_move(self, newpos: list[float], speed: float, drip_completion):
         """
         Drip move callback, needed for homing flow. Creates and add moves to trapq then
         waits for homing to complete or exits once max time is hit.
@@ -412,8 +414,10 @@ class AFCExtruderStepper(AFCLane):
         # Look up a pre-created endstop; do not create at runtime (MCU cb won't run)
         mcu_endstop, name = self._endstops.get(key, (None, None))
         if mcu_endstop is None:
-            raise error("Unknown ENDSTOP '{}' for lane '{}'. Declare it in [AFC_stepper {}] using 'homing_endstop_pins: {}' or use ENDSTOP=load/hub/tool/buffer".format(
-                endstop_spec, self.name, self.name, endstop_spec))
+            raise_string = f"Unknown ENDSTOP '{endstop_spec}' for lane '{self.name}'. "\
+                           f"Declare it in [AFC_stepper {self.name}] using 'homing_endstop_pins: "\
+                           f"{endstop_spec}' or use ENDSTOP=load/hub/tool/buffer"
+            raise error(raise_string)
         return (mcu_endstop, name)
 
     def _init_endstops(self):
@@ -611,7 +615,8 @@ class AFCExtruderStepper(AFCLane):
             endstop = self._resolve_endstop_pin(endstop_spec)
         except Exception as e_resolve:
             self._info(f"ENDSTOP '{endstop_spec}' could not be resolved ({e_resolve}); using software homing.")
-            raise self.gcode.error(f"ENDSTOP '{endstop_spec}' could not be resolved ({e_resolve})")
+            raise_string = f"ENDSTOP '{endstop_spec}' could not be resolved ({e_resolve})"
+            raise self.gcode.error(raise_string)
 
         # Try MCU-based homing first
         # Start/stop assist exactly with homing lifetime
@@ -722,12 +727,12 @@ class AFCExtruderStepper(AFCLane):
         ----
         ENABLE - Use the ENABLE parameter to enable/disable the stepper.<br>
         SPEED - If SPEED is specified then the given value will be used instead of the default specified in the config file.<br>
-        ACCEL - If SPEED is specified then the given value will be used instead of the default specified in the config file.<br>
+        ACCEL - If ACCEL is specified then the given value will be used instead of the default specified in the config file.<br>
         STOP_ON_ENDSTOP - If STOP_ON_ENDSTOP=1 is specified then the move will end early should the endstop report as
         triggered (use STOP_ON_ENDSTOP=2 to complete the move without error even if the endstop does not trigger,
         use -1 or -2 to stop when the endstop reports not triggered).<br>
         DIST - Distance to move stepper<br>
-        ENDSTOP - Endstop to try and home to, default names to use are: load, hub, tool_start, buffer_adv, buffer_trailing<br>
+        ENDSTOP - Endstop to try and home to, default names to use are: load, hub, tool_start, buffer_advance, buffer_trailing<br>
         SYNC - Only valid when not using STOP_ON_ENDSTOP, setting sync 0 will allow the stepper
         to be moved in paralled with other stepper movement.
 

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -56,6 +56,7 @@ class afcUnit:
         self.short_moves_accel           = config.getfloat("short_moves_accel", self.afc.short_moves_accel) # Acceleration in mm/s squared when doing short moves. Setting value here overrides values set in AFC.cfg file
         self.short_move_dis              = config.getfloat("short_move_dis", self.afc.short_move_dis)       # Move distance in mm for failsafe moves. Setting value here overrides values set in AFC.cfg file
         self.max_move_dis                = config.getfloat("max_move_dis", self.afc.max_move_dis)            # Maximum distance to move filament. AFC breaks filament moves over this number into multiple moves. Useful to lower this number if running into timer too close errors when doing long filament moves. Setting value here overrides values set in AFC.cfg file
+        self.homing_overshoot            = config.getfloat("homing_overshoot", 50)                           # Amount to add to homing distance so that distance is long enough to actually hit endstop
         self.debug                       = config.getboolean("debug",            False)                      # Turns on/off debug messages to console
         self.rev_long_moves_speed_factor = config.getfloat("rev_long_moves_speed_factor", self.afc.rev_long_moves_speed_factor)
 

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -59,6 +59,7 @@ class afcUnit:
         self.homing_overshoot            = config.getfloat("homing_overshoot", 50)                           # Amount to add to homing distance so that distance is long enough to actually hit endstop
         self.debug                       = config.getboolean("debug",            False)                      # Turns on/off debug messages to console
         self.rev_long_moves_speed_factor = config.getfloat("rev_long_moves_speed_factor", self.afc.rev_long_moves_speed_factor)
+        self.extruder_clear_dis          = config.getfloat("extruder_clear_dis", 50)                        # Amount to move to clear extruder gears when ejecting filament
 
         # Espooler defines
         # Time in seconds to wait between breaking n20 motors(nSleep/FWD/RWD all 1) and then releasing the break to allow coasting. Setting value here overrides values set in AFC.cfg file

--- a/templates/AFC_HTLF_1-ERB.cfg
+++ b/templates/AFC_HTLF_1-ERB.cfg
@@ -84,8 +84,8 @@ load: ^!ERB:LOAD4
 
 [AFC_hub HTLF_1]
 afc_bowden_length: 1990.0      # Length of the Bowden tube from the hub to the toolhead sensor in mm.
-move_dis: 60                   # Distance to move the filament within the hub in mm.
-hub_clear_move_dis: 55
+move_dis: 75                   # Distance to move the filament within the hub in mm.
+hub_clear_move_dis: 65
 switch_pin: ^ERB:HUB
 
 [AFC_led AFC_Indicator_HTLF_1]

--- a/templates/AFC_HTLF_1-MMB.cfg
+++ b/templates/AFC_HTLF_1-MMB.cfg
@@ -84,8 +84,8 @@ load: !MMB_HTLF:LOAD4
 
 [AFC_hub HTLF_1]
 afc_bowden_length: 1750        # Length of the Bowden tube from the hub to the toolhead sensor in mm.
-move_dis: 60                   # Distance to move the filament within the hub in mm.
-hub_clear_move_dis: 55
+move_dis: 75                   # Distance to move the filament within the hub in mm.
+hub_clear_move_dis: 65
 switch_pin: ^MMB_HTLF:HUB
 
 [AFC_led AFC_Indicator_HTLF_1]

--- a/templates/AFC_Hardware-MMB.cfg
+++ b/templates/AFC_Hardware-MMB.cfg
@@ -119,8 +119,8 @@ tool_load_speed: 25             # Load speed in mm/s. Default is 25mm/s.
 [AFC_hub Turtle_1]
 switch_pin: ^AFC:HUB            # Pin for the hub switch
 afc_bowden_length: 940          # Length of the Bowden tube from the hub to the toolhead sensor in mm.
-move_dis: 50                    # Distance to move the filament within the hub in mm.
-#hub_clear_move_dis: 25         # Distance after hub switch becomes fast to retract to insure hub is clear
+move_dis: 75                    # Distance to move the filament within the hub in mm.
+#hub_clear_move_dis: 65         # Distance after hub switch becomes fast to retract to insure hub is clear
 cut: False                      # Hub has Cutter
 
 #--=================================================================================--

--- a/templates/AFC_Pro_Turtle_1.cfg
+++ b/templates/AFC_Pro_Turtle_1.cfg
@@ -216,8 +216,8 @@ sense_resistor: 0.110
 [AFC_hub Turtle_1]
 switch_pin: ^Turtle_1:HUB   # Pin for the hub switch
 afc_bowden_length: 1725     # Length of the Bowden tube from the hub to the toolhead sensor in mm.
-move_dis: 50                # Distance to move the filament within the hub in mm.
-#hub_clear_move_dis: 25     # Distance after hub switch becomes fast to retract to insure hub is clear
+move_dis: 75                # Distance to move the filament within the hub in mm.
+#hub_clear_move_dis: 65     # Distance after hub switch becomes fast to retract to insure hub is clear
 cut: False                  # Hub cutter installed (e.g. Snappy)
 
 #--=================================================================================--#

--- a/templates/AFC_QuattroBox_14.cfg
+++ b/templates/AFC_QuattroBox_14.cfg
@@ -125,9 +125,9 @@ sense_resistor: 0.110
 
 [AFC_hub QuattroBox_Hub]
 afc_bowden_length: 1145.0
-move_dis: 50                # Distance to move the filament within the hub in mm.
+move_dis: 75                # Distance to move the filament within the hub in mm.
 cut: False                  # Hub has Cutter
-hub_clear_move_dis: 55
+hub_clear_move_dis: 65
 
 #--=================================================================================--#
 ######### Hub Cut #####################################################################

--- a/templates/AFC_QuattroBox_17.cfg
+++ b/templates/AFC_QuattroBox_17.cfg
@@ -121,9 +121,9 @@ sense_resistor: 0.110
 
 [AFC_hub QuattroBox_Hub]
 afc_bowden_length: 1110.0 
-move_dis: 50                # Distance to move the filament within the hub in mm.
+move_dis: 75                # Distance to move the filament within the hub in mm.
 cut: False                  # Hub has Cutter
-hub_clear_move_dis: 30
+hub_clear_move_dis: 65
 
 #--=================================================================================--#
 ######### Hub Cut #####################################################################

--- a/templates/AFC_Turtle_1.cfg
+++ b/templates/AFC_Turtle_1.cfg
@@ -122,8 +122,8 @@ sense_resistor: 0.110
 [AFC_hub Turtle_1]
 switch_pin: ^Turtle_1:HUB   # Pin for the hub switch
 afc_bowden_length: 1725     # Length of the Bowden tube from the hub to the toolhead sensor in mm.
-move_dis: 50                # Distance to move the filament within the hub in mm.
-#hub_clear_move_dis: 25     # Distance after hub switch becomes fast to retract to insure hub is clear
+move_dis: 75                # Distance to move the filament within the hub in mm.
+#hub_clear_move_dis: 65     # Distance after hub switch becomes fast to retract to insure hub is clear
 cut: False                  # Hub cutter installed (e.g. Snappy)
 
 #--=================================================================================--#


### PR DESCRIPTION
## Major Changes in this PR
- Introduce endstop-driven filament moves and optional homing behavior across AFC by replacing many incremental `move`/`move_advanced` calls with `move_to`, adding three homing config flags, and improving type annotations and calibration flows.
- Added new macro `AFC_STEPPER_HOME`
- Updated all calibration to use homing moves at necessary steps.

AT-Documentation [PR](https://github.com/ArmoredTurtle/AT-Documentation/pull/157)

@weemantella 
## Notes to Code Reviewers

## How the changes in this PR are tested
- Tested all loading/unloading/ejecting and calibration routines

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.