### PR TITLE
Z Axis cutting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2026-03-11]
 ### Update
 - Updated the Cut.cfg macro to support cut locations with axes configurations other than XY. New configuration variables were added for individual axis. The behavior of `pin_loc_xy` remains unchanged. New axis-specific variables were added to avoid pin/toolhead collisions. The behavior of `safe_margin_xy` did change slightly and the Y coordinate is now used when calculating the safe coordinate for the move. An option has been added to skip the post-cut safe move for configurations where the next move is known to be safe (such as a move to purge or wipe.)
+- Updated the Cut.cfg macro to support cut locations with broader axis configurations:
+  - Added per-axis configuration variables (`pin_loc_x`, `pin_loc_y`, `pin_loc_z`) to support axis combinations beyond XY (e.g., XZ, YZ, XYZ). The behavior of `pin_loc_xy` remains unchanged.
+  - **Breaking change**: `safe_margin_xy` now calculates the safe Y-coordinate using the Y-axis midpoint (`max_y/2`) instead of the X-axis midpoint, improving collision avoidance for diverse printer geometries.
+  - Added `safe_move_first` option to specify which axes to move in first when doing the safe move.
+  - Added `post_cut_safe_move` option to skip the post-cut safe move when the next move is already known to be safe (e.g., moves to purge or wipe locations).
 
 ## [2026-03-07]
 ### Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,12 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2026-03-11]
 ### Update
-- Updated the Cut.cfg macro to support cut locations with axes configurations other than XY.  New configuration
-variables were added for individual axis.  The behavior of `pin_loc_xy` remains unchainged. New axis specific
-variables were added to avoid pin/toolhead collisions.  The behavior of `safe_margin_xy` did change slightly
-and the Y coordinate is now used when calculating the safe coordinate for the move.  An option has been added 
-to skip the post-cut safe move for configurations where the next move is known to be safe (such as a move
-to purge or wipe.)
+- Updated the Cut.cfg macro to support cut locations with axes configurations other than XY. New configuration variables were added for individual axis. The behavior of `pin_loc_xy` remains unchanged. New axis-specific variables were added to avoid pin/toolhead collisions. The behavior of `safe_margin_xy` did change slightly and the Y coordinate is now used when calculating the safe coordinate for the move. An option has been added to skip the post-cut safe move for configurations where the next move is known to be safe (such as a move to purge or wipe.)
 
 ## [2026-03-07]
 ### Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Toolchanger: Added `NEW_EXTRUDER_TEMP` parameter to Tn commands to set temperature before the tool change begins.
 - Toolchanger: Added `toolchange_temp_drop` config option to automatically lower the old extruder's temperature during toolchange.
 
+## [2026-03-11]
+### Update
+- Updated the Cut.cfg macro to support cut locations with axes configurations other than XY.  New configuration
+variables were added for individual axis.  The behavior of `pin_loc_xy` remains unchainged. New axis specific
+variables were added to avoid pin/toolhead collisions.  The behavior of `safe_margin_xy` did change slightly
+and the Y coordinate is now used when calculating the safe coordinate for the move.  An option has been added 
+to skip the post-cut safe move for configurations where the next move is known to be safe (such as a move
+to purge or wipe.)
+
 ## [2026-03-07]
 ### Fix
 - Added error checking when homing during a Tool Load or Unload, if a homing error (like communication timeout or something similar) happens during these calls that AFC displays error and returns early.

--- a/config/AFC_Macro_Vars.cfg
+++ b/config/AFC_Macro_Vars.cfg
@@ -32,7 +32,7 @@ gcode: # Leave empty
 # 1, 2, or 3 axis.
 
 # pin_loc_xy can be used for most printers. 
-variable_pin_loc_xy               : -1, -1    # x,y coordinates of depressor pin
+variable_pin_loc_xy               : -99, -99    # x,y coordinates of depressor pin
 
 # If moving to the cutter is something other than an XY motion, then set the location
 # variables for the specific axis involved in the motion to the depressor.
@@ -76,7 +76,7 @@ variable_extruder_move_speed      : 25        # Speed mm/s for all extruder move
 variable_restore_position         : False     # True = return to initial position, False = don't return
 
 # Set to True to perform a safe move after the cut.  If restore_position is True, then a safe move
-# will be always be performed.  The position for the safe move is calculated from either the safe
+# will always be performed.  The position for the safe move is calculated from either the safe
 # margin or the safe location variables.
 variable_post_cut_safe_move       : True
 
@@ -113,7 +113,10 @@ variable_pushback_dwell_time      : 20        # Time to dwell between the pushba
 # we make a safer but longer move if we are closer to the pin than this
 # specified margin. Usually setting these to the size of the toolhead
 # (plus a small margin) should be good enough 
-variable_safe_margin_xy           : 0, 30
+variable_safe_margin_xy           : 60, 60
+# Axis' to move in first when performing the safe margin move away from the cutter pin.
+# Valid options are: x, y, z, xy, xz, yz, xyz
+variable_safe_move_first          : "x"
 
 # Safe position to move to.  If the macro calculates that the toolhead has the
 # potential to collide with the cutter pin, it will first move to the safe location

--- a/config/AFC_Macro_Vars.cfg
+++ b/config/AFC_Macro_Vars.cfg
@@ -36,7 +36,7 @@ variable_pin_loc_xy               : -1, -1    # x,y coordinates of depressor pin
 
 # If moving to the cutter is something other than an XY motion, then set the location
 # variables for the specific axis involved in the motion to the depressor.
-# If these are used, then variable_pin_loc_xy needs to be comment out.
+# If these are used, then variable_pin_loc_xy needs to be commented out.
 # variable_pin_loc_x                : -1
 # variable_pin_loc_y                : -1
 # variable_pin_loc_z                : -1
@@ -101,7 +101,7 @@ variable_rip_speed                : 3         # Speed mm/s
 variable_pushback_length          : 15        # Distance in mm
 variable_pushback_dwell_time      : 20        # Time to dwell between the pushback
 
-# Variables for safetly moving the toolhead to the pin location.  Most cutter
+# Variables for safely moving the toolhead to the pin location.  Most cutter
 # configurations will have no-go zones when moving to the pin location in order
 # to avoid crashing the toolhead into the pin.
 #

--- a/config/AFC_Macro_Vars.cfg
+++ b/config/AFC_Macro_Vars.cfg
@@ -96,6 +96,29 @@ variable_rip_speed                : 3         # Speed mm/s
 variable_pushback_length          : 15        # Distance in mm
 variable_pushback_dwell_time      : 20        # Time to dwell between the pushback
 
+# Variables for safetly moving the toolhead to the pin location.  Most cutter
+# configurations will have no-go zones when moving to the pin location in order
+# to avoid crashing the toolhead into the pin.
+#
+# Safe moves can be specified by either the safe margin variable or the safe
+# location variables.  Both can be omitted for configurations that don't need
+# these checks.
+
+# Safety margin. When traveling to the pin location
+# we make a safer but longer move if we are closer to the pin than this
+# specified margin. Usually setting these to the size of the toolhead
+# (plus a small margin) should be good enough 
+variable_safe_margin_xy           : 60, 60
+
+# Safe position to move to.  If the macro calculates that the toolhead has the
+# potential to collide with the cutter pin, it will first move to the safe location
+# specified by these variables.  For example, the safe position might be forward (y - something)
+# of the cutter pin.  For that instance, only variable_safe_loc_y will need to be specified.
+# The move will use the pin location for any other coordinates needed for the move.
+# variable_safe_loc_x                : -1
+# variable_safe_loc_y                : -1
+# variable_safe_loc_z                : -1
+
 # Some printers may need a boost of power to complete the cut without skipping steps.
 # One option is to increase the current for the steppers in printer.cfg. Another
 # option is to use these variables to set a current that is only used during the

