### PR TITLE
Add new feature to not lower extruder if it is already at sufficient …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-02-26]
+### Added
+- New `lower_extruder_temp_on_change` config option in `AFC.cfg`. When set to `False`, AFC will not lower the extruder temperature during a filament change as long as the current temperature is already sufficient for the target material (within 5°C). Defaults to `True` to preserve existing behaviour.
+
 ## [2026-02-25]
 ### Fixed
 - Error where level was removed from AFC_error method, but calling functions were not updated and were still trying to pass in level parameter

--- a/config/AFC.cfg
+++ b/config/AFC.cfg
@@ -19,6 +19,8 @@ default_material_temps: default: 235, PLA:210, PETG:235, ABS:235, ASA:235 # Defa
                                                   # set in spoolman. Follow current format to add more
 #restore_extruder_temp_on_load_or_unload: False  # When True, AFC restores the extruder target temp after tool load/unload when not printing
 #ignore_spoolman_material_temps: False  # When True, AFC will ignore temperatures set in Spoolman and use default_material_temps instead.
+#lower_extruder_temp_on_change: True  # When False, AFC will not lower the extruder temperature during a filament change,
+                                      # as long as the current temperature is above the target material temp - 5°C.
 common_density_values: PLA:1.24, PETG:1.23, ABS:1.04, ASA:1.07 # Generic default density values.  Follow current format to add more
 #default_material_type: PLA      # Default material type to assign to a spool once loaded into a lane
 

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -215,6 +215,7 @@ class afc:
         self.restore_extruder_temp_on_load_or_unload = config.getboolean(
             "restore_extruder_temp_on_load_or_unload", False
         )  # Restore extruder target temp after tool load/unload when not printing
+        self.lower_extruder_temp_on_change = config.getboolean('lower_extruder_temp_on_change', True)  # When False, AFC will not lower extruder temp during filament change if already above target - 5
         self.load_to_hub            = config.getboolean("load_to_hub", True)        # Fast loads filament to hub when inserted, set to False to disable. This is a global setting and can be overridden at AFC_stepper
         self.assisted_unload        = config.getboolean("assisted_unload", True)    # If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool
         self.bypass_pause           = config.getboolean("pause_when_bypass_active", False) # When true AFC pauses print when change tool is called and bypass is loaded
@@ -566,10 +567,13 @@ class afc:
             pheaters.set_temperature(extruder.get_heater(), current_temp[0], wait=wait)
             self.logger.info('Current temp {:.1f} is below set temp {}'.format(current_temp[0], target_temp))
 
-        # Check to make sure temp is with +/-5 of target temp, not setting if temp is over target temp and using min_extrude_temp value
-        if self.heater.target_temp <= (target_temp-5) or (self.heater.target_temp >= (target_temp+5) and not using_min_value):
-            wait = False if self.heater.target_temp >= (target_temp+5) else True
-
+        # Check to make sure temp is within +/-5 of target temp, not setting if temp is over target temp and using min_extrude_temp value
+        need_lower = self.heater.target_temp >= (target_temp + 5) and not using_min_value
+        need_heat  = self.heater.target_temp <= (target_temp - 5)
+        # Skip lowering if disabled and the actual current temp is already sufficient for the target material
+        skip_lower = need_lower and not self.lower_extruder_temp_on_change and current_temp[0] >= (target_temp - 5)
+        if (need_heat or need_lower) and not skip_lower:
+            wait = False if need_lower else True
             self.logger.info('Setting extruder temperature to {} {}'.format(target_temp, "and waiting for extruder to reach temperature" if wait else ""))
             pheaters.set_temperature(extruder.get_heater(), target_temp, wait=wait)
 

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -224,3 +224,129 @@ class TestGetStatus:
         obj.message_queue = [("test msg", "warning")]
         msg = obj.get_status()["message"]
         assert msg["message"] == "test msg"
