### PR TITLE
(Enhancement): Adds ability to check if filament is loaded to toolhead when using buffer as toolhead sensor and sprung buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-03-06]
+### Added
+- Ability to check if toolhead is loaded when using buffer as toolhead sensor, add `enable_buffer_tool_check: True` to AFC_Boxturtle/AFC_vivid etc config section to enable.
+
 ## [2026-03-03]
 ### Update
 - Updated PREP logic for ViViD to check if filament is loaded by moving filament to load sensor. ViViD no longer relies on saved `loaded_to_hub` state.

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -39,7 +39,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 try: from extras.AFC_stats import AFCStats
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
 
-AFC_VERSION="1.0.50"
+AFC_VERSION="1.0.51"
 
 # Class for holding different states so its clear what all valid states are
 class State:

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -122,7 +122,7 @@ class afcBoxTurtle(afcUnit):
                             msg +="<span class=primary--text> in ToolHead</span>"
                             if (cur_lane.extruder_obj.tool_start == "buffer"
                                 and (not self.afc.homing_enabled
-                                     or cur_lane.unit_obj.skip_buffer_check)):
+                                     or cur_lane.unit_obj.enable_buffer_tool_check)):
                                 msg += "<span class=warning--text>\n Ram sensor enabled, confirm tool is loaded</span>"
 
                             if self.afc.function.get_current_lane() == cur_lane.name:

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -44,7 +44,7 @@ class afcBoxTurtle(afcUnit):
         firstLeg = '<span class=warning--text>|</span><span class=error--text>_</span>'
         secondLeg = firstLeg + '<span class=warning--text>|</span>'
         self.logo ='<span class=success--text>R  _____     ____\n'
-        self.logo+='E /      \  |  </span><span class=info--text>o</span><span class=success--text> | \n'
+        self.logo+='E /      \\  |  </span><span class=info--text>o</span><span class=success--text> | \n'
         self.logo+='A |       |/ ___/ \n'
         self.logo+='D |_________/     \n'
         self.logo+='Y {first}{second} {first}{second}\n'.format(first=firstLeg, second=secondLeg)
@@ -52,10 +52,10 @@ class afcBoxTurtle(afcUnit):
 
         self.logo_error ='<span class=error--text>E  _ _   _ _\n'
         self.logo_error+='R |_|_|_|_|_|\n'
-        self.logo_error+='R |         \____\n'
-        self.logo_error+='O |              \ \n'
-        self.logo_error+='R |          |\ <span class=secondary--text>X</span> |\n'
-        self.logo_error+='! \_________/ |___|</span>\n'
+        self.logo_error+='R |         \\____\n'
+        self.logo_error+='O |              \\ \n'
+        self.logo_error+='R |          |\\ <span class=secondary--text>X</span> |\n'
+        self.logo_error+='! \\_________/ |___|</span>\n'
         self.logo_error+= '  ' + self.name + '\n'
 
     def _move_lane(self, lane: AFCLane|AFCExtruderStepper, delay: float,

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -111,7 +111,7 @@ class afcBoxTurtle(afcUnit):
                 if (cur_lane.tool_loaded
                     and cur_lane.extruder_obj.lane_loaded == cur_lane.name):
                     ramming_loaded = False
-                    if cur_lane.extruder_obj.tool_start != "buffer":
+                    if cur_lane.extruder_obj.tool_start == "buffer":
                         ramming_loaded = self._buffer_toolhead_load_check(cur_lane)
                     if (cur_lane.get_toolhead_pre_sensor_state() == True
                         or ramming_loaded

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -122,7 +122,7 @@ class afcBoxTurtle(afcUnit):
                             msg +="<span class=primary--text> in ToolHead</span>"
                             if (cur_lane.extruder_obj.tool_start == "buffer"
                                 and (not self.afc.homing_enabled
-                                     or cur_lane.unit_obj.enable_buffer_tool_check)):
+                                     or not cur_lane.unit_obj.enable_buffer_tool_check)):
                                 msg += "<span class=warning--text>\n Ram sensor enabled, confirm tool is loaded</span>"
 
                             if self.afc.function.get_current_lane() == cur_lane.name:

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -77,7 +77,7 @@ class afcBoxTurtle(afcUnit):
             self.afc.reactor.pause(self.afc.reactor.monotonic() + 0.7)
         return lane.load_state
 
-    def system_Test(self, cur_lane, delay, assignTcmd, enable_movement):
+    def system_Test(self, cur_lane: AFCLane|AFCExtruderStepper, delay, assignTcmd, enable_movement):
         msg = ''
         succeeded = True
 
@@ -108,15 +108,21 @@ class afcBoxTurtle(afcUnit):
                 msg +="<span class=success--text> AND LOADED</span>"
                 self.afc.function.afc_led(cur_lane.led_spool_illum, cur_lane.led_spool_index)
 
