### PR TITLE
(fix): Adding error checking when homing and returning early if error occurred when homing, update to cut/poop/kick macros to help prevent TTCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2026-03-07]
 ### Fix
-- Added error checking when homing during a Tool Load or Unload, if a homing error(like communication timeout or something similar) happens during these calls that AFC displays error and returns early.
+- Added error checking when homing during a Tool Load or Unload, if a homing error (like communication timeout or something similar) happens during these calls that AFC displays error and returns early.
 - Updating cut/kick/poop macros to help with TTCs when calling these macros
 
 ## [2026-03-06]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-03-07]
+### Fix
+- Added error checking when homing during a Tool Load or Unload, if a homing error(like communication timeout or something similar) happens during these calls that AFC displays error and returns early.
+- Updating cut/kick/poop macros to help with TTCs when calling these macros
+
 ## [2026-03-06]
 ### Added
 - Ability to check if toolhead is loaded when using buffer as toolhead sensor, add `enable_buffer_tool_check: True` to AFC_Boxturtle/AFC_vivid etc config section to enable.

--- a/config/AFC.cfg
+++ b/config/AFC.cfg
@@ -107,8 +107,8 @@ form_tip_cmd: AFC               # AFC is default routine. Name to custom macro i
 [AFC_prep]
 enable: True                    # Enable the AFC Prep routine.
 
-[delayed_gcode welcome]
-initial_duration: 0.5
+[delayed_gcode afc_welcome]
+initial_duration: 2
 gcode:
  PREP
 

--- a/config/macros/Cut.cfg
+++ b/config/macros/Cut.cfg
@@ -118,6 +118,8 @@ gcode:
           RESPOND TYPE=command MSG='AFC_Cut: Cut Move...'
     {% endif %}
 
+    M400
+
     {% if cut_current_x > 0 or cut_current_dc > 0 %}
         # Check for IDEX
         {% if printer.dual_carriage is defined %}
@@ -144,7 +146,9 @@ gcode:
 
         {% endif %}
     {% endif %}
-
+    
+    M400
+    
     {% if cut_current_y > 0 %}
         {% set conf_name = vars['conf_name_stepper_y']|default('tmc2209 stepper_y') %}
         {% set conf_current_y = printer.configfile.settings[conf_name].run_current|float %}

--- a/config/macros/Kick.cfg
+++ b/config/macros/Kick.cfg
@@ -1,5 +1,6 @@
+
 [gcode_macro AFC_KICK]
-description: Perform a kick movement to remove purged filament from bed
+
 gcode:
   {% set gVars              = printer['gcode_macro _AFC_GLOBAL_VARS'] %}
   {% set accel              = gVars['accel']            | default(2000)     | float %}
@@ -14,28 +15,30 @@ gcode:
   {% set z_after_kick       = vars['z_after_kick']      | default(10)       | float %}
   {% set kick_speed         = vars['kick_speed']        | default(150)*60   | float %}
   {% set kick_accel         = vars['kick_accel']        | default(0)        | float %}
-  
-  M400
-  # Get printer bounds to make sure none of our kick moves fall outside of them
-  # Check for IDEX
+
+  # Determine Axis Limits immediately
+  {% set x_max = printer.toolhead.axis_maximum.x %}
+  {% set x_min = printer.toolhead.axis_minimum.x %}
   {% if printer.dual_carriage is defined %}
     {% if printer.dual_carriage.carriage_0 == "INACTIVE" %}
-      # Carriage_1 is active, use its axis limits
       {% set x_max = printer.configfile.config.dual_carriage.position_max|float|round(3) %}
       {% set x_min = printer.configfile.config.dual_carriage.position_min|float|round(3) %}
-    {% else %}
-      # Carriage_0 is active, use its axis limits
-      {% set x_max = printer.toolhead.axis_maximum.x %}
-      {% set x_min = printer.toolhead.axis_minimum.x %}
     {% endif %}
-  {% else %}
-    # Non-IDEX printer, grab the X axis limits
-    {% set x_max = printer.toolhead.axis_maximum.x %}
-    {% set x_min = printer.toolhead.axis_minimum.x %}
   {% endif %}
   {% set y_max = printer.toolhead.axis_maximum.y %}
   {% set y_min = printer.toolhead.axis_minimum.y %}
 
+  # Calculate limits based on direction
+  {% set location_factor = {
+        'left'  : { 'x': -1, 'y':  0 },
+        'right' : { 'x':  1, 'y':  0 },
+        'front' : { 'x':  0, 'y': -1 },
+        'back'  : { 'x':  0, 'y':  1 }
+    } %}
+  
+  # --- Execution Block ---
+  M400 
+  
   # Save current Accel
   {% set saved_accel = printer.toolhead.max_accel %}
 
@@ -72,35 +75,28 @@ gcode:
     G1 Z0.5 F{z_travel_speed}
   {% endif %}
 
-  {% set location_factor = {
-        'left'  : { 'x': -1, 'y':  0 },
-        'right' : { 'x':  1, 'y':  0 },
-        'front' : { 'x':  0, 'y': -1 },
-        'back'  : { 'x':  0, 'y':  1 }
-    } %}
-
   {% if verbose > 1 %}
     RESPOND TYPE=command MSG='AFC_Kick: Kick filament'
   {% endif %}
+  
   {% if kick_direction == "left" or kick_direction == "right" %}
     {% if (kick_start_x + location_factor[kick_direction].x * kick_move_dist) > x_max or (kick_start_x + location_factor[kick_direction].x * kick_move_dist) < x_min %}
       { action_raise_error("X Kick move is outside your printer bounds. Check the kick_move_dist in your AFC_Macro_Vars.cfg file!") }
     {% else %}