+
+
+# ── _check_extruder_temp ──────────────────────────────────────────────────────
+
+def _make_afc_for_check_extruder_temp(
+    heater_target_temp,
+    actual_temp,
+    target_material_temp,
+    lower_extruder_temp_on_change=True,
+    using_min_value=False,
+):
+    """Build an afc instance wired up for _check_extruder_temp tests."""
+    obj = _make_afc()
+    obj.lower_extruder_temp_on_change = lower_extruder_temp_on_change
+
+    heater = MagicMock()
+    heater.target_temp = heater_target_temp
+    heater.can_extrude = False
+    heater.get_temp = MagicMock(return_value=(actual_temp, 0.0))
+
+    extruder = MagicMock()
+    extruder.get_heater.return_value = heater
+
+    obj.toolhead = MagicMock()
+    obj.toolhead.get_extruder.return_value = extruder
+
+    pheaters = MagicMock()
+    obj.printer._objects["heaters"] = pheaters
+
+    obj.function.is_printing.return_value = False
+    obj._get_default_material_temps = MagicMock(
+        return_value=(float(target_material_temp), using_min_value)
+    )
+
+    return obj, heater, extruder, pheaters
+
+
+class TestCheckExtruderTemp:
+    """Tests for afc._check_extruder_temp().
+
+    Covers the two-action logic:
+      need_lower: set temp > target+5 → lower without waiting
+      need_heat:  set temp < target-5 → heat and wait
+      skip_lower: need_lower AND lower_extruder_temp_on_change=False
+                  AND actual temp already sufficient → skip the lower call
+    """
+
+    # ── Default behaviour (lower_extruder_temp_on_change=True) ───────────────
+
+    def test_lowers_to_target_when_above(self):
+        """Set temp more than 5° above target → lower to target, no wait."""
+        obj, heater, extruder, pheaters = _make_afc_for_check_extruder_temp(
+            heater_target_temp=250, actual_temp=248, target_material_temp=210
+        )
+        result = obj._check_extruder_temp(MagicMock())
+        pheaters.set_temperature.assert_called_once_with(heater, 210.0, wait=False)
+        assert result is False
+
+    def test_heats_to_target_when_below(self):
+        """Set temp more than 5° below target → heat to target and wait."""
+        obj, heater, extruder, pheaters = _make_afc_for_check_extruder_temp(
+            heater_target_temp=150, actual_temp=148, target_material_temp=210
+        )
+        result = obj._check_extruder_temp(MagicMock())
+        pheaters.set_temperature.assert_called_once_with(heater, 210.0, wait=True)
+        assert result is True
+
+    def test_no_change_when_within_range(self):
+        """Set temp within ±5° of target → no set_temperature call."""
+        obj, heater, extruder, pheaters = _make_afc_for_check_extruder_temp(
+            heater_target_temp=212, actual_temp=210, target_material_temp=210
+        )
+        obj._check_extruder_temp(MagicMock())
+        pheaters.set_temperature.assert_not_called()
+
+    def test_no_lower_when_using_min_extrude_temp(self):
+        """When using min_extrude_temp fallback, do not lower even if above target+5."""
+        obj, heater, extruder, pheaters = _make_afc_for_check_extruder_temp(
+            heater_target_temp=250, actual_temp=248, target_material_temp=210,
+            using_min_value=True,
+        )
+        obj._check_extruder_temp(MagicMock())
+        pheaters.set_temperature.assert_not_called()
+
+    # ── lower_extruder_temp_on_change=False ──────────────────────────────────
+
+    def test_skip_lower_when_disabled_and_actual_sufficient(self):
+        """lower=False, actual ≥ target-5 → lowering is skipped entirely."""
+        obj, heater, extruder, pheaters = _make_afc_for_check_extruder_temp(
+            heater_target_temp=250, actual_temp=248, target_material_temp=210,
+            lower_extruder_temp_on_change=False,
+        )
+        obj._check_extruder_temp(MagicMock())
+        pheaters.set_temperature.assert_not_called()
+
+    def test_lower_not_skipped_when_actual_insufficient(self):
+        """lower=False but actual < target-5 → skip_lower stays False, lower fires."""
+        obj, heater, extruder, pheaters = _make_afc_for_check_extruder_temp(
+            heater_target_temp=250, actual_temp=200, target_material_temp=210,
+            lower_extruder_temp_on_change=False,
+        )
+        obj._check_extruder_temp(MagicMock())
+        pheaters.set_temperature.assert_any_call(heater, 210.0, wait=False)
+
+    def test_heating_unaffected_by_lower_flag(self):
+        """lower=False does not suppress heating up to a higher target."""
+        obj, heater, extruder, pheaters = _make_afc_for_check_extruder_temp(
+            heater_target_temp=150, actual_temp=148, target_material_temp=210,
+            lower_extruder_temp_on_change=False,
+        )
+        result = obj._check_extruder_temp(MagicMock())
+        pheaters.set_temperature.assert_called_once_with(heater, 210.0, wait=True)
+        assert result is True
+
+    # ── Early-return guard ────────────────────────────────────────────────────
+
+    def test_no_change_when_printing(self):
+        """can_extrude=True + is_printing=True → early return, no temp change."""
+        obj, heater, extruder, pheaters = _make_afc_for_check_extruder_temp(
+            heater_target_temp=150, actual_temp=148, target_material_temp=210
+        )
+        heater.can_extrude = True
+        obj.function.is_printing.return_value = True
+        result = obj._check_extruder_temp(MagicMock())
+        pheaters.set_temperature.assert_not_called()
+        assert result is None


### PR DESCRIPTION
…temperature to extrude.

## Major Changes in this PR
Adds an optional flag to AFC/AFC.cfg to not lower the extruder temperature if it is already at a sufficient temperature to melt plastic (e.g., it is set to 250, and the next material temperature is 235).

## Notes to Code Reviewers

## How the changes in this PR are tested
Unit tests are included; also have manually tested by homing, setting temperature to a temperature that is > 5C above next target temp, commanding a lane change and observing temperature target does not change.

Note that slicer filament temperature control will still take place during printing, after AFC control of the Tx command ends.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.