### PR TITLE
feat: add per-extruder variable overrides for AFC macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-[2026-02-21]
+## [2026-02-21]
 ### Added
 - Toolchanger: Merged homing changes from DEV and updated homing code to work properly with toolchanger
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-02-24]
+### Added
+- Added per-toolhead variable overrides for macros via `_AFC_<base>_VARS_<extruder>` companion macros.
+
 ## [2026-02-21]
 ### Added
 - Toolchanger: Merged homing changes from DEV and updated homing code to work properly with toolchanger

--- a/config/AFC_Macro_Vars.cfg
+++ b/config/AFC_Macro_Vars.cfg
@@ -240,3 +240,25 @@ variable_z_hop                    : 0         # Height to raise Z when moving to
 variable_park_z                   : 0         # Absolute height to lower to after park move.  Leave 0 to disable
                                               # This is intended to be used to reduce oozing during loading / unload right before a poop.
                                               # Typically this would be set at the variable_purge_start value when needed.
+
+
+# ---------------------------------------------------------------------------------
+# Per-toolhead overrides
+# ---------------------------------------------------------------------------------
+# On multi-toolhead printers (IDEX, toolchangers) each toolhead can have its own
+# set of variables by defining an additional macro named
+#   _AFC_<macro_name>_VARS_<extruder_name>
+# where <extruder_name> matches the [AFC_extruder ...] section name (e.g. extruder,
+# extruder1, for tools t0, t1, etc.).
+#
+# Only the variables that differ from the global defaults need to be set.
+# All unset variables fall back to the values defined in [gcode_macro _AFC_<macro_name>_VARS].
+#
+# Example for a second toolhead with a different cutter pin location and cut direction:
+#
+# [gcode_macro _AFC_CUT_TIP_VARS_extruder1]
+# gcode: # Leave empty
+# variable_pin_loc_xy     : 250, 5     # cutter pin position for T1
+# variable_cut_direction  : "right"    # T1 cuts in the opposite direction
+#
+# ---------------------------------------------------------------------------------

--- a/config/macros/Brush.cfg
+++ b/config/macros/Brush.cfg
@@ -6,7 +6,12 @@ gcode:
     {% set travel_speed      = gVars['travel_speed']    | default(120)*60| float %}
     {% set z_travel_speed    = gVars['z_travel_speed']  | default(30)*60 | float %}
     {% set verbose           = gVars['verbose']         | default(1)     | int %}
-    {% set vars              = printer['gcode_macro _AFC_BRUSH_VARS'] %}
+    {% set vars              = printer['gcode_macro _AFC_BRUSH_VARS'].copy() %}
+    {% set extruder          = params.EXTRUDER|default('') %}
+    {% set _th_key           = 'gcode_macro _AFC_BRUSH_VARS_' ~ extruder %}
+    {% if extruder and printer[_th_key] is defined %}
+        {% set _ = vars.update(printer[_th_key]) %}
+    {% endif %}
     {% set Bx, By, Bz        = vars.brush_loc           | default([-1,-1,-1])| map('float') %}
     {% set brush_clean_accel = vars['brush_clean_accel']| default(0)         | float %}
     {% set y_brush           = vars['y_brush']          | default(false)     | lower == 'true' %}
@@ -63,7 +68,7 @@ gcode:
           RESPOND TYPE=command MSG='Brush Servo Extended'
         {% endif %}
         # Extend brush servo
-        _BRUSH_SERVO POS=out
+        _BRUSH_SERVO POS=out EXTRUDER={extruder}
     {% endif %}
 
     {% if verbose > 0 %}
@@ -137,7 +142,7 @@ gcode:
           RESPOND TYPE=command MSG='Brush Servo Retracted'
         {% endif %}
         # Retract brush servo
-        _BRUSH_SERVO POS=in
+        _BRUSH_SERVO POS=in EXTRUDER={extruder}
     {% endif %}
 
     # Reset acceleration values to what it was before
@@ -153,7 +158,12 @@ gcode:
 # Increase this value (in milliseconds) if the servo doesn't have enough time to fully retract or extend
 variable_dwell_time: 200
 gcode:
-  {% set c1 = printer['gcode_macro _AFC_BRUSH_VARS'] %}
+  {% set c1 = printer['gcode_macro _AFC_BRUSH_VARS'].copy() %}
+  {% set extruder = params.EXTRUDER|default('') %}
+  {% set _th_key = 'gcode_macro _AFC_BRUSH_VARS_' ~ extruder %}
+  {% if extruder and printer[_th_key] is defined %}
+      {% set _ = c1.update(printer[_th_key]) %}
+  {% endif %}
   {% set pos = params.POS %}
   {% if pos == "in" %}
     SET_SERVO SERVO={c1.tool_servo_name} ANGLE={c1.tool_servo_angle_in}

--- a/config/macros/Cut.cfg
+++ b/config/macros/Cut.cfg
@@ -5,7 +5,12 @@ gcode:
     {% set accel                = gVars['accel']                |default(2000)  | float %}
     {% set travel_speed         = gVars['travel_speed']         |default(120)*60| float %}
     {% set verbose              = gVars['verbose']              |default(1)     | int %}
-    {% set vars                 = printer['gcode_macro _AFC_CUT_TIP_VARS'] %}
+    {% set vars                 = printer['gcode_macro _AFC_CUT_TIP_VARS'].copy() %}
+    {% set extruder             = params.EXTRUDER|default('') %}
+    {% set _th_key              = 'gcode_macro _AFC_CUT_TIP_VARS_' ~ extruder %}
+    {% if extruder and printer[_th_key] is defined %}
+        {% set _ = vars.update(printer[_th_key]) %}
+    {% endif %}
     {% set pin_loc_x, pin_loc_y = vars.pin_loc_xy               |default([-1, -1])| map('float') %}
     {% set pin_park_dist        = vars['pin_park_dist']         |default(6.0)   | float %}
     {% set retract_length       = vars['retract_length']        |default(8.5)   | float %}
@@ -78,7 +83,7 @@ gcode:
     G90  # Absolute positioning
     M83  # Relative extrusion
     G92 E0
-    _MOVE_TO_CUTTER_PIN PIN_PARK_X_LOC={pin_park_x_loc} PIN_PARK_Y_LOC={pin_park_y_loc}
+    _MOVE_TO_CUTTER_PIN PIN_PARK_X_LOC={pin_park_x_loc} PIN_PARK_Y_LOC={pin_park_y_loc} EXTRUDER={extruder}
     
     G90  # Absolute positioning
     M83  # Relative extrusion
@@ -111,7 +116,7 @@ gcode:
           RESPOND TYPE=command MSG='Cut Servo Extended'
         {% endif %}
         # Extend cutter pin servo
-        _CUTTER_SERVO POS=out
+        _CUTTER_SERVO POS=out EXTRUDER={extruder}
     {% endif %}
 
     {% if verbose > 1 %}
@@ -163,7 +168,7 @@ gcode:
     {% endif %}    
     
     {% for cut in range(cut_count - 1) %}
-        _DO_CUT_MOTION PIN_PARK_X_LOC={pin_park_x_loc} PIN_PARK_Y_LOC={pin_park_y_loc} RIP_LENGTH=0
+        _DO_CUT_MOTION PIN_PARK_X_LOC={pin_park_x_loc} PIN_PARK_Y_LOC={pin_park_y_loc} RIP_LENGTH=0 EXTRUDER={extruder}
     {% endfor %}
 
     {% if verbose > 1 %}
@@ -171,7 +176,7 @@ gcode:
     {% endif %}
 
     # Do a rip on final cut pass
-    _DO_CUT_MOTION PIN_PARK_X_LOC={pin_park_x_loc} PIN_PARK_Y_LOC={pin_park_y_loc} RIP_LENGTH={rip_length}
+    _DO_CUT_MOTION PIN_PARK_X_LOC={pin_park_x_loc} PIN_PARK_Y_LOC={pin_park_y_loc} RIP_LENGTH={rip_length} EXTRUDER={extruder}
     {% if cut_current_x > 0 or cut_current_dc > 0 %}
         # Check for IDEX
         {% if printer.dual_carriage is defined %}