-    	G1 X{kick_start_x + location_factor[kick_direction].x * kick_move_dist}  F{kick_speed}
+        G1 X{kick_start_x + location_factor[kick_direction].x * kick_move_dist}  F{kick_speed}
     {% endif %}
   {% elif kick_direction == "front" or kick_direction == "back" %}
     {% if (kick_start_y + location_factor[kick_direction].y * kick_move_dist) > y_max or (kick_start_y + location_factor[kick_direction].y * kick_move_dist) < y_min %}
       { action_raise_error("Y Kick move is outside your printer bounds. Check the kick_move_dist in your AFC_Macro_Vars.cfg file!") }
     {% else %}
-    	G1 Y{kick_start_y + location_factor[kick_direction].y * kick_move_dist}  F{kick_speed}
+        G1 Y{kick_start_y + location_factor[kick_direction].y * kick_move_dist}  F{kick_speed}
     {% endif %}
   {% else %}
-	{ action_raise_error("Error in kick movement. Check the directions in your AFC_Macro_Vars.cfg file!") }
+    { action_raise_error("Error in kick movement. Check the directions in your AFC_Macro_Vars.cfg file!") }
   {% endif %}
-  
+   
   G1 Z{z_after_kick} F{z_travel_speed}
 
   # Reset acceleration values to what it was before
   SET_VELOCITY_LIMIT ACCEL={saved_accel}
   AFC_ENABLE_SKEW
-  

--- a/config/macros/Poop.cfg
+++ b/config/macros/Poop.cfg
@@ -39,7 +39,7 @@ gcode:
     {% set backup_fan_speed = printer.fan.speed %}
     M106 S{(part_cooling_fan_speed * 255)|int}
   {% endif %}
-  
+   
   {% set backup_feedrate = printer.gcode_move.speed_factor %}
   M220 S100
     
@@ -58,7 +58,7 @@ gcode:
   {% if verbose > 1 %}
     RESPOND TYPE=command MSG='AFC_Poop: Move To Purge Location'
   {% endif %}
-  
+   
   G1 X{purge_x} Y{purge_y} F{travel_speed}
 
   {% if verbose > 1 %}
@@ -73,9 +73,6 @@ gcode:
 
   # Repeat the process until purge_len is reached
   {% for n in range(iterations) %}
-    {% if verbose > 1 %}
-      RESPOND TYPE=command MSG='AFC_Poop: Purge Iteration {n}'
-    {% endif %}
 
     # Calculate current iteration in current blob
     {% set step = n % max_iterations_per_blob %}
@@ -99,13 +96,13 @@ gcode:
 
     {% set duration = extrude_amount / purge_spd %} 
 
-    {% if z_poop %}
+    {% if z_poop and raise_z > 0.05 %}
       {% set speed = raise_z / duration %}
       G1 Z{raise_z} E{extrude_amount} F{speed}
     {% else %}
+      # Fallback if Z raise is 0 or z_poop is off
       G1 E{extrude_amount} F{purge_spd}
     {% endif %}
-
 
     {% set max_iterations_reached = step == max_iterations_per_blob - 1 %}
     {% set purge_length_reached = purge_len - max_iteration_length * (n + 1) <= 0 %}

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1232,7 +1232,6 @@ class afc:
             # Verify that printer is in absolute mode
             self.function.check_absolute_mode("TOOL_LOAD")
 
-
             cur_extruder = cur_lane.extruder_obj
             self.current_state = State.LOADING
             self.current_loading = cur_lane.name
@@ -1261,16 +1260,17 @@ class afc:
                         _, _, warn = cur_lane.unit_obj.load_then_home(cur_lane, dist_to_hub,
                                                                       AssistActive.DYNAMIC,
                                                                       home_endstop)
-                        # Check for error and return, if error state is set then AFC tried pausing
-                        # during the homing
-                        if warn == AFCMoveWarning.ERROR:
-                            self.error.AFC_error("Homing error occurred when trying to move to"\
-                                                 f" hub sensor for {cur_lane.name}")
-                            return False
                     else:
-                        cur_lane.unit_obj.move_to_hub(cur_lane, dist_to_hub, MoveDirection.POS,
-                                                    self.homing_enabled,
-                                                    speedMode=SpeedMode.LONG)
+                        _, _, warn = cur_lane.unit_obj.move_to_hub(cur_lane, dist_to_hub,
+                                                                   MoveDirection.POS,
+                                                                   self.homing_enabled,
+                                                                   speedMode=SpeedMode.LONG)
+                    # Check for error and return, if error state is set then AFC tried pausing
+                    # during the homing
+                    if warn == AFCMoveWarning.ERROR:
+                        self.error.AFC_error("Homing error occurred when trying to move to"\
+                                             f" hub sensor for {cur_lane.name}", pause=False)
+                        return False
                     self.afcDeltaTime.log_with_time(
                         f"Loaded to {'hub' if cur_lane.hub != 'direct' else 'toolhead'}"
                     )
@@ -1280,8 +1280,15 @@ class afc:
 
                 # Ensure filament moves past the hub.
                 while not cur_hub.state and cur_lane.hub != 'direct':
-                    cur_lane.unit_obj.move_to_hub(cur_lane, cur_hub.move_dis,
-                                                MoveDirection.POS, self.homing_enabled)
+                    _, _, warn = cur_lane.unit_obj.move_to_hub(cur_lane, cur_hub.move_dis,
+                                                               MoveDirection.POS,
+                                                               self.homing_enabled)
+                    # Check for error and return, if error state is set then AFC tried pausing
+                    # during the homing
+                    if warn == AFCMoveWarning.ERROR:
+                        self.error.AFC_error("Homing error occurred when trying to short move to"\
+                                             f" hub sensor for {cur_lane.name}", pause=False)
+                        return False
                     hub_attempts += 1
                     if hub_attempts > 20:
                         message = 'filament did not trigger hub sensor, CHECK FILAMENT PATH\n||=====||==>--||-----||\nTRG   LOAD   HUB   TOOL.'
