### PR TITLE
(Update): Updating ViViD PREP logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-03-03]
+## Updates
+- Updated PREP logic for ViViD to check if filament is loaded by moving filament to load sensor. ViViD no longer relies on saved `loaded_to_hub` state.
+
 ## [2026-03-01]
 ### Added
 - Added `selector_cal_distance` to AFC_lane for units like ViViD that have selectors. If this value is set AFC will move the selector the supplied distance in mm. This is to help make sure selectors have a good grip on the filament.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2026-03-03]
-## Updates
+### Update
 - Updated PREP logic for ViViD to check if filament is loaded by moving filament to load sensor. ViViD no longer relies on saved `loaded_to_hub` state.
 
 ## [2026-03-01]

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -61,10 +61,10 @@ class afcBoxTurtle(afcUnit):
     def _move_lane(self, lane: AFCLane|AFCExtruderStepper, delay: float,
                    enable_movement: bool=True) -> bool:
         """
-        Helper method to move BoxTurtles lane forwards than backwards
+        Helper method to move BoxTurtle's lane forward then backward
 
         :param lane: Lane to move and check if filament is present.
-        :param delay: Delay amount to wait between the forward than backwards movement.
+        :param delay: Delay amount to wait between the forward then backward movements.
         :param enable_movement: When True movement is enabled, if False movement is disabled and
                                 a delay happens instead.
         :return: Returns current lanes load state

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from extras.AFC_lane import AFCLane, MoveDirection
+    from extras.AFC_stepper import AFCExtruderStepper
 
 try: from extras.AFC_utils import ERROR_STR
 except: raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".format(trace=traceback.format_exc()))
@@ -57,21 +58,35 @@ class afcBoxTurtle(afcUnit):
         self.logo_error+='! \_________/ |___|</span>\n'
         self.logo_error+= '  ' + self.name + '\n'
 
+    def _move_lane(self, lane: AFCLane|AFCExtruderStepper, delay: float,
+                   enable_movement: bool=True) -> bool:
+        """
+        Helper method to move BoxTurtles lane forwards than backwards
+
+        :param lane: Lane to move and check if filament is present.
+        :param delay: Delay amount to wait between the forward than backwards movement.
+        :param enable_movement: When True movement is enabled, if False movement is disabled and
+                                a delay happens instead.
+        :return: Returns current lanes load state
+        """
+        if enable_movement:
+            lane.move(5, self.afc.short_moves_speed, self.afc.short_moves_accel, True)
+            self.afc.reactor.pause(self.afc.reactor.monotonic() + delay)
+            lane.move(-5, self.afc.short_moves_speed, self.afc.short_moves_accel, True)
+        else:
+            self.afc.reactor.pause(self.afc.reactor.monotonic() + 0.7)
+        return lane.load_state
+
     def system_Test(self, cur_lane, delay, assignTcmd, enable_movement):
         msg = ''
         succeeded = True
 
         # Run test reverse/forward on each lane
         cur_lane.unsync_to_extruder(False)
-        if enable_movement:
-            cur_lane.move(5, self.afc.short_moves_speed, self.afc.short_moves_accel, True)
-            self.afc.reactor.pause(self.afc.reactor.monotonic() + delay)
-            cur_lane.move(-5, self.afc.short_moves_speed, self.afc.short_moves_accel, True)
-        else:
-            self.afc.reactor.pause(self.afc.reactor.monotonic() + 0.7)
+        loaded = self._move_lane(cur_lane, delay, enable_movement)
 
         if not cur_lane.prep_state:
-            if not cur_lane.load_state:
+            if not loaded:
                 self.afc.function.afc_led(cur_lane.led_not_ready, cur_lane.led_index)
                 msg += 'EMPTY READY FOR SPOOL'
             else:
@@ -84,7 +99,7 @@ class afcBoxTurtle(afcUnit):
         else:
             self.afc.function.afc_led(cur_lane.led_ready, cur_lane.led_index)
             msg +="<span class=success--text>LOCKED</span>"
-            if not cur_lane.load_state:
+            if not loaded:
                 msg +="<span class=error--text> NOT LOADED</span>"
                 self.afc.function.afc_led(cur_lane.led_not_ready, cur_lane.led_index)
                 succeeded = False

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -555,6 +555,10 @@ class afcUnit:
     def unselect_lane(self, move_distance: float=50):
         self._print_function_not_defined(self.unselect_lane.__name__)
 
+    def _move_lane(self, lane: AFCLane|AFCExtruderStepper, delay: float,
+                enable_movement: bool=True) -> bool:
+        self._print_function_not_defined(self._move_lane.__name__)
+
     def calibration_lane_message(self) -> str:
         return ""
 

--- a/extras/AFC_vivid.py
+++ b/extras/AFC_vivid.py
@@ -100,6 +100,7 @@ class AFC_vivid(afcBoxTurtle):
         :return: Returns True if homing was successful, False when homing is not successful
         """
         loaded = False