--- a/config/AFC_Macro_Vars.cfg
+++ b/config/AFC_Macro_Vars.cfg
@@ -28,8 +28,18 @@ description: Toolhead tip cutting macro configuration variables
 gcode: # Leave empty
 
 # This should be the position of the toolhead where the cutter arm just
-# lightly touches the depressor pin
-variable_pin_loc_xy               : -99, -99    # x,y coordinates of depressor pin
+# lightly touches the depressor pin.  This can be configured to move on
+# 1, 2, or 3 axis.
+
+# pin_loc_xy can be used for most printers. 
+variable_pin_loc_xy               : -1, -1    # x,y coordinates of depressor pin
+
+# If moving to the cutter is something other than an XY motion, then set the location
+# variables for the specific axis involved in the motion to the depressor.
+# If these are used, then variable_pin_loc_xy needs to be comment out.
+# variable_pin_loc_x                : -1
+# variable_pin_loc_y                : -1
+# variable_pin_loc_z                : -1
 
 # Accel during cut. This will overwrite the global accel for this macro. Set to 0 to use global accel
 variable_cut_accel                : 0
@@ -85,12 +95,6 @@ variable_rip_speed                : 3         # Speed mm/s
 # *Must be less then retract_length
 variable_pushback_length          : 15        # Distance in mm
 variable_pushback_dwell_time      : 20        # Time to dwell between the pushback
-
-# Safety margin for fast vs slow travel. When traveling to the pin location
-# we make a safer but longer move if we are closer to the pin than this
-# specified margin. Usually setting these to the size of the toolhead
-# (plus a small margin) should be good enough 
-variable_safe_margin_xy           : 60, 60
 
 # Some printers may need a boost of power to complete the cut without skipping steps.
 # One option is to increase the current for the steppers in printer.cfg. Another

--- a/config/AFC_Macro_Vars.cfg
+++ b/config/AFC_Macro_Vars.cfg
@@ -75,6 +75,11 @@ variable_extruder_move_speed      : 25        # Speed mm/s for all extruder move
 # If the toolhead returns to initial position after the cut is complete.
 variable_restore_position         : False     # True = return to initial position, False = don't return
 
+# Set to True to perform a safe move after the cut.  If restore_position is True, then a safe move
+# will be always be performed.  The position for the safe move is calculated from either the safe
+# margin or the safe location variables.
+variable_post_cut_safe_move       : True
+
 # Distance to retract prior to making the cut, this reduces wasted filament but might cause clog 
 # if set too large and/or if there are gaps in the hotend assembly 
 # *This must be less than the distance from the nozzle to the cutter
@@ -108,7 +113,7 @@ variable_pushback_dwell_time      : 20        # Time to dwell between the pushba
 # we make a safer but longer move if we are closer to the pin than this
 # specified margin. Usually setting these to the size of the toolhead
 # (plus a small margin) should be good enough 
-variable_safe_margin_xy           : 60, 60
+variable_safe_margin_xy           : 0, 30
 
 # Safe position to move to.  If the macro calculates that the toolhead has the
 # potential to collide with the cutter pin, it will first move to the safe location

--- a/config/AFC_Macro_Vars.cfg
+++ b/config/AFC_Macro_Vars.cfg
@@ -114,7 +114,7 @@ variable_pushback_dwell_time      : 20        # Time to dwell between the pushba
 # specified margin. Usually setting these to the size of the toolhead
 # (plus a small margin) should be good enough 
 variable_safe_margin_xy           : 60, 60
-# Axis' to move in first when performing the safe margin move away from the cutter pin.
+# Axes to move in first when performing the safe margin move away from the cutter pin.
 # Valid options are: x, y, z, xy, xz, yz, xyz
 variable_safe_move_first          : "x"
 

--- a/config/macros/Cut.cfg
+++ b/config/macros/Cut.cfg
@@ -94,11 +94,12 @@ gcode:
     G90  # Absolute positioning
     M83  # Relative extrusion
     G92 E0
+
+    {% if verbose > 1 %}
+          RESPOND TYPE=command MSG='AFC_Cut: Move to Cut Pin Location'
+    {% endif %}
     _MOVE_TO_CUTTER_PIN PIN_PARK_X_LOC={pin_park_x_loc} PIN_PARK_Y_LOC={pin_park_y_loc} PIN_PARK_Z_LOC={pin_park_z_loc} EXTRUDER={extruder} MOVE_IN={move_in}
     
-    G90  # Absolute positioning
-    M83  # Relative extrusion
-    G92 E0
     {% if retract_length > 0 %}
 
         {% if verbose > 1 %}
@@ -115,11 +116,6 @@ gcode:
             G1 E-{retract_length / 2} F{extruder_move_speed}
         {% endif %}
     {% endif %}
-
-    {% if verbose > 1 %}
-          RESPOND TYPE=command MSG='AFC_Cut: Move to Cut Pin Location'
-    {% endif %}
-    _MOVE_TO_CUTTER_PIN PIN_PARK_X_LOC={pin_park_x_loc} PIN_PARK_Y_LOC={pin_park_y_loc} PIN_PARK_Z_LOC={pin_park_z_loc} MOVE_IN={move_in}
 
     # Extend servo if enabled
     {% if tool_servo_enable %}
@@ -245,7 +241,7 @@ gcode:
 
     # Reset acceleration values to what it was before
     SET_VELOCITY_LIMIT ACCEL={saved_accel}
-    _CLEAR_PIN PIN_PARK_X_LOC={pin_park_x_loc} PIN_PARK_Y_LOC={pin_park_y_loc} EXTRUDER={extruder}
+    _CLEAR_PIN PIN_PARK_X_LOC={pin_park_x_loc} PIN_PARK_Y_LOC={pin_park_y_loc} PIN_PARK_Z_LOC={pin_park_z_loc}  EXTRUDER={extruder} MOVE_IN={move_in}
     AFC_ENABLE_SKEW
 
     # Restore state and optionally position
@@ -272,63 +268,81 @@ gcode:
     {% endif %}
     {% set cut_direction = vars['cut_direction']|default('')|lower %}
     {% set act_x = printer.toolhead.position.x|float %}
-    {% set act_y = printer.toolhead.position.y|float %}
     {% set max_x = printer.toolhead.axis_maximum.x|float %}
-    {% set max_y = printer.toolhead.axis_maximum.y|float %}
-    {% set safe_margin_x, safe_margin_y = vars.safe_margin_xy|map('float') %}
+    {% set safe_x_loc = vars.safe_loc_x|default(pin_park_x_loc)|float %}
+    {% set safe_y_loc = vars.safe_loc_y|default(pin_park_y_loc)|float %}
+    {% set safe_z_loc = vars.safe_loc_z|default(pin_park_z_loc)|float %}
+    {% set safe_margin_x, safe_margin_y = vars.safe_margin_xy|default([0,0])|map('float') %}
     {% set verbose = gVars['verbose']              |default(1)     | int %}
 
-    # Make traveling to cutter pin safer overall
-    {% if cut_direction == "front" or cut_direction == "back" or cut_direction == "left" or cut_direction == "right"%}
+    {% if cut_direction == "front" or cut_direction == "back" or cut_direction == "left" or cut_direction == "right" %}
         {% if verbose > 1 %}
           RESPOND TYPE=command MSG='AFC_Cut: Moving to cutter pin'
         {% endif %}
