### PR TITLE
multi_extruder: fix m109 ooze logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-02-18]
+### Fixed
+- Fixed M104/M109 macros to work as expected on tools when a lane is not yet loaded
+
 ## [2026-01-29]
 ### Added:
 - Ability to supply custom macro name for tool_swaps with `custom_tool_swap` variable.

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -2060,9 +2060,12 @@ class afc:
                 extruder = lane.extruder_obj
 
                 # Checking if slicer is trying to set temperature(ooze prevention) for another lane
-                #   thats connected to the currently loaded extruder
+                #   thats connected to the currently loaded extruder. Bypass this check if current
+                #   extruder does not have a lane loaded, so that M109 can set temperature in a
+                #   start macro for the initial tool, prior to loading filament.
                 if (not self.disable_ooze_check
-                    and curr_extruder):
+                    and curr_extruder
+                    and curr_extruder.lane_loaded is not None):
                     for curr_extr_lane in curr_extruder.lanes:
                         lane_obj = self.lanes.get(curr_extr_lane, None)
                         if lane_obj:


### PR DESCRIPTION
## Major Changes in this PR

Ooze prevention logic was checking if the temperature was changing for the current extruder so that M109 commands from the slicer don't try to drop the temp for a lane that already has something in it.

Need to check if the lane actually has something in it, or else we can't use M109 in a start macro prior to loading filament in it.

## How the changes in this PR are tested

Start macro with this pattern

```
    M109 T{INITIAL_TOOL} S{EXTRUDER_TEMP} # wait for extruder temp
    T{INITIAL_TOOL} # Load Initial Tool
```

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description