+        homed = False
         if lane.prep_state:
             homed, _, _ = self.move_to_load(lane, lane.dist_hub, MoveDirection.POS,
                                             True, SpeedMode.SHORT)

--- a/extras/AFC_vivid.py
+++ b/extras/AFC_vivid.py
@@ -106,8 +106,9 @@ class AFC_vivid(afcBoxTurtle):
             if homed:
                 loaded = True
                 lane.loaded_to_hub = True
-                lane.move_to(lane.hub_obj.hub_clear_move_dis * MoveDirection.NEG,
-                             SpeedMode.SHORT, use_homing=False)
+                if not lane.tool_loaded:
+                    lane.move_to(lane.hub_obj.hub_clear_move_dis * MoveDirection.NEG,
+                                SpeedMode.SHORT, use_homing=False)
         # Resetting internal states when prep sensor is not triggered but loaded to hub is still
         # set, or when failed to home to load sensor
         if ((not lane.prep_state

--- a/extras/AFC_vivid.py
+++ b/extras/AFC_vivid.py
@@ -87,6 +87,41 @@ class AFC_vivid(afcBoxTurtle):
         self.logo = '<span class=success--text>ViViD Ready\n</span>'
         self.logo_error = '<span class=error--text>ViViD Not Ready</span>\n'
 
+    def _move_lane(self, lane: AFCLane, delay: float=1,
+                enable_movement: bool=True) -> bool:
+        """
+        Method to check and see if filament is loaded into lane. This method tries to move filament
+        to load sensor, once successful lane is retracted by hubs `hub_clear_move_dis`. If homing
+        is not successful, internal lane states are reset.
+
+        :param lane: Lane to move and check if filament is present
+        :param delay: Not used
+        :param enable_movement: Not used
+        :return: Returns True if homing was successful, False when homing is not successful
+        """
+        loaded = False
+        if lane.prep_state:
+            homed, _, _ = self.move_to_load(lane, lane.dist_hub, MoveDirection.POS,
+                                            True, SpeedMode.SHORT)
+            if homed:
+                loaded = True
+                lane.loaded_to_hub = True
+                lane.move_to(lane.hub_obj.hub_clear_move_dis * MoveDirection.NEG,
+                             SpeedMode.SHORT, use_homing=False)
+        # Resetting internal states when prep sensor is not triggered but loaded to hub is still
+        # set, or when failed to home to load sensor
+        if ((not lane.prep_state
+             and lane.loaded_to_hub)
+             or not homed):
+            self.lane_unloaded(lane)
+            lane.tool_loaded = False
+            lane.status = AFCLaneState.NONE
+            lane.loaded_to_hub = False
+            lane.td1_data = {}
+            if not lane.remember_spool:
+                lane.afc.spool.clear_values(lane)
+        return loaded
+
     def system_Test(self, cur_lane, delay, assignTcmd, enable_movement):
         return super().system_Test( cur_lane, delay, assignTcmd, enable_movement=False)
 
@@ -204,8 +239,9 @@ class AFC_vivid(afcBoxTurtle):
                                                 f"{lane.name} calibrated, updating dist_hub")
                 self.afc.function.ConfigRewrite(lane.fullname, "calibrated_lane",
                                                 lane.calibrated_lane, "")
-            # Retract a bit so load sensor is not triggered
-            lane.move_to( -10, SpeedMode.SHORT, use_homing=False)
+            # Retract so load sensor is not triggered
+            lane.move_to(lane.hub_obj.hub_clear_move_dis * MoveDirection.NEG,
+                         SpeedMode.SHORT, use_homing=False)
             self.lane_loaded(lane)
         else:
             self.logger.error(f"Failed to move {lane.name} to load sensor.")

--- a/templates/AFC_Vivid_1.cfg
+++ b/templates/AFC_Vivid_1.cfg
@@ -36,7 +36,7 @@ gear_ratio: 2.5:1
 [tmc2209 AFC_stepper Vivid_1_selector]
 uart_pin: Vivid_1:MSEL_UART
 uart_address: 0
-run_current: 0.8
+run_current: 1.0
 sense_resistor: 0.110
 
 [AFC_lane lane1]
@@ -79,8 +79,6 @@ multiplier_low: 0.90
 
 [AFC_hub Vivid_1]
 afc_bowden_length: 2000     # Length of the Bowden tube from the hub to the toolhead sensor in mm.
-move_dis: 20                   # Distance to move the filament within the hub in mm.
-hub_clear_move_dis: 20
 switch_pin: virtual
 
 [AFC_led AFC_Indicator_1]

--- a/tests/test_AFC_BoxTurtle.py
+++ b/tests/test_AFC_BoxTurtle.py
@@ -148,3 +148,23 @@ class TestSystemTestReactorPause:
         unit.afc.reactor.pause = pause_mock
         unit.system_Test(lane, delay=0.0, assignTcmd=True, enable_movement=False)
         pause_mock.assert_called()
+
+# ── _move_lane ──────────────────────────────────────────────────
+class Test_MoveLane:
+    def test_returns_not_enable_movement_loaded(self):
+        from unittest.mock import PropertyMock
+        unit = _make_box_turtle()
+        lane = _make_lane()
+        type(lane).load_state = PropertyMock(side_effect=[True])
+
+        result = unit._move_lane(lane, delay=1, enable_movement=False)
+        assert result is True
+    
+    def test_returns_not_enable_movement_not_loaded(self):
+        from unittest.mock import PropertyMock
+        unit = _make_box_turtle()
+        lane = _make_lane()
+        type(lane).load_state = PropertyMock(side_effect=[False])
+
+        result = unit._move_lane(lane, delay=1, enable_movement=False)
+        assert result is False

--- a/tests/test_AFC_BoxTurtle.py
+++ b/tests/test_AFC_BoxTurtle.py
@@ -50,6 +50,7 @@ def _make_box_turtle(name="Turtle_1"):
 
 def _make_lane(prep_state=False, load_state=False, tool_loaded=False):
     lane = MagicMock()
+    lane.move = MagicMock()
     lane.name = "lane1"
     lane.prep_state = prep_state
     lane.load_state = load_state

--- a/tests/test_AFC_vivid.py
+++ b/tests/test_AFC_vivid.py
@@ -103,6 +103,7 @@ class Test_MoveLane:
         lane.prep_state = True
         lane.spool_id = 10
         lane.remember_spool = True
+        lane.tool_loaded = False
         lane.move_to.return_value = (True, 100.0, False)
         result = unit._move_lane(lane, 1, True)
         assert result is True
@@ -115,6 +116,7 @@ class Test_MoveLane:
         lane.loaded_to_hub = True
         lane.spool_id = 10
         lane.remember_spool = True
+        lane.tool_loaded = False
         lane.move_to.return_value = (False, 100.0, False)
         result = unit._move_lane(lane, 1, True)
         assert result is False
@@ -131,6 +133,7 @@ class Test_MoveLane:
         lane.loaded_to_hub = True
         lane.spool_id = 10
         lane.remember_spool = True
+        lane.tool_loaded = False
         lane.move_to.return_value = (False, 100.0, False)
         result = unit._move_lane(lane, 1, True)
         assert result is False
@@ -147,6 +150,7 @@ class Test_MoveLane:
         lane.loaded_to_hub = True
         lane.spool_id = 10
         lane.remember_spool = False
+        lane.tool_loaded = False
         lane.move_to.return_value = (False, 100.0, False)
         result = unit._move_lane(lane, 1, True)
         assert result is False

--- a/tests/test_AFC_vivid.py
+++ b/tests/test_AFC_vivid.py
@@ -95,6 +95,64 @@ class TestVivdConstants:
     def test_is_subclass_of_box_turtle(self):
         assert issubclass(AFC_vivid, afcBoxTurtle)
 
+# ── _move_lane ──────────────────────────────────────────────────
+class Test_MoveLane:
+    def test_returns_prep_true_filament_loaded(self):
+        unit = _make_vivid()
+        lane = _make_lane(has_selector=True)
+        lane.prep_state = True
+        lane.spool_id = 10
+        lane.remember_spool = True
+        lane.move_to.return_value = (True, 100.0, False)
+        result = unit._move_lane(lane, 1, True)
+        assert result is True
+        assert lane.spool_id is 10
+    
+    def test_returns_prep_true_filament_not_loaded(self):
+        unit = _make_vivid()
+        lane = _make_lane(has_selector=True)
+        lane.prep_state = True
+        lane.loaded_to_hub = True
+        lane.spool_id = 10
+        lane.remember_spool = True
+        lane.move_to.return_value = (False, 100.0, False)
+        result = unit._move_lane(lane, 1, True)
+        assert result is False
+        assert lane.tool_loaded is False
+        assert lane.loaded_to_hub is False
+        assert lane.spool_id is 10
+    
+    def test_returns_prep_false_filament_not_loaded(self):
+        from extras.AFC_spool import AFCSpool
+        unit = _make_vivid()
+        lane = _make_lane(has_selector=True)
+        lane.afc.spool = AFCSpool.__new__(AFCSpool)
+        lane.prep_state = False
+        lane.loaded_to_hub = True
+        lane.spool_id = 10
+        lane.remember_spool = True
+        lane.move_to.return_value = (False, 100.0, False)
+        result = unit._move_lane(lane, 1, True)
+        assert result is False
+        assert lane.tool_loaded is False
+        assert lane.loaded_to_hub is False
+        assert lane.spool_id is 10
+    
+    def test_returns_prep_false_filament_not_loaded_not_remember_spool(self):
+        from extras.AFC_spool import AFCSpool
+        unit = _make_vivid()
+        lane = _make_lane(has_selector=True)
+        lane.afc.spool = AFCSpool.__new__(AFCSpool)
+        lane.prep_state = False
+        lane.loaded_to_hub = True
+        lane.spool_id = 10
+        lane.remember_spool = False
+        lane.move_to.return_value = (False, 100.0, False)
+        result = unit._move_lane(lane, 1, True)
+        assert result is False
+        assert lane.tool_loaded is False
+        assert lane.loaded_to_hub is False
+        assert lane.spool_id is None
 
 # ── _get_lane_selector_state ──────────────────────────────────────────────────
 

--- a/tests/test_AFC_vivid.py
+++ b/tests/test_AFC_vivid.py
@@ -107,7 +107,7 @@ class Test_MoveLane:
         lane.move_to.return_value = (True, 100.0, False)
         result = unit._move_lane(lane, 1, True)
         assert result is True
-        assert lane.spool_id is 10
+        assert lane.spool_id == 10
     
     def test_returns_prep_true_filament_not_loaded(self):
         unit = _make_vivid()
@@ -122,7 +122,7 @@ class Test_MoveLane:
         assert result is False
         assert lane.tool_loaded is False
         assert lane.loaded_to_hub is False
-        assert lane.spool_id is 10
+        assert lane.spool_id == 10
     
     def test_returns_prep_false_filament_not_loaded(self):
         from extras.AFC_spool import AFCSpool
@@ -139,7 +139,7 @@ class Test_MoveLane:
         assert result is False
         assert lane.tool_loaded is False
         assert lane.loaded_to_hub is False
-        assert lane.spool_id is 10
+        assert lane.spool_id == 10
     
     def test_returns_prep_false_filament_not_loaded_not_remember_spool(self):
         from extras.AFC_spool import AFCSpool


### PR DESCRIPTION
## Major Changes in this PR
- ViViDs PREP logic has been updated to try and move filament to load sensor to verify filament is actually loaded when starting up.
- New unit tests were added for the new method that was added.
- Removed custom hub move distances and just defaulting to AFC default values.

## Notes to Code Reviewers

## How the changes in this PR are tested
- Tested with ViViD unit, ran unit tests
- Verified that states get reset when filament is removed while printer is powered off

Correctly erroring out when prep sensor is triggered but load sensor does not trigger:
<img width="458" height="209" alt="image" src="https://github.com/user-attachments/assets/d863490d-f4fa-4320-b869-bc92ed4a75ef" />

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.