-                if cur_lane.tool_loaded:
+                if (cur_lane.tool_loaded
+                    and cur_lane.extruder_obj.lane_loaded == cur_lane.name):
+                    ramming_loaded = False
+                    if "buffer" in cur_lane.extruder_obj.tool_start:
+                        ramming_loaded = self._buffer_toolhead_load_check(cur_lane)
                     if (cur_lane.get_toolhead_pre_sensor_state() == True
-                        or cur_lane.extruder_obj.tool_start == "buffer"
+                        or ramming_loaded
                         or cur_lane.extruder_obj.tool_end_state):
                         if cur_lane.extruder_obj.lane_loaded == cur_lane.name:
                             self.afc.current = cur_lane.name
                             cur_lane.sync_to_extruder()
                             msg +="<span class=primary--text> in ToolHead</span>"
-                            if cur_lane.extruder_obj.tool_start == "buffer":
+                            if (cur_lane.extruder_obj.tool_start == "buffer"
+                                and (not self.afc.homing_enabled
+                                     or cur_lane.unit_obj.skip_buffer_check)):
                                 msg += "<span class=warning--text>\n Ram sensor enabled, confirm tool is loaded</span>"
 
                             if self.afc.function.get_current_lane() == cur_lane.name:

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -111,7 +111,7 @@ class afcBoxTurtle(afcUnit):
                 if (cur_lane.tool_loaded
                     and cur_lane.extruder_obj.lane_loaded == cur_lane.name):
                     ramming_loaded = False
-                    if "buffer" in cur_lane.extruder_obj.tool_start:
+                    if cur_lane.extruder_obj.tool_start != "buffer":
                         ramming_loaded = self._buffer_toolhead_load_check(cur_lane)
                     if (cur_lane.get_toolhead_pre_sensor_state() == True
                         or ramming_loaded

--- a/extras/AFC_NightOwl.py
+++ b/extras/AFC_NightOwl.py
@@ -28,10 +28,10 @@ class afcNightOwl(afcBoxTurtle):
 
         self.logo = '<span class=success--text>Night Owl Ready</span>'
         self.logo ='<span class=success--text>R  ,     ,\n'
-        self.logo+='E  )\___/(\n'
+        self.logo+='E  )\\___/(\n'
         self.logo+='A {(@)v(@)}\n'
         self.logo+='D  {|~~~|}\n'
-        self.logo+='Y  {/^^^\}\n'
+        self.logo+='Y  {/^^^\\}\n'
         self.logo+='!   `m-m`</span>\n'
 
         self.logo_error = '<span class=error--text>Night Owl Not Ready</span>\n'

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -87,7 +87,7 @@ class afcError:
             failed_to_retract_msg = f"Failed to retract {cur_lane.name} to load sensor"
             if (cur_lane.raw_load_state
                 and cur_lane.hub != 'direct'
-                and "buffer" not in  cur_lane.extruder_obj.tool_start):
+                and cur_lane.extruder_obj.tool_start != "buffer"):
                 self.logger.info(f"Retracting {cur_lane.name} back to load switch")
                 if self.afc.homing_enabled:
                     num_tries = 0

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -3,11 +3,19 @@
 # Copyright (C) 2024-2026 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import annotations
+
 import traceback
 import logging
 import inspect
 
 from configparser import Error as error
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from extras.AFC_lane import AFCLane
+    from extras.AFC_stepper import AFCExtruderStepper
 
 try: from extras.AFC_utils import ERROR_STR
 except: raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".format(trace=traceback.format_exc()))
@@ -65,7 +73,7 @@ class afcError:
 
         return error_handled
 
-    def ToolHeadFix(self, cur_lane):
+    def ToolHeadFix(self, cur_lane: AFCLane|AFCExtruderStepper):
         if cur_lane.get_toolhead_pre_sensor_state():   #toolhead has filament
             if cur_lane.extruder_obj.lane_loaded == cur_lane.name:   #var has right lane loaded
                 if not cur_lane.raw_load_state: #Lane has filament
@@ -78,7 +86,8 @@ class afcError:
         else: #toolhead empty
             failed_to_retract_msg = f"Failed to retract {cur_lane.name} to load sensor"
             if (cur_lane.raw_load_state
-                and cur_lane.hub != 'direct'):
+                and cur_lane.hub != 'direct'
+                and "buffer" not in  cur_lane.extruder_obj.tool_start):
                 self.logger.info(f"Retracting {cur_lane.name} back to load switch")
                 if self.afc.homing_enabled:
                     num_tries = 0

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -129,9 +129,6 @@ class afcError:
                 self.logger.info(f"Done resetting {cur_lane.name}")
                 return True
 
-            else:
-                self.PauseUserIntervention('Filament not loaded in Lane')
-
     def PauseUserIntervention(self,message):
         #pause for user intervention
         self.logger.error(message)

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -149,7 +149,7 @@ class afcFunction:
         taskdone = False
         sectionfound = False
         # Creating regex pattern based off rawsection
