### PR TITLE
(Addition) Added new load‑then‑home support, new DIST_HUB speed mode, and lane/unit config propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2026-02-26]
+## [2026-02-27]
 ### Added
 - New `lower_extruder_temp_on_change` config option in `AFC.cfg`. When set to `False`, AFC will not lower the extruder temperature during a filament change as long as the current temperature is already sufficient for the target material (within 5°C). Defaults to `True` to preserve existing behaviour.
+- Added load‑then‑home support with new load_then_home and load_undershoot config options at AFC, unit, and lane levels.
+- Added new DIST_HUB speed mode and updated speed/accel selection logic; BoxTurtle now uses DIST_HUB for hub‑distance moves.
+- Adjusted HUB speed‑mode mapping to short‑move parameters and cleaned up related move‑to‑tool logic.
 
 ## [2026-02-25]
 ### Fixed

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -194,6 +194,8 @@ class afc:
         self.home_to_hub            = config.getboolean("home_to_hub", True)        # Global setting to auto-home to hub during moves
         self.home_to_tool           = config.getboolean("home_to_tool", True)       # Global setting to auto-home to tool during moves
         self.homing_enabled         = config.getboolean("homing_enabled", True)
+        self.load_then_home         = config.getboolean("load_then_home", True)
+        self.load_undershoot        = config.getfloat("load_undershoot", 50)
 
         self.tool_max_unload_attempts= config.getint('tool_max_unload_attempts', 4) # Max number of attempts to unload filament from toolhead when using buffer as ramming sensor
         self.tool_max_load_checks   = config.getint('tool_max_load_checks', 4)      # Max number of attempts to check to make sure filament is loaded into toolhead extruder when using buffer as ramming sensor
@@ -1245,6 +1247,7 @@ class afc:
                 if self._check_extruder_temp(cur_lane):
                     self.afcDeltaTime.log_with_time("Done heating toolhead")
 
+                # TODO: add and verify load_then_home logic for direct lanes
                 # Move filament to the hub if it's not already loaded there.
                 if (not cur_lane.loaded_to_hub
                     or cur_lane.hub == 'direct'):
@@ -1286,8 +1289,17 @@ class afc:
 
                 # Move filament towards the toolhead.
                 if cur_lane.hub != 'direct':