@@ -1303,7 +1310,7 @@ class afc:
                     # during the homing
                     if warn == AFCMoveWarning.ERROR:
                         self.error.AFC_error("Homing error occurred when trying to move to"\
-                                             f" toolhead for {cur_lane.name}")
+                                             f" toolhead for {cur_lane.name}", pause=False)
                         return False
                 # Ensure filament reaches the toolhead.
                 tool_attempts = 0
@@ -1319,8 +1326,9 @@ class afc:
                             max_attempts = 2
                             self.logger.info("Distance stopped short of commanded distance to toolhead, "\
                                             "backing up and retrying load.")
-                            cur_lane.move_to(100 * MoveDirection.NEG, SpeedMode.SHORT,
+                            _, _, warn = cur_lane.move_to(100 * MoveDirection.NEG, SpeedMode.SHORT,
                                             use_homing=False)
+
                         _, dist, warn = cur_lane.move_to(move_distance, SpeedMode.SHORT,
                                                         endstop=cur_lane.get_toolhead_endstop(),
                                                         use_homing=self.homing_enabled and self.home_to_tool)
@@ -1328,7 +1336,7 @@ class afc:
                         # during the homing
                         if warn == AFCMoveWarning.ERROR:
                             self.error.AFC_error("Homing error occurred when trying to slow move to"\
-                                                 f" toolhead for {cur_lane.name}")
+                                                 f" toolhead for {cur_lane.name}", pause=False)
                             return False
                         if (dist > 50.0
                             and self.homing_enabled):
@@ -1728,9 +1736,14 @@ class afc:
                 if self.homing_enabled:
                     max_attempts = 2
                     move_dist = cur_hub.afc_unload_bowden_length
-                cur_lane.unit_obj.move_to_hub(cur_lane, move_dist,
-                                            MoveDirection.NEG, self.homing_enabled)
-
+                _, _, warn = cur_lane.unit_obj.move_to_hub(cur_lane, move_dist,
+                                                           MoveDirection.NEG, self.homing_enabled)
+                # Check for error and return, if error state is set then AFC tried pausing
+                # during the homing
+                if warn == AFCMoveWarning.ERROR:
+                    self.error.AFC_error("Homing error occurred when trying to move back to"\
+                                         f" hub sensor for {cur_lane.name}", pause=False)
+                    return False
                 num_tries += 1
                 if num_tries >= max_attempts:
                     # Handle failure if the filament doesn't clear the hub.

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 ERROR_STR = "Error trying to import {import_lib}, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper\n\n{trace}"
 
 try: from extras.AFC_lane import (
-    AFCLaneState, SpeedMode, AssistActive, MoveDirection
+    AFCLaneState, SpeedMode, AssistActive, MoveDirection, AFCMoveWarning
 )
 except: raise error(ERROR_STR.format(import_lib="AFC_logger", trace=traceback.format_exc()))
 
@@ -1261,6 +1261,12 @@ class afc:
                         _, _, warn = cur_lane.unit_obj.load_then_home(cur_lane, dist_to_hub,
                                                                       AssistActive.DYNAMIC,
                                                                       home_endstop)
+                        # Check for error and return, if error state is set then AFC tried pausing
+                        # during the homing
+                        if warn == AFCMoveWarning.ERROR:
+                            self.error.AFC_error("Homing error occurred when trying to move to"\
+                                                 f" hub sensor for {cur_lane.name}")
+                            return False
                     else:
                         cur_lane.unit_obj.move_to_hub(cur_lane, dist_to_hub, MoveDirection.POS,
                                                     self.homing_enabled,
@@ -1293,11 +1299,17 @@ class afc:
                                                                     cur_hub.afc_bowden_length,
                                                                     AssistActive.DYNAMIC,
                                                                     cur_lane.get_toolhead_endstop())
-
+                    # Check for error and return, if error state is set then AFC tried pausing
+                    # during the homing
+                    if warn == AFCMoveWarning.ERROR:
+                        self.error.AFC_error("Homing error occurred when trying to move to"\
+                                             f" toolhead for {cur_lane.name}")
+                        return False
                 # Ensure filament reaches the toolhead.
                 tool_attempts = 0
                 if cur_extruder.tool_start:
-                    while not cur_lane.get_toolhead_pre_sensor_state() or warn:
+                    while (not cur_lane.get_toolhead_pre_sensor_state()
+                           or warn == AFCMoveWarning.WARN):
                         tool_attempts += 1
                         move_distance = cur_lane.short_move_dis
                         max_attempts = int(self.tool_homing_distance/cur_lane.short_move_dis)
@@ -1312,9 +1324,15 @@ class afc:
                         _, dist, warn = cur_lane.move_to(move_distance, SpeedMode.SHORT,
                                                         endstop=cur_lane.get_toolhead_endstop(),
                                                         use_homing=self.homing_enabled and self.home_to_tool)
+                        # Check for error and return, if error state is set then AFC tried pausing
+                        # during the homing
+                        if warn == AFCMoveWarning.ERROR:
+                            self.error.AFC_error("Homing error occurred when trying to slow move to"\
+                                                 f" toolhead for {cur_lane.name}")
+                            return False
                         if (dist > 50.0
                             and self.homing_enabled):
-                            warn = False
+                            warn = AFCMoveWarning.NONE
                         if tool_attempts >= max_attempts:
                             message = 'filament failed to trigger pre extruder gear toolhead sensor, CHECK FILAMENT PATH\n||=====||====||==>--||\nTRG   LOAD   HUB   TOOL'
                             message += f'\nTo resolve set lane loaded with `SET_LANE_LOADED LANE={cur_lane.name}` macro.'
@@ -1674,14 +1692,26 @@ class afc:
             # Synchronize and move filament out of the hub.
             cur_lane.unsync_to_extruder()
             if cur_lane.hub != 'direct':