-        pattern = re.compile("^\[\s*{}\s*\]".format(rawsection))
+        pattern = re.compile("^\\[\\s*{}\\s*\\]".format(rawsection))
         for filename in os.listdir(self.afc.cfgloc):
             file_path = os.path.join(self.afc.cfgloc, filename)
             if os.path.isfile(file_path) and filename.endswith(".cfg"):

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -760,7 +760,7 @@ class AFCExtruderStepper(AFCLane):
         Example
         ----
         ```
-        AFC_STEPPER_HOME STEPPER=lane1 MOVE=10 SPEED=5
+        AFC_STEPPER_HOME STEPPER=lane1 DIST=10 SPEED=5
         ```
         Example
         ----

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -764,21 +764,13 @@ class afcUnit:
             or self.skip_buffer_check):
             loaded = lane.tool_loaded
         else:
-            if lane.buffer_obj.advance_state:
-                # Move buffer back
-                homed, _, _ = lane.move_to(200 * MoveDirection.NEG, SpeedMode.SHORT,
-                                           AFCHomingPoints.BUFFER_TRAIL)
-                if homed:
-                    homed, _, _ = lane.move_to(200, SpeedMode.SHORT, AFCHomingPoints.BUFFER)
-            else:
-                homed, _, _ = lane.move_to(200, SpeedMode.SHORT, AFCHomingPoints.BUFFER)
-                if homed:
-                    homed, _, _ = lane.move_to(200 * MoveDirection.NEG, SpeedMode.SHORT,
-                                               AFCHomingPoints.BUFFER_TRAIL)
+            homed, _, _ = lane.move_to(200, SpeedMode.SHORT, AFCHomingPoints.BUFFER)
+
             if not homed:
                 msg = f"Buffer toolhead loaded check failed for {lane.name}. Please verify"
                 msg +=f" than {lane.name} is loaded to toolhead. If lane is not loaded to "
                 msg +=f"toolhead then run AFC_RESET and choose {lane.name} to reset back to hub."
+                msg +=" Once lane is reset run UNSET_LANE_LOADED macro."
                 self.afc.error.AFC_error(msg, False)
             loaded = homed
         return loaded

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -96,7 +96,7 @@ class afcUnit:
         self.debug                       = config.getboolean("debug",            False)                      # Turns on/off debug messages to console
         self.rev_long_moves_speed_factor = config.getfloat("rev_long_moves_speed_factor", self.afc.rev_long_moves_speed_factor)
         self.extruder_clear_dis          = config.getfloat("extruder_clear_dis", 50)                        # Amount to move to clear extruder gears when ejecting filament
-        self.skip_buffer_check           = config.getfloat("skip_buffer_check", True)
+        self.enable_buffer_tool_check    = config.getfloat("enable_buffer_tool_check", False)
 
         # Espooler defines
         # Time in seconds to wait between breaking n20 motors(nSleep/FWD/RWD all 1) and then releasing the break to allow coasting. Setting value here overrides values set in AFC.cfg file
@@ -749,11 +749,12 @@ class afcUnit:
     def _buffer_toolhead_load_check(self, lane: AFCLane|AFCExtruderStepper):
         """
         Method for checking if filament is loaded to toolhead when using buffer in ramming mode.
-        If homing is not enabled or skip_buffer_check is enabled, lanes tool_loaded status is returned.
+        If homing is not enabled or enable_buffer_tool_check is enabled, lanes tool_loaded status
+        is returned.
 
-        When homing is enabled and skip_buffer_check is not enabled, this method will try to move the
-        filament so that both advance and trail sensor in buffer are hit. If this is successful, then
-        it's deemed that filament is actually loaded to the toolhead.
+        When homing is enabled and enable_buffer_tool_check is not enabled, this method will try to
+        move the filament so that both advance and trail sensor in buffer are hit. If this is
+        successful, then it's deemed that filament is actually loaded to the toolhead.
 
         :param lane: Lane to check if filament is loaded to toolhead.
         :return: Returns true if check is successful.
@@ -761,7 +762,7 @@ class afcUnit:
         loaded = False
         homed = False
         if (not self.afc.homing_enabled
-            or self.skip_buffer_check):
+            or not self.enable_buffer_tool_check):
             loaded = lane.tool_loaded
         else:
             homed, move_dis, _ = lane.move_to(200, SpeedMode.SHORT, AFCHomingPoints.BUFFER)

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -96,7 +96,7 @@ class afcUnit:
         self.debug                       = config.getboolean("debug",            False)                      # Turns on/off debug messages to console
         self.rev_long_moves_speed_factor = config.getfloat("rev_long_moves_speed_factor", self.afc.rev_long_moves_speed_factor)
         self.extruder_clear_dis          = config.getfloat("extruder_clear_dis", 50)                        # Amount to move to clear extruder gears when ejecting filament
-        self.skip_buffer_check           = config.getfloat("skip_buffer_check", False)
+        self.skip_buffer_check           = config.getfloat("skip_buffer_check", True)
 
         # Espooler defines
         # Time in seconds to wait between breaking n20 motors(nSleep/FWD/RWD all 1) and then releasing the break to allow coasting. Setting value here overrides values set in AFC.cfg file

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -96,7 +96,7 @@ class afcUnit:
         self.debug                       = config.getboolean("debug",            False)                      # Turns on/off debug messages to console
         self.rev_long_moves_speed_factor = config.getfloat("rev_long_moves_speed_factor", self.afc.rev_long_moves_speed_factor)
         self.extruder_clear_dis          = config.getfloat("extruder_clear_dis", 50)                        # Amount to move to clear extruder gears when ejecting filament
-        self.enable_buffer_tool_check    = config.getfloat("enable_buffer_tool_check", False)
+        self.enable_buffer_tool_check    = config.getboolean("enable_buffer_tool_check", False)
 
         # Espooler defines
         # Time in seconds to wait between breaking n20 motors(nSleep/FWD/RWD all 1) and then releasing the break to allow coasting. Setting value here overrides values set in AFC.cfg file
@@ -749,10 +749,10 @@ class afcUnit:
     def _buffer_toolhead_load_check(self, lane: AFCLane|AFCExtruderStepper):
         """
         Method for checking if filament is loaded to toolhead when using buffer in ramming mode.