@@ -197,7 +202,7 @@ gcode:
           RESPOND TYPE=command MSG='Cut Servo Retracted'
         {% endif %}
         # Retract cutter pin servo
-        _CUTTER_SERVO POS=in
+        _CUTTER_SERVO POS=in EXTRUDER={extruder}
     {% endif %}
 
     {% if cut_current_y > 0 %}
@@ -229,7 +234,7 @@ gcode:
 
     # Reset acceleration values to what it was before
     SET_VELOCITY_LIMIT ACCEL={saved_accel}
-    _CLEAR_PIN PIN_PARK_X_LOC={pin_park_x_loc} PIN_PARK_Y_LOC={pin_park_y_loc}
+    _CLEAR_PIN PIN_PARK_X_LOC={pin_park_x_loc} PIN_PARK_Y_LOC={pin_park_y_loc} EXTRUDER={extruder}
     AFC_ENABLE_SKEW
 
     # Restore state and optionally position
@@ -246,7 +251,12 @@ gcode:
     {% set pin_park_y_loc = params.PIN_PARK_Y_LOC|float %}
     {% set gVars = printer['gcode_macro _AFC_GLOBAL_VARS'] %}
     {% set travel_speed = gVars['travel_speed'] * 60|float %}
-    {% set vars = printer['gcode_macro _AFC_CUT_TIP_VARS'] %}
+    {% set vars = printer['gcode_macro _AFC_CUT_TIP_VARS'].copy() %}
+    {% set extruder = params.EXTRUDER|default('') %}
+    {% set _th_key = 'gcode_macro _AFC_CUT_TIP_VARS_' ~ extruder %}
+    {% if extruder and printer[_th_key] is defined %}
+        {% set _ = vars.update(printer[_th_key]) %}
+    {% endif %}
     {% set cut_direction = vars['cut_direction']|default('')|lower %}
     {% set act_x = printer.toolhead.position.x|float %}
     {% set act_y = printer.toolhead.position.y|float %}
@@ -290,7 +300,12 @@ gcode:
     {% set pin_park_y_loc = params.PIN_PARK_Y_LOC|float %}
     {% set rip_length = params.RIP_LENGTH|float %}
 
-    {% set vars = printer['gcode_macro _AFC_CUT_TIP_VARS'] %}
+    {% set vars = printer['gcode_macro _AFC_CUT_TIP_VARS'].copy() %}
+    {% set extruder = params.EXTRUDER|default('') %}
+    {% set _th_key = 'gcode_macro _AFC_CUT_TIP_VARS_' ~ extruder %}
+    {% if extruder and printer[_th_key] is defined %}
+        {% set _ = vars.update(printer[_th_key]) %}
+    {% endif %}
     {% set cut_move_dist = vars['cut_move_dist']|float %}
     {% set cut_direction = vars['cut_direction']|default('')|lower %}
     {% set cut_fast_move_fraction = vars['cut_fast_move_fraction']|float %}
@@ -376,7 +391,12 @@ gcode:
 # Increase this value if the servo doesn't have enough time to fully retract or extend
 variable_dwell_time: 200
 gcode:
-  {% set c1 = printer['gcode_macro _AFC_CUT_TIP_VARS'] %}
+  {% set c1 = printer['gcode_macro _AFC_CUT_TIP_VARS'].copy() %}
+  {% set extruder = params.EXTRUDER|default('') %}
+  {% set _th_key = 'gcode_macro _AFC_CUT_TIP_VARS_' ~ extruder %}
+  {% if extruder and printer[_th_key] is defined %}
+      {% set _ = c1.update(printer[_th_key]) %}
+  {% endif %}
   {% set pos = params.POS %}
   {% if pos == "in" %}
     SET_SERVO SERVO={c1.tool_servo_name} ANGLE={c1.tool_servo_angle_in}
@@ -399,7 +419,12 @@ gcode:
     {% set pin_park_y_loc = params.PIN_PARK_Y_LOC|float %}
     {% set gVars = printer['gcode_macro _AFC_GLOBAL_VARS'] %}
     {% set travel_speed = gVars['travel_speed'] * 60|float %}
