### PR TITLE
(fix): Fixing issue where AFC was using picking up AFC_hub/AFC_buffer as the unit when trying to lookup unit object

### DIFF
--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -38,6 +38,11 @@ except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.for
 EXCLUDE_TYPES = ["HTLF", "ViViD"]
 # Class for holding different states so its clear what all valid states are
 
+# Names to exclude from search when trying to find unit name in config file
+# These are more for name that could be in config files
+INVALID_UNIT_NAMES = ["AFC_buffer", "AFC_button", "AFC_extruder",
+                      "AFC_hub", "AFC_lane", "AFC_led", "AFC_prep" "AFC_stepper"]
+
 class AssistActive(Enum):
     YES = 1
     NO = 2
@@ -634,7 +639,11 @@ class AFCLane:
         Helper function to get steppers for lane and setup for proper homing
         """
         try:
-            unit_cfg = next(config.getsection(s) for s in config.fileconfig.sections() if self.unit in s and "AFC" in s)
+            unit_cfg = next(
+                config.getsection(s) for s in config.fileconfig.sections()
+                if self.unit in s
+                and "AFC" in s
+                and not any(x in s for x in INVALID_UNIT_NAMES))
             self.unit_obj: afcUnit = self.printer.load_object(config, unit_cfg.get_name())
 
             drive_stepper = self


### PR DESCRIPTION
## Major Changes in this PR
- Fixed issue where AFC was using picking up AFC_hub/AFC_buffer as the unit when trying to lookup unit object

## Notes to Code Reviewers

## How the changes in this PR are tested
- Was able to replicate the error on my machine and verified that the fix worked.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.