-        If homing is not enabled or enable_buffer_tool_check is enabled, lanes tool_loaded status
+        If homing is not enabled or enable_buffer_tool_check is not enabled, lanes tool_loaded status
         is returned.
 
-        When homing is enabled and enable_buffer_tool_check is not enabled, this method will try to
+        When homing is enabled and enable_buffer_tool_check is enabled, this method will try to
         move the filament so that both advance and trail sensor in buffer are hit. If this is
         successful, then it's deemed that filament is actually loaded to the toolhead.
 

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -769,7 +769,7 @@ class afcUnit:
 
             if not homed:
                 msg = f"Buffer toolhead loaded check failed for {lane.name}. Please verify"
-                msg +=f" than {lane.name} is loaded to toolhead. If lane is not loaded to "
+                msg +=f" that {lane.name} is loaded to toolhead. If lane is not loaded to "
                 msg +=f"toolhead then run AFC_RESET and choose {lane.name} to reset back to hub."
                 msg +=" Once lane is reset run UNSET_LANE_LOADED macro."
                 self.afc.error.AFC_error(msg, False)

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -13,10 +13,7 @@ from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 if TYPE_CHECKING:
-    from extras.AFC_lane import (
-        afc, AFCLane, AssistActive,
-        AFCHomingPoints, MoveDirection
-    )
+    from extras.AFC_lane import afc, AFCLane
     from extras.AFC_stepper import AFCExtruderStepper
     from extras.AFC_buffer import AFCTrigger
     from extras.AFC_hub import afc_hub
@@ -33,7 +30,7 @@ except:
 try: from extras.AFC_respond import AFCprompt
 except: raise config_error(ERROR_STR.format(import_lib="AFC_respond", trace=traceback.format_exc()))
 
-try: from extras.AFC_lane import SpeedMode, AssistActive, AFCHomingPoints
+try: from extras.AFC_lane import SpeedMode, AssistActive, AFCHomingPoints, MoveDirection
 except:
     err_str = ERROR_STR.format(import_lib="AFC_lane", trace=traceback.format_exc())
     raise config_error(err_str)
@@ -99,6 +96,7 @@ class afcUnit:
         self.debug                       = config.getboolean("debug",            False)                      # Turns on/off debug messages to console
         self.rev_long_moves_speed_factor = config.getfloat("rev_long_moves_speed_factor", self.afc.rev_long_moves_speed_factor)
         self.extruder_clear_dis          = config.getfloat("extruder_clear_dis", 50)                        # Amount to move to clear extruder gears when ejecting filament
+        self.skip_buffer_check           = config.getfloat("skip_buffer_check", False)
 
         # Espooler defines
         # Time in seconds to wait between breaking n20 motors(nSleep/FWD/RWD all 1) and then releasing the break to allow coasting. Setting value here overrides values set in AFC.cfg file
@@ -747,6 +745,43 @@ class afcUnit:
                                         endstop=endstop, use_homing=home_to_tool)
 
         return home, dist, warn
