### PR TITLE
[Fix] Adding homing logic to work with HTLF home pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-02-17]
+### Added
+- HTLF homing to home pin now uses homing logic when enabled
+
 ## [2026-02-15]
 ### Added
 - ViViD unit support, including new MCU configuration and pin mappings (RFID has yet to be implemented).

--- a/extras/AFC_HTLF.py
+++ b/extras/AFC_HTLF.py
@@ -233,7 +233,7 @@ class AFC_HTLF(afcBoxTurtle):
             else:
                 self.logger.error(f"HTLF: failed to home when selecting {lane.name}")
                 return False, 0.0
-        return False, 0.0
+        return True, 0.0
 
     def check_runout(self, cur_lane):
         """

--- a/extras/AFC_HTLF.py
+++ b/extras/AFC_HTLF.py
@@ -3,31 +3,39 @@
 # Copyright (C) 2024-2026 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import annotations
+
 import traceback
 
-from configparser import Error as error
+from configparser import Error as config_error
+
+from typing import TYPE_CHECKING
 
 try: from extras.AFC_utils import ERROR_STR
-except: raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".format(trace=traceback.format_exc()))
+except:
+    trace=traceback.format_exc()
+    err_str = f"Error when trying to import AFC_utils.ERROR_STR\n{trace}"
+    raise config_error(err_str)
 
-try: from extras.AFC_lane import AFCLaneState
-except: raise error(ERROR_STR.format(import_lib="AFC_lane", trace=traceback.format_exc()))
+try: from extras.AFC_lane import AFCLaneState, MoveDirection, SpeedMode
+except: raise config_error(ERROR_STR.format(import_lib="AFC_lane", trace=traceback.format_exc()))
 
 try: from extras.AFC_BoxTurtle import afcBoxTurtle
-except: raise error(ERROR_STR.format(import_lib="AFC_BoxTurtle", trace=traceback.format_exc()))
+except: raise config_error(ERROR_STR.format(import_lib="AFC_BoxTurtle", trace=traceback.format_exc()))
 
 try: from extras.AFC_utils import add_filament_switch
-except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.format_exc()))
+except: raise config_error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.format_exc()))
+
+if TYPE_CHECKING:
+    from configfile import ConfigWrapper
 
 class AFC_HTLF(afcBoxTurtle):
     VALID_CAM_ANGLES = [30,45,60]
-    def __init__(self, config):
+    def __init__(self, config: ConfigWrapper):
         super().__init__(config)
-        self.type                   = config.get('type', 'HTLF')
-        self.drive_stepper          = config.get("drive_stepper")                                                   # Name of AFC_stepper for drive motor
-        self.selector_stepper       = config.get("selector_stepper")                                                # Name of AFC_stepper for selector motor
-        self.drive_stepper_obj      = None
-        self.selector_stepper_obj   = None
+        self.type: str              = config.get('type', 'HTLF')
+        self.drive_stepper: str     = config.get("drive_stepper")                                                   # Name of AFC_stepper for drive motor
+        self.selector_stepper: str  = config.get("selector_stepper")                                                # Name of AFC_stepper for selector motor
         self.current_selected_lane  = None
         self.home_state             = False
         self.mm_move_per_rotation   = config.getint("mm_move_per_rotation", 32)                                     # How many mm moves pulley a full rotation
@@ -37,18 +45,45 @@ class AFC_HTLF(afcBoxTurtle):
         self.enable_sensors_in_gui  = config.getboolean("enable_sensors_in_gui", self.afc.enable_sensors_in_gui)    # Set to True to show prep and load sensors switches as filament sensors in mainsail/fluidd gui, overrides value set in AFC.cfg
         self.prep_homed             = False
         self.failed_to_home         = False
+        self._homed_distance        = 0.0
 
 
         if self.cam_angle not in self.VALID_CAM_ANGLES:
-            raise error("{} is not a valid cam angle, please choose from the following {}".format(self.cam_angle, self.VALID_CAM_ANGLES))
+            raise config_error("{} is not a valid cam angle, please choose from the following {}".format(self.cam_angle, self.VALID_CAM_ANGLES))
 
         self.lobe_current_pos   = 0
 
         buttons = self.printer.load_object(config, "buttons")
         buttons.register_buttons([self.home_pin], self.home_callback)
 
+        query_endstops              = self.printer.load_object( config, "query_endstops")
+        ppins                       = self.printer.lookup_object('pins')
+        self.home_endstop           = None
+        self.home_endstop_name      = None
         if self.home_pin is not None:
             self.home_sensor = add_filament_switch(f"{self.name}_home_pin", self.home_pin, self.printer, self.enable_sensors_in_gui )
+
+            ppins.allow_multi_use_pin(self.home_pin.strip("!^"))
+            ppins.parse_pin(self.home_pin, True, True)
+            self.home_endstop = ppins.setup_pin('endstop', self.home_pin)
+            self.home_endstop_name = f"{self.name}_home"
+            try:
+                query_endstops.register_endstop(self.home_endstop,
+                                                self.home_endstop_name)
+            except Exception as e:
+                err_msg = f"Error trying to register home endstop for {self.name}.\n Error:{e}"
+                raise config_error(err_msg)
+
+        self._lookup_objects(config)
+
+        # Adding home endstop to selector
+        self.home_endstop.add_stepper(self.selector_stepper_obj.extruder_stepper.stepper)
+        self.selector_stepper_obj._endstops[self.home_endstop_name] = (self.home_endstop, self.home_endstop_name)
+
+        self.function.register_commands(self.afc.show_macros, "AFC_HOME_UNIT",
+                                        self.cmd_AFC_HOME_UNIT,
+                                        description=self.cmd_AFC_HOME_UNIT_help,
+                                        options=self.cmd_AFC_HOME_UNIT_options)
 
     def handle_connect(self):
         """