-                cur_lane.unit_obj.move_to_hub(cur_lane, cur_hub.afc_unload_bowden_length,
-                                            MoveDirection.NEG, self.homing_enabled,
-                                            speedMode=SpeedMode.LONG)
+                _, _, warn = cur_lane.unit_obj.move_to_hub(cur_lane, cur_hub.afc_unload_bowden_length,
+                                                           MoveDirection.NEG, self.homing_enabled,
+                                                           speedMode=SpeedMode.LONG)
+                # Check for error and return, if error state is set then AFC tried pausing
+                # during the homing
+                if warn == AFCMoveWarning.ERROR:
+                    self.error.AFC_error("Homing error occurred when trying to move back to"\
+                                         f" hub sensor for {cur_lane.name}")
+                    return False
             else:
-                cur_lane.move_to(cur_lane.dist_hub * -1, SpeedMode.LONG,
-                                assist_active = AssistActive.DYNAMIC,
-                                endstop=cur_lane.load_es,
-                                use_homing=self.homing_enabled)
+                _, _, warn = cur_lane.move_to(cur_lane.dist_hub * -1, SpeedMode.LONG,
+                                              assist_active = AssistActive.DYNAMIC,
+                                              endstop=cur_lane.load_es,
+                                              use_homing=self.homing_enabled)
+                # Check for error and return, if error state is set then AFC tried pausing
+                # during the homing
+                if warn == AFCMoveWarning.ERROR:
+                    self.error.AFC_error("Homing error occurred when trying to move back to"\
+                                         f" load sensor for {cur_lane.name}")
+                    return False
 
             self.afcDeltaTime.log_with_time("Long retract done")
 

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -20,7 +20,7 @@ try: from extras.AFC_utils import ERROR_STR
 except: raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".format(trace=traceback.format_exc()))
 
 try: from extras.AFC_lane import (
-    AFCLaneState, SpeedMode, AssistActive, MoveDirection
+    AFCLaneState, SpeedMode, AssistActive, MoveDirection, AFCMoveWarning
 )
 except: raise error(ERROR_STR.format(import_lib="AFC_lane", trace=traceback.format_exc()))
 
@@ -180,9 +180,13 @@ class afcBoxTurtle(afcUnit):
                 if self.afc.homing_enabled:
                     dis = fault_dis
                 homed, distance, warn = cur_lane.move_to(distance=dis,
-                                                         speed_mode=SpeedMode.CALIBRATION,
-                                                         endstop=cur_lane.get_toolhead_endstop(),
-                                                         use_homing=self.afc.homing_enabled)
+                                                                speed_mode=SpeedMode.CALIBRATION,
+                                                                endstop=cur_lane.get_toolhead_endstop(),
+                                                                use_homing=self.afc.homing_enabled)
+                # Check for error and return, if error state is set then AFC tried pausing
+                # during the homing
+                if warn == AFCMoveWarning.ERROR:
+                    return False, "Error occurred when trying to move lane", 0
                 bow_pos += distance
                 self.afc.reactor.pause(self.afc.reactor.monotonic() + 0.1)
                 if bow_pos >= fault_dis:
@@ -441,6 +445,10 @@ class afcBoxTurtle(afcUnit):
                                                   speed_mode=SpeedMode.CALIBRATION,
                                                   endstop=cur_lane.load_es,
                                                   assist_active=AssistActive.YES)