+
+    def _buffer_toolhead_load_check(self, lane: AFCLane|AFCExtruderStepper):
+        """
+        Method for checking if filament is loaded to toolhead when using buffer in ramming mode.
+        If homing is not enabled or skip_buffer_check is enabled, lanes tool_loaded status is returned.
+
+        When homing is enabled and skip_buffer_check is not enabled, this method will try to move the
+        filament so that both advance and trail sensor in buffer are hit. If this is successful, then
+        it's deemed that filament is actually loaded to the toolhead.
+
+        :param lane: Lane to check if filament is loaded to toolhead.
+        :return: Returns true if check is successful.
+        """
+        loaded = False
+        homed = False
+        if (not self.afc.homing_enabled
+            or self.skip_buffer_check):
+            loaded = lane.tool_loaded
+        else:
+            if lane.buffer_obj.advance_state:
+                # Move buffer back
+                homed, _, _ = lane.move_to(200 * MoveDirection.NEG, SpeedMode.SHORT,
+                                           AFCHomingPoints.BUFFER_TRAIL)
+                if homed:
+                    homed, _, _ = lane.move_to(200, SpeedMode.SHORT, AFCHomingPoints.BUFFER)
+            else:
+                homed, _, _ = lane.move_to(200, SpeedMode.SHORT, AFCHomingPoints.BUFFER)
+                if homed:
+                    homed, _, _ = lane.move_to(200 * MoveDirection.NEG, SpeedMode.SHORT,
+                                               AFCHomingPoints.BUFFER_TRAIL)
+            if not homed:
+                msg = f"Buffer toolhead loaded check failed for {lane.name}. Please verify"
+                msg +=f" than {lane.name} is loaded to toolhead. If lane is not loaded to "
+                msg +=f"toolhead then run AFC_RESET and choose {lane.name} to reset back to hub."
+                self.afc.error.AFC_error(msg, False)
+            loaded = homed
+        return loaded
 
     cmd_AFC_SELECT_LANE_help = "Command to home to lane selector for specified lane in selector style units."
     cmd_AFC_SELECT_LANE_options = {"LANE": {"type":"string", "default":"lane1"}}

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -764,7 +764,7 @@ class afcUnit:
             or self.skip_buffer_check):
             loaded = lane.tool_loaded
         else:
-            homed, _, _ = lane.move_to(200, SpeedMode.SHORT, AFCHomingPoints.BUFFER)
+            homed, move_dis, _ = lane.move_to(200, SpeedMode.SHORT, AFCHomingPoints.BUFFER)
 
             if not homed:
                 msg = f"Buffer toolhead loaded check failed for {lane.name}. Please verify"
@@ -772,6 +772,9 @@ class afcUnit:
                 msg +=f"toolhead then run AFC_RESET and choose {lane.name} to reset back to hub."
                 msg +=" Once lane is reset run UNSET_LANE_LOADED macro."
                 self.afc.error.AFC_error(msg, False)
+            else:
+                lane.move(move_dis * MoveDirection.NEG, lane.short_moves_speed,
+                          lane.short_moves_accel, False)
             loaded = homed
         return loaded
 

--- a/extras/AFC_vivid.py
+++ b/extras/AFC_vivid.py
@@ -281,7 +281,8 @@ class AFC_vivid(afcBoxTurtle):
         self.select_lane(lane)
         move_dis = lane.dist_hub
         if move_dis > 400:
-            move_dis = lane.dist_hub - (self.LANE_OVERSHOOT+100)
+            move_dis = lane.dist_hub - (self.LANE_OVERSHOOT+100) - \
+                       lane.hub_obj.hub_clear_move_dis - lane.homing_overshoot
         lane.move_to( move_dis * MoveDirection.NEG, SpeedMode.LONG,
                      endstop=lane.prep_endstop_name,
                      assist_active=AssistActive.NO, use_homing=True)

--- a/templates/AFC_Pro_Turtle_1.cfg
+++ b/templates/AFC_Pro_Turtle_1.cfg
@@ -237,7 +237,7 @@ cut_servo_prep_angle: 80    # Servo angle to prepare the filament for cutting (a
 
 [AFC_led AFC_Indicator]
 pin: Turtle_1:RGB1
-chain_count: 4
+chain_count: 8
 color_order: GRBW
 
 #[neopixel Extra2]

--- a/templates/AFC_Vivid_1.cfg
+++ b/templates/AFC_Vivid_1.cfg
@@ -8,6 +8,7 @@ drive_stepper: Vivid_1_drive
 selector_stepper: Vivid_1_selector
 long_moves_speed: 120
 long_moves_accel:50
+enable_buffer_tool_check: True
 
 [AFC_stepper Vivid_1_drive]
 unit: Vivid_1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -237,9 +237,6 @@ class MockReactor:
     def monotonic(self):
         return self._monotonic
 
-    # def pause(self, until):
-    #     pass
-
     def mutex(self, is_locked=False):
         return MagicMock()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -233,9 +233,11 @@ class MockReactor:
     def __init__(self, monotonic_value=100.0):
         self._monotonic = monotonic_value
 
-    pause = MagicMock()
     def monotonic(self):
         return self._monotonic
+    
+    def pause(self, until):
+        pass
 
     def mutex(self, is_locked=False):
         return MagicMock()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -233,11 +233,12 @@ class MockReactor:
     def __init__(self, monotonic_value=100.0):
         self._monotonic = monotonic_value
 
+    pause = MagicMock()
     def monotonic(self):
         return self._monotonic
 