@@ -62,16 +97,14 @@ class AFC_HTLF(afcBoxTurtle):
         except:
             error_string = 'Error: No config found for drive_stepper: {drive_stepper} in [AFC_HTLF {stepper}]. Please make sure [AFC_stepper {drive_stepper}] section exists in your config'.format(
                 drive_stepper=self.drive_stepper, stepper=self.name )
-            raise error(error_string)
+            raise config_error(error_string)
 
         try:
             self.selector_stepper_obj = self.printer.lookup_object('AFC_stepper {}'.format(self.selector_stepper))
         except:
             error_string = 'Error: No config found for selector_stepper: {selector_stepper} in [AFC_HTLF {stepper}]. Please make sure [AFC_stepper {selector_stepper}] section exists in your config'.format(
                 selector_stepper=self.selector_stepper, stepper=self.name )
-            raise error(error_string)
-
-        self.gcode.register_mux_command('HOME_UNIT',     "UNIT", self.name, self.cmd_HOME_UNIT)
+            raise config_error(error_string)
 
         super().handle_connect()
 
@@ -93,21 +126,45 @@ class AFC_HTLF(afcBoxTurtle):
         """
         self.home_state = state
 
-    def cmd_HOME_UNIT(self, gcmd):
+    cmd_AFC_HOME_UNIT_help = "Command to move lane selector back to home position for specified in "\
+                             "selector style units that utilizes a home sensor."
+    cmd_AFC_HOME_UNIT_options = {"UNIT": {"type":"string", "default":"HTLF_1"}}
+    def cmd_AFC_HOME_UNIT(self, gcmd):
         """
         Moves unit lane selection back to home position
 
         Usage
         -----
-        `HOME_UNIT UNIT=<unit_name>`
+        `AFC_HOME_UNIT UNIT=<unit_name>`
 
         Example:
         -----
         ```
-        HOME_UNIT UNIT=HTLF_1
+        AFC_HOME_UNIT UNIT=HTLF_1
         ```
         """
         self.return_to_home()
+
+    def _move_selector_home(self, distance: float):
+        """
+        Helper function to move stepper with correct function call depending on if homing is enabled
+        or not
+
+        :param distance: Distance to move selectore stepper
+        """
+        if self.afc.homing_enabled:
+            homed, self._homed_distance = self.selector_stepper_obj.home_to(
+                self.home_endstop_name,
+                distance * MoveDirection.NEG,
+                SpeedMode.SHORT,
+                assist_active=False
+            )
+            self.logger.debug(f"HTLF: Homing done, success:{homed}, distance:{self._homed_distance}")
+        else:
+            self.selector_stepper_obj.move(distance * MoveDirection.NEG,
+                                           self.short_moves_speed,
+                                           self.short_moves_accel,
+                                           False)
 
     def return_to_home(self, prep=False, disable_selector=True):
         """
