### PR TITLE
Add integration tests for AFC buffer commands and update configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-02-23]
+### Fixed
+- The update-afc.sh script will now check to ensure the printer is returning any status other than `Printing` when checking
+  if it can restart Klipper. This includes the `idle` state, which was not checked before.
+
 ## [2026-02-22]
 ### Fixed
 - Stutters in toolhead movement when print assist kicks in are fixed.

--- a/include/check_commands.sh
+++ b/include/check_commands.sh
@@ -135,7 +135,11 @@ query_printer_status() {
   local state
 
   response=$(curl -s "$moonraker"/printer/objects/query?idle_timeout)
-  state=$(echo "$response" | jq -r '.result.status.idle_timeout.state')
+  state=$(echo "$response" | jq -r '.result.status.idle_timeout.state' 2>/dev/null)
+
+  if [ -z "$state" ] || [ "$state" = "null" ]; then
+    return 1
+  fi
 
   if [ "$state" != "Printing" ]; then
     return 0

--- a/include/check_commands.sh
+++ b/include/check_commands.sh
@@ -137,7 +137,7 @@ query_printer_status() {
   response=$(curl -s "$moonraker"/printer/objects/query?idle_timeout)
   state=$(echo "$response" | jq -r '.result.status.idle_timeout.state')
 
-  if [ "$state" == "Ready" ]; then
+  if [ "$state" != "Printing" ]; then
     return 0
   else
     return 1

--- a/include/install_functions.sh
+++ b/include/install_functions.sh
@@ -72,7 +72,7 @@ copy_unit_files() {
   "ViViD")
     cp "${afc_path}/templates/AFC_Vivid_1.cfg" "${afc_config_dir}/AFC_Vivid_1.cfg"
     cp "${afc_path}/templates/AFC_Hardware-AFC.cfg" "${afc_config_dir}/AFC_Hardware.cfg"
-    cp "${afc_path}/config/mcu/Vivid.cfg" "${afc_config_dir}/mcu/Vivid.cfg"
+    cp "${afc_path}/config/mcu/Vivid.cfg" "${afc_config_dir}/mcu/Vivid_1.cfg"
     ;;
   "BoxTurtle (4-Lane)")
     cp "${afc_path}/config/mcu/AFC_Lite.cfg" "${afc_config_dir}/mcu/AFC_Lite.cfg"

--- a/tests/klippy/afc_buffer_commands.test
+++ b/tests/klippy/afc_buffer_commands.test
@@ -1,0 +1,35 @@
+# AFC buffer commands integration test
+#
+# Verifies that AFC_buffer GCode commands register and execute correctly
+# in a Klipper environment with one TurtleNeck-style buffer (buf1) configured.
+# No lane needs to be loaded — commands that depend on an active lane are
+# safe no-ops when get_current_lane_obj() returns None.
+#
+# Prerequisites:
+#   - tests/dict/stm32h723.dict must exist
+#   - KLIPPER_PATH must point to a Klipper clone with chelper built
+
+DICTIONARY stm32h723.dict
+CONFIG afc_with_buffer.cfg
+
+# --- Query buffer state ---
+# Reports current enable state, last_state, and fault-detection info.
+QUERY_BUFFER BUFFER=buf1
+
+# --- Enable / disable buffer ---
+# No active lane, so the internal set_multiplier call is a no-op.
+ENABLE_BUFFER BUFFER=buf1
+DISABLE_BUFFER BUFFER=buf1
+
+# --- Fault detection sensitivity transitions ---
+# 0 → 5: registers extruder position timer and starts fault detection.
+AFC_SET_ERROR_SENSITIVITY BUFFER=buf1 SENSITIVITY=5.0
+# 5 → 7: both non-zero — updates filament error position threshold only.
+AFC_SET_ERROR_SENSITIVITY BUFFER=buf1 SENSITIVITY=7.0
+# 7 → 0: stops the fault detection timer.
+AFC_SET_ERROR_SENSITIVITY BUFFER=buf1 SENSITIVITY=0
+
+# --- Multiplier adjustment ---
+# Buffer is disabled and no lane is loaded, so these are logged no-ops.
+SET_BUFFER_MULTIPLIER BUFFER=buf1 MULTIPLIER=HIGH FACTOR=1.15
+SET_BUFFER_MULTIPLIER BUFFER=buf1 MULTIPLIER=LOW FACTOR=0.85

--- a/tests/klippy/afc_with_buffer.cfg
+++ b/tests/klippy/afc_with_buffer.cfg
@@ -1,0 +1,167 @@
+
+# Minimal Klipper + AFC configuration with one BoxTurtle unit, one lane, and
+# one TurtleNeck-style AFC_buffer.
+#
+# Pin assignment summary:
+#   PA0–PA7  stepper_x + stepper_y (step/dir/enable/endstop)
+#   PB0–PB8  stepper_z + extruder + heater_bed
+#   PC0–PC5  AFC lane + hub switch  (from afc_with_lane.cfg)
+#   PC6      AFC_buffer buf1 advance (expanded) pin
+#   PC7      AFC_buffer buf1 trailing (compressed) pin
+#
+# This file is self-contained — it duplicates the printer/AFC base so that
+# klippy can load it standalone without an include directive.
+
+# ---------------------------------------------------------------------------
+# MCU — path is irrelevant in dict/simulation mode
+# ---------------------------------------------------------------------------
+[mcu]
+serial: /dev/null
+
+# ---------------------------------------------------------------------------
+# Printer kinematics (required by Klipper)
+# ---------------------------------------------------------------------------
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100
+
+[stepper_x]
+step_pin: PA0
+dir_pin: PA1
+enable_pin: !PA2
+microsteps: 16
+rotation_distance: 40
+endstop_pin: PA3
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_y]
+step_pin: PA4
+dir_pin: PA5
+enable_pin: !PA6
+microsteps: 16
+rotation_distance: 40
+endstop_pin: PA7
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_z]
+step_pin: PB0
+dir_pin: PB1
+enable_pin: !PB2
+microsteps: 16
+rotation_distance: 8
+endstop_pin: PB3
+position_endstop: 0
+position_max: 200
+
+[extruder]
+step_pin: PB4
+dir_pin: PB5
+enable_pin: !PB6
+microsteps: 16
+rotation_distance: 33.5
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PB7
+sensor_type: temperature_host
+min_temp: 0
+max_temp: 250
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+
+[heater_bed]
+heater_pin: PB8
+sensor_type: temperature_host
+min_temp: 0
+max_temp: 130
+control: pid
+pid_Kp: 54.027
+pid_Ki: 0.770
+pid_Kd: 948.182
+
+# save_variables is required by AFC to persist spool/lane state.
+[save_variables]
+filename: /tmp/afc_klippy_buffer_test.cfg
+
+# pause_resume is required by AFC_error
+[pause_resume]
+
+# ---------------------------------------------------------------------------
+# AFC core
+# ---------------------------------------------------------------------------
+
+[testing]
+
+[AFC]
+VarFile: /tmp/afc_klippy_buffer_test.var
+long_moves_speed: 150
+long_moves_accel: 250
+short_moves_speed: 50
+short_moves_accel: 300
+short_move_dis: 10
+enable_sensors_in_gui: False
+load_to_hub: False
+z_hop: 5
+resume_speed: 120
+resume_z_speed: 30
+error_timeout: 36000
+tool_cut: False
+park: False
+poop: False
+kick: False
+wipe: False
+form_tip: False
+
+[AFC_prep]
+enable: False
+
+[AFC_form_tip]
+cooling_tube_position: 35
+cooling_tube_length: 10
+cooling_moves: 4
+
+# ---------------------------------------------------------------------------
+# One BoxTurtle unit with a single lane — uses PC0–PC5
+# ---------------------------------------------------------------------------
+
+[AFC_extruder extruder]
+
+[AFC_BoxTurtle unit_1]
+hub: hub_1
+extruder: extruder
+
+[AFC_hub hub_1]
+switch_pin: PC5
+afc_bowden_length: 900
+move_dis: 75
+cut: False
+
+[AFC_stepper lane1]
+unit: unit_1:1
+step_pin: PC0
+dir_pin: PC1
+enable_pin: !PC2
+microsteps: 16
+rotation_distance: 4.65
+dist_hub: 155.0
+park_dist: 10
+prep: PC3
+load: PC4
+
+# ---------------------------------------------------------------------------
+# TurtleNeck-style buffer — uses PC6 (advance/expanded) and PC7 (trailing/compressed)
+# ---------------------------------------------------------------------------
+
+[AFC_buffer buf1]
+advance_pin: PC6
+trailing_pin: PC7
+multiplier_high: 1.05
+multiplier_low: 0.95