-    {% set vars = printer['gcode_macro _AFC_CUT_TIP_VARS'] %}
+    {% set vars = printer['gcode_macro _AFC_CUT_TIP_VARS'].copy() %}
+    {% set extruder = params.EXTRUDER|default('') %}
+    {% set _th_key = 'gcode_macro _AFC_CUT_TIP_VARS_' ~ extruder %}
+    {% if extruder and printer[_th_key] is defined %}
+        {% set _ = vars.update(printer[_th_key]) %}
+    {% endif %}
     {% set cut_direction = vars['cut_direction']|default('')|lower %}
     {% set act_x = printer.toolhead.position.x|float %}
     {% set act_y = printer.toolhead.position.y|float %}

--- a/config/macros/Kick.cfg
+++ b/config/macros/Kick.cfg
@@ -6,7 +6,12 @@ gcode:
   {% set travel_speed       = gVars['travel_speed']     | default(120)*60   | float %}
   {% set z_travel_speed     = gVars['z_travel_speed']   | default(30)*60    | float %}
   {% set verbose            = gVars['verbose']          | default(1)        | int %}
-  {% set vars               = printer['gcode_macro _AFC_KICK_VARS'] %}
+  {% set vars               = printer['gcode_macro _AFC_KICK_VARS'].copy() %}
+  {% set extruder           = params.EXTRUDER|default('') %}
+  {% set _th_key            = 'gcode_macro _AFC_KICK_VARS_' ~ extruder %}
+  {% if extruder and printer[_th_key] is defined %}
+      {% set _ = vars.update(printer[_th_key]) %}
+  {% endif %}
   {% set kick_start_x, kick_start_y, kick_start_z = vars.kick_start_loc|default([-1,-1,5])|map('float') %}
   {% set kick_z             = vars['kick_z']            | default(1.5)      | float %}
   {% set kick_direction     = vars['kick_direction']    | default('')       | lower %}

--- a/config/macros/Park.cfg
+++ b/config/macros/Park.cfg
@@ -5,7 +5,12 @@ gcode:
   {% set travel_speed   = gVars['travel_speed']     | default(120)*60   | float %}
   {% set verbose        = gVars['verbose']          | default(1)        | int %}
   {% set z_travel_speed = gVars['z_travel_speed']   | default(30)*60    | float %}
-  {% set vars           = printer['gcode_macro _AFC_PARK_VARS'] %}
+  {% set vars           = printer['gcode_macro _AFC_PARK_VARS'].copy() %}
+  {% set extruder       = params.EXTRUDER|default('') %}
+  {% set _th_key        = 'gcode_macro _AFC_PARK_VARS_' ~ extruder %}
+  {% if extruder and printer[_th_key] is defined %}
+      {% set _ = vars.update(printer[_th_key]) %}
+  {% endif %}
   {% set Px, Py         = vars.park_loc_xy          | default([-1,-1])  | map('float') %}
   {% set Px             = params.X                  | default(Px)       | float %}
   {% set Py             = params.Y                  | default(Py)       | float %}

--- a/config/macros/Poop.cfg
+++ b/config/macros/Poop.cfg
@@ -6,7 +6,12 @@ gcode:
   {% set travel_speed           = gVars['travel_speed']     | default(120)*60   | float %}
   {% set z_travel_speed         = gVars['z_travel_speed']   | default(30)*60    | float %}
   {% set verbose                = gVars['verbose']          | default(1)        | int %}
-  {% set vars                   = printer['gcode_macro _AFC_POOP_VARS'] %}
+  {% set vars                   = printer['gcode_macro _AFC_POOP_VARS'].copy() %}
+  {% set extruder               = params.EXTRUDER|default('') %}
+  {% set _th_key                = 'gcode_macro _AFC_POOP_VARS_' ~ extruder %}
+  {% if extruder and printer[_th_key] is defined %}
+      {% set _ = vars.update(printer[_th_key]) %}
+  {% endif %}
   {% set purge_x, purge_y       = vars.purge_loc_xy         | default([-1,-1])  | map('float') %}
   {% set purge_spd              = vars['purge_spd']         | default(6.5)*60   | float %}
   {% set z_poop                 = vars['z_purge_move']      | default(true)     | lower == 'true' %}

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1286,26 +1286,26 @@ class afc:
                     cur_lane.espooler.do_assist_move()
                     if self.poop:
                         if purge_length is not None:
-                            self.gcode.run_script_from_command("%s %s=%s" % (self.poop_cmd, 'PURGE_LENGTH', purge_length))
+                            self.gcode.run_script_from_command("{} PURGE_LENGTH={} EXTRUDER={}".format(self.poop_cmd, purge_length, cur_extruder.name))
 
                         else:
-                            self.gcode.run_script_from_command(self.poop_cmd)
+                            self.gcode.run_script_from_command("{} EXTRUDER={}".format(self.poop_cmd, cur_extruder.name))
 
                         self.afcDeltaTime.log_with_time("TOOL_LOAD: After poop")
                         self.function.log_toolhead_pos()
 
                         if self.wipe:
-                            self.gcode.run_script_from_command(self.wipe_cmd)
+                            self.gcode.run_script_from_command("{} EXTRUDER={}".format(self.wipe_cmd, cur_extruder.name))
                             self.afcDeltaTime.log_with_time("TOOL_LOAD: After first wipe")
                             self.function.log_toolhead_pos()
 
                     if self.kick:
-                        self.gcode.run_script_from_command(self.kick_cmd)
+                        self.gcode.run_script_from_command("{} EXTRUDER={}".format(self.kick_cmd, cur_extruder.name))
                         self.afcDeltaTime.log_with_time("TOOL_LOAD: After kick")
                         self.function.log_toolhead_pos()
 
                     if self.wipe:
-                        self.gcode.run_script_from_command(self.wipe_cmd)
+                        self.gcode.run_script_from_command("{} EXTRUDER={}".format(self.wipe_cmd, cur_extruder.name))
                         self.afcDeltaTime.log_with_time("TOOL_LOAD: After second wipe")
                         self.function.log_toolhead_pos()
 
@@ -1696,19 +1696,19 @@ class afc:
             # Perform filament cutting and parking if specified.
             if self.tool_cut:
                 cur_lane.extruder_obj.estats.increase_cut_total()
-                self.gcode.run_script_from_command(self.tool_cut_cmd)
+                self.gcode.run_script_from_command("{} EXTRUDER={}".format(self.tool_cut_cmd, cur_extruder.name))
                 self.afcDeltaTime.log_with_time("TOOL_UNLOAD: After cut")
                 self.function.log_toolhead_pos()
 
                 if self.park:
-                    self.gcode.run_script_from_command(self.park_cmd)
+                    self.gcode.run_script_from_command("{} EXTRUDER={}".format(self.park_cmd, cur_extruder.name))
                     self.afcDeltaTime.log_with_time("TOOL_UNLOAD: After park")
                     self.function.log_toolhead_pos()
 
             # Form filament tip if necessary.
             if self.form_tip:
                 if self.park:
-                    self.gcode.run_script_from_command(self.park_cmd)
+                    self.gcode.run_script_from_command("{} EXTRUDER={}".format(self.park_cmd, cur_extruder.name))
                     self.afcDeltaTime.log_with_time("TOOL_UNLOAD: After form tip park")
                     self.function.log_toolhead_pos()
 


### PR DESCRIPTION
Allows each toolhead on multi-toolhead printers (IDEX, toolchangers) to have its own macro settings without changing the global defaults. Only the variables that differ need to be defined.

Each macro builds its vars dict by shallow-copying the base `_AFC_X_VARS` macro, then merging in `_AFC_X_VARS_<extruder>` on top if it exists, and AFC.py now passes `EXTRUDER=<extruder.name>` to `AFC_CUT`, `AFC_POOP`, `AFC_BRUSH`, `AFC_KICK`, and `AFC_PARK`.

Klipper ignores unknown params so users who haven't updated their local macros won't see any change in behavior. Single-toolhead setups are unaffected.
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description