-        #assume left side pin
-        {% if (pin_park_x_loc) < (max_x/2) %}
-            {% if act_x <= safe_margin_x+pin_park_x_loc %}
-                G1 X{safe_margin_x+pin_park_x_loc} Y{pin_park_y_loc} F{travel_speed}
-                G1 X{pin_park_x_loc} F{travel_speed}
-            {% else %}
-                G1 X{pin_park_x_loc} Y{pin_park_y_loc} F{travel_speed}
+
+        # Check if we need to do a safe move
+        {% if vars.safe_loc_x is defined or vars.safe_loc_y is defined or vars.safe_loc_z is defined %}
+            {% if vars.safe_margin_xy is defined %}
+                { action_raise_error("Invalid safe move configuration. Specify either safe_margin_xy or the needed safe_ _loc variables") }
             {% endif %}
-        #assume right side pin
-        {% elif (pin_park_x_loc) > (max_x/2) %}
-            {% if act_x >= pin_park_x_loc-safe_margin_x %}
-                G1 X{pin_park_x_loc-safe_margin_x} Y{pin_park_y_loc} F{travel_speed}
-                G1 X{pin_park_x_loc} F{travel_speed}
-            {% else %}
-                G1 X{pin_park_x_loc} Y{pin_park_y_loc} F{travel_speed}
+            # Safely move in any axis configuration
+            {% if (pin_park_x_loc < max_x/2 and act_x <= safe_x_loc) or (pin_park_x_loc > max_x/2 and  act_x >= safe_x_loc) %}
+                {% set safe_move = "" %}
+                {% if 'x' in move_in %}
+                    {% set safe_move = safe_move ~ " X" ~ safe_x_loc %}
+                {% endif %}
+                {% if 'y' in move_in %}
+                    {% set safe_move = safe_move ~ " Y" ~ safe_y_loc %}
+                {% endif %}
+                {% if 'z' in move_in %}
+                    {% set safe_move = safe_move ~ " Z" ~ safe_z_loc %}
+                {% endif %}
+                {% if verbose > 1 %}
+                    RESPOND TYPE=command MSG='Safe move {safe_move}'
+                {% endif %}
+                G1 {safe_move} F{travel_speed}
+            {% endif %}
+        {% elif vars.safe_margin_xy is defined %}
+            # Original XY behavior
+            #assume left side pin
+            {% if (pin_park_x_loc) < (max_x/2) %}
+                {% if verbose > 1 %}
+                  RESPOND TYPE=command MSG='AFC_Cut: Safe move with margin'
+                {% endif %}
+                {% if act_x <= safe_margin_x+pin_park_x_loc %}
+                    G1 X{safe_margin_x+pin_park_x_loc} Y{pin_park_y_loc} F{travel_speed}
+                {% endif %}
+            #assume right side pin
+            {% elif (pin_park_x_loc) > (max_x/2) %}
+                {% if verbose > 1 %}
+                  RESPOND TYPE=command MSG='AFC_Cut: Safe move with margin'
+                {% endif %}
+                {% if act_x >= pin_park_x_loc-safe_margin_x %}
+                    G1 X{pin_park_x_loc-safe_margin_x} Y{pin_park_y_loc} F{travel_speed}
+                {% endif %}
             {% endif %}
         {% endif %}
+        {% set quick_move = "" %}
+
+        {% if 'x' in move_in %}
+            {% set quick_move = quick_move ~ " X" ~ pin_park_x_loc %}
+        {% endif %}
+    
+        {% if 'y' in move_in %}
+            {% set quick_move = quick_move ~ " Y" ~ pin_park_y_loc %}
+        {% endif %}
+    
+        {% if 'z' in move_in %}
+            {% set quick_move = quick_move ~ " Z" ~ pin_park_z_loc %}
+        {% endif %}
+    
+        RESPOND TYPE=command MSG='Move to pin {quick_move}'
+    
+        G1 {quick_move} F{travel_speed}
     {% else %}
         { action_raise_error("Invalid cut direction. Check the cut_direction in your AFC_Macro_Vars.cfg file!") }
     {% endif %}
-    {% set quick_move = "" %}
 
-    {% if 'x' in move_in %}
-        {% set quick_move = quick_move ~ " X" ~ pin_park_x_loc %}
-
-        {% if (cut_direction == "left" and printer.gcode_move.gcode_position.x < pin_park_x_loc) or
-        (cut_direction == "right" and printer.gcode_move.gcode_position.x > pin_park_x_loc) %}
-            G1 X{pin_park_x_loc} F{travel_speed}
-        {% endif %}
-    {% endif %}
-
-    {% if 'y' in move_in %}
-        {% set quick_move = quick_move ~ " Y" ~ pin_park_y_loc %}
-        {% if (cut_direction == "front" and printer.gcode_move.gcode_position.y < pin_park_y_loc) or
-        (cut_direction == "back" and printer.gcode_move.gcode_position.y > pin_park_y_loc) %}
-            G1 Y{pin_park_y_loc} F{travel_speed}
-        {% endif %}
-    {% endif %}
-
-    {% if 'z' in move_in %}
-        {% set quick_move = quick_move ~ " Z" ~ pin_park_z_loc %}
-    {% endif %}
-
-  RESPOND TYPE=command MGG='Move to pin {quick_move}'
-
-    G1 {quick_move} F{travel_speed}
 
 #--=================================================================================-
 #------- Helper macro for tip cutting -----------------------------------------------
@@ -379,49 +393,37 @@ gcode:
     # Add the safe park distance to the cut move
     {% set cut_dist = cut_move_dist + pin_park_dist %}
 
+
     {% set location_factor = {
-        'left'  : { 'x': -1, 'y':  0 },
-        'right' : { 'x':  1, 'y':  0 },
-        'front' : { 'x':  0, 'y': -1 },
-        'back'  : { 'x':  0, 'y':  1 }
+        'left'  : { 'factor': -1, 'axis': 'X', 'park':  pin_park_x_loc, 'limit': x_min },
+        'right' : { 'factor':  1, 'axis': 'X', 'park':  pin_park_x_loc, 'limit': x_max },
+        'front' : { 'factor': -1, 'axis': 'Y', 'park':  pin_park_y_loc, 'limit': y_min },
+        'back'  : { 'factor':  1, 'axis': 'Y', 'park':  pin_park_y_loc, 'limit': y_max }
     } %}
 
-    {% if cut_direction == "left" or cut_direction == "right" %}
-        {% set fast_slow_transition_loc_x = pin_park_x_loc + location_factor[cut_direction].x * (cut_dist * cut_fast_move_fraction)| float %}
-        {% set full_cut_loc_x = pin_park_x_loc + location_factor[cut_direction].x * cut_dist| float %}
-      
-        {% if full_cut_loc_x > x_max or full_cut_loc_x < x_min %}
-            { action_raise_error("X Cut move is outside your printer bounds. Check the cut_move_dist in your AFC_Macro_Vars.cfg file!") }
-        {% else %}
-            G1 X{fast_slow_transition_loc_x} F{cut_fast_move_speed} # Fast move to initiate contact of the blade with filament
-            G1 X{full_cut_loc_x} F{cut_slow_move_speed} # Do the cut in slow move
-            G4 P{cut_dwell_time}
-            {% if rip_length > 0 %}
-                G1 E-{rip_length} F{rip_speed}
-            {% endif %}
-            G4 P200
-            G1 X{pin_park_x_loc} F{evacuate_speed} # Evacuate
-            G4 P200
-        {% endif %}
-    {% elif cut_direction == "front" or cut_direction == "back" %}
-        {% set fast_slow_transition_loc_y = pin_park_y_loc + location_factor[cut_direction].y * (cut_dist * cut_fast_move_fraction)| float %}
-        {% set full_cut_loc_y = pin_park_y_loc + location_factor[cut_direction].y * cut_dist| float %}
-      
-        {% if full_cut_loc_y > y_max or full_cut_loc_y < y_min %}
-            { action_raise_error("Y Cut move is outside your printer bounds. Check the cut_move_dist in your AFC_Macro_Vars.cfg file!") }
-        {% else %}
-            G1 Y{fast_slow_transition_loc_y} F{cut_fast_move_speed} # Fast move to initiate contact of the blade with filament
-            G1 Y{full_cut_loc_y} F{cut_slow_move_speed} # Do the cut in slow move
-            G4 P{cut_dwell_time}
-            {% if rip_length > 0 %}
-                G1 E-{rip_length} F{rip_speed}
-            {% endif %}
-            G4 P200
-            G1 Y{pin_park_y_loc} F{evacuate_speed} # Evacuate
-            G4 P200
-        {% endif %}
-    {% else %}
+    {% if cut_direction not in location_factor %}
         { action_raise_error("Invalid cut direction. Check the cut_direction in your AFC_Macro_Vars.cfg file!") }
