### PR TITLE
Update klipper restart warning message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-02-09]
+### Added
+- The `update-afc.sh` and `install-afc.sh` script will now show a warning if it is unable to restart Klipper when either upgrading or installing the 
+software. 
 ## [2026-02-05]
 ### Added:
 - User can now set an AFC_POST_PREP macro which will automatically run immediately after a new spool is loaded into a lane. Macro is also configurable by adding a `post_prep_macro` variable to AFC_stepper/AFC_lane or in AFC Units (AFC_BoxTurtle, AFC_HTLF, etc).

--- a/include/utils.sh
+++ b/include/utils.sh
@@ -148,7 +148,7 @@ restart_klipper() {
   if query_printer_status; then
     restart_service klipper
   else
-    print_msg WARNING "We could not determine the state of your printer. Please manually restart the klipper service to apply changes."
+    print_msg WARNING "Your printer is not idle/ready, or its status could not be confirmed. Automatic Klipper restart has been skipped; please restart the Klipper service manually once the printer is idle."
   fi
 }
 

--- a/include/utils.sh
+++ b/include/utils.sh
@@ -147,6 +147,8 @@ restart_service() {
 restart_klipper() {
   if query_printer_status; then
     restart_service klipper
+  else
+    print_msg WARNING "We could not determine the state of your printer. Please manually restart the klipper service to apply changes."
   fi
 }
 


### PR DESCRIPTION
## Major Changes in this PR

This pull request adds a user-friendly warning message to the `restart_klipper()` function in `include/utils.sh`. If the printer status cannot be determined, the script now instructs the user to manually restart the Klipper service to apply changes.

## Notes to Code Reviewers

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.