### PR TITLE
Issue 657

### DIFF
--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -75,25 +75,60 @@ class AFCSpool:
 
         map_cmd = map_cmd.upper()
 
-        if map_cmd not in self.afc.tool_cmds:
-            self.logger.error("Invalid map command: {}".format(map_cmd))
-            return
-
-        lane_switch = self.afc.tool_cmds[map_cmd]
-        self.logger.debug("lane to switch is {}".format(lane_switch))
         if lane not in self.afc.lanes:
             self.logger.info('{} Unknown'.format(lane))
             return
         cur_lane = self.afc.lanes[lane]
-        self.afc.tool_cmds[map_cmd]=lane
-        map_switch = cur_lane.map
-        cur_lane.map = map_cmd
-        cur_lane.send_lane_data()
 
-        sw_lane = self.afc.lanes[lane_switch]
-        self.afc.tool_cmds[map_switch] = lane_switch
-        sw_lane.map = map_switch
-        sw_lane.send_lane_data()
+        if map_cmd in self.afc.tool_cmds:
+            # Swap mode: exchange mappings between two lanes
+            lane_switch = self.afc.tool_cmds[map_cmd]
+            self.logger.debug("lane to switch is {}".format(lane_switch))
+
+            if lane_switch == lane:
+                self.logger.info("{} is already mapped to {}".format(lane, map_cmd))
+                return
+
+            sw_lane = self.afc.lanes[lane_switch]
+            map_switch = cur_lane.map
+
+            self.afc.tool_cmds[map_cmd] = lane
+            cur_lane.map = map_cmd
+            cur_lane.send_lane_data()
+
+            self.afc.tool_cmds[map_switch] = lane_switch
+            sw_lane.map = map_switch
+            sw_lane.send_lane_data()
+        else:
+            # Assign mode: map lane to a T command not currently in use
+            old_map = cur_lane.map
+
+            # Unregister old gcode handler and remove from tool_cmds
+            if old_map is not None:
+                try:
+                    self.afc.gcode.register_command(old_map, None)
+                except:
+                    pass
+                if old_map in self.afc.tool_cmds:
+                    del self.afc.tool_cmds[old_map]
+
+            # Check for existing non-AFC gcode handler conflict
+            existing = self.afc.gcode.ready_gcode_handlers.get(map_cmd) if hasattr(self.afc.gcode, 'ready_gcode_handlers') else None
+            if existing:
+                self.logger.error("Error trying to map lane {} to {}, please make sure there are no macros already setup for {}".format(lane, map_cmd, map_cmd))
+                return
+
+            # Register new gcode handler
+            try:
+                self.afc.gcode.register_command(map_cmd, self.afc.cmd_CHANGE_TOOL, desc=self.afc.cmd_CHANGE_TOOL_help)
+            except:
+                self.logger.error("Error trying to map lane {} to {}".format(lane, map_cmd))
+                return
+
+            self.afc.tool_cmds[map_cmd] = lane
+            cur_lane.map = map_cmd
+            cur_lane.send_lane_data()
+
         self.afc.save_vars()
 
     cmd_SET_COLOR_help = "Set filaments color for a lane"