+    {% else %}
+
+        {% set fast_slow_transition_loc = location_factor[cut_direction].park + location_factor[cut_direction].factor * (cut_dist * cut_fast_move_fraction)| float %}
+        {% set full_cut_loc = location_factor[cut_direction].park + location_factor[cut_direction].factor * cut_dist| float %}
+        {% set axis = location_factor[cut_direction].axis %}
+
+        {% if (location_factor[cut_direction].factor < 0 and  full_cut_loc < location_factor[cut_direction].limit) or ( location_factor[cut_direction].factor > 0 and full_cut_loc > location_factor[cut_direction].limit) %}
+            { action_raise_error("{axis} Cut move is outside your printer bounds. Check the cut_move_dist in your AFC_Macro_Vars.cfg file!") }
+        {% else %}
+
+            G1 {axis}{fast_slow_transition_loc} F{cut_fast_move_speed} # Fast move to initiate contact of the blade with filament
+            G1 {axis}{full_cut_loc} F{cut_slow_move_speed} # Do the cut in slow move
+            G4 P{cut_dwell_time}
+            {% if rip_length > 0 %}
+                G1 E-{rip_length} F{rip_speed}
+            {% endif %}
+            G4 P200
+            G1 {axis}{location_factor[cut_direction].park} F{evacuate_speed} # Evacuate
+            G4 P200
+
+        {% endif %}
     {% endif %}
 
 #--=================================================================================-
@@ -457,6 +459,8 @@ description: Helper to move the toolhead to the target pin in either safe or fas
 gcode:
     {% set pin_park_x_loc = params.PIN_PARK_X_LOC|float %}
     {% set pin_park_y_loc = params.PIN_PARK_Y_LOC|float %}
+    {% set pin_park_z_loc = params.PIN_PARK_Z_LOC|float %}
+    {% set move_in = params.MOVE_IN|default('')|lower %}
     {% set gVars = printer['gcode_macro _AFC_GLOBAL_VARS'] %}
     {% set travel_speed = gVars['travel_speed'] * 60|float %}
     {% set vars = printer['gcode_macro _AFC_CUT_TIP_VARS'].copy() %}
@@ -467,23 +471,45 @@ gcode:
     {% endif %}
     {% set cut_direction = vars['cut_direction']|default('')|lower %}
     {% set act_x = printer.toolhead.position.x|float %}
-    {% set act_y = printer.toolhead.position.y|float %}
     {% set max_x = printer.toolhead.axis_maximum.x|float %}
-    {% set max_y = printer.toolhead.axis_maximum.y|float %}
-    {% set safe_margin_x, safe_margin_y = vars.safe_margin_xy|map('float') %}
+    {% set safe_x_loc = vars.safe_loc_x|default(pin_park_x_loc)|float %}
+    {% set safe_y_loc = vars.safe_loc_y|default(pin_park_y_loc)|float %}
+    {% set safe_z_loc = vars.safe_loc_z|default(pin_park_z_loc)|float %}
+    {% set safe_margin_x, safe_margin_y = vars.safe_margin_xy|default([0,0])|map('float') %}
     {% set verbose = gVars['verbose']              |default(1)     | int %}
 
     # Make moving away from cutter pin safer overall
     {% if cut_direction == "front" or cut_direction == "back" or cut_direction == "left" or cut_direction == "right" %}
-        {% if verbose > 1 %}
-          RESPOND TYPE=command MSG='AFC_Cut: Clearing cutter pin'
-        {% endif %}
-        #assume left side pin
-        {% if (pin_park_x_loc) < (max_x/2) %}
-            G1 X{pin_park_x_loc+safe_margin_x} F{travel_speed}
-        #assume right side pin
-        {% elif (pin_park_x_loc) > (max_x/2) %}
-            G1 X{pin_park_x_loc-safe_margin_x} F{travel_speed}
+        {% if vars.safe_loc_x is defined or vars.safe_loc_y is defined or vars.safe_loc_z is defined %}
+            {% if vars.safe_margin_xy is defined %}
+                { action_raise_error("Invalid safe move configuration. Specify either safe_margin_xy or the needed safe_ _loc variables") }
+            {% endif %}
+            # Safely move in any axis configuration
+            {% set safe_move = "" %}
+            {% if 'x' in move_in %}
+                {% set safe_move = safe_move ~ " X" ~ safe_x_loc %}
+            {% endif %}
+            {% if 'y' in move_in %}
+                {% set safe_move = safe_move ~ " Y" ~ safe_y_loc %}
+            {% endif %}
+            {% if 'z' in move_in %}
+                {% set safe_move = safe_move ~ " Z" ~ safe_z_loc %}
+            {% endif %}
+            {% if verbose > 1 %}
+                RESPOND TYPE=command MSG='Post-cut safe move {safe_move}'
+            {% endif %}
+            G1 {safe_move} F{travel_speed}
+        {% elif vars.safe_margin_xy is defined %}
+            {% if verbose > 1 %}
+                RESPOND TYPE=command MSG='AFC_Cut: Post-cut move out from cutter pin margin'
+            {% endif %}
+            #assume left side pin
+            {% if (pin_park_x_loc) < (max_x/2) %}
+                G1 X{pin_park_x_loc+safe_margin_x} F{travel_speed}
+            #assume right side pin
+            {% elif (pin_park_x_loc) > (max_x/2) %}
+                G1 X{pin_park_x_loc-safe_margin_x} F{travel_speed}
+            {% endif %}
         {% endif %}
     {% else %}
         { action_raise_error("Invalid cut direction. Check the cut_direction in your AFC_Macro_Vars.cfg file!") }

--- a/config/macros/Cut.cfg
+++ b/config/macros/Cut.cfg
@@ -293,7 +293,9 @@ gcode:
             {% set quick_move = quick_move ~ " Z" ~ pin_park_z_loc %}
         {% endif %}
     
-        RESPOND TYPE=command MSG='Move to pin {quick_move}'
+        {% if verbose > 1 %}
+            RESPOND TYPE=command MSG='Move to pin {quick_move}'
+        {% endif %}
     
         G1 {quick_move} F{travel_speed}
     {% else %}
@@ -367,7 +369,7 @@ gcode:
         {% set axis = location_factor[cut_direction].axis %}
 
         {% if (location_factor[cut_direction].factor < 0 and  full_cut_loc < location_factor[cut_direction].limit) or ( location_factor[cut_direction].factor > 0 and full_cut_loc > location_factor[cut_direction].limit) %}
-            { action_raise_error("{axis} Cut move is outside your printer bounds. Check the cut_move_dist in your AFC_Macro_Vars.cfg file!") }
+            { action_raise_error('{axis} Cut move is outside your printer bounds. Check the cut_move_dist in your AFC_Macro_Vars.cfg file!') }
         {% else %}
 
             G1 {axis}{fast_slow_transition_loc} F{cut_fast_move_speed} # Fast move to initiate contact of the blade with filament