-    def pause(self, until):
-        pass
+    # def pause(self, until):
+    #     pass
 
     def mutex(self, is_locked=False):
         return MagicMock()

--- a/tests/test_AFC_BoxTurtle.py
+++ b/tests/test_AFC_BoxTurtle.py
@@ -169,3 +169,13 @@ class Test_MoveLane:
 
         result = unit._move_lane(lane, delay=1, enable_movement=False)
         assert result is False
+    
+    def test_returns_enable_movement_not_loaded(self):
+        from unittest.mock import PropertyMock
+        unit = _make_box_turtle()
+        lane = _make_lane()
+        type(lane).load_state = PropertyMock(side_effect=[False])
+
+        result = unit._move_lane(lane, delay=1, enable_movement=True)
+        assert result is False
+        unit.afc.reactor.pause.assert_called()

--- a/tests/test_AFC_BoxTurtle.py
+++ b/tests/test_AFC_BoxTurtle.py
@@ -174,8 +174,10 @@ class Test_MoveLane:
         from unittest.mock import PropertyMock
         unit = _make_box_turtle()
         lane = _make_lane()
+        pause_mock = MagicMock()
+        unit.afc.reactor.pause = pause_mock
         type(lane).load_state = PropertyMock(side_effect=[False])
 
         result = unit._move_lane(lane, delay=1, enable_movement=True)
         assert result is False
-        unit.afc.reactor.pause.assert_called()
+        pause_mock.assert_called()

--- a/tests/test_AFC_error.py
+++ b/tests/test_AFC_error.py
@@ -456,16 +456,6 @@ class TestToolHeadFix:
         err.ToolHeadFix(lane)
         err.PauseUserIntervention.assert_called_with("laneloaded does not match extruder")
 
-    def test_toolhead_empty_no_lane_filament_pauses(self):
-        err, afc = _make_afc_error()
-        err.PauseUserIntervention = MagicMock()
-        lane = MagicMock()
-        lane.get_toolhead_pre_sensor_state.return_value = False  # toolhead empty
-        lane.raw_load_state = False  # lane also empty
-        result = err.ToolHeadFix(lane)
-        err.PauseUserIntervention.assert_called_with("Filament not loaded in Lane")
-        assert result is None  # no explicit return
-
     def test_toolhead_empty_with_lane_filament_returns_true_no_homing(self):
         """Filament is retracted to lane and reloaded; returns True."""
         from unittest.mock import PropertyMock

--- a/tests/test_AFC_unit.py
+++ b/tests/test_AFC_unit.py
@@ -48,7 +48,7 @@ def _make_unit(name="Turtle_1"):
     unit.type = "Box_Turtle"
     unit.gcode = afc.gcode
     unit.led_logo_index = None
-    unit.skip_buffer_check = False
+    unit.enable_buffer_tool_check = True
 
     return unit
 
@@ -272,12 +272,12 @@ class TestBufferToolheadLoadCheck:
         result = unit._buffer_toolhead_load_check(lane)
         assert result is True
 
-    def test_homing_enabled_skip_buffer_check_loaded(self):
+    def test_homing_enabled_disable_buffer_tool_check_loaded(self):
         unit = _make_unit()
         lane = _make_lane()
         unit.afc.homing_enabled = True
         lane.tool_loaded = True
-        unit.skip_buffer_check = True
+        unit.enable_buffer_tool_check = False
         result = unit._buffer_toolhead_load_check(lane)
         assert result is True
 

--- a/tests/test_AFC_unit.py
+++ b/tests/test_AFC_unit.py
@@ -26,11 +26,12 @@ def _make_unit(name="Turtle_1"):
     unit = afcUnit.__new__(afcUnit)
 
     from tests.conftest import MockAFC, MockPrinter, MockLogger
-
+    from extras.AFC_error import afcError
     afc = MockAFC()
     printer = MockPrinter(afc=afc)
     afc.logger = MockLogger()
-
+    afc.error = afcError.__new__(afcError)
+    afc.error.logger = afc.logger
     unit.printer = printer
     unit.afc = afc
     unit.logger = afc.logger
@@ -47,6 +48,7 @@ def _make_unit(name="Turtle_1"):
     unit.type = "Box_Turtle"
     unit.gcode = afc.gcode
     unit.led_logo_index = None
+    unit.skip_buffer_check = False
 
     return unit
 
@@ -250,3 +252,109 @@ class TestSetLogoColor:
         unit = _make_unit()
         unit.set_logo_color("")
         unit.afc.function.afc_led.assert_not_called()