+            # Check for error and return, if error state is set then AFC tried pausing
+            # during the homing
+            if warn == AFCMoveWarning.ERROR:
+                return False, "Error occurred when trying to move lane", 0
         else:
             pos, checkpoint, success = self.calc_position(cur_lane,
                                                           lambda: cur_lane.raw_load_state, 0,

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -701,8 +701,9 @@ class AFCLane:
                   True, 0, AFCMoveWarning.NONE.
         """
         warn = AFCMoveWarning.NONE
+        extruder_stepper = getattr(self, "extruder_stepper", None)
         if (self.drive_stepper
-            or hasattr(self, "extruder_stepper")):
+            or extruder_stepper):
             if use_homing:
                 if self.drive_stepper:
                     home_to = self.drive_stepper.home_to

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -73,6 +73,11 @@ class AFCHomingPoints(str):
     BUFFER      = "buffer"
     BUFFER_TRAIL= "buffer_trailing"
 
+class AFCMoveWarning(Enum):
+    NONE = 0
+    WARN = 1
+    ERROR = 2
+
 class AFCLane:
     UPDATE_WEIGHT_DELAY = 10.0
     def __init__(self, config):
@@ -676,7 +681,7 @@ class AFCLane:
 
     def move_to(self, distance: float, speed_mode: SpeedMode,
                 endstop:AFCHomingPoints=AFCHomingPoints.NONE,
-                assist_active=AssistActive.NO, use_homing=True) -> tuple[bool, float|int, bool]:
+                assist_active=AssistActive.NO, use_homing=True) -> tuple[bool, float|int, AFCMoveWarning]:
         """
         Helper method for calling stepper move_advance or home_to functions based
         off use_homing parameter
@@ -686,11 +691,16 @@ class AFCLane:
         :param endstop: When homing is enabled, used to specify which endstop to home to
         :param assist_active: AssistActive type to enable/disable espoolers when moving stepper
         :param use_homing: When enabled home_to logic is used, else move_advance logic is used
-        :return tuple: Returns if move was successful, distance moved, and boolean set to true if
-                movement moved is not within 300mm of total distance. When homing is
-                disabled, always returns True, 0, False.
+        :return tuple[bool, float|int, AFCMoveWarning]: A tuple containing:
+
+            - Returns True if move was successful
+            - Total distance moved
+            - AFCMoveWarning.WARN set if movement moved is not within 300mm of total distance,
+                  AFCMoveWarning.ERROR when error is detected during homing, AFCMoveWarning.NONE
+                  when no error or not full movement detected. When homing is disabled, always returns
+                  True, 0, AFCMoveWarning.NONE.
         """
-        warn = False
+        warn = AFCMoveWarning.NONE
         if (self.drive_stepper
             or hasattr(self, "extruder_stepper")):
             if use_homing:
@@ -703,15 +713,20 @@ class AFCLane:
                 if distance < 0:
                     new_distance = distance - self.homing_overshoot
                 self.unit_obj.select_lane(self)
-                homed, mov_dis = home_to(endstop, new_distance, speed_mode,
-                        distance > 0, assist_active=self.get_active_assist(distance, assist_active))
-                if (abs(distance) - mov_dis) > self.homing_delta:
-                    warn = True
+                homed, mov_dis, error = home_to(endstop, new_distance, speed_mode,
+                        distance > 0, assist_active=self.get_active_assist(distance, assist_active)
+                )
+                if error:
+                    warn = AFCMoveWarning.ERROR
+                elif (abs(distance) - mov_dis) > self.homing_delta:
+                    warn = AFCMoveWarning.WARN
 
                 return homed, mov_dis, warn
             else:
                 self.move_advanced(distance, speed_mode, assist_active )
                 return True, 0, warn
+        else:
+            return False, 0, AFCMoveWarning.ERROR
 
 
     def move_advanced(self, distance, speed_mode: SpeedMode, assist_active: AssistActive = AssistActive.NO):

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -680,7 +680,7 @@ class AFCExtruderStepper(AFCLane):
 
     # ------------------ Convenience homing helpers ------------------
     def home_to(self, endstop_spec:AFCHomingPoints, distance:Optional[float], speed_mode: SpeedMode,
-                triggered=True, check_trigger=True, assist_active=True) -> tuple[bool, float]:
+                triggered=True, check_trigger=True, assist_active=True) -> tuple[bool, float, bool]:
         """
         Home towards an endstop relative to current position by distance (mm).
         If 'distance' is None, callers should prefer the typed helpers which pick a
@@ -695,10 +695,12 @@ class AFCExtruderStepper(AFCLane):
         :param triggered: If True, movement stops when the endstop triggers. Defaults to True.
         :param check_trigger: If True, verify that the endstop is actually triggered at the
                               end of the move. Defaults to True.
-        :return tuple: bool indicated if homing was successful or not, float indicated movement
-                       weather homing was successful or not. When not successful distance
-                       will equal max move distance.
+        :return tuple: bool: indicated if homing was successful or not.
+                       float: indicated movement weather homing was successful or not. When not
+                         successful distance will equal max move distance.
+                       bool: indicate if an error happened while homing
         """
+        error = False
         speed, accel = self.get_speed_accel(speed_mode)
 
         if distance is None:
@@ -714,11 +716,12 @@ class AFCExtruderStepper(AFCLane):
                                                        check_trigger=check_trigger,
                                                        assist_active=assist_active)
         except Exception:
+            error = True
             msg = f"Error occurred when trying to home to {endstop_spec}, PAUSING!"
             self.afc.error.AFC_error(msg, self.afc.function.in_print())
             self.logger.debug(f"{traceback.format_exc()}")
         self.sync_print_time()
-        return homed, move_distance
+        return homed, move_distance, error
 
     cmd_AFC_STEPPER_HOME_help = "Command a manually home stepper to specified endstop"
     cmd_AFC_STEPPER_HOME_options = {"STEPPER": {"type":"string", "default":"lane1"},

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -696,7 +696,7 @@ class AFCExtruderStepper(AFCLane):
         :param check_trigger: If True, verify that the endstop is actually triggered at the
                               end of the move. Defaults to True.
         :return tuple: bool: indicated if homing was successful or not.
-                       float: indicated movement weather homing was successful or not. When not
+                       float: indicated movement wheather homing was successful or not. When not
                          successful distance will equal max move distance.
                        bool: indicate if an error happened while homing
         """

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -13,7 +13,7 @@ from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 if TYPE_CHECKING:
-    from extras.AFC_lane import afc, AFCLane
+    from extras.AFC_lane import afc, AFCLane, AFCMoveWarning
     from extras.AFC_stepper import AFCExtruderStepper
     from extras.AFC_buffer import AFCTrigger
     from extras.AFC_hub import afc_hub
@@ -661,7 +661,7 @@ class afcUnit:
     def move_to_hub(self, lane: AFCLane, dist: float,
                     dir:MoveDirection, use_homing=True,
                     speedMode=SpeedMode.HUB,
-                    assist_active=AssistActive.DYNAMIC) -> tuple[bool, float|int, bool]:
+                    assist_active=AssistActive.DYNAMIC) -> tuple[bool, float|int, AFCMoveWarning]:
         """
         Helper method to move filament to hub sensor, calls lanes move_to method with HUB as trigger
         point when homing is enabled.
@@ -676,16 +676,21 @@ class afcUnit:
         :param assist_active: Set appropriate to enabled/disable or use Dynamic logic to enabled/disable
                               spoolers based off move distance.
 
-        :return tuple: Returns if move was successful, distance moved, and boolean set to true if
-                movement moved is not within 300mm of total distance. When homing is
-                disabled, always returns True, 0, False.
+        :return tuple[bool, float|int, AFCMoveWarning]: A tuple containing:
+
+            - Returns True if move was successful
+            - Total distance moved
+            - AFCMoveWarning.WARN set if movement moved is not within 300mm of total distance,
+                  AFCMoveWarning.ERROR when error is detected during homing, AFCMoveWarning.NONE
+                  when no error or not full movement detected. When homing is disabled, always returns
+                  True, 0, AFCMoveWarning.NONE.
         """
         return lane.move_to(dist * dir, speedMode, assist_active=assist_active,
                             endstop=AFCHomingPoints.HUB, use_homing=use_homing)
 
     def move_to_load(self, lane: AFCLane, dist: float,
                      dir: MoveDirection, use_homing=True,
-                     speedMode:SpeedMode=SpeedMode.LONG) -> tuple[bool, float|int, bool]:
+                     speedMode:SpeedMode=SpeedMode.LONG) -> tuple[bool, float|int, AFCMoveWarning]:
         """
         Helper method to move filament to load sensor, calls lane's move_to method with the load
         sensor endpoint (lane.load_es) as trigger point when homing is enabled.
@@ -701,15 +706,20 @@ class afcUnit:
         :param use_homing: When enabled home_to logic is used, else move_advance logic is used
         :param speedMode: SpeedMode type to use when moving stepper
 
-        :return tuple: Returns if move was successful, distance moved, and boolean set to true if
-                       movement moved is not within 300mm of total distance. When homing is
-                       disabled, always returns True, 0, False.
+        :return tuple[bool, float|int, AFCMoveWarning]: A tuple containing:
+
+            - Returns True if move was successful
+            - Total distance moved
+            - AFCMoveWarning.WARN set if movement moved is not within 300mm of total distance,
+                  AFCMoveWarning.ERROR when error is detected during homing, AFCMoveWarning.NONE
+                  when no error or not full movement detected. When homing is disabled, always returns
+                  True, 0, AFCMoveWarning.NONE.
         """
         return lane.move_to(dist * dir, speedMode, endstop=lane.load_es,
                             assist_active=AssistActive.DYNAMIC, use_homing=use_homing)
 
     def load_then_home(self, lane: AFCLane|AFCExtruderStepper, distance: float,
-                       assist_active: AssistActive, endstop: AFCHomingPoints) -> tuple[bool, float|int, bool]:
+                       assist_active: AssistActive, endstop: AFCHomingPoints) -> tuple[bool, float|int, AFCMoveWarning]:
         """
         Helper method to move filament to toolhead. If load_then_home boolean is set, AFC will do
         a normal move without homing enabled for a distance of: distance - load_undershoot.

--- a/extras/AFC_vivid.py
+++ b/extras/AFC_vivid.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
     from configfile import ConfigWrapper
-    from extras.AFC_lane import AFCLane
+    from extras.AFC_lane import AFCLane, AFCMoveWarning
 
 try: from extras.AFC_utils import ERROR_STR
 except:
@@ -109,7 +109,7 @@ class AFC_vivid(afcBoxTurtle):
                 lane.loaded_to_hub = True
                 if not lane.tool_loaded:
                     lane.move_to(lane.hub_obj.hub_clear_move_dis * MoveDirection.NEG,
-                                SpeedMode.SHORT, use_homing=False)
+                                 SpeedMode.SHORT, use_homing=False)
         # Resetting internal states when prep sensor is not triggered but loaded to hub is still
         # set, or when failed to home to load sensor
         if ((not lane.prep_state
@@ -229,8 +229,8 @@ class AFC_vivid(afcBoxTurtle):
         while (num_tries < 2
                and lane.prep_state
                and not lane.raw_load_state):
-            homed, distance, warn = lane.move_to(distance, move_speed, assist_active=AssistActive.NO,
-                                                 endstop=lane.load_endstop_name, use_homing=True)
+            homed, distance, _ = lane.move_to(distance, move_speed, assist_active=AssistActive.NO,
+                                              endstop=lane.load_endstop_name, use_homing=True)
             num_tries += 1
         if homed:
             lane.loaded_to_hub = True
@@ -283,7 +283,7 @@ class AFC_vivid(afcBoxTurtle):
         if move_dis > 400:
             move_dis = lane.dist_hub - (self.LANE_OVERSHOOT+100) - \
                        lane.hub_obj.hub_clear_move_dis - lane.homing_overshoot
-        lane.move_to( move_dis * MoveDirection.NEG, SpeedMode.LONG,
+        lane.move_to(move_dis * MoveDirection.NEG, SpeedMode.LONG,
                      endstop=lane.prep_endstop_name,
                      assist_active=AssistActive.NO, use_homing=True)
         self.unselect_lane()
@@ -292,7 +292,7 @@ class AFC_vivid(afcBoxTurtle):
 
     def move_to_hub(self, lane: AFCLane, dist: float, dir:MoveDirection, use_homing=True,
                     speedMode=SpeedMode.HUB, assist_active=AssistActive.DYNAMIC
-                    ) -> tuple[bool, float|int, bool]:
+                    ) -> tuple[bool, float|int, AFCMoveWarning]:
         """
         Helper method for calling lanes move_to method and passing in lanes load endstop as trigger
         point when homing is enabled.