--- a/config/macros/Cut.cfg
+++ b/config/macros/Cut.cfg
@@ -11,8 +11,8 @@ gcode:
     {% if extruder and printer[_th_key] is defined %}
         {% set _ = vars.update(printer[_th_key]) %}
     {% endif %}
-    {% set pin_loc_x            = vars['pin_loc_x']             |default(0)     | float %}
-    {% set pin_loc_y            = vars['pin_loc_y']             |default(0)     | float %}
+    {% set pin_loc_x            = vars['pin_loc_x']             |default(-99)   | float %}
+    {% set pin_loc_y            = vars['pin_loc_y']             |default(-99)   | float %}
     {% set pin_loc_z            = vars['pin_loc_z']             |default(0)     | float %}
     {% set pin_park_dist        = vars['pin_park_dist']         |default(6.0)   | float %}
     {% set retract_length       = vars['retract_length']        |default(8.5)   | float %}
@@ -277,7 +277,7 @@ gcode:
           RESPOND TYPE=command MSG='AFC_Cut: Moving to cutter pin'
         {% endif %}
         
-        _CLEAR_PIN PIN_PARK_X_LOC={pin_park_x_loc} PIN_PARK_Y_LOC={pin_park_y_loc} PIN_PARK_Z_LOC={pin_park_z_loc} MOVE_IN={move_in}
+        _CLEAR_PIN PIN_PARK_X_LOC={pin_park_x_loc} PIN_PARK_Y_LOC={pin_park_y_loc} PIN_PARK_Z_LOC={pin_park_z_loc} EXTRUDER={extruder} MOVE_IN={move_in}
 
         {% set quick_move = "" %}
 
@@ -369,7 +369,7 @@ gcode:
         {% set axis = location_factor[cut_direction].axis %}
 
         {% if (location_factor[cut_direction].factor < 0 and  full_cut_loc < location_factor[cut_direction].limit) or ( location_factor[cut_direction].factor > 0 and full_cut_loc > location_factor[cut_direction].limit) %}
-            { action_raise_error('{axis} Cut move is outside your printer bounds. Check the cut_move_dist in your AFC_Macro_Vars.cfg file!') }
+            { action_raise_error({axis} ~ ' Cut move is outside your printer bounds. Check the cut_move_dist in your AFC_Macro_Vars.cfg file!') }
         {% else %}
 
             G1 {axis}{fast_slow_transition_loc} F{cut_fast_move_speed} # Fast move to initiate contact of the blade with filament
@@ -437,7 +437,12 @@ gcode:
     {% set safe_y_loc = vars.safe_loc_y|default(pin_park_y_loc)|float %}
     {% set safe_z_loc = vars.safe_loc_z|default(pin_park_z_loc)|float %}
     {% set safe_margin_x, safe_margin_y = vars.safe_margin_xy|default([0,0])|map('float') %}
+    {% set safe_move_first = vars.safe_move_first|default('x')|lower %}
     {% set verbose = gVars['verbose']              |default(1)     | int %}
+
+    {% if safe_move_first not in ['x', 'y', 'z', 'xy', 'xz', 'yz', 'xyz'] %}
+        { action_raise_error("Invalid safe_move_first value '" ~ safe_move_first ~ "'. Must be one of: x, y, z, xy, xz, yz, xyz") }
+    {% endif %}
 
     {% if cut_direction == "front" or cut_direction == "back" or cut_direction == "left" or cut_direction == "right" %}
         {% if safe_margin_x > 0 or safe_margin_y > 0 %}
@@ -448,20 +453,52 @@ gcode:
         {% if safe_x_loc != pin_park_x_loc or safe_y_loc != pin_park_y_loc or safe_z_loc != pin_park_z_loc %}
             # Safely move in any axis configuration
             {% if force_move or (pin_park_x_loc < max_x/2 and act_x <= safe_x_loc) or (pin_park_x_loc > max_x/2 and  act_x >= safe_x_loc) %}
-                {% set safe_move = "" %}
+                {% set safe_move_x = "" %}
+                {% set safe_move_y = "" %}
+                {% set safe_move_z = "" %}
                 {% if 'x' in move_in %}
-                    {% set safe_move = safe_move ~ " X" ~ safe_x_loc %}
+                    {% set safe_move_x = " X" ~ safe_x_loc %}
                 {% endif %}
                 {% if 'y' in move_in %}
-                    {% set safe_move = safe_move ~ " Y" ~ safe_y_loc %}
+                    {% set safe_move_y = " Y" ~ safe_y_loc %}
                 {% endif %}
                 {% if 'z' in move_in %}
-                    {% set safe_move = safe_move ~ " Z" ~ safe_z_loc %}
+                    {% set safe_move_z = " Z" ~ safe_z_loc %}
                 {% endif %}
-                {% if verbose > 1 %}
-                    RESPOND TYPE=command MSG='Safe move {safe_move}'
+                
+                {% if safe_move_first == "x" %}
+                    G1 {safe_move_x} F{travel_speed}
+                    G1 {safe_move_y} {safe_move_z} F{travel_speed}
                 {% endif %}
-                G1 {safe_move} F{travel_speed}
+
+                {% if safe_move_first == "y" %}
+                    G1 {safe_move_y} F{travel_speed}
+                    G1 {safe_move_x} {safe_move_z} F{travel_speed}
+                {% endif %}
+
+                {% if safe_move_first == "z" %}
+                    G1 {safe_move_z} F{travel_speed}
+                    G1 {safe_move_x} {safe_move_y} F{travel_speed}
+                {% endif %}
+
+                {% if safe_move_first == "xy" %}
+                    G1 {safe_move_x} {safe_move_y} F{travel_speed}
+                    G1 {safe_move_z} F{travel_speed}
+                {% endif %}
+
+                {% if safe_move_first == "xz" %}
+                    G1 {safe_move_x} {safe_move_z} F{travel_speed}
+                    G1 {safe_move_y} F{travel_speed}
+                {% endif %}
+
+                {% if safe_move_first == "yz" %}
+                    G1 {safe_move_y} {safe_move_z} F{travel_speed}
+                    G1 {safe_move_x} F{travel_speed}
+                {% endif %}
+
+                {% if safe_move_first == "xyz" %}
+                    G1 {safe_move_x} {safe_move_y} {safe_move_z} F{travel_speed}
+                {% endif %}
             {% endif %}
         {% endif %}
     {% else %}

--- a/config/macros/Cut.cfg
+++ b/config/macros/Cut.cfg
@@ -32,6 +32,7 @@ gcode:
     {% set cut_current_dc       = vars['cut_current_dual_carriage']|default(0)  | float %}
     {% set cut_current_y        = vars['cut_current_stepper_y'] |default(0)     | float %}
     {% set cut_current_z        = vars['cut_current_stepper_z'] |default(0)     | float %}
+    {% set post_cut_safe_move   = vars['post_cut_safe_move']    |default(true)  | lower == 'true' %}
 
     {% if verbose > 0 %}
       RESPOND TYPE=command MSG='AFC_Cut: Cut Filament'
@@ -241,7 +242,9 @@ gcode:
 
     # Reset acceleration values to what it was before
     SET_VELOCITY_LIMIT ACCEL={saved_accel}
-    _CLEAR_PIN PIN_PARK_X_LOC={pin_park_x_loc} PIN_PARK_Y_LOC={pin_park_y_loc} PIN_PARK_Z_LOC={pin_park_z_loc}  EXTRUDER={extruder} MOVE_IN={move_in}
+    {% if restore_position or post_cut_safe_move %}
+        _CLEAR_PIN PIN_PARK_X_LOC={pin_park_x_loc} PIN_PARK_Y_LOC={pin_park_y_loc} PIN_PARK_Z_LOC={pin_park_z_loc} EXTRUDER={extruder} MOVE_IN={move_in} FORCE=true
+    {% endif %}
     AFC_ENABLE_SKEW
 
     # Restore state and optionally position