+
+
+# ── _buffer_toolhead_load_check ────────────────────────────────────────────────────────────
+class TestBufferToolheadLoadCheck:
+    def test_homing_not_enabled_not_loaded(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        unit.afc.homing_enabled = False
+        lane.tool_loaded = False
+        result = unit._buffer_toolhead_load_check(lane)
+        assert result is False
+    
+    def test_homing_not_enabled_loaded(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        unit.afc.homing_enabled = False
+        lane.tool_loaded = True
+        result = unit._buffer_toolhead_load_check(lane)
+        assert result is True
+
+    def test_homing_enabled_skip_buffer_check_loaded(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        unit.afc.homing_enabled = True
+        lane.tool_loaded = True
+        unit.skip_buffer_check = True
+        result = unit._buffer_toolhead_load_check(lane)
+        assert result is True
+    
+    def test_homing_enabled_loaded_advance_triggered_fail_retract(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.buffer_obj = MagicMock()
+        unit.afc.homing_enabled = True
+        lane.tool_loaded = True
+        lane.buffer_obj.advance_state = True
+        lane.move_to.return_value = (False, 200, False)
+        result = unit._buffer_toolhead_load_check(lane)
+        assert result is False
+        error_msgs = [m for lvl, m in unit.logger.messages if lvl == "error"]
+        assert any(f"Buffer toolhead loaded check failed for {lane.name}. Please verify" in m for m in error_msgs)
+
+    def test_homing_enabled_loaded_advance_triggered_retracted_fail_extend(self):
+        from unittest.mock import PropertyMock
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.buffer_obj = MagicMock()
+        unit.afc.homing_enabled = True
+        lane.tool_loaded = True
+        lane.buffer_obj.advance_state = True
+        lane.move_to.side_effect = [(True, 200, False), (False, 200, False)]
+        result = unit._buffer_toolhead_load_check(lane)
+        assert result is False
+        error_msgs = [m for lvl, m in unit.logger.messages if lvl == "error"]
+        assert any(f"Buffer toolhead loaded check failed for {lane.name}. Please verify" in m for m in error_msgs)
+    
+    def test_homing_enabled_loaded_advance_triggered_retracted_extended(self):
+        from unittest.mock import PropertyMock
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.buffer_obj = MagicMock()
+        unit.afc.homing_enabled = True
+        lane.tool_loaded = True
+        lane.buffer_obj.advance_state = True
+        lane.move_to.side_effect = [(True, 200, False), (True, 200, False)]
+        result = unit._buffer_toolhead_load_check(lane)
+        assert result is True
+
+    def test_homing_enabled_loaded_fail_extend(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.buffer_obj = MagicMock()
+        unit.afc.homing_enabled = True
+        lane.tool_loaded = True
+        lane.buffer_obj.advance_state = False
+        lane.move_to.return_value = (False, 200, False)
+        result = unit._buffer_toolhead_load_check(lane)
+        assert result is False
+        error_msgs = [m for lvl, m in unit.logger.messages if lvl == "error"]
+        assert any(f"Buffer toolhead loaded check failed for {lane.name}. Please verify" in m for m in error_msgs)
+
+    def test_homing_enabled_loaded_extended_failed_retract(self):
+        from unittest.mock import PropertyMock
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.buffer_obj = MagicMock()
+        unit.afc.homing_enabled = True
+        lane.tool_loaded = True
+        lane.buffer_obj.advance_state = False
+        lane.move_to.side_effect = [(True, 200, False), (False, 200, False)]
+        result = unit._buffer_toolhead_load_check(lane)
+        assert result is False
+        error_msgs = [m for lvl, m in unit.logger.messages if lvl == "error"]
+        assert any(f"Buffer toolhead loaded check failed for {lane.name}. Please verify" in m for m in error_msgs)
+    
+    def test_homing_enabled_loaded_extended_retracted(self):
+        from unittest.mock import PropertyMock
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.buffer_obj = MagicMock()
+        unit.afc.homing_enabled = True
+        lane.tool_loaded = True
+        lane.buffer_obj.advance_state = False
+        lane.move_to.side_effect = [(True, 200, False), (True, 200, False)]
+        result = unit._buffer_toolhead_load_check(lane)
+        assert result is True

--- a/tests/test_AFC_unit.py
+++ b/tests/test_AFC_unit.py
@@ -280,45 +280,6 @@ class TestBufferToolheadLoadCheck:
         unit.skip_buffer_check = True
         result = unit._buffer_toolhead_load_check(lane)
         assert result is True
-    
-    def test_homing_enabled_loaded_advance_triggered_fail_retract(self):
-        unit = _make_unit()
-        lane = _make_lane()
-        lane.buffer_obj = MagicMock()
-        unit.afc.homing_enabled = True
-        lane.tool_loaded = True
-        lane.buffer_obj.advance_state = True
-        lane.move_to.return_value = (False, 200, False)
-        result = unit._buffer_toolhead_load_check(lane)
-        assert result is False
-        error_msgs = [m for lvl, m in unit.logger.messages if lvl == "error"]
-        assert any(f"Buffer toolhead loaded check failed for {lane.name}. Please verify" in m for m in error_msgs)
-
-    def test_homing_enabled_loaded_advance_triggered_retracted_fail_extend(self):
-        from unittest.mock import PropertyMock
-        unit = _make_unit()
-        lane = _make_lane()
-        lane.buffer_obj = MagicMock()
-        unit.afc.homing_enabled = True
-        lane.tool_loaded = True
-        lane.buffer_obj.advance_state = True
-        lane.move_to.side_effect = [(True, 200, False), (False, 200, False)]
-        result = unit._buffer_toolhead_load_check(lane)
-        assert result is False
-        error_msgs = [m for lvl, m in unit.logger.messages if lvl == "error"]
-        assert any(f"Buffer toolhead loaded check failed for {lane.name}. Please verify" in m for m in error_msgs)
-    
-    def test_homing_enabled_loaded_advance_triggered_retracted_extended(self):
-        from unittest.mock import PropertyMock
-        unit = _make_unit()
-        lane = _make_lane()
-        lane.buffer_obj = MagicMock()
-        unit.afc.homing_enabled = True
-        lane.tool_loaded = True
-        lane.buffer_obj.advance_state = True
-        lane.move_to.side_effect = [(True, 200, False), (True, 200, False)]
-        result = unit._buffer_toolhead_load_check(lane)
-        assert result is True
 
     def test_homing_enabled_loaded_fail_extend(self):
         unit = _make_unit()
@@ -332,29 +293,18 @@ class TestBufferToolheadLoadCheck:
         assert result is False
         error_msgs = [m for lvl, m in unit.logger.messages if lvl == "error"]
         assert any(f"Buffer toolhead loaded check failed for {lane.name}. Please verify" in m for m in error_msgs)
-
-    def test_homing_enabled_loaded_extended_failed_retract(self):
-        from unittest.mock import PropertyMock
-        unit = _make_unit()
-        lane = _make_lane()
-        lane.buffer_obj = MagicMock()
-        unit.afc.homing_enabled = True
-        lane.tool_loaded = True
-        lane.buffer_obj.advance_state = False
-        lane.move_to.side_effect = [(True, 200, False), (False, 200, False)]
-        result = unit._buffer_toolhead_load_check(lane)
-        assert result is False
-        error_msgs = [m for lvl, m in unit.logger.messages if lvl == "error"]
-        assert any(f"Buffer toolhead loaded check failed for {lane.name}. Please verify" in m for m in error_msgs)
     
-    def test_homing_enabled_loaded_extended_retracted(self):
-        from unittest.mock import PropertyMock
+    def test_homing_enabled_loaded_extended(self):
+        from extras.AFC_lane import MoveDirection
+        SIDE_EFFECT_DIST = 200
         unit = _make_unit()
         lane = _make_lane()
         lane.buffer_obj = MagicMock()
         unit.afc.homing_enabled = True
         lane.tool_loaded = True
         lane.buffer_obj.advance_state = False
-        lane.move_to.side_effect = [(True, 200, False), (True, 200, False)]
+        lane.move_to.side_effect = [(True, SIDE_EFFECT_DIST, False)]
         result = unit._buffer_toolhead_load_check(lane)
+        call_args = lane.move.call_args[0]
         assert result is True
+        assert call_args[0] == (SIDE_EFFECT_DIST * MoveDirection.NEG)

--- a/tests/test_AFC_vivid.py
+++ b/tests/test_AFC_vivid.py
@@ -600,13 +600,16 @@ class TestEjectLane:
         from extras.AFC_lane import MoveDirection
         unit = _make_vivid()
         lane = MagicMock()
+        lane.hub_obj = MagicMock()
+        lane.hub_obj.hub_clear_move_dis = 65
         lane.dist_hub = 600.0  # > 400 → should subtract LANE_OVERSHOOT+100
         unit.select_lane = MagicMock()
         unit.unselect_lane = MagicMock()
 
         unit.eject_lane(lane)
 
-        expected_dist = (600.0 - (AFC_vivid.LANE_OVERSHOOT + 100)) * MoveDirection.NEG
+        expected_dist = (600.0 - (AFC_vivid.LANE_OVERSHOOT + 100) - \
+                         lane.hub_obj.hub_clear_move_dis - lane.homing_overshoot) * MoveDirection.NEG
         call_args = lane.move_to.call_args[0]
         assert call_args[0] == expected_dist
 


### PR DESCRIPTION
## Major Changes in this PR
- (Minor) Fixing all invalid escaped character warnings.
- Added new method to check if toolhead is loaded when using ramming mode as toolhead sensor. Can be enabled by setting `enable_buffer_tool_check: True`
- Fixing eject distance got ViViD units
- Fixing chain count for AFC-Pro Indicator config

## Notes to Code Reviewers

## How the changes in this PR are tested
- Tested with VVD unit
- Tested with BT unit

Error displayed when check fails to verify that filament is loaded to toolhead:
<img width="846" height="174" alt="image" src="https://github.com/user-attachments/assets/a3998309-3979-4e88-b427-4d6cc675a68e" />

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.