@@ -120,11 +177,17 @@ class AFC_HTLF(afcBoxTurtle):
         """
         total_moved = 0
 
+        move_distance = 200
         if self.current_selected_lane is not None and not self.home_state and not prep:
-            self.selector_stepper_obj.move( self.calculate_lobe_movement(self.current_selected_lane.index) * -1, 20, 20, False)
+            if not self.afc.homing_enabled:
+                move_distance = self.calculate_lobe_movement(self.current_selected_lane.index)
+
+            self._move_selector_home(move_distance)
 
         while not self.home_state and not self.failed_to_home:
-            self.selector_stepper_obj.move(-1, 20, 20, False)
+            if not self.afc.homing_enabled:
+                move_distance = -1
+            self._move_selector_home(move_distance)
             total_moved += 1
             if total_moved > (self.mm_move_per_rotation/360)*(self.MAX_ANGLE_MOVEMENT+self.cam_angle):
                 self.failed_to_home = True
@@ -151,20 +214,26 @@ class AFC_HTLF(afcBoxTurtle):
         self.logger.debug("HTLF: Lobe Movement angle : {}".format(angle_movement))
         return (self.mm_move_per_rotation/360)*angle_movement
 
-    def select_lane( self, lane ):
+    def select_lane( self, lane ) -> tuple[bool, float|int]:
         """
         Moves lobe selector to specified lane based off lanes index
 
         :param lane: Lane object to move selector to
         """
+        if "stepper" in lane.fullname.lower():
+            return False, 0.0
+
         if self.current_selected_lane != lane:
             self.logger.debug("HTLF: {} Homing to endstop.".format(self.name))
             if self.return_to_home( disable_selector=False ):
                 self.selector_stepper_obj.move(self.calculate_lobe_movement( lane.index ), 50, 50, False)
-                self.logger.debug("HTLF: {} selected".format(lane))
+                self.logger.debug("HTLF: Selecting {}".format(lane))
                 self.current_selected_lane = lane
+                return True, self._homed_distance
             else:
                 self.logger.error(f"HTLF: failed to home when selecting {lane.name}")
+                return False, 0.0
+        return False, 0.0
 
     def check_runout(self, cur_lane):
         """

--- a/extras/AFC_HTLF.py
+++ b/extras/AFC_HTLF.py
@@ -17,7 +17,7 @@ except:
     err_str = f"Error when trying to import AFC_utils.ERROR_STR\n{trace}"
     raise config_error(err_str)
 
-try: from extras.AFC_lane import AFCLaneState, MoveDirection, SpeedMode
+try: from extras.AFC_lane import AFCLaneState, MoveDirection
 except: raise config_error(ERROR_STR.format(import_lib="AFC_lane", trace=traceback.format_exc()))
 
 try: from extras.AFC_BoxTurtle import afcBoxTurtle
@@ -43,6 +43,8 @@ class AFC_HTLF(afcBoxTurtle):
         self.home_pin               = config.get("home_pin")                                                        # Pin for homing sensor
         self.MAX_ANGLE_MOVEMENT     = config.getint("MAX_ANGLE_MOVEMENT", 215)                                      # Max angle to move lobes, this is when lobe 1 is fully engaged with its lane
         self.enable_sensors_in_gui  = config.getboolean("enable_sensors_in_gui", self.afc.enable_sensors_in_gui)    # Set to True to show prep and load sensors switches as filament sensors in mainsail/fluidd gui, overrides value set in AFC.cfg
+        self.selector_movement_speed: float = config.getfloat("selector_movement_speed", 50)
+        self.selector_movement_accel: float = config.getfloat("selector_movement_accel", 50)
         self.prep_homed             = False
         self.failed_to_home         = False
         self._homed_distance        = 0.0
@@ -76,9 +78,10 @@ class AFC_HTLF(afcBoxTurtle):
 
         self._lookup_objects(config)
 