@@ -267,61 +270,15 @@ gcode:
         {% set _ = vars.update(printer[_th_key]) %}
     {% endif %}
     {% set cut_direction = vars['cut_direction']|default('')|lower %}
-    {% set act_x = printer.toolhead.position.x|float %}
-    {% set max_x = printer.toolhead.axis_maximum.x|float %}
-    {% set safe_x_loc = vars.safe_loc_x|default(pin_park_x_loc)|float %}
-    {% set safe_y_loc = vars.safe_loc_y|default(pin_park_y_loc)|float %}
-    {% set safe_z_loc = vars.safe_loc_z|default(pin_park_z_loc)|float %}
-    {% set safe_margin_x, safe_margin_y = vars.safe_margin_xy|default([0,0])|map('float') %}
     {% set verbose = gVars['verbose']              |default(1)     | int %}
 
     {% if cut_direction == "front" or cut_direction == "back" or cut_direction == "left" or cut_direction == "right" %}
         {% if verbose > 1 %}
           RESPOND TYPE=command MSG='AFC_Cut: Moving to cutter pin'
         {% endif %}
+        
+        _CLEAR_PIN PIN_PARK_X_LOC={pin_park_x_loc} PIN_PARK_Y_LOC={pin_park_y_loc} PIN_PARK_Z_LOC={pin_park_z_loc} MOVE_IN={move_in}
 
-        # Check if we need to do a safe move
-        {% if vars.safe_loc_x is defined or vars.safe_loc_y is defined or vars.safe_loc_z is defined %}
-            {% if vars.safe_margin_xy is defined %}
-                { action_raise_error("Invalid safe move configuration. Specify either safe_margin_xy or the needed safe_ _loc variables") }
-            {% endif %}
-            # Safely move in any axis configuration
-            {% if (pin_park_x_loc < max_x/2 and act_x <= safe_x_loc) or (pin_park_x_loc > max_x/2 and  act_x >= safe_x_loc) %}
-                {% set safe_move = "" %}
-                {% if 'x' in move_in %}
-                    {% set safe_move = safe_move ~ " X" ~ safe_x_loc %}
-                {% endif %}
-                {% if 'y' in move_in %}
-                    {% set safe_move = safe_move ~ " Y" ~ safe_y_loc %}
-                {% endif %}
-                {% if 'z' in move_in %}
-                    {% set safe_move = safe_move ~ " Z" ~ safe_z_loc %}
-                {% endif %}
-                {% if verbose > 1 %}
-                    RESPOND TYPE=command MSG='Safe move {safe_move}'
-                {% endif %}
-                G1 {safe_move} F{travel_speed}
-            {% endif %}
-        {% elif vars.safe_margin_xy is defined %}
-            # Original XY behavior
-            #assume left side pin
-            {% if (pin_park_x_loc) < (max_x/2) %}
-                {% if verbose > 1 %}
-                  RESPOND TYPE=command MSG='AFC_Cut: Safe move with margin'
-                {% endif %}
-                {% if act_x <= safe_margin_x+pin_park_x_loc %}
-                    G1 X{safe_margin_x+pin_park_x_loc} Y{pin_park_y_loc} F{travel_speed}
-                {% endif %}
-            #assume right side pin
-            {% elif (pin_park_x_loc) > (max_x/2) %}
-                {% if verbose > 1 %}
-                  RESPOND TYPE=command MSG='AFC_Cut: Safe move with margin'
-                {% endif %}
-                {% if act_x >= pin_park_x_loc-safe_margin_x %}
-                    G1 X{pin_park_x_loc-safe_margin_x} Y{pin_park_y_loc} F{travel_speed}
-                {% endif %}
-            {% endif %}
-        {% endif %}
         {% set quick_move = "" %}
 
         {% if 'x' in move_in %}
@@ -457,6 +414,7 @@ gcode:
 [gcode_macro _CLEAR_PIN]
 description: Helper to move the toolhead to the target pin in either safe or faster way, depending on toolhead clearance
 gcode:
+    {% set force_move = params.FORCE|default(false)|lower == 'true' %}
     {% set pin_park_x_loc = params.PIN_PARK_X_LOC|float %}
     {% set pin_park_y_loc = params.PIN_PARK_Y_LOC|float %}
     {% set pin_park_z_loc = params.PIN_PARK_Z_LOC|float %}
@@ -472,43 +430,36 @@ gcode:
     {% set cut_direction = vars['cut_direction']|default('')|lower %}
     {% set act_x = printer.toolhead.position.x|float %}
     {% set max_x = printer.toolhead.axis_maximum.x|float %}
+    {% set max_y = printer.toolhead.axis_maximum.y|float %}
     {% set safe_x_loc = vars.safe_loc_x|default(pin_park_x_loc)|float %}
     {% set safe_y_loc = vars.safe_loc_y|default(pin_park_y_loc)|float %}
     {% set safe_z_loc = vars.safe_loc_z|default(pin_park_z_loc)|float %}
     {% set safe_margin_x, safe_margin_y = vars.safe_margin_xy|default([0,0])|map('float') %}
     {% set verbose = gVars['verbose']              |default(1)     | int %}
 
-    # Make moving away from cutter pin safer overall
     {% if cut_direction == "front" or cut_direction == "back" or cut_direction == "left" or cut_direction == "right" %}
-        {% if vars.safe_loc_x is defined or vars.safe_loc_y is defined or vars.safe_loc_z is defined %}
-            {% if vars.safe_margin_xy is defined %}
-                { action_raise_error("Invalid safe move configuration. Specify either safe_margin_xy or the needed safe_ _loc variables") }
-            {% endif %}
+        {% if safe_margin_x > 0 or safe_margin_y > 0 %}
+            {% set safe_x_loc = pin_park_x_loc + (safe_margin_x if pin_park_x_loc < max_x/2 else -safe_margin_x) %}
+            {% set safe_y_loc = pin_park_y_loc + (safe_margin_y if pin_park_y_loc < max_y/2 else -safe_margin_y) %}
+        {% endif %}
+        # Check if we need to do a safe move
+        {% if safe_x_loc != pin_park_x_loc or safe_y_loc != pin_park_y_loc or safe_z_loc != pin_park_z_loc %}
             # Safely move in any axis configuration
-            {% set safe_move = "" %}
-            {% if 'x' in move_in %}
-                {% set safe_move = safe_move ~ " X" ~ safe_x_loc %}
-            {% endif %}
-            {% if 'y' in move_in %}
-                {% set safe_move = safe_move ~ " Y" ~ safe_y_loc %}
-            {% endif %}
-            {% if 'z' in move_in %}
-                {% set safe_move = safe_move ~ " Z" ~ safe_z_loc %}
-            {% endif %}
-            {% if verbose > 1 %}
-                RESPOND TYPE=command MSG='Post-cut safe move {safe_move}'
-            {% endif %}
-            G1 {safe_move} F{travel_speed}
-        {% elif vars.safe_margin_xy is defined %}
-            {% if verbose > 1 %}
-                RESPOND TYPE=command MSG='AFC_Cut: Post-cut move out from cutter pin margin'
-            {% endif %}
-            #assume left side pin
-            {% if (pin_park_x_loc) < (max_x/2) %}
-                G1 X{pin_park_x_loc+safe_margin_x} F{travel_speed}
-            #assume right side pin
-            {% elif (pin_park_x_loc) > (max_x/2) %}
-                G1 X{pin_park_x_loc-safe_margin_x} F{travel_speed}
+            {% if force_move or (pin_park_x_loc < max_x/2 and act_x <= safe_x_loc) or (pin_park_x_loc > max_x/2 and  act_x >= safe_x_loc) %}
+                {% set safe_move = "" %}
+                {% if 'x' in move_in %}
+                    {% set safe_move = safe_move ~ " X" ~ safe_x_loc %}
+                {% endif %}
+                {% if 'y' in move_in %}
+                    {% set safe_move = safe_move ~ " Y" ~ safe_y_loc %}
+                {% endif %}
+                {% if 'z' in move_in %}
+                    {% set safe_move = safe_move ~ " Z" ~ safe_z_loc %}
+                {% endif %}
+                {% if verbose > 1 %}
+                    RESPOND TYPE=command MSG='Safe move {safe_move}'
+                {% endif %}
+                G1 {safe_move} F{travel_speed}
             {% endif %}
         {% endif %}
     {% else %}

