### PR TITLE
(fix) Fixing error where level was removed but calling functions were not updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-02-25]
+### Fixed
+- Error where level was removed from AFC_error method, but calling functions were not updated and were still trying to pass in level parameter
+
 ## [2026-02-24]
 ### Fixed
 - Issue where trying to load another lane while loading a lane could cause klipper to crash

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -685,7 +685,8 @@ class afc:
                 else:
                     msg = "Filament loaded in bypass, not doing tool load"
                     # If printing report as error, only pause if in a print and bypass_pause variable is True
-                    self.error.AFC_error(msg, pause= (self.function.in_print() and self.bypass_pause), level=2)
+                    self.error.AFC_error(msg, pause=(self.function.in_print() and self.bypass_pause),
+                                         stack_name=inspect.currentframe().f_back.f_code.co_name)
                 return True
         except:
             pass

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -120,12 +120,14 @@ class afcError:
         self.afc.error_state = state
         self.afc.current_state = State.ERROR if state else State.IDLE
 
-    def AFC_error(self, msg, pause=True):
+    def AFC_error(self, msg, pause=True, stack_name=None):
         # Print to logger since respond_raw does not write to logger
         logging.warning(msg)
+        if stack_name is None:
+            stack_name = inspect.currentframe().f_back.f_code.co_name
         # Handle AFC errors
         self.logger.error(message=msg,
-                          stack_name=inspect.currentframe().f_back.f_code.co_name )
+                          stack_name=stack_name )
         if pause: self.pause_print()
 
     cmd_RESET_FAILURE_help = "CLEAR STATUS ERROR"
@@ -257,5 +259,5 @@ class afcError:
         cur_lane.do_enable(False)
         cur_lane.status = AFCLaneState.ERROR
         msg = "{} {}".format(cur_lane.name, message)
-        self.AFC_error(msg, pause, level=2)
+        self.AFC_error(msg, pause, stack_name=inspect.currentframe().f_back.f_code.co_name)
         self.afc.function.afc_led(self.afc.led_fault, cur_lane.led_index)

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -15,6 +15,7 @@ import random
 import re
 import traceback
 import configparser
+import inspect
 
 from configfile import error
 from datetime import datetime
@@ -252,11 +253,13 @@ class afcFunction:
                         self.afc.gcode.run_script_from_command(self.afc.auto_level_macro)
                         self.afc.toolhead.wait_moves()
                     else:
-                        self.afc.error.AFC_error("Auto level macro defined, but not found in printer configuration.", False, level=2)
+                        self.afc.error.AFC_error("Auto level macro defined, but not found in printer configuration.",
+                                                 False, stack_name=inspect.currentframe().f_back.f_code.co_name)
                         return False
                 return True
             else:
-                self.afc.error.AFC_error("Please home printer before doing a tool load", False, level=2)
+                self.afc.error.AFC_error("Please home printer before doing a tool load",
+                                         False, stack_name=inspect.currentframe().f_back.f_code.co_name)
                 return False
         else:
             return True


### PR DESCRIPTION
## Major Changes in this PR
- Fixed error where level was removed from AFC_error method, but calling functions were not updated and were still trying to pass in level parameter

## Notes to Code Reviewers

## How the changes in this PR are tested
- Tested setting virtual bypass and tried to load a lane since this goes down a path with an AFC_error call with level passed in.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.