@@ -411,21 +446,45 @@ class AFCSpool:
         ```
         """
 
-        # Gathering existing lane mapping and add to list
-        existing_cmds = [lane.map for lane in self.afc.lanes.values()]
-        # Gather manually assigned mappings and add to list
-        manually_assigned = [ lane._map for lane in self.afc.lanes.values()]
-        # Remove manually assigned mappings from auto assigned mappings
-        existing_cmds = list(set(existing_cmds) - set(manually_assigned))
-        # Sort list in numerical order
-        existing_cmds = sorted(existing_cmds, key=lambda x: int("".join([i for i in x if i.isdigit()])))
+        # Clean stale tool_cmds entries referencing lanes no longer in config
+        stale_keys = [k for k, v in self.afc.tool_cmds.items() if v not in self.afc.lanes]
+        for k in stale_keys:
+            del self.afc.tool_cmds[k]
+
+        # Unregister all current T command gcode handlers for AFC lanes
+        for lane in self.afc.lanes.values():
+            if lane.map is not None:
+                try:
+                    self.afc.gcode.register_command(lane.map, None)
+                except:
+                    pass
+        self.afc.tool_cmds.clear()
+
+        # Collect manually assigned mappings to reserve them
+        manually_assigned = {lane._map for lane in self.afc.lanes.values() if lane._map is not None}
+
+        # Assign sequential T commands, respecting manual assignments
+        auto_index = 0
         for key, unit in self.afc.units.items():
             for lane in unit.lanes.values():
-                # Reassigning manually assigned mapping to lane
                 if lane._map is not None:
                     map_cmd = lane._map
                 else:
-                    map_cmd = existing_cmds.pop(0)
+                    # Find next available sequential T command
+                    while True:
+                        candidate = 'T{}'.format(auto_index)
+                        auto_index += 1
+                        if candidate not in manually_assigned:
+                            existing = self.afc.gcode.ready_gcode_handlers.get(candidate) if hasattr(self.afc.gcode, 'ready_gcode_handlers') else None
+                            if not existing:
+                                map_cmd = candidate
+                                break
+
+                # Register gcode handler for the new mapping
+                try:
+                    self.afc.gcode.register_command(map_cmd, self.afc.cmd_CHANGE_TOOL, desc=self.afc.cmd_CHANGE_TOOL_help)
+                except:
+                    self.logger.info("Error trying to map lane {} to {}".format(lane.name, map_cmd))
 
                 self.afc.tool_cmds[map_cmd] = lane.name
                 self.afc.lanes[lane.name].map = map_cmd

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -263,7 +263,10 @@ class MockGcode:
         self.run_script_from_command = MagicMock()
 
     def register_command(self, name, func, desc=None):
-        self._commands[name] = func
+        if func is None:
+            self._commands.pop(name, None)
+        else:
+            self._commands[name] = func
 
     def register_mux_command(self, cmd, key, value, func, desc=None):
         pass

--- a/tests/test_AFC_spool.py
+++ b/tests/test_AFC_spool.py
@@ -34,6 +34,8 @@ def _make_spool():
     afc.spoolman = None
     afc.tool_cmds = {}
     afc.lanes = {}
+    afc.cmd_CHANGE_TOOL = MagicMock()
+    afc.cmd_CHANGE_TOOL_help = "Tool change"
 
     spool.printer = printer
     spool.afc = afc
@@ -90,14 +92,14 @@ class TestSetMap:
         assert lane1.map == "T0"
         assert spool.afc.tool_cmds.get("T0") == "lane1"
 
-    def test_set_map_invalid_lane_logs_error(self):
+    def test_set_map_invalid_lane_logs_info(self):
         spool = _make_spool()
         spool.afc.lanes = {}
         gcmd = _make_gcmd(LANE="nonexistent", MAP="T1")
         spool.cmd_SET_MAP(gcmd)
-        # Should log an error about invalid lane
-        error_msgs = [m for lvl, m in spool.logger.messages if lvl == "error"]
-        assert len(error_msgs) > 0
+        # Should log info about unknown lane
+        info_msgs = [m for lvl, m in spool.logger.messages if lvl == "info"]
+        assert any("nonexistent" in m for m in info_msgs)
 
     def test_no_lane_param_logs_info(self):
         """Covers lines 66-68: lane is None → log info + return."""
@@ -124,6 +126,30 @@ class TestSetMap:
         spool.cmd_SET_MAP(gcmd)
         info_msgs = [m for lvl, m in spool.logger.messages if lvl == "info"]
         assert any("lane1" in m for m in info_msgs)
+
+    def test_set_map_assign_mode_new_t_command(self):
+        """SET_MAP should allow mapping a lane to a T command not currently in
+        tool_cmds (assign mode), registering the new gcode handler and cleaning
+        up the old one.
+
+        Scenario: After removing NightOwl, T2 no longer exists in tool_cmds.
+        SET_MAP LANE=lane3 MAP=T2 should assign T2 to lane3.
+        """
+        spool = _make_spool()
+
+        lane3 = _make_lane("lane3")
+        lane3.map = "T4"
+        lane3._map = None
+
+        spool.afc.lanes = {"lane3": lane3}
+        spool.afc.tool_cmds = {"T4": "lane3"}
+
+        gcmd = _make_gcmd(LANE="lane3", MAP="T2")
+        spool.cmd_SET_MAP(gcmd)
+
+        assert lane3.map == "T2"
+        assert spool.afc.tool_cmds.get("T2") == "lane3"
+        assert "T4" not in spool.afc.tool_cmds
 
 
 # ── cmd_SET_COLOR ──────────────────────────────────────────────────────────────
@@ -379,6 +405,59 @@ class TestResetAFCMapping:
         spool.cmd_RESET_AFC_MAPPING(gcmd)
         # The manually assigned T0 should be applied
         assert spool.afc.tool_cmds.get("T0") == "lane1"
+
+    def test_reset_fills_gaps_after_unit_removal(self):
+        """Bug reproduction: After removing a unit (e.g., NightOwl), lanes that were
+        remapped to higher T commands (T4, T5) should be reassigned to fill gaps
+        (T2, T3) when RESET_AFC_MAPPING is called.
+
+        Scenario:
+        - BoxTurtle had 4 lanes. NightOwl had 2 lanes.
+        - BT lanes 3-4 were remapped to T4, T5 (swapped with NightOwl lanes).
+        - NightOwl is removed from config.
+        - Remaining BT lanes have maps: T0, T1, T4, T5.
+        - RESET_AFC_MAPPING should produce: T0, T1, T2, T3.
+        """
+        spool = _make_spool()
+
+        # 4 BoxTurtle lanes with stale mappings (T4, T5 from removed NightOwl swap)
+        lane1 = self._make_lane_for_reset("lane1", "T0")
+        lane2 = self._make_lane_for_reset("lane2", "T1")
+        lane3 = self._make_lane_for_reset("lane3", "T4")  # was swapped with NightOwl
+        lane4 = self._make_lane_for_reset("lane4", "T5")  # was swapped with NightOwl
+
+        spool.afc.lanes = {
+            "lane1": lane1, "lane2": lane2, "lane3": lane3, "lane4": lane4,
+        }
+        spool.afc.tool_cmds = {
+            "T0": "lane1", "T1": "lane2", "T4": "lane3", "T5": "lane4",
+        }
+
+        # Single unit with all 4 lanes (NightOwl unit is gone)
+        unit_lanes = {}
+        for lane in [lane1, lane2, lane3, lane4]:
+            ul = MagicMock()
+            ul.name = lane.name
+            ul._map = None
+            unit_lanes[lane.name] = ul
+        unit = MagicMock()
+        unit.lanes = unit_lanes
+        spool.afc.units = {"BoxTurtle_1": unit}
+
+        gcmd = self._make_reset_gcmd()
+        spool.cmd_RESET_AFC_MAPPING(gcmd)
+
+        # After reset, lanes should be sequentially mapped T0-T3
+        assert spool.afc.lanes["lane1"].map == "T0"
+        assert spool.afc.lanes["lane2"].map == "T1"
+        assert spool.afc.lanes["lane3"].map == "T2", \
+            f"Expected T2 but got {spool.afc.lanes['lane3'].map} — gap not filled"
+        assert spool.afc.lanes["lane4"].map == "T3", \
+            f"Expected T3 but got {spool.afc.lanes['lane4'].map} — gap not filled"
+        assert spool.afc.tool_cmds == {
+            "T0": "lane1", "T1": "lane2", "T2": "lane3", "T3": "lane4",
+        }
+
 
 
 # ── cmd_SET_NEXT_SPOOL_ID ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Major Changes in this PR

Closes #657 
This pull request improves the reliability and flexibility of lane-to-tool command mapping in the AFC spool system, particularly when units or lanes are added or removed. Major changes include robust handling of mapping assignments and resets, cleaning up stale mappings, and adding comprehensive tests for these scenarios.

**Enhancements to mapping logic:**

* Refactored `cmd_SET_MAP` to support two modes: swap mode (exchanging mappings between two lanes) and assign mode (mapping a lane to a new T command). The new assign mode cleans up old mappings, unregisters obsolete gcode handlers, checks for conflicts with existing handlers, and registers the new mapping.
* Improved `cmd_RESET_AFC_MAPPING` to remove stale tool command mappings, unregister old gcode handlers, and reassign T commands sequentially, filling any gaps left by removed units or lanes while respecting manual assignments.

**Testing improvements:**

* Added tests to verify assign mode in `SET_MAP`, ensuring that a lane can be mapped to a new T command and that old mappings are properly removed.
* Added a test to reproduce and verify that `RESET_AFC_MAPPING` correctly fills gaps in T command assignments after unit removal, ensuring sequential mapping without leftovers from removed units.
* Updated tests to check for correct logging behavior and improved test setup for AFC spool and gcode handler mocks. [[1]](diffhunk://#diff-38f66a43af34f26bc5348b36c9d78620e9fb1cefed03fc2b602285413be57e67R37-R38) [[2]](diffhunk://#diff-38f66a43af34f26bc5348b36c9d78620e9fb1cefed03fc2b602285413be57e67L93-R102)

**Test infrastructure:**

* Modified the `register_command` method in the test gcode mock to support unregistering commands by removing them when `func` is `None`, aligning test behavior with production code.

## Notes to Code Reviewers

I can't really test this without multiple units. :(

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.