--- a/config/macros/Cut.cfg
+++ b/config/macros/Cut.cfg
@@ -461,51 +461,24 @@ gcode:
             {% endif %}
             # Safely move in any axis configuration
             {% if do_safe_move %}
-                {% set safe_move_x = "" %}
-                {% set safe_move_y = "" %}
-                {% set safe_move_z = "" %}
-                {% if 'x' in move_in %}
-                    {% set safe_move_x = " X" ~ safe_x_loc %}
-                {% endif %}
-                {% if 'y' in move_in %}
-                    {% set safe_move_y = " Y" ~ safe_y_loc %}
-                {% endif %}
-                {% if 'z' in move_in %}
-                    {% set safe_move_z = " Z" ~ safe_z_loc %}
-                {% endif %}
-                
-                {% if safe_move_first == "x" %}
-                    G1 {safe_move_x} F{travel_speed}
-                    G1 {safe_move_y} {safe_move_z} F{travel_speed}
-                {% endif %}
+                {% set x_str = (" X" ~ safe_x_loc) if 'x' in move_in else "" %}
+                {% set y_str = (" Y" ~ safe_y_loc) if 'y' in move_in else "" %}
+                {% set z_str = (" Z" ~ safe_z_loc) if 'z' in move_in else "" %}
 
-                {% if safe_move_first == "y" %}
-                    G1 {safe_move_y} F{travel_speed}
-                    G1 {safe_move_x} {safe_move_z} F{travel_speed}
-                {% endif %}
+                {% set ns = namespace(first="", second="") %}
+                {% for axis, val in [('x', x_str), ('y', y_str), ('z', z_str)] %}
+                    {% if axis in safe_move_first %}
+                        {% set ns.first = ns.first ~ val %}
+                    {% else %}
+                        {% set ns.second = ns.second ~ val %}
+                    {% endif %}
+                {% endfor %}
 
-                {% if safe_move_first == "z" %}
-                    G1 {safe_move_z} F{travel_speed}
-                    G1 {safe_move_x} {safe_move_y} F{travel_speed}
+                {% if ns.first %}
+                    G1 {ns.first} F{travel_speed}
                 {% endif %}
-
-                {% if safe_move_first == "xy" %}
-                    G1 {safe_move_x} {safe_move_y} F{travel_speed}
-                    G1 {safe_move_z} F{travel_speed}
-                {% endif %}
-
-                {% if safe_move_first == "xz" %}
-                    G1 {safe_move_x} {safe_move_z} F{travel_speed}
-                    G1 {safe_move_y} F{travel_speed}
-                {% endif %}
-
-                {% if safe_move_first == "yz" %}
-                    G1 {safe_move_y} {safe_move_z} F{travel_speed}
-                    G1 {safe_move_x} F{travel_speed}
-                {% endif %}
-
-                {% if safe_move_first == "xyz" %}
-                    G1 {safe_move_x} {safe_move_y} {safe_move_z} F{travel_speed}
+                {% if ns.second %}
+                    G1 {ns.second} F{travel_speed}
                 {% endif %}
             {% endif %}
         {% endif %}

--- a/config/macros/Cut.cfg
+++ b/config/macros/Cut.cfg
@@ -86,7 +86,7 @@ gcode:
 
     SET_VELOCITY_LIMIT ACCEL={selected_accel}
 
-    {% set prev_pa = printer.extruder.pressure_advance %}  # Save current PA
+    {% set prev_pa = printer.extruder.linear_advance|default(printer.extruder.pressure_advance) %}  # Save current PA
     SET_PRESSURE_ADVANCE ADVANCE=0  # Temporarily disable PA
 
     AFC_DISABLE_SKEW

--- a/config/macros/Cut.cfg
+++ b/config/macros/Cut.cfg
@@ -451,8 +451,16 @@ gcode:
         {% endif %}
         # Check if we need to do a safe move
         {% if safe_x_loc != pin_park_x_loc or safe_y_loc != pin_park_y_loc or safe_z_loc != pin_park_z_loc %}
+            {% set do_safe_move = force_move %}
+            {% if not do_safe_move %}
+                {% if cut_direction == "front" or cut_direction == "back" %}
+                    {% set do_safe_move = (pin_park_y_loc < max_y/2 and act_y <= safe_y_loc) or (pin_park_y_loc > max_y/2 and act_y >= safe_y_loc) %}
+                {% else %}
+                    {% set do_safe_move = (pin_park_x_loc < max_x/2 and act_x <= safe_x_loc) or (pin_park_x_loc > max_x/2 and act_x >= safe_x_loc) %}
+                {% endif %}
+            {% endif %}
             # Safely move in any axis configuration
-            {% if force_move or (pin_park_x_loc < max_x/2 and act_x <= safe_x_loc) or (pin_park_x_loc > max_x/2 and  act_x >= safe_x_loc) %}
+            {% if do_safe_move %}
                 {% set safe_move_x = "" %}
                 {% set safe_move_y = "" %}
                 {% set safe_move_z = "" %}

--- a/config/macros/Cut.cfg
+++ b/config/macros/Cut.cfg
@@ -11,7 +11,9 @@ gcode:
     {% if extruder and printer[_th_key] is defined %}
         {% set _ = vars.update(printer[_th_key]) %}
     {% endif %}
-    {% set pin_loc_x, pin_loc_y = vars.pin_loc_xy               |default([-1, -1])| map('float') %}
+    {% set pin_loc_x            = vars['pin_loc_x']             |default(0)     | float %}
+    {% set pin_loc_y            = vars['pin_loc_y']             |default(0)     | float %}
+    {% set pin_loc_z            = vars['pin_loc_z']             |default(0)     | float %}
     {% set pin_park_dist        = vars['pin_park_dist']         |default(6.0)   | float %}
     {% set retract_length       = vars['retract_length']        |default(8.5)   | float %}
     {% set quick_tip_forming    = vars['quick_tip_forming']     |default(true)  | lower == 'true' %}
@@ -23,7 +25,6 @@ gcode:
     {% set extruder_move_speed  = vars['extruder_move_speed']   |default(25)*60 | float %}
     {% set restore_position     = vars['restore_position']      |default(true)  | lower == 'true' %}
     {% set cut_count            = vars['cut_count']             |default(2)     | int %}
-    {% set y_cut                = vars['y_cut']                 |default(false) | lower == 'true' %}
     {% set awd                  = vars['awd']                   |default(false) | lower == 'true' %}
     {% set tool_servo_enable    = vars['tool_servo_enable']     |default(false) | lower == 'true' %}
 
@@ -43,22 +44,32 @@ gcode:
         'back'  : { 'x':  0, 'y': -1 }
     } %}
     
