### PR TITLE
Add logging options for klippy tests and update run-tests script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,7 @@ uv.lock
 
 # Klippy integration test artifacts (generated in CI, not committed)
 tests/dict/*.dict
+tests/logs/
 klippy-test-results*.xml
 
 .idea/

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -7,6 +7,7 @@
 #   ./run-tests.sh --klippy     # klippy integration tests only (both firmwares)
 #   ./run-tests.sh --klipper    # klippy integration tests vs klipper only
 #   ./run-tests.sh --kalico     # klippy integration tests vs kalico only
+#   ./run-tests.sh -k           # keep temporary files after klippy tests
 
 set -euo pipefail
 
@@ -37,6 +38,7 @@ Options:
   --klippy    Run klippy integration tests only (both klipper and kalico)
   --klipper   Run klippy integration tests against klipper only
   --kalico    Run klippy integration tests against kalico only
+  -k          Keep klippy temporary files (logs, gcode) after tests
   --help      Show this help message and exit
 
 With no options, runs unit tests + klippy integration tests against both
@@ -48,6 +50,7 @@ EOF
 RUN_UNIT=true
 RUN_KLIPPER=true
 RUN_KALICO=true
+KLIPPY_EXTRA_ARGS=()
 
 for arg in "$@"; do
     case "$arg" in
@@ -55,6 +58,7 @@ for arg in "$@"; do
         --klippy)  RUN_UNIT=false; RUN_KLIPPER=true;  RUN_KALICO=true  ;;
         --klipper) RUN_UNIT=false; RUN_KLIPPER=true;  RUN_KALICO=false ;;
         --kalico)  RUN_UNIT=false; RUN_KLIPPER=false; RUN_KALICO=true  ;;
+        -k)        KLIPPY_EXTRA_ARGS+=("--klippy-keep") ;;
         --help)    usage; exit 0 ;;
         *) echo "Unknown option: $arg"; echo; usage; exit 1 ;;
     esac
@@ -109,7 +113,8 @@ run_klippy_tests() {
     fi
 
     if KLIPPER_PATH="$fw_dir" DICTDIR="$DICT_DIR" \
-        $PYTEST tests/klippy/ -v --junitxml="klippy-test-results-$name.xml"; then
+        $PYTEST tests/klippy/ -v --junitxml="klippy-test-results-$name.xml" \
+        "${KLIPPY_EXTRA_ARGS[@]+"${KLIPPY_EXTRA_ARGS[@]}"}"; then
         success "Klippy tests ($name)"
         PASS+=("klippy-$name")
     else

--- a/tests/klippy/conftest.py
+++ b/tests/klippy/conftest.py
@@ -12,6 +12,9 @@ from __future__ import annotations
 # Usage:
 #   KLIPPER_PATH=/path/to/klipper pytest tests/klippy/
 #   DICTDIR=/path/to/dicts pytest tests/klippy/
+#
+# Debugging options:
+#   pytest tests/klippy/ --klippy-keep      Keep temp files after test completion
 
 import os
 import pathlib
@@ -29,6 +32,14 @@ KLIPPER_PATH = pathlib.Path(
 DICT_DIR = pathlib.Path(
     os.environ.get("DICTDIR", str(ROOT / "tests" / "dict"))
 )
+LOG_DIR = ROOT / "tests" / "logs"
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--klippy-keep", action="store_true", default=False,
+        help="Keep temporary files (logs, gcode) after test completion",
+    )
 
 
 def pytest_collect_file(parent, file_path):
@@ -73,6 +84,8 @@ class KlippyTest(pytest.File):
                 else:
                     gcode.append(line.strip())
 
+        keepfiles = self.config.getoption("--klippy-keep")
+
         yield KlippyTestItem.from_parent(
             self,
             name=str(config_file),
@@ -81,6 +94,7 @@ class KlippyTest(pytest.File):
             dictionaries=dictionaries,
             should_fail=should_fail,
             klipper_path=KLIPPER_PATH,
+            keepfiles=keepfiles,
         )
 
 
@@ -93,6 +107,7 @@ class KlippyTestItem(pytest.Item):
         gcode,
         should_fail=False,
         klipper_path,
+        keepfiles=False,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -100,15 +115,26 @@ class KlippyTestItem(pytest.Item):
         self.dictionaries = dictionaries
         self.gcode = gcode
         self.klipper_path = klipper_path
+        self.keepfiles = keepfiles
         if should_fail:
             self.add_marker(pytest.mark.xfail)
 
     def setup(self):
-        self.tmp_dir = pathlib.Path(tempfile.mkdtemp())
+        # Build a descriptive directory name from the firmware, .test file, and config.
+        firmware = self.klipper_path.name                     # e.g. "klipper" or "kalico"
+        test_file = pathlib.Path(self.parent.path).stem       # e.g. "afc_buffer_commands"
+        config_name = pathlib.Path(self.config_file).stem     # e.g. "afc_with_buffer"
+        prefix = f"{firmware}_{test_file}_{config_name}_"
+
+        LOG_DIR.mkdir(parents=True, exist_ok=True)
+        self.tmp_dir = pathlib.Path(tempfile.mkdtemp(prefix=prefix, dir=LOG_DIR))
         # AFC_logger writes to AFC.log in the same directory as klippy.log.
         self.afc_log_path = self.tmp_dir / "AFC.log"
 
     def teardown(self):
+        if self.keepfiles:
+            sys.stderr.write(f"  Keeping temp files in: {self.tmp_dir}\n")
+            return
         shutil.rmtree(self.tmp_dir, ignore_errors=True)
 
     def runtest(self):


### PR DESCRIPTION
## Major Changes in this PR

This pull request introduces a new debugging option to the klippy integration test workflow, allowing temporary files (such as logs and gcode) to be preserved after test completion. The changes span both the test runner script and the pytest configuration, improving the developer experience when troubleshooting test failures.

Enhancements to test debugging and workflow:

* Added a `-k` option to the `run-tests.sh` script to keep temporary files generated during klippy integration tests, updating both the usage instructions and option parsing logic. [[1]](diffhunk://#diff-50e66c6df89650688e920df8b6ec6b81cf3c32b7eeedb2eda0357b593011228cR10) [[2]](diffhunk://#diff-50e66c6df89650688e920df8b6ec6b81cf3c32b7eeedb2eda0357b593011228cR41) [[3]](diffhunk://#diff-50e66c6df89650688e920df8b6ec6b81cf3c32b7eeedb2eda0357b593011228cR53-R61)
* Modified the `run_klippy_tests` function in `run-tests.sh` to pass the `--klippy-keep` option to pytest when the `-k` flag is used.

Pytest configuration and test collection improvements:

* Introduced the `--klippy-keep` pytest option in `tests/klippy/conftest.py`, allowing tests to access this flag and control whether temporary files are deleted or preserved.
* Updated the `KlippyTestItem` class to accept and handle the `keepfiles` argument, using it in the `teardown` method to conditionally retain temp directories and provide informative output. [[1]](diffhunk://#diff-4feaff3b843c5c5a63a52dc69cf3f1b933a83658d5da514015b69e5512c88244R87-R88) [[2]](diffhunk://#diff-4feaff3b843c5c5a63a52dc69cf3f1b933a83658d5da514015b69e5512c88244R97) [[3]](diffhunk://#diff-4feaff3b843c5c5a63a52dc69cf3f1b933a83658d5da514015b69e5512c88244R110-R137)

Documentation updates:

* Added documentation in `tests/klippy/conftest.py` to describe the new `--klippy-keep` option and its usage for debugging purposes.

## Notes to Code Reviewers

## How the changes in this PR are tested

`./run-tests.sh -k`

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.