-        # Adding home endstop to selector
-        self.home_endstop.add_stepper(self.selector_stepper_obj.extruder_stepper.stepper)
-        self.selector_stepper_obj._endstops[self.home_endstop_name] = (self.home_endstop, self.home_endstop_name)
+        if self.home_endstop:
+            # Adding home endstop to selector
+            self.home_endstop.add_stepper(self.selector_stepper_obj.extruder_stepper.stepper)
+            self.selector_stepper_obj._endstops[self.home_endstop_name] = (self.home_endstop, self.home_endstop_name)
 
         self.function.register_commands(self.afc.show_macros, "AFC_HOME_UNIT",
                                         self.cmd_AFC_HOME_UNIT,
@@ -91,20 +94,6 @@ class AFC_HTLF(afcBoxTurtle):
         This function is called when the printer connects. It looks up AFC info
         and assigns it to the instance variable `self.AFC`.
         """
-
-        try:
-            self.drive_stepper_obj = self.printer.lookup_object('AFC_stepper {}'.format(self.drive_stepper))
-        except:
-            error_string = 'Error: No config found for drive_stepper: {drive_stepper} in [AFC_HTLF {stepper}]. Please make sure [AFC_stepper {drive_stepper}] section exists in your config'.format(
-                drive_stepper=self.drive_stepper, stepper=self.name )
-            raise config_error(error_string)
-
-        try:
-            self.selector_stepper_obj = self.printer.lookup_object('AFC_stepper {}'.format(self.selector_stepper))
-        except:
-            error_string = 'Error: No config found for selector_stepper: {selector_stepper} in [AFC_HTLF {stepper}]. Please make sure [AFC_stepper {selector_stepper}] section exists in your config'.format(
-                selector_stepper=self.selector_stepper, stepper=self.name )
-            raise config_error(error_string)
 
         super().handle_connect()
 
@@ -150,20 +139,21 @@ class AFC_HTLF(afcBoxTurtle):
         Helper function to move stepper with correct function call depending on if homing is enabled
         or not
 
-        :param distance: Distance to move selectore stepper
+        :param distance: Distance to move selector stepper
         """
         if self.afc.homing_enabled:
-            homed, self._homed_distance = self.selector_stepper_obj.home_to(
+            homed, self._homed_distance = self.selector_stepper_obj.do_homing_move(
+                distance *MoveDirection.NEG,
+                self.selector_movement_speed,
+                self.selector_movement_accel,
                 self.home_endstop_name,
-                distance * MoveDirection.NEG,
-                SpeedMode.SHORT,
                 assist_active=False
             )
             self.logger.debug(f"HTLF: Homing done, success:{homed}, distance:{self._homed_distance}")
         else:
             self.selector_stepper_obj.move(distance * MoveDirection.NEG,
-                                           self.short_moves_speed,
-                                           self.short_moves_accel,
+                                           self.selector_movement_speed,
+                                           self.selector_movement_accel,
                                            False)
 
     def return_to_home(self, prep=False, disable_selector=True):
@@ -226,7 +216,10 @@ class AFC_HTLF(afcBoxTurtle):
         if self.current_selected_lane != lane:
             self.logger.debug("HTLF: {} Homing to endstop.".format(self.name))
             if self.return_to_home( disable_selector=False ):
-                self.selector_stepper_obj.move(self.calculate_lobe_movement( lane.index ), 50, 50, False)
+                self.selector_stepper_obj.move(self.calculate_lobe_movement( lane.index ),
+                                               self.selector_movement_speed,
+                                               self.selector_movement_accel,
+                                               False)
                 self.logger.debug("HTLF: Selecting {}".format(lane))
                 self.current_selected_lane = lane
                 return True, self._homed_distance

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -287,6 +287,14 @@ class AFCLane:
                                            self.cmd_SET_LANE_LOAD_options )
         self._get_steppers(config)
 
+        if getattr(self.unit_obj, "selector_stepper_obj", None):
+            # Register macro for units that have selectors
+            self.function.register_mux_command(self.afc.show_macros, "AFC_SELECT_LANE",
+                                               "LANE", self.name,
+                                               self.unit_obj.cmd_AFC_SELECT_LANE,
+                                               description=self.unit_obj.cmd_AFC_SELECT_LANE_help,
+                                               options=self.unit_obj.cmd_AFC_SELECT_LANE_options)
+
     def __str__(self):
         return self.name
 

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -10,7 +10,7 @@ import traceback
 from configfile import error as config_error
 from datetime import datetime, timedelta
 
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 if TYPE_CHECKING:
     from extras.AFC_lane import (
@@ -21,9 +21,14 @@ if TYPE_CHECKING:
     from extras.AFC_buffer import AFCTrigger
     from extras.AFC_hub import afc_hub
     from extras.AFC_extruder import AFCExtruder
+    from gcode import GCodeCommand
+    from configfile import ConfigWrapper
 
-try: from extras.AFC_utils import ERROR_STR
-except: raise config_error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".format(trace=traceback.format_exc()))
+try: from extras.AFC_utils import ERROR_STR, section_in_config
+except:
+    trace=traceback.format_exc()
+    err_str = f"Error when trying to import AFC_utils.ERROR_STR\n{trace}"
+    raise config_error(err_str)
 
 try: from extras.AFC_respond import AFCprompt
 except: raise config_error(ERROR_STR.format(import_lib="AFC_respond", trace=traceback.format_exc()))
@@ -142,6 +147,38 @@ class afcUnit:
         if check_obj is None:
             return True, error_string
         return False, ""
+
+
+    def _lookup_objects(self, config: ConfigWrapper) -> None:
+        """
+        Helper method for looking up drive and selector stepper config sections in config file
+        and loading their respective object. If config is not found and error is raised. This should
+        only be called if Unit relies on drive stepper and selector steppers.
+
+        :param config: Config object to search for config sections
+        """
+        error_string = ""
+        error_bool   = False
+        config_name = f'AFC_stepper {self.drive_stepper}'
+        if section_in_config(config, config_name):
+            self.drive_stepper_obj: Optional[AFCExtruderStepper] = \
+                self.printer.load_object(config, config_name, None)
+        error, rtn_str = self._check_and_errorout(self.drive_stepper_obj, config_name,
+                                                  "drive_stepper")
+        error_string += rtn_str
+        error_bool |= error
+
+        config_name = f'AFC_stepper {self.selector_stepper}'
+        if section_in_config(config, config_name):
+            self.selector_stepper_obj: Optional[AFCExtruderStepper] = \
+                self.printer.load_object(config, config_name, None)
+
+        error, rtn_str = self._check_and_errorout(self.selector_stepper_obj, config_name,
+                                                  "selector_stepper")
+        error_string += rtn_str
+        error_bool |= error
+        if error_bool:
+            raise config_error(error_string)
 
     def handle_connect(self):
         """
@@ -449,7 +486,7 @@ class afcUnit:
         self.afc.function.afc_led(lane.led_ready, lane.led_index)
         return
 
-    def select_lane( self, lane: AFCLane, sel_prep:bool=False ):
+    def select_lane( self, lane: AFCLane, sel_prep:bool=False ) -> tuple[bool, float|int]:
         """
         Common method to select a units lane.
 
@@ -458,7 +495,7 @@ class afcUnit:
         :param lane: AFCLane object for lane to select
         :param sel_prep: Set to true is selection is happing during prep macro
         """
-        return
+        return True, 0.0
     def return_to_home(self):
         """
         Function to home unit if unit has homing sensor
@@ -631,3 +668,31 @@ class afcUnit:
         """
         return lane.move_to(dist * dir, SpeedMode.LONG, endstop=lane.load_es,
                             assist_active=AssistActive.DYNAMIC, use_homing=use_homing)
+
+    cmd_AFC_SELECT_LANE_help = "Command to home to lane selector for specified lane in selector style units."
+    cmd_AFC_SELECT_LANE_options = {"LANE": {"type":"string", "default":"lane1"}}
+    def cmd_AFC_SELECT_LANE(self, gcmd: GCodeCommand):
+        """
+        Macro handles selecting specific lane for selector style units.
+
+        Usage
+        -----
+        `AFC_SELECT_LANE LANE=<lane>`
+
+        Example
+        -----
+        ```
+        AFC_SELECT_LANE LANE=lane1`
+        ```
+        """
+        lane = gcmd.get("LANE")
+        lane_obj = self.afc.lanes.get(lane, None)
+        if lane_obj:
+            homed, distance = self.select_lane(lane_obj)
+            if homed:
+                self.logger.info(f"Successfully homed to {lane_obj.name} selector after {distance}mm")
+            else:
+                self.logger.error(f"Failed to home to {lane_obj.name}")
+        else:
+            error_string = f"Invalid lane {lane}"
+            gcmd.error(error_string)

--- a/extras/AFC_vivid.py
+++ b/extras/AFC_vivid.py
@@ -9,15 +9,13 @@ import traceback
 
 from configparser import Error as config_error
 
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
     from configfile import ConfigWrapper
-    from gcode import GCodeCommand
-    from extras.AFC_stepper import AFCExtruderStepper
     from extras.AFC_lane import AFCLane
 
-try: from extras.AFC_utils import ERROR_STR, section_in_config
+try: from extras.AFC_utils import ERROR_STR
 except:
     trace=traceback.format_exc()
     err_str = f"Error when trying to import AFC_utils.ERROR_STR\n{trace}"
@@ -67,8 +65,6 @@ class AFC_vivid(afcBoxTurtle):
         self.type:str               = config.get('type', 'ViViD')
         self.drive_stepper:str      = config.get("drive_stepper")                                                   # Name of AFC_stepper for drive motor
         self.selector_stepper:str   = config.get("selector_stepper")                                                # Name of AFC_stepper for selector motor
-        self.drive_stepper_obj: AFCExtruderStepper = None
-        self.selector_stepper_obj: AFCExtruderStepper = None
         self.current_selected_lane  = None
         self.home_state             = False
         self.enable_sensors_in_gui  = config.getboolean("enable_sensors_in_gui",
@@ -79,43 +75,7 @@ class AFC_vivid(afcBoxTurtle):
         self.selector_homing_accel  = config.getfloat("selector_homing_accel", 150)
         self.max_selector_movement  = config.getfloat("max_selector_movement", 800)
 
-        self.function.register_commands(self.afc.show_macros, "AFC_SELECT_LANE",
-                                        self.cmd_AFC_SELECT_LANE,
-                                        description=self.cmd_AFC_SELECT_LANE_help,
-                                        options=self.cmd_AFC_SELECT_LANE_options)
-
-
         self._lookup_objects(config)
-
-    def _lookup_objects(self, config: ConfigWrapper) -> None:
-        """
-        Helper method for looking up drive and selector stepper config sections in config file
-        and loading their respective object. If config is not found and error is raised.
-
-        :param config: Config object to search for config sections
-        """
-        error_string = ""
-        error_bool   = False
-        config_name = f'AFC_stepper {self.drive_stepper}'
-        if section_in_config(config, config_name):
-            self.drive_stepper_obj: Optional[AFCExtruderStepper] = \
-                self.printer.load_object(config, config_name, None)
-        error, rtn_str = self._check_and_errorout(self.drive_stepper_obj, config_name,
-                                                  "drive_stepper")
-        error_string += rtn_str
-        error_bool |= error
-
-        config_name = f'AFC_stepper {self.selector_stepper}'
-        if section_in_config(config, config_name):
-            self.selector_stepper_obj: Optional[AFCExtruderStepper] = \
-                self.printer.load_object(config, config_name, None)
-
-        error, rtn_str = self._check_and_errorout(self.selector_stepper_obj, config_name,
-                                                  "selector_stepper")
-        error_string += rtn_str
-        error_bool |= error
-        if error_bool:
-            raise config_error(error_string)
 
     def handle_connect(self):
         super().handle_connect()
@@ -322,34 +282,6 @@ class AFC_vivid(afcBoxTurtle):
         msg = "\nThe following lanes were ejected and calibration flag set to false. "
         msg += "Please reinsert filament into ViViD to automatically calibrate distance.\n"
         return msg
-
-    cmd_AFC_SELECT_LANE_help = "Command to home to lane selector for specified lane in selector style units."
-    cmd_AFC_SELECT_LANE_options = {"LANE": {"type":"string", "default":"lane1"}}
-    def cmd_AFC_SELECT_LANE(self, gcmd: GCodeCommand):
-        """
-        Macro handles selecting specific lane for selector style units.
-
-        Usage
-        -----
-        `AFC_SELECT_LANE LANE=<lane>`
-
-        Example
-        -----
-        ```
-        AFC_SELECT_LANE LANE=lane1`
-        ```
-        """
-        lane = gcmd.get("LANE")
-        lane_obj = self.afc.lanes.get(lane, None)
-        if lane_obj:
-            homed, distance = self.select_lane(lane_obj)
-            if homed:
-                self.logger.info(f"Successfully homed to {lane_obj.name} selector after {distance}mm")
-            else:
-                self.logger.error(f"Failed to home to {lane_obj.name}")
-        else:
-            error_string = f"Invalid lane {lane}"
-            gcmd.error(error_string)
 
 def load_config_prefix(config):
     return AFC_vivid(config)


### PR DESCRIPTION
## Major Changes in this PR
- Updated code to use homing when moving to home sensor for selector
- Moved functions(`_lookup_objects`, `cmd_AFC_SELECT_LANE`)  from AFC_vivid.py to AFC_unit.py since its common with AFC_HTLF.py functionality
- Renamed HOME_UNIT to AFC_HOME_UNIT
- Added more typing

## Notes to Code Reviewers

## How the changes in this PR are tested
- Tested with my HTLF

Homing in action:

https://github.com/user-attachments/assets/9f195464-0e25-4a17-b38a-af8d90918503

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.