@@ -304,12 +304,17 @@ class AFC_vivid(afcBoxTurtle):
         :param speedMode: SpeedMode type to use when moving stepper
         :param assist_active: ViViD does not have spoolers, setting this parameter does nothing.
 
-        :return tuple: Returns if move was successful, distance moved, and boolean set to true if
-                movement moved is not within 300mm of total distance. When homing is
-                disabled, always returns True, 0, False.
+        :return tuple[bool, float|int, AFCMoveWarning]: A tuple containing:
+
+            - Returns True if move was successful
+            - Total distance moved
+            - AFCMoveWarning.WARN set if movement moved is not within 300mm of total distance,
+                  AFCMoveWarning.ERROR when error is detected during homing, AFCMoveWarning.NONE
+                  when no error or not full movement detected. When homing is disabled, always returns
+                  True, 0, AFCMoveWarning.NONE.
         """
         homed, distance, warn = lane.move_to(dist * dir, speedMode, assist_active=assist_active,
-                                       endstop=lane.load_es, use_homing=use_homing)
+                                             endstop=lane.load_es, use_homing=use_homing)
         return homed, distance, warn
 
     def calibrate_lane(

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -23,7 +23,9 @@ from extras.AFC_lane import (
     AFCHomingPoints,
     AFCLane,
     EXCLUDE_TYPES,
+    AFCMoveWarning
 )
+from extras.AFC_stepper import AFCExtruderStepper
 
 
 # ── SpeedMode ─────────────────────────────────────────────────────────────────
@@ -654,3 +656,162 @@ class TestLoadCallback:
         lane.printer.state_message = "Printer is ready"
         lane.load_callback(100.0, True)
         assert lane.prep_state is False
+
+# ── move_to ───────────────────────────────────────────────────────────────────
+
+class TestMoveTo:
+    def test_no_drive_stepper_no_extruder_stepper(self):
+        lane = _make_afc_lane()
+        lane.drive_stepper = None
+        homed, dist, warn = lane.move_to(100, SpeedMode.SHORT, AFCHomingPoints.BUFFER,
+                                          False, False)
+        assert homed == False
+        assert dist == 0
+        assert warn == AFCMoveWarning.ERROR
+    
+    def test_drive_stepper_no_extruder_stepper_no_homing(self):
+        lane = _make_afc_lane()
+        lane.drive_stepper = AFCExtruderStepper.__new__(AFCExtruderStepper)
+        lane.move_advanced = MagicMock()
+        homed, dist, warn = lane.move_to(100, SpeedMode.SHORT, AFCHomingPoints.BUFFER,
+                                          False, False)
+        assert homed == True
+        assert dist == 0
+        assert warn == AFCMoveWarning.NONE
+    
+    def test_drive_stepper_no_extruder_stepper_homing_pos_movement(self):
+        HOMING_OVERSHOOT = 50
+        HOMING_DELTA = 300
+        MOVE_DISTANCE = 1000
+        ASSIST_ACTIVE = AssistActive.NO
+        HOMING = True
+        lane = _make_afc_lane()
+        lane.homing_overshoot = HOMING_OVERSHOOT
+        lane.homing_delta = HOMING_DELTA
+        lane.drive_stepper = AFCExtruderStepper.__new__(AFCExtruderStepper)
+        home_to = MagicMock()
+        lane.drive_stepper.home_to = home_to
+        lane.move_advanced = MagicMock()
+        home_to.return_value = (True, MOVE_DISTANCE, False)
+        homed, dist, warn = lane.move_to(MOVE_DISTANCE, SpeedMode.SHORT, AFCHomingPoints.BUFFER,
+                                         ASSIST_ACTIVE, HOMING)
+        call_args = home_to.call_args[0]
+        kwargs = home_to.call_args[1]
+        assert homed == True
+        assert dist == abs(MOVE_DISTANCE)
+        assert warn == AFCMoveWarning.NONE
+        assert call_args[0] == AFCHomingPoints.BUFFER
+        assert call_args[1] == MOVE_DISTANCE + HOMING_OVERSHOOT
+        assert call_args[2] == SpeedMode.SHORT
+        assert call_args[3] == HOMING
+        assert kwargs["assist_active"] == False
+    
+    def test_drive_stepper_no_extruder_stepper_homing_neg_movement(self):
+        HOMING_OVERSHOOT = 50
+        HOMING_DELTA = 300
+        MOVE_DISTANCE = -1000
+        ASSIST_ACTIVE = AssistActive.NO
+        HOMING = True
+        lane = _make_afc_lane()
+        lane.homing_overshoot = HOMING_OVERSHOOT
+        lane.homing_delta = HOMING_DELTA
+        lane.drive_stepper = AFCExtruderStepper.__new__(AFCExtruderStepper)
+        home_to = MagicMock()
+        lane.drive_stepper.home_to = home_to
+        lane.move_advanced = MagicMock()
+        home_to.return_value = (True, abs(MOVE_DISTANCE), False)
+        homed, dist, warn = lane.move_to(MOVE_DISTANCE, SpeedMode.SHORT, AFCHomingPoints.BUFFER,
+                                         ASSIST_ACTIVE, HOMING)
+        call_args = home_to.call_args[0]
+        kwargs = home_to.call_args[1]
+        assert homed == True
+        assert dist == abs(MOVE_DISTANCE)
+        assert warn == AFCMoveWarning.NONE
+        assert call_args[0] == AFCHomingPoints.BUFFER
+        assert call_args[1] == MOVE_DISTANCE - HOMING_OVERSHOOT
+        assert call_args[2] == SpeedMode.SHORT
+        assert call_args[3] == False
+        assert kwargs["assist_active"] == False
+
+    def test_drive_stepper_no_extruder_stepper_homing_neg_movement_homing_error(self):
+        HOMING_OVERSHOOT = 50
+        HOMING_DELTA = 300
+        MOVE_DISTANCE = -1000
+        ASSIST_ACTIVE = AssistActive.NO
+        HOMING = True
+        lane = _make_afc_lane()
+        lane.homing_overshoot = HOMING_OVERSHOOT
+        lane.homing_delta = HOMING_DELTA
+        lane.drive_stepper = AFCExtruderStepper.__new__(AFCExtruderStepper)
+        home_to = MagicMock()
+        lane.drive_stepper.home_to = home_to
+        lane.move_advanced = MagicMock()
+        home_to.return_value = (False, 0, True)
+        homed, dist, warn = lane.move_to(MOVE_DISTANCE, SpeedMode.SHORT, AFCHomingPoints.BUFFER,
+                                         ASSIST_ACTIVE, HOMING)
+        call_args = home_to.call_args[0]
+        kwargs = home_to.call_args[1]
+        assert homed == False
+        assert dist == 0
+        assert warn == AFCMoveWarning.ERROR
+        assert call_args[0] == AFCHomingPoints.BUFFER
+        assert call_args[1] == MOVE_DISTANCE - HOMING_OVERSHOOT
+        assert call_args[2] == SpeedMode.SHORT
+        assert call_args[3] == False
+        assert kwargs["assist_active"] == False
+
+    def test_drive_stepper_no_extruder_stepper_homing_pos_movement_short(self):
+        HOMING_OVERSHOOT = 50
+        HOMING_DELTA = 300
+        MOVE_DISTANCE = 1000
+        ASSIST_ACTIVE = AssistActive.NO
+        HOMING = True
+        MOVE_SHORT = 300
+        lane = _make_afc_lane()
+        lane.homing_overshoot = HOMING_OVERSHOOT
+        lane.homing_delta = HOMING_DELTA
+        lane.drive_stepper = AFCExtruderStepper.__new__(AFCExtruderStepper)
+        home_to = MagicMock()
+        lane.drive_stepper.home_to = home_to
+        lane.move_advanced = MagicMock()
+        home_to.return_value = (False, MOVE_SHORT, False)
+        homed, dist, warn = lane.move_to(MOVE_DISTANCE, SpeedMode.SHORT, AFCHomingPoints.BUFFER,
+                                         ASSIST_ACTIVE, HOMING)
+        call_args = home_to.call_args[0]
+        kwargs = home_to.call_args[1]
+        assert homed == False
+        assert dist == MOVE_SHORT
+        assert warn == AFCMoveWarning.WARN
+        assert call_args[0] == AFCHomingPoints.BUFFER
+        assert call_args[1] == MOVE_DISTANCE + HOMING_OVERSHOOT
+        assert call_args[2] == SpeedMode.SHORT
+        assert call_args[3] == HOMING
+        assert kwargs["assist_active"] == False
+    
+    def test_drive_stepper_no_drive_stepper_homing_pos_movement_short(self):
+        HOMING_OVERSHOOT = 50
+        HOMING_DELTA = 300
+        MOVE_DISTANCE = 1000
+        ASSIST_ACTIVE = AssistActive.NO
+        HOMING = True
+        MOVE_SHORT = 300
+        lane = _make_afc_lane()
+        lane.homing_overshoot = HOMING_OVERSHOOT
+        lane.homing_delta = HOMING_DELTA
+        lane.extruder_stepper = AFCExtruderStepper.__new__(AFCExtruderStepper)
+        home_to = MagicMock()
+        lane.home_to = home_to
+        lane.move_advanced = MagicMock()
+        home_to.return_value = (False, MOVE_SHORT, False)
+        homed, dist, warn = lane.move_to(MOVE_DISTANCE, SpeedMode.SHORT, AFCHomingPoints.BUFFER,
+                                         ASSIST_ACTIVE, HOMING)
+        call_args = home_to.call_args[0]
+        kwargs = home_to.call_args[1]
+        assert homed == False
+        assert dist == MOVE_SHORT
+        assert warn == AFCMoveWarning.WARN
+        assert call_args[0] == AFCHomingPoints.BUFFER
+        assert call_args[1] == MOVE_DISTANCE + HOMING_OVERSHOOT
+        assert call_args[2] == SpeedMode.SHORT
+        assert call_args[3] == HOMING
+        assert kwargs["assist_active"] == False

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -663,6 +663,7 @@ class TestMoveTo:
     def test_no_drive_stepper_no_extruder_stepper(self):
         lane = _make_afc_lane()
         lane.drive_stepper = None
+        lane.extruder_stepper = None
         homed, dist, warn = lane.move_to(100, SpeedMode.SHORT, AFCHomingPoints.BUFFER,
                                           False, False)
         assert homed == False
@@ -788,7 +789,7 @@ class TestMoveTo:
         assert call_args[3] == HOMING
         assert kwargs["assist_active"] == False
     
-    def test_drive_stepper_no_drive_stepper_homing_pos_movement_short(self):
+    def test_extruder_stepper_no_drive_stepper_homing_pos_movement_short(self):
         HOMING_OVERSHOOT = 50
         HOMING_DELTA = 300
         MOVE_DISTANCE = 1000

--- a/tests/test_AFC_vivid.py
+++ b/tests/test_AFC_vivid.py
@@ -327,24 +327,24 @@ class TestUnselectLane:
 
 class TestMoveToHub:
     def test_delegates_to_lane_move_to(self):
-        from extras.AFC_lane import SpeedMode, MoveDirection, AssistActive
+        from extras.AFC_lane import SpeedMode, MoveDirection, AssistActive, AFCMoveWarning
         unit = _make_vivid()
         lane = MagicMock()
-        lane.move_to.return_value = (True, 100.0, False)
+        lane.move_to.return_value = (True, 100.0, AFCMoveWarning.NONE)
         lane.load_es = "load_endstop"
         result = unit.move_to_hub(lane, 100.0, MoveDirection.POS)
         lane.move_to.assert_called_once()
-        assert result == (True, 100.0, False)
+        assert result == (True, 100.0, AFCMoveWarning.NONE)
 
     def test_returns_homed_distance_warn_tuple(self):
-        from extras.AFC_lane import SpeedMode, MoveDirection
+        from extras.AFC_lane import SpeedMode, MoveDirection, AFCMoveWarning
         unit = _make_vivid()
         lane = MagicMock()
-        lane.move_to.return_value = (False, 50.0, True)
+        lane.move_to.return_value = (False, 50.0, AFCMoveWarning.WARN)
         lane.load_es = "load_endstop"
         homed, dist, warn = unit.move_to_hub(lane, 50.0, MoveDirection.NEG)
         assert homed is False
-        assert warn is True
+        assert warn is AFCMoveWarning.WARN
 
 
 # ── select_lane ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Major Changes in this PR
- Added error checking when homing during a Tool Load or Unload, if a homing error(like communication timeout or something similar) happens during these calls that AFC displays error and returns early.
- Added unit tests for `move_to` lane method.
- Added updates from trev1AK for cut/kick/poop macros so help prevent TTCs during these macro calls
## Notes to Code Reviewers

## How the changes in this PR are tested
- Can't really test, verified unit tests passed

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.