-                    _, _, warn = cur_lane.move_to(cur_hub.afc_bowden_length,
-                                    SpeedMode.LONG,
+                    total_length = cur_hub.afc_bowden_length
+                    speed_mode = SpeedMode.LONG
+                    if self.load_then_home:
+                        load_length = total_length - cur_lane.homing_overshoot - self.load_undershoot
+                        cur_lane.move_to(load_length, SpeedMode.LONG,
+                                         assist_active=AssistActive.YES,
+                                         use_homing=False)
+                        total_length -= load_length
+                        speed_mode = SpeedMode.SHORT
+                    _, _, warn = cur_lane.move_to(total_length,
+                                    speed_mode,
                                     assist_active=AssistActive.YES,
                                     endstop=cur_lane.get_toolhead_endstop(),
                                     use_homing=self.homing_enabled and self.home_to_tool)

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -194,8 +194,8 @@ class afc:
         self.home_to_hub            = config.getboolean("home_to_hub", True)        # Global setting to auto-home to hub during moves
         self.home_to_tool           = config.getboolean("home_to_tool", True)       # Global setting to auto-home to tool during moves
         self.homing_enabled         = config.getboolean("homing_enabled", True)
-        self.load_then_home         = config.getboolean("load_then_home", True)
-        self.load_undershoot        = config.getfloat("load_undershoot", 50)
+        self.load_then_home_var     = config.getboolean("load_then_home", True)
+        self.load_undershoot        = config.getfloat("load_undershoot", 20)
 
         self.tool_max_unload_attempts= config.getint('tool_max_unload_attempts', 4) # Max number of attempts to unload filament from toolhead when using buffer as ramming sensor
         self.tool_max_load_checks   = config.getint('tool_max_load_checks', 4)      # Max number of attempts to check to make sure filament is loaded into toolhead extruder when using buffer as ramming sensor
@@ -1258,9 +1258,9 @@ class afc:
 
                     if cur_lane.hub == 'direct':
                         home_endstop= cur_lane.get_toolhead_endstop()
-                        _, _, warn = cur_lane.move_to(dist_to_hub, SpeedMode.LONG,
-                                        assist_active=AssistActive.DYNAMIC,
-                                        endstop=home_endstop, use_homing=self.homing_enabled)
+                        _, _, warn = cur_lane.unit_obj.load_then_home(cur_lane, dist_to_hub,
+                                                                      AssistActive.DYNAMIC,
+                                                                      home_endstop)
                     else:
                         cur_lane.unit_obj.move_to_hub(cur_lane, dist_to_hub, MoveDirection.POS,
                                                     self.homing_enabled,
@@ -1289,20 +1289,10 @@ class afc:
 
                 # Move filament towards the toolhead.
                 if cur_lane.hub != 'direct':
-                    total_length = cur_hub.afc_bowden_length
-                    speed_mode = SpeedMode.LONG
-                    if self.load_then_home:
-                        load_length = total_length - cur_lane.homing_overshoot - self.load_undershoot
-                        cur_lane.move_to(load_length, SpeedMode.LONG,
-                                         assist_active=AssistActive.YES,
-                                         use_homing=False)
-                        total_length -= load_length
-                        speed_mode = SpeedMode.SHORT
-                    _, _, warn = cur_lane.move_to(total_length,
-                                    speed_mode,
-                                    assist_active=AssistActive.YES,
-                                    endstop=cur_lane.get_toolhead_endstop(),
-                                    use_homing=self.homing_enabled and self.home_to_tool)
+                    _, _, warn = cur_lane.unit_obj.load_then_home(cur_lane,
+                                                                    cur_hub.afc_bowden_length,
+                                                                    AssistActive.DYNAMIC,
+                                                                    cur_lane.get_toolhead_endstop())
 
                 # Ensure filament reaches the toolhead.
                 tool_attempts = 0

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -523,7 +523,7 @@ class afcBoxTurtle(afcUnit):
         """
         try:
             if lane.loaded_to_hub:
-                lane.move_to(lane.dist_hub * -1, SpeedMode.HUB,
+                lane.move_to(lane.dist_hub * -1, SpeedMode.DIST_HUB,
                              endstop=lane.load_es, assist_active=AssistActive.DYNAMIC,
                              use_homing=self.afc.homing_enabled)
             max_tries = 0

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -46,6 +46,7 @@ class SpeedMode(Enum):
     HUB = 3
     NIGHT = 4
     CALIBRATION = 5
+    DIST_HUB = 6
 
 class MoveDirection(float):
     POS = 1.
@@ -627,9 +628,10 @@ class AFCLane:
             elif mode == SpeedMode.LONG:
                 return self.long_moves_speed, self.long_moves_accel
             elif (mode == SpeedMode.SHORT
-                  or mode == SpeedMode.CALIBRATION):
+                  or mode == SpeedMode.CALIBRATION
+                  or mode == SpeedMode.HUB):
                 return self.short_moves_speed, self.short_moves_accel
-            elif mode == SpeedMode.HUB:
+            elif (mode == SpeedMode.DIST_HUB):
                 return self.dist_hub_move_speed, self.dist_hub_move_accel
             else:
                 return self.short_moves_speed, self.short_moves_accel

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -151,6 +151,8 @@ class AFCLane:
         self.n20_break_delay_time: float = config.getfloat("n20_break_delay_time", None)        # Time to wait between breaking n20 motors(nSleep/FWD/RWD all 1) and then releasing the break to allow coasting. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
         self.homing_overshoot: float   = config.getfloat("homing_overshoot", None)             # Amount to add to homing distance so that distance is long enough to actually hit endstop
         self.homing_delta: float       = config.getfloat("homing_delta", None)                 # Delta for which to warn if homing move delta is not within this amount from command move distance.
+        self.load_then_home_var: bool  = config.getboolean("load_then_home", None)
+        self.load_undershoot: float    = config.getfloat("load_undershoot", None)
         self.extruder_clear_dis: float = config.getfloat("extruder_clear_dis", None)
 
         self.rev_long_moves_speed_factor: float = config.getfloat("rev_long_moves_speed_factor", None)     # scalar speed factor when reversing filamentalist
@@ -489,6 +491,8 @@ class AFCLane:
         if self.max_move_dis                is None: self.max_move_dis      = self.unit_obj.max_move_dis
         if self.homing_overshoot            is None: self.homing_overshoot  = self.unit_obj.homing_overshoot
         if self.homing_delta                is None: self.homing_delta      = self.unit_obj.homing_delta
+        if self.load_then_home_var          is None: self.load_then_home_var= self.unit_obj.load_then_home_var
+        if self.load_undershoot             is None: self.load_undershoot   = self.unit_obj.load_undershoot
         if self.td1_when_loaded             is None: self.td1_when_loaded   = self.unit_obj.td1_when_loaded
         if self.td1_device_id               is None: self.td1_device_id     = self.unit_obj.td1_device_id
         if self.extruder_clear_dis          is None: self.extruder_clear_dis= self.unit_obj.extruder_clear_dis

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -94,6 +94,8 @@ class afcUnit:
         self.max_move_dis                = config.getfloat("max_move_dis", self.afc.max_move_dis)            # Maximum distance to move filament. AFC breaks filament moves over this number into multiple moves. Useful to lower this number if running into timer too close errors when doing long filament moves. Setting value here overrides values set in AFC.cfg file
         self.homing_overshoot            = config.getfloat("homing_overshoot", 50)                           # Amount to add to homing distance so that distance is long enough to actually hit endstop
         self.homing_delta                = config.getfloat("homing_delta", self.HOMING_DELTA)                # Delta for which to warn if homing move delta is not within this amount from command move distance.
+        self.load_then_home_var          = config.getboolean("load_then_home", self.afc.load_then_home_var)
+        self.load_undershoot             = config.getfloat("load_undershoot", self.afc.load_undershoot)
         self.debug                       = config.getboolean("debug",            False)                      # Turns on/off debug messages to console
         self.rev_long_moves_speed_factor = config.getfloat("rev_long_moves_speed_factor", self.afc.rev_long_moves_speed_factor)
         self.extruder_clear_dis          = config.getfloat("extruder_clear_dis", 50)                        # Amount to move to clear extruder gears when ejecting filament
@@ -698,6 +700,39 @@ class afcUnit:
         """
         return lane.move_to(dist * dir, SpeedMode.LONG, endstop=lane.load_es,
                             assist_active=AssistActive.DYNAMIC, use_homing=use_homing)
+
+    def load_then_home(self, lane: AFCLane|AFCExtruderStepper, distance: float,
+                       assist_active: AssistActive, endstop: str) -> tuple[bool, float, bool]:
+        """
+        Helper method to move filament to toolhead. If load_then_home boolean is set, AFC will do
+        a normal move wihtout homing enabled for a distance of: distance - load_undershoot.
+        Once this move is done, AFC will them home the rest of the way to toolhead sensor or buffer for ramming.
+
+        :param lane: AFCLane object to move
+        :param distance: Total distance in mm to move filament
+        :param assist_active: Set appropriate to enabled/disable or use Dynamic logic to enabled/disable
+                              spoolers based off move distance.
+        :param endstop: Endstop to use when loading to toolhead
+
+        :return tuple: Returns if move was successful, distance moved, and boolean set to true if
+                       movement moved is not within 300mm of total distance. When homing is
+                       disabled, always returns True, 0, False.
+        """
+        total_distance = distance
+        speed_mode = SpeedMode.LONG
+        # Only do load then home if user has buffer defined and load then home enabled
+        home_to_tool = self.afc.homing_enabled and self.afc.home_to_tool
+        if (lane.load_then_home_var
+            and lane.extruder_obj.tool_start == "buffer"):
+            load_length = distance - lane.load_undershoot
+            home, dist, warn = lane.move_to(load_length, speed_mode, assist_active=assist_active,
+                                            endstop=endstop, use_homing=False)
+            total_distance -= load_length
+            speed_mode = SpeedMode.SHORT
+        home, dist, warn = lane.move_to(total_distance, speed_mode, assist_active=assist_active,
+                                        endstop=endstop, use_homing=home_to_tool)
+
+        return home, dist, warn
 
     cmd_AFC_SELECT_LANE_help = "Command to home to lane selector for specified lane in selector style units."
     cmd_AFC_SELECT_LANE_options = {"LANE": {"type":"string", "default":"lane1"}}

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -702,11 +702,13 @@ class afcUnit:
                             assist_active=AssistActive.DYNAMIC, use_homing=use_homing)
 
     def load_then_home(self, lane: AFCLane|AFCExtruderStepper, distance: float,
-                       assist_active: AssistActive, endstop: str) -> tuple[bool, float, bool]:
+                       assist_active: AssistActive, endstop: AFCHomingPoints) -> tuple[bool, float|int, bool]:
         """
         Helper method to move filament to toolhead. If load_then_home boolean is set, AFC will do
-        a normal move wihtout homing enabled for a distance of: distance - load_undershoot.
+        a normal move without homing enabled for a distance of: distance - load_undershoot.
         Once this move is done, AFC will them home the rest of the way to toolhead sensor or buffer for ramming.
+
+        If load_then_home is set false, then AFC will do a homing move from hub to toolhead.
 
         :param lane: AFCLane object to move
         :param distance: Total distance in mm to move filament
@@ -722,7 +724,10 @@ class afcUnit:
         speed_mode = SpeedMode.LONG
         # Only do load then home if user has buffer defined and load then home enabled
         home_to_tool = self.afc.homing_enabled and self.afc.home_to_tool
-        if (lane.load_then_home_var
+        # Adding in check to make sure distance is greater than load_undershoot value for lane
+        # when load_then_home is enabled
+        load_and_home = lane.load_then_home_var and distance > lane.load_undershoot
+        if (load_and_home
             and lane.extruder_obj.tool_start == "buffer"):
             load_length = distance - lane.load_undershoot
             home, dist, warn = lane.move_to(load_length, speed_mode, assist_active=assist_active,

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -46,6 +46,9 @@ class TestSpeedMode:
 
     def test_calibration_value(self):
         assert SpeedMode.CALIBRATION.value == 5
+    
+    def test_dist_hub_value(self):
+        assert SpeedMode.DIST_HUB.value == 6
 
     def test_all_members_unique(self):
         values = [m.value for m in SpeedMode if m.value is not None]


### PR DESCRIPTION
## Major Changes in this PR
- Added load‑then‑home support with new load_then_home and load_undershoot config options at AFC, unit, and lane levels.
- Added new DIST_HUB speed mode and updated speed/accel selection logic; BoxTurtle now uses DIST_HUB for hub‑distance moves.
- Adjusted HUB speed‑mode mapping to short‑move parameters and cleaned up related move‑to‑tool logic.

## Notes to Code Reviewers

## How the changes in this PR are tested
Load then home working:


https://github.com/user-attachments/assets/72f221b7-8b11-46e9-b641-edea2e54d4ed



## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.