--- a/tests/test_AFC_buffer.py
+++ b/tests/test_AFC_buffer.py
@@ -11,6 +11,8 @@ Covers:
   - update_filament_error_pos / get_extruder_pos
   - start/stop fault timers
   - cmd_QUERY_BUFFER string construction
+  - cmd_ENABLE_BUFFER / cmd_DISABLE_BUFFER GCode commands
+  - cmd_AFC_SET_ERROR_SENSITIVITY GCode command
   - TRAILING_STATE_NAME / ADVANCING_STATE_NAME constants
 """
 
@@ -347,3 +349,160 @@ class TestGetStatus:
         buf = _make_buffer()
         result = buf.get_status()
         assert result["rotation_distance"] is None
+
+
+# ── cmd_ENABLE_BUFFER ─────────────────────────────────────────────────────────
+
+class TestCmdEnableBuffer:
+    def test_delegates_to_enable_buffer(self):
+        """cmd_ENABLE_BUFFER should call enable_buffer() exactly once."""
+        buf = _make_buffer()
+        buf.enable_buffer = MagicMock()
+        buf.cmd_ENABLE_BUFFER(MagicMock())
+        buf.enable_buffer.assert_called_once()
+
+    def test_buffer_is_enabled_after_command(self):
+        """Issuing ENABLE_BUFFER leaves enable set to True."""
+        buf = _make_buffer()
+        buf.set_multiplier = MagicMock()
+        buf.cmd_ENABLE_BUFFER(MagicMock())
+        assert buf.enable is True
+
+
+# ── cmd_DISABLE_BUFFER ────────────────────────────────────────────────────────
+
+class TestCmdDisableBuffer:
+    def test_delegates_to_disable_buffer(self):
+        """cmd_DISABLE_BUFFER should call disable_buffer() exactly once."""
+        buf = _make_buffer()
+        buf.disable_buffer = MagicMock()
+        buf.cmd_DISABLE_BUFFER(MagicMock())
+        buf.disable_buffer.assert_called_once()
+
+    def test_buffer_is_disabled_after_command(self):
+        """Issuing DISABLE_BUFFER leaves enable set to False."""
+        buf = _make_buffer()
+        buf.enable = True
+        buf.reset_multiplier = MagicMock()
+        buf.cmd_DISABLE_BUFFER(MagicMock())
+        assert buf.enable is False
+
+
+# ── cmd_AFC_SET_ERROR_SENSITIVITY ─────────────────────────────────────────────
+
+def _gcmd(sensitivity):
+    """Return a mock gcmd whose get_float returns the given sensitivity."""
+    gcmd = MagicMock()
+    gcmd.get_float.return_value = sensitivity
+    return gcmd
+
+
+class TestCmdSetErrorSensitivity:
+    def test_updates_error_sensitivity(self):
+        """The new sensitivity value is stored on the buffer."""
+        buf = _make_buffer(error_sensitivity=0.0)
+        buf.setup_fault_timer = MagicMock()
+        buf.start_fault_detection = MagicMock()
+        buf.cmd_AFC_SET_ERROR_SENSITIVITY(_gcmd(5.0))
+        assert buf.error_sensitivity == 5.0
+
+    def test_updates_fault_sensitivity(self):
+        """fault_sensitivity is recalculated from the new error_sensitivity."""
+        buf = _make_buffer(error_sensitivity=0.0)
+        buf.setup_fault_timer = MagicMock()
+        buf.start_fault_detection = MagicMock()
+        buf.cmd_AFC_SET_ERROR_SENSITIVITY(_gcmd(5.0))
+        assert buf.fault_sensitivity == buf.get_fault_sensitivity(5.0)
+
+    # ── 0 → >0 transition ────────────────────────────────────────────────────
+
+    def test_disabled_to_enabled_calls_setup_fault_timer(self):
+        """Transitioning from 0 to >0 calls setup_fault_timer."""
+        buf = _make_buffer(error_sensitivity=0.0)
+        buf.setup_fault_timer = MagicMock()
+        buf.start_fault_detection = MagicMock()
+        buf.cmd_AFC_SET_ERROR_SENSITIVITY(_gcmd(5.0))
+        buf.setup_fault_timer.assert_called_once()
+
+    def test_disabled_to_enabled_calls_start_fault_detection(self):
+        """Transitioning from 0 to >0 calls start_fault_detection."""
+        buf = _make_buffer(error_sensitivity=0.0)
+        buf.setup_fault_timer = MagicMock()
+        buf.start_fault_detection = MagicMock()
+        buf.cmd_AFC_SET_ERROR_SENSITIVITY(_gcmd(5.0))
+        buf.start_fault_detection.assert_called_once()
+
+    def test_disabled_to_enabled_uses_multiplier_low_when_trailing(self):
+        """Transitioning 0 → >0 with trailing state passes multiplier_low."""
+        buf = _make_buffer(error_sensitivity=0.0)
+        buf.last_state = TRAILING_STATE_NAME
+        buf.setup_fault_timer = MagicMock()
+        buf.start_fault_detection = MagicMock()
+        buf.cmd_AFC_SET_ERROR_SENSITIVITY(_gcmd(5.0))
+        _, multiplier = buf.start_fault_detection.call_args[0]
+        assert multiplier == buf.multiplier_low
+
+    def test_disabled_to_enabled_uses_multiplier_high_when_advancing(self):
+        """Transitioning 0 → >0 with advancing state passes multiplier_high."""
+        buf = _make_buffer(error_sensitivity=0.0)
+        buf.last_state = ADVANCING_STATE_NAME
+        buf.setup_fault_timer = MagicMock()
+        buf.start_fault_detection = MagicMock()
+        buf.cmd_AFC_SET_ERROR_SENSITIVITY(_gcmd(5.0))
+        _, multiplier = buf.start_fault_detection.call_args[0]
+        assert multiplier == buf.multiplier_high
+
+    # ── >0 → 0 transition ────────────────────────────────────────────────────
+
+    def test_enabled_to_disabled_calls_stop_fault_timer(self):
+        """Transitioning from >0 to 0 calls stop_fault_timer."""
+        buf = _make_buffer(error_sensitivity=5.0)
+        buf.stop_fault_timer = MagicMock()
+        buf.cmd_AFC_SET_ERROR_SENSITIVITY(_gcmd(0.0))
+        buf.stop_fault_timer.assert_called_once()
+
+    def test_enabled_to_disabled_does_not_call_setup_fault_timer(self):
+        """Transitioning from >0 to 0 does not call setup_fault_timer."""
+        buf = _make_buffer(error_sensitivity=5.0)
+        buf.stop_fault_timer = MagicMock()
+        buf.setup_fault_timer = MagicMock()
+        buf.cmd_AFC_SET_ERROR_SENSITIVITY(_gcmd(0.0))
+        buf.setup_fault_timer.assert_not_called()
+
+    # ── >0 → >0 transition ───────────────────────────────────────────────────
+
+    def test_enabled_to_enabled_calls_update_filament_error_pos(self):
+        """Transitioning from >0 to another >0 calls update_filament_error_pos."""
+        buf = _make_buffer(error_sensitivity=3.0)
+        buf.update_filament_error_pos = MagicMock()
+        buf.cmd_AFC_SET_ERROR_SENSITIVITY(_gcmd(7.0))
+        buf.update_filament_error_pos.assert_called_once()
+
+    def test_enabled_to_enabled_does_not_call_stop_fault_timer(self):
+        """Transitioning from >0 to another >0 does not call stop_fault_timer."""
+        buf = _make_buffer(error_sensitivity=3.0)
+        buf.update_filament_error_pos = MagicMock()
+        buf.stop_fault_timer = MagicMock()
+        buf.cmd_AFC_SET_ERROR_SENSITIVITY(_gcmd(7.0))
+        buf.stop_fault_timer.assert_not_called()
+
+    def test_enabled_to_enabled_does_not_call_setup_fault_timer(self):
+        """Transitioning from >0 to another >0 does not call setup_fault_timer."""
+        buf = _make_buffer(error_sensitivity=3.0)
+        buf.update_filament_error_pos = MagicMock()
+        buf.setup_fault_timer = MagicMock()
+        buf.cmd_AFC_SET_ERROR_SENSITIVITY(_gcmd(7.0))
+        buf.setup_fault_timer.assert_not_called()
+
+    # ── logging ───────────────────────────────────────────────────────────────
+
+    def test_logs_info_with_new_sensitivity(self):
+        """Setting sensitivity logs an info message containing the new value."""
+        buf = _make_buffer(error_sensitivity=0.0)
+        buf.setup_fault_timer = MagicMock()
+        buf.start_fault_detection = MagicMock()
+        buf.logger = MagicMock()
+        buf.cmd_AFC_SET_ERROR_SENSITIVITY(_gcmd(5.0))
+        buf.logger.info.assert_called_once()
+        msg = buf.logger.info.call_args[0][0]
+        assert "5.0" in msg


### PR DESCRIPTION
## Major Changes in this PR

This pull request introduces new integration and unit tests for AFC buffer GCode commands, updates a unit file copy path, and adjusts a printer status query check. The main focus is on improving test coverage for AFC buffer command handling in the Klipper environment, ensuring that enabling/disabling the buffer and adjusting error sensitivity are robustly tested.

**Test coverage improvements:**

* Added a new integration test file `afc_buffer_commands.test` to verify that AFC buffer GCode commands (such as enabling/disabling the buffer and setting error sensitivity) register and execute correctly in a simulated Klipper environment.
* Added a minimal configuration file `afc_with_buffer.cfg` for Klipper to support buffer command testing, including one BoxTurtle unit, one lane, and one TurtleNeck-style buffer.
* Extended `test_AFC_buffer.py` with comprehensive unit tests for `cmd_ENABLE_BUFFER`, `cmd_DISABLE_BUFFER`, and `cmd_AFC_SET_ERROR_SENSITIVITY`, covering state transitions, method delegation, and logging. [[1]](diffhunk://#diff-59dc8ef2bb9ba4e84385bfd3330e7cd727c855ea05e9830813b05d61155acdc7R14-R15) [[2]](diffhunk://#diff-59dc8ef2bb9ba4e84385bfd3330e7cd727c855ea05e9830813b05d61155acdc7R352-R508)

**Bug fix:**

* Fixed the destination filename when copying the `Vivid.cfg` unit file for the "ViViD" variant to ensure the correct file is installed (`Vivid_1.cfg` instead of `Vivid.cfg`).

**Behavioral change:**

* Modified the printer status query in `check_commands.sh` to return ready unless the state is explicitly "Printing", improving detection logic.

## Notes to Code Reviewers

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.