### PR TITLE
(fix): Fixes issue where klipper can crash when trying to load another lane while a lane is already in the progress of loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-02-24]
+### Fixed
+- Issue where trying to load another lane while loading a lane could cause klipper to crash
+
 ## [2026-02-23]
 ### Fixed
 - The update-afc.sh script will now check to ensure the printer is returning any status other than `Printing` when checking

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -120,11 +120,12 @@ class afcError:
         self.afc.error_state = state
         self.afc.current_state = State.ERROR if state else State.IDLE
 
-    def AFC_error(self, msg, pause=True, level=1):
+    def AFC_error(self, msg, pause=True):
         # Print to logger since respond_raw does not write to logger
         logging.warning(msg)
         # Handle AFC errors
-        self.logger.error( message=msg, stack_name=inspect.stack()[level].function )
+        self.logger.error(message=msg,
+                          stack_name=inspect.currentframe().f_back.f_code.co_name )
         if pause: self.pause_print()
 
     cmd_RESET_FAILURE_help = "CLEAR STATUS ERROR"

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -886,7 +886,7 @@ class AFCLane:
                 if self.printer.state_message == 'Printer is ready' and self._afc_prep_done and self.status != AFCLaneState.TOOL_UNLOADING:
                     # Check to see if the printer is printing or moving, as trying to load while printer is doing something will crash klipper
                     if self.afc.function.is_printing(check_movement=True):
-                        self.afc.error.AFC_error("Cannot load spools while printer is actively moving or homing", False)
+                        self.afc.error.AFC_error(f"Cannot load {self.name} spool while printer is actively moving or homing", False)
                         self.prep_active = False
                         return
 


### PR DESCRIPTION
## Major Changes in this PR
- Fixed issue where klipper can crash when trying to load another lane while a lane is already in the progress of loading
- Removed very expensive `inspect.stack()[level].function` call with `inspect.currentframe().f_back.f_code.co_name`

## Notes to Code Reviewers

## How the changes in this PR are tested
- Able to replicate crash is fix on my printer

Klipper not crashing when running G28:
<img width="743" height="776" alt="image" src="https://github.com/user-attachments/assets/1a4b5291-ef01-44c6-a744-5703d14a5074" />

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.