-    # Add safe move distance to x or y depending on cut type
-    {% if cut_direction == "left" or cut_direction == "right" %}
-        {% set pin_park_x_loc = pin_loc_x + location_factor[cut_direction].x * pin_park_dist %}
-        {% set pin_park_y_loc = pin_loc_y %}
-    {% elif cut_direction == "front" or cut_direction == "back" %}
-        {% set pin_park_x_loc = pin_loc_x %}
-        {% set pin_park_y_loc = pin_loc_y + location_factor[cut_direction].y * pin_park_dist %}
-    {% else %}
+    {% if cut_direction not in location_factor %}
         { action_raise_error("Invalid cut direction. Check the cut_direction in your AFC_Macro_Vars.cfg file!") }
     {% endif %}
 
-    # Track total extruder move dist for future use
-    {% set _extruder_moved_dist = 0 %}
+    {% if vars.pin_loc_x is defined or vars.pin_loc_y is defined or vars.pin_loc_z is defined %}
+        {% if vars.pin_loc_xy is defined %}
+            { action_raise_error("Invalid pin location configuration. pin_loc_xy should be used by itself.") }
+        {% else %}
+            {% set move_in = ("x" if vars.pin_loc_x is defined else "") ~ ("y" if vars.pin_loc_y is defined else "") ~ ("z" if vars.pin_loc_z is defined else "") %}
+        {% endif %}
+    {% else %}
+        {% if vars.pin_loc_xy is defined %}
+            {% set pin_loc_x, pin_loc_y = vars.pin_loc_xy|map('float') %}
+            {% set move_in = "xy" %}
+        {% else %}
+            { action_raise_error("Invalid pin location configuration. The pin location must be set.") }
+        {% endif %}
+    {% endif %}
 
-    {% if "xy" not in printer.toolhead.homed_axes %}
-        G28 X Y
+    # Add safe move distance to x or y depending on cut type
+    {% set pin_park_x_loc = pin_loc_x + location_factor[cut_direction].x * pin_park_dist %}
+    {% set pin_park_y_loc = pin_loc_y + location_factor[cut_direction].y * pin_park_dist %}
+    {% set pin_park_z_loc = pin_loc_z %}
+
+    {% if "xyz" not in printer.toolhead.homed_axes %}
+        G28
     {% endif %}
 
     SAVE_GCODE_STATE NAME=_AFC_CUT
@@ -75,7 +86,7 @@ gcode:
 
     SET_VELOCITY_LIMIT ACCEL={selected_accel}
 
-    {% set prev_pa = printer.extruder.linear_advance|default(printer.extruder.pressure_advance) %}  # Save current PA
+    {% set prev_pa = printer.extruder.pressure_advance %}  # Save current PA
     SET_PRESSURE_ADVANCE ADVANCE=0  # Temporarily disable PA
 
     AFC_DISABLE_SKEW
@@ -83,7 +94,7 @@ gcode:
     G90  # Absolute positioning
     M83  # Relative extrusion
     G92 E0
-    _MOVE_TO_CUTTER_PIN PIN_PARK_X_LOC={pin_park_x_loc} PIN_PARK_Y_LOC={pin_park_y_loc} EXTRUDER={extruder}
+    _MOVE_TO_CUTTER_PIN PIN_PARK_X_LOC={pin_park_x_loc} PIN_PARK_Y_LOC={pin_park_y_loc} PIN_PARK_Z_LOC={pin_park_z_loc} EXTRUDER={extruder} MOVE_IN={move_in}
     
     G90  # Absolute positioning
     M83  # Relative extrusion
@@ -103,13 +114,13 @@ gcode:
             G1 E{retract_length / 2} F{extruder_move_speed}
             G1 E-{retract_length / 2} F{extruder_move_speed}
         {% endif %}
-        
-        {% set _extruder_moved_dist = _extruder_moved_dist + retract_length %}
     {% endif %}
 
     {% if verbose > 1 %}
           RESPOND TYPE=command MSG='AFC_Cut: Move to Cut Pin Location'
     {% endif %}
+    _MOVE_TO_CUTTER_PIN PIN_PARK_X_LOC={pin_park_x_loc} PIN_PARK_Y_LOC={pin_park_y_loc} PIN_PARK_Z_LOC={pin_park_z_loc} MOVE_IN={move_in}
+
     # Extend servo if enabled
     {% if tool_servo_enable %}
         {% if verbose > 1 %}
@@ -220,8 +231,6 @@ gcode:
         SET_TMC_CURRENT STEPPER=stepper_z CURRENT={conf_current_z}
     {% endif %}
 
-    {% set _extruder_moved_dist = _extruder_moved_dist + rip_length %}
-
     # Optionally pushback of the cut piece into the hotend to avoid potential clog
     {% if pushback_length > 0 %}
         {% if verbose > 1 %}
@@ -230,8 +239,6 @@ gcode:
         G1 E{pushback_length} F{extruder_move_speed}
         G4 P{pushback_dwell_time}
         G1 E-{pushback_length} F{extruder_move_speed}
-        
-        {% set _extruder_moved_dist = _extruder_moved_dist - pushback_length %}
     {% endif %}
 
     SET_PRESSURE_ADVANCE ADVANCE={prev_pa}  # Restore PA
@@ -253,6 +260,8 @@ description: Helper to move the toolhead to the target pin in either safe or fas
 gcode:
     {% set pin_park_x_loc = params.PIN_PARK_X_LOC|float %}
     {% set pin_park_y_loc = params.PIN_PARK_Y_LOC|float %}
+    {% set pin_park_z_loc = params.PIN_PARK_Z_LOC|float %}
+    {% set move_in = params.MOVE_IN|default('')|lower %}
     {% set gVars = printer['gcode_macro _AFC_GLOBAL_VARS'] %}
     {% set travel_speed = gVars['travel_speed'] * 60|float %}
     {% set vars = printer['gcode_macro _AFC_CUT_TIP_VARS'].copy() %}
@@ -294,6 +303,33 @@ gcode:
     {% else %}
         { action_raise_error("Invalid cut direction. Check the cut_direction in your AFC_Macro_Vars.cfg file!") }
     {% endif %}
+    {% set quick_move = "" %}
+
+    {% if 'x' in move_in %}
+        {% set quick_move = quick_move ~ " X" ~ pin_park_x_loc %}
+
+        {% if (cut_direction == "left" and printer.gcode_move.gcode_position.x < pin_park_x_loc) or
+        (cut_direction == "right" and printer.gcode_move.gcode_position.x > pin_park_x_loc) %}
+            G1 X{pin_park_x_loc} F{travel_speed}
+        {% endif %}
+    {% endif %}
+
+    {% if 'y' in move_in %}
+        {% set quick_move = quick_move ~ " Y" ~ pin_park_y_loc %}
+        {% if (cut_direction == "front" and printer.gcode_move.gcode_position.y < pin_park_y_loc) or
+        (cut_direction == "back" and printer.gcode_move.gcode_position.y > pin_park_y_loc) %}
+            G1 Y{pin_park_y_loc} F{travel_speed}
+        {% endif %}
+    {% endif %}
+
+    {% if 'z' in move_in %}
+        {% set quick_move = quick_move ~ " Z" ~ pin_park_z_loc %}
+    {% endif %}
+
+  RESPOND TYPE=command MGG='Move to pin {quick_move}'
+
+    G1 {quick_move} F{travel_speed}
+
 #--=================================================================================-
 #------- Helper macro for tip cutting -----------------------------------------------
 #--=================================================================================-


### PR DESCRIPTION
## Major Changes in this PR

## Notes to Code Reviewers

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Cut.cfg docs to describe support for cut locations with axis layouts beyond XY via per-axis pin configuration.
  * Clarified safe-margin now computes the safe Y coordinate using the Y-axis midpoint.
  * Documented a new option to control which axes move first during safe moves.
  * Documented an option to skip the post-cut safe move when the next move is already known to be safe.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AFCProject/AFC-Klipper-Add-On/pull/641?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->