### PR TITLE
Use Spoolman filament color for lane LEDs

### DIFF
--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -167,6 +167,7 @@ class afc:
         self.led_trailing           = config.get('led_buffer_trailing','0,1,0,0')      # LED color to set when buffer is trailing
         self.led_buffer_disabled    = config.get('led_buffer_disable', '0,0,0,0.25')   # LED color to set when buffer is disabled
         self.led_spool_illum        = config.get('led_spool_illuminate', "1,1,1,1")    # LED color to illuminate under spool
+        self.use_filament_color     = config.getboolean('use_filament_color', False)   # When True, uses filament color from color field for lane LEDs instead of configured LED colors
 
         # TOOL Cutting Settings
         self.tool                   = ''

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -523,12 +523,7 @@ class afcFunction:
 
         # Switch spoolman ID
         self.afc.spool.set_active_spool(cur_lane_loaded.spool_id)
-        # Set lanes tool loaded led
-        # TODO: Add check to see if users want to change status led to spool color if set
-        # if cur_lane_loaded.color is not None and cur_lane_loaded.color:
-        #     led_color = self.HexToLedString(cur_lane_loaded.color.replace("#", ""))
-        #     self.afc_led( led_color, cur_lane_loaded.led_index )
-        # else:
+        # Set lanes tool loaded led (uses Spoolman filament color if available)
         cur_lane_loaded.unit_obj.lane_tool_loaded( cur_lane_loaded )
         # Enable stepper
         cur_lane_loaded.do_enable(True)

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -160,6 +160,7 @@ class AFCLane:
         self.led_tool_unloaded    = config.get('led_tool_unloaded', None)               # LED color to set when lanes extruder is unloaded
         self.led_spool_index      = config.get('led_spool_index', None)                 # LED index to illuminate under spool
         self.led_spool_illum      = config.get('led_spool_illuminate', None)            # LED color to illuminate under spool
+        self.use_filament_color   = config.getboolean('use_filament_color', None)      # When True, uses filament color from color field for lane LEDs instead of configured LED colors
 
         self.long_moves_speed: float   = config.getfloat("long_moves_speed", None)             # Speed in mm/s to move filament when doing long moves. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
         self.long_moves_accel: float   = config.getfloat("long_moves_accel", None)             # Acceleration in mm/s squared when doing long moves. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
@@ -591,6 +592,7 @@ class AFCLane:
         if self.led_tool_loaded_idle is None: self.led_tool_loaded_idle = self.unit_obj.led_tool_loaded_idle
         if self.led_tool_unloaded    is None: self.led_tool_unloaded    = self.unit_obj.led_tool_unloaded
         if self.led_spool_illum      is None: self.led_spool_illum      = self.unit_obj.led_spool_illum
+        if self.use_filament_color   is None: self.use_filament_color   = self.unit_obj.use_filament_color
 
         if self.rev_long_moves_speed_factor is None: self.rev_long_moves_speed_factor  = self.unit_obj.rev_long_moves_speed_factor
         if self.long_moves_speed            is None: self.long_moves_speed  = self.unit_obj.long_moves_speed

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -495,7 +495,8 @@ class afcUnit:
 
         :param lane: Lane object to set led
         """
-        self.afc.function.afc_led(lane.led_ready, lane.led_index)
+        color = self._get_lane_color(lane, lane.led_ready)
+        self.afc.function.afc_led(color, lane.led_index)
 
     def lane_unloading(self, lane):
         """
@@ -528,8 +529,9 @@ class afcUnit:
 
         :param lane: Lane object to set led
         """
-        self.afc.function.afc_led(lane.led_tool_loaded, lane.led_index)
-        lane.extruder_obj.set_status_led(lane.led_tool_loaded)
+        color = self._get_lane_color(lane, lane.led_tool_loaded)
+        self.afc.function.afc_led(color, lane.led_index)
+        lane.extruder_obj.set_status_led(color)
 
     def lane_tool_unloaded(self, lane: AFCLane):
         """
@@ -538,7 +540,8 @@ class afcUnit:
 
         :param lane: Lane object to set led
         """
-        self.afc.function.afc_led(lane.led_ready, lane.led_index)
+        color = self._get_lane_color(lane, lane.led_ready)
+        self.afc.function.afc_led(color, lane.led_index)
         lane.extruder_obj.set_status_led(lane.led_tool_unloaded)
 
     def lane_tool_loaded_idle(self, lane):
@@ -549,8 +552,15 @@ class afcUnit:
 
         :param lane: Lane object to set led
         """
-        self.afc.function.afc_led(lane.led_tool_loaded_idle, lane.led_index)
-        lane.extruder_obj.set_status_led(lane.led_tool_loaded_idle)
+        color = self._get_lane_color(lane, lane.led_tool_loaded_idle)
+        self.afc.function.afc_led(color, lane.led_index)
+        lane.extruder_obj.set_status_led(color)
+
+    def _get_lane_color(self, lane, fallback):
+        """Use Spoolman filament color if available, otherwise use the default LED color."""
+        if lane.color:
+            return self.afc.function.HexToLedString(lane.color.replace("#", ""))
+        return fallback
 
     def lane_illuminate_spool(self, lane):
         """

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -90,6 +90,7 @@ class afcUnit:
         self.led_logo_index              = config.get('led_logo_index', None)                                # LED Logo index
         self.led_logo_color              = self.afc.function.HexConvert(config.get('led_logo_color', '0,0,0,0'))# Default logo color when nothing is loaded
         self.led_logo_loading            = self.afc.function.HexConvert(config.get('led_logo_loading', self.led_loading ))
+        self.use_filament_color          = config.getboolean('use_filament_color', self.afc.use_filament_color)  # When True, uses filament color from color field for lane LEDs instead of configured LED colors
 
         self.long_moves_speed            = config.getfloat("long_moves_speed", self.afc.long_moves_speed)   # Speed in mm/s to move filament when doing long moves. Setting value here overrides values set in AFC.cfg file
         self.long_moves_accel            = config.getfloat("long_moves_accel", self.afc.long_moves_accel)   # Acceleration in mm/s squared when doing long moves. Setting value here overrides values set in AFC.cfg file
@@ -531,7 +532,7 @@ class afcUnit:
         """
         color = self._get_lane_color(lane, lane.led_tool_loaded)
         self.afc.function.afc_led(color, lane.led_index)
-        lane.extruder_obj.set_status_led(color)
+        lane.extruder_obj.set_status_led(lane.led_tool_loaded)
 
     def lane_tool_unloaded(self, lane: AFCLane):
         """
@@ -554,12 +555,14 @@ class afcUnit:
         """
         color = self._get_lane_color(lane, lane.led_tool_loaded_idle)
         self.afc.function.afc_led(color, lane.led_index)
-        lane.extruder_obj.set_status_led(color)
+        lane.extruder_obj.set_status_led(lane.led_tool_loaded_idle)
 
     def _get_lane_color(self, lane, fallback):
-        """Use Spoolman filament color if available, otherwise use the default LED color."""
-        if lane.color:
-            return self.afc.function.HexToLedString(lane.color.replace("#", ""))
+        """Use filament color if available, otherwise use the default LED color."""
+        if lane.use_filament_color and lane.color:
+            hex_str = lane.color.replace("#", "").strip().upper()
+            if len(hex_str) in (6, 8) and all(c in "0123456789ABCDEF" for c in hex_str):
+                return self.afc.function.HexToLedString(hex_str)
         return fallback
 
     def lane_illuminate_spool(self, lane):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,585 @@
+"""
+Shared test fixtures and Klipper mock infrastructure for AFC unit tests.
+
+All Klipper-specific modules (configfile, queuelogger, webhooks) are mocked
+here at the module level so that all test files can import AFC extras modules
+without a running Klipper instance.
+"""
+
+import configparser
+import logging
+import logging.handlers
+import os
+import pathlib
+import queue
+import sys
+import types
+from unittest.mock import MagicMock, patch  # noqa: F401
+
+import pytest
+
+# ── Path setup ────────────────────────────────────────────────────────────────
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+
+# ── Klipper module mocks ──────────────────────────────────────────────────────
+# These must be installed before any extras.* imports happen.
+
+def _make_configfile_mock():
+    """Mock for Klipper's configfile module (not the PyPI configfile package)."""
+    mod = types.ModuleType("configfile")
+
+    class KlipperError(Exception):
+        """Klipper-style configuration error."""
+
+    class ConfigWrapper:
+        def __init__(self, printer=None, fileconfig=None, access_tracking=None, section=""):
+            self._printer = printer
+            self.fileconfig = fileconfig or configparser.RawConfigParser()
+            self._section = section
+
+        def get_printer(self):
+            return self._printer
+
+        def get_name(self):
+            return self._section
+
+        def get(self, option, default=None):
+            return default
+
+        def getfloat(self, option, default=0.0, **kwargs):
+            return float(default)
+
+        def getboolean(self, option, default=False, **kwargs):
+            return bool(default)
+
+        def getint(self, option, default=0, **kwargs):
+            return int(default)
+
+        def getlist(self, option, default=None, **kwargs):
+            return default or []
+
+        def error(self, msg):
+            raise KlipperError(msg)
+
+        def deprecate(self, option):
+            pass
+
+    mod.error = KlipperError
+    mod.ConfigWrapper = ConfigWrapper
+    return mod
+
+
+def _make_queuelogger_mock():
+    """Mock for Klipper's queuelogger module."""
+    mod = types.ModuleType("queuelogger")
+
+    class QueueListener:
+        def __init__(self, *args, **kwargs):
+            self.bg_queue = queue.Queue()
+
+        def stop(self):
+            pass
+
+        def setFormatter(self, fmt):
+            pass
+
+        def start(self):
+            pass
+
+    class QueueHandler(logging.Handler):
+        def __init__(self, q):
+            super().__init__()
+            self.queue = q
+
+        def emit(self, record):
+            pass
+
+    mod.QueueListener = QueueListener
+    mod.QueueHandler = QueueHandler
+    return mod
+
+
+def _make_webhooks_mock():
+    """Mock for Klipper's webhooks module."""
+    mod = types.ModuleType("webhooks")
+
+    class GCodeHelper:
+        pass
+
+    mod.GCodeHelper = GCodeHelper
+    return mod
+
+
+def _make_led_mock():
+    """Mock for extras.led (Klipper's shared LED helper module).
+
+    AFC_led.py uses ``from . import led`` (relative import within the extras
+    package), which resolves to ``extras.led``.
+    """
+    mod = types.ModuleType("extras.led")
+
+    class LEDHelper:
+        def __init__(self, config, update_func, chain_count):
+            self.led_count = chain_count
+            self._color_data = [(0.0, 0.0, 0.0, 0.0)] * chain_count
+
+        def get_status(self, eventtime=None):
+            return {"color_data": self._color_data}
+
+        def _set_color(self, index, color):
+            pass
+
+        def _check_transmit(self, print_time):
+            pass
+
+        def set_color(self, index, color):
+            pass
+
+        def check_transmit(self, print_time):
+            pass
+
+    mod.LEDHelper = LEDHelper
+    return mod
+
+
+# ── Additional Klipper C-extension mocks ─────────────────────────────────────
+
+def _make_chelper_mock():
+    """Mock for Klipper's chelper C extension."""
+    mod = types.ModuleType("chelper")
+
+    def get_ffi():
+        ffi_main = MagicMock()
+        ffi_lib = MagicMock()
+        ffi_main.gc = lambda obj, free_fn: obj
+        return ffi_main, ffi_lib
+
+    mod.get_ffi = get_ffi
+    return mod
+
+
+def _make_kinematics_mocks():
+    """Mock for Klipper's kinematics package."""
+    kin_mod = types.ModuleType("kinematics")
+    ext_mod = types.ModuleType("kinematics.extruder")
+
+    class FakeExtruderStepper:
+        def __init__(self, config):
+            self.stepper = MagicMock()
+
+        def sync_to_extruder(self, name):
+            pass
+
+    ext_mod.ExtruderStepper = FakeExtruderStepper
+    kin_mod.extruder = ext_mod
+    return kin_mod, ext_mod
+
+
+def _make_force_move_mock():
+    """Mock for extras.force_move (used by AFC_stepper)."""
+    mod = types.ModuleType("extras.force_move")
+
+    def calc_move_time(dist, speed, accel):
+        # Returns axis_r, accel_t, cruise_t, cruise_v
+        return 1.0, 0.05, 0.1, speed
+
+    mod.calc_move_time = calc_move_time
+    return mod
+
+def _make_klippy_ready_mock():
+    mod = types.ModuleType("klippy")
+    mod.message_ready = "Printer is ready"
+    return mod
+
+
+# Install mocks before any extras imports happen
+sys.modules.setdefault("configfile", _make_configfile_mock())
+sys.modules.setdefault("queuelogger", _make_queuelogger_mock())
+sys.modules.setdefault("webhooks", _make_webhooks_mock())
+
+# C-extension / Klipper internals mocks
+sys.modules.setdefault("chelper", _make_chelper_mock())
+_kin_mod, _kin_ext_mod = _make_kinematics_mocks()
+sys.modules.setdefault("kinematics", _kin_mod)
+sys.modules.setdefault("kinematics.extruder", _kin_ext_mod)
+sys.modules.setdefault("extras.force_move", _make_force_move_mock())
+sys.modules.setdefault("klippy", _make_klippy_ready_mock())
+
+_led_mock = _make_led_mock()
+sys.modules.setdefault("extras.led", _led_mock)
+
+# Attach the led mock as an attribute on the extras package after it's loaded
+try:
+    import extras  # noqa: E402 (intentionally after sys.modules manipulation)
+    if not hasattr(extras, "led"):
+        extras.led = _led_mock
+except ImportError:
+    pass
+
+
+# ── Reusable helper ───────────────────────────────────────────────────────────
+
+def _make_fileconfig(*sections):
+    """Return a RawConfigParser pre-populated with the given sections."""
+    raw = configparser.RawConfigParser()
+    for section in sections:
+        raw.add_section(section)
+    return raw
+
+
+# ── Mock building blocks ──────────────────────────────────────────────────────
+
+class MockReactor:
+    NEVER = 9_999_999_999.0
+    NOW = 0.0
+
+    def __init__(self, monotonic_value=100.0):
+        self._monotonic = monotonic_value
+
+    def monotonic(self):
+        return self._monotonic
+    
+    def pause(self, until):
+        pass
+
+    def mutex(self, is_locked=False):
+        return MagicMock()
+
+    def register_timer(self, callback, waketime=None):
+        return MagicMock()
+
+    def update_timer(self, timer, waketime):
+        pass
+
+    def register_callback(self, callback, waketime=None):
+        pass
+
+    def unregister_timer(self, timer):
+        pass
+
+
+class MockGcode:
+    def __init__(self):
+        self.output_callbacks = []
+        self._commands = {}
+        # Use MagicMock so tests can assert call counts / args
+        self.run_script_from_command = MagicMock()
+
+    def register_command(self, name, func, desc=None):
+        self._commands[name] = func
+
+    def register_mux_command(self, cmd, key, value, func, desc=None):
+        pass
+
+    def respond_info(self, msg):
+        pass
+
+    def respond_raw(self, msg):
+        pass
+
+
+class MockLogger:
+    """Lightweight stand-in for AFC_logger.AFC_logger."""
+
+    def __init__(self):
+        self.messages: list = []
+
+    def info(self, msg, **kwargs):
+        self.messages.append(("info", msg))
+
+    def warning(self, msg, **kwargs):
+        self.messages.append(("warning", msg))
+
+    def debug(self, msg, **kwargs):
+        self.messages.append(("debug", msg))
+
+    def error(self, msg=None, **kwargs):
+        # AFC_logger.error() can be called as error(msg) or error(message=msg, ...)
+        message = msg if msg is not None else kwargs.get("message", "")
+        self.messages.append(("error", message))
+
+    def raw(self, msg, **kwargs):
+        self.messages.append(("raw", msg))
+
+    def set_debug(self, val):
+        pass
+
+
+class MockMoonraker:
+    """Minimal AFC_moonraker stand-in for unit tests."""
+
+    def __init__(self):
+        self.logger = MockLogger()
+        self._stats: dict = {}
+        self.afc_stats_key = "afc_stats"
+
+    def get_afc_stats(self):
+        return self._stats or None
+
+    def update_afc_stats(self, key, value):
+        self._stats[key] = value
+
+    def remove_database_entry(self, namespace, key):
+        pass
+
+
+class MockAFC:
+    """Mock for the main afc object that most extras modules depend on."""
+
+    def __init__(self):
+        self.logger = MockLogger()
+        self.reactor = MockReactor()
+        self.gcode = MockGcode()
+        self.error_state = False
+        self.current_state = "Idle"
+        self.hubs: dict = {}
+        self.lanes: dict = {}
+        self.tools: dict = {}
+        self.units: dict = {}
+        self.buffers: dict = {}
+        self.led_obj: dict = {}
+        self.current = None
+        self.enable_sensors_in_gui = False
+        self.debounce_delay = 0.1
+        self.enable_hub_runout = False
+        self.show_macros = True
+        self.message_queue: list = []
+        self.log_frame_data = True
+        self.position_saved = False
+        self.in_toolchange = False
+        self.error_timeout = 600
+        self.td1_defined = False
+        self.td1_present = False
+        self.moonraker = MockMoonraker()
+        self.function = MagicMock()
+        self.error = MagicMock()
+        self.spool = MagicMock()
+        self.short_moves_speed = 50.0
+        self.short_moves_accel = 400.0
+        self.long_moves_speed = 100.0
+        self.long_moves_accel = 400.0
+        self.z_hop = 0.5
+        self.last_gcode_position = [0.0, 0.0, 0.0, 0.0]
+        self.gcode_move = MagicMock()
+        self.prep_done = False
+        self.spoolman = None
+        self.disable_weight_check = False
+        self.ignore_spoolman_material_temps = False
+        self.default_material_type = "PLA"
+        self.bypass = MagicMock()
+        self.save_vars = MagicMock()
+        self.tool_cmds: dict = {}
+        self.VarFile = "/tmp/afc_test_vars"
+        # LED colour defaults
+        self.led_fault = "1,0,0,0"
+        self.led_ready = "0,1,0,0"
+        self.led_not_ready = "0,0,0,0.25"
+        self.led_loading = "0,0,1,0"
+        self.led_unloading = "0,0,1,0"
+        self.led_tool_loaded = "0,1,0,0"
+        self.led_spool_illum = "1,1,1,0"
+        self.led_off = "0,0,0,0"
+        # function mock helpers
+        self.function.HexConvert = lambda x: x
+
+
+class MockPrinter:
+    """Mock for Klipper's printer object."""
+    command_error = Exception
+    def __init__(self, afc=None):
+        self._afc = afc or MockAFC()
+        self._reactor = MockReactor()
+        self.reactor = self._reactor  # AFC_logger accesses printer.reactor directly
+        self._gcode = MockGcode()
+        self._objects: dict = {}
+        self.state_message = "Printer is ready"
+        self.start_args: dict = {}
+        self.objects: dict = {}
+        self._event_handlers: dict = {}
+
+    # ------------------------------------------------------------------
+    def lookup_object(self, name, default=None):
+        mapping = {
+            "AFC": self._afc,
+            "gcode": self._gcode,
+        }
+        if name in mapping:
+            return mapping[name]
+        if name in self._objects:
+            return self._objects[name]
+        if name == "webhooks":
+            return MagicMock()
+        if name == "pause_resume":
+            obj = MagicMock()
+            obj.send_pause_command = MagicMock()
+            return obj
+        if name == "idle_timeout":
+            obj = MagicMock()
+            obj.idle_timeout = 600
+            return obj
+        if name == "toolhead":
+            return MagicMock()
+        if name == "heaters":
+            return MagicMock()
+        if name == "pins":
+            return MagicMock()
+        if name == "buttons":
+            return MagicMock()
+        return default
+
+    def load_object(self, config, name):
+        result = self.lookup_object(name)
+        if result is None:
+            result = MagicMock()
+        return result
+
+    def get_reactor(self):
+        return self._reactor
+
+    def register_event_handler(self, event, callback):
+        self._event_handlers.setdefault(event, []).append(callback)
+
+    def send_event(self, event, *args):
+        for handler in self._event_handlers.get(event, []):
+            handler(*args)
+
+    def get_start_args(self):
+        return self.start_args
+
+
+class MockConfig:
+    """Mock for Klipper's ConfigWrapper, used to construct extras objects."""
+
+    def __init__(self, name="test_section", printer=None, values=None):
+        self._name = name
+        self._printer = printer or MockPrinter()
+        self._values: dict = values or {}
+        self.fileconfig = _make_fileconfig()
+
+    def get_printer(self):
+        return self._printer
+
+    def get_name(self):
+        return self._name
+
+    def get(self, option, default=None):
+        return self._values.get(option, default)
+
+    def getfloat(self, option, default=0.0, **kwargs):
+        val = self._values.get(option, default)
+        if val is None:
+            return None
+        return float(val)
+
+    def getboolean(self, option, default=False, **kwargs):
+        val = self._values.get(option, default)
+        if isinstance(val, bool):
+            return val
+        if isinstance(val, str):
+            return val.lower() in ("true", "1", "yes")
+        return bool(val)
+
+    def getint(self, option, default=0, **kwargs):
+        val = self._values.get(option, default)
+        return int(val)
+
+    def getlist(self, option, default=None, **kwargs):
+        val = self._values.get(option, default)
+        return val if val is not None else []
+
+    def error(self, msg):
+        from configfile import error as KlipperError
+        raise KlipperError(msg)
+
+    def deprecate(self, option):
+        pass
+
+
+# ── pytest fixtures ───────────────────────────────────────────────────────────
+
+@pytest.fixture
+def mock_reactor():
+    return MockReactor()
+
+
+@pytest.fixture
+def mock_gcode():
+    return MockGcode()
+
+
+@pytest.fixture
+def mock_logger():
+    return MockLogger()
+
+
+@pytest.fixture
+def mock_moonraker():
+    return MockMoonraker()
+
+
+@pytest.fixture
+def mock_afc():
+    return MockAFC()
+
+
+@pytest.fixture
+def mock_printer(mock_afc):
+    return MockPrinter(afc=mock_afc)
+
+
+@pytest.fixture
+def mock_config(mock_printer):
+    return MockConfig(printer=mock_printer)
+
+
+# ── Klippy integration-test session hooks ─────────────────────────────────────
+# Sets up the Klipper environment by symlinking AFC extras and the testing
+# plugin into the cloned Klipper tree before any .test files are collected.
+
+_ROOT = pathlib.Path(__file__).parent.parent
+_KLIPPER_PATH = pathlib.Path(os.environ.get("KLIPPER_PATH", str(_ROOT / "klipper")))
+_AFC_EXTRAS = _ROOT / "extras"
+_TESTING_PLUGIN_SRC = _ROOT / "tests" / "klippy_testing_plugin.py"
+
+
+def pytest_sessionstart(session):
+    """Link AFC extras and the testing plugin into Klipper for integration tests."""
+    if not _KLIPPER_PATH.exists():
+        return  # Klipper not cloned yet — klippy tests will be skipped
+
+    klippy_dir = _KLIPPER_PATH / "klippy"
+    if not klippy_dir.exists():
+        return
+
+    klippy_extras = klippy_dir / "extras"
+    linked: list[pathlib.Path] = []
+
+    # Symlink each AFC_*.py module into Klipper's extras directory so that
+    # "from extras.AFC_xxx import ..." resolves correctly inside klippy.
+    if klippy_extras.exists():
+        for src in sorted(_AFC_EXTRAS.glob("AFC*.py")):
+            dst = klippy_extras / src.name
+            if not dst.exists():
+                os.symlink(src.resolve(), dst)
+                linked.append(dst)
+
+    # Symlink the testing plugin (provides the ASSERT gcode command) into
+    # Klipper's extras directory so it loads when [testing] appears in a config.
+    plugin_link = klippy_extras / "testing.py"
+    if not plugin_link.exists() and _TESTING_PLUGIN_SRC.exists():
+        os.symlink(_TESTING_PLUGIN_SRC.resolve(), plugin_link)
+        linked.append(plugin_link)
+
+    session._afc_klippy_links = linked
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Remove symlinks created during the test session."""
+    for link in getattr(session, "_afc_klippy_links", []):
+        try:
+            link.unlink()
+        except FileNotFoundError:
+            pass

--- a/tests/klippy/afc_base.cfg
+++ b/tests/klippy/afc_base.cfg
@@ -1,0 +1,126 @@
+
+# Minimal Klipper + AFC configuration for integration testing.
+# Uses a simulated STM32H723 MCU (via test/dict/stm32h723.dict).
+#
+# Pin naming uses STM32H723 port/pin notation (e.g. PA0, PB1, …)
+# matching the AFC Lite board (config/mcu/AFC_Lite.cfg).
+
+# ---------------------------------------------------------------------------
+# MCU — path is irrelevant in dict/simulation mode
+# ---------------------------------------------------------------------------
+[mcu]
+serial: /dev/null
+
+# ---------------------------------------------------------------------------
+# Printer kinematics (required by Klipper)
+# ---------------------------------------------------------------------------
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100
+
+[stepper_x]
+step_pin: PA0
+dir_pin: PA1
+enable_pin: !PA2
+microsteps: 16
+rotation_distance: 40
+endstop_pin: PA3
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_y]
+step_pin: PA4
+dir_pin: PA5
+enable_pin: !PA6
+microsteps: 16
+rotation_distance: 40
+endstop_pin: PA7
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_z]
+step_pin: PB0
+dir_pin: PB1
+enable_pin: !PB2
+microsteps: 16
+rotation_distance: 8
+endstop_pin: PB3
+position_endstop: 0
+position_max: 200
+
+[extruder]
+step_pin: PB4
+dir_pin: PB5
+enable_pin: !PB6
+microsteps: 16
+rotation_distance: 33.5
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PB7
+sensor_type: temperature_host
+min_temp: 0
+max_temp: 250
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+
+[heater_bed]
+heater_pin: PB8
+sensor_type: temperature_host
+min_temp: 0
+max_temp: 130
+control: pid
+pid_Kp: 54.027
+pid_Ki: 0.770
+pid_Kd: 948.182
+
+# save_variables is required by AFC to persist spool/lane state.
+[save_variables]
+filename: /tmp/afc_klippy_test.cfg
+
+# pause_resume is required by AFC_error
+[pause_resume]
+
+# ---------------------------------------------------------------------------
+# AFC core modules (no hardware units — simplest possible AFC config)
+# ---------------------------------------------------------------------------
+
+# The [testing] section activates the klippy_testing_plugin (ASSERT command).
+[testing]
+
+[AFC]
+VarFile: /tmp/afc_klippy_test.var
+long_moves_speed: 150
+long_moves_accel: 250
+short_moves_speed: 50
+short_moves_accel: 300
+short_move_dis: 10
+enable_sensors_in_gui: False
+load_to_hub: False
+z_hop: 5
+resume_speed: 120
+resume_z_speed: 30
+error_timeout: 36000
+# LED omitted — keeping config minimal for testing.
+tool_cut: False
+park: False
+poop: False
+kick: False
+wipe: False
+form_tip: False
+
+[AFC_prep]
+# Disable the PREP startup routine so the test does not require
+# homing moves or loaded filament.
+enable: False
+
+[AFC_form_tip]
+cooling_tube_position: 35
+cooling_tube_length: 10
+cooling_moves: 4

--- a/tests/klippy/afc_basic.test
+++ b/tests/klippy/afc_basic.test
@@ -1,0 +1,14 @@
+# Basic AFC integration test
+#
+# Verifies that AFC modules load under a real Klipper environment and that
+# core GCode commands are registered and respond without error.
+#
+# Prerequisites:
+#   - test/dict/stm32h723.dict must exist (built from test/klippy/stm32h723.config)
+#   - KLIPPER_PATH must point to a Klipper clone with chelper built
+
+DICTIONARY stm32h723.dict
+CONFIG afc_base.cfg
+
+AFC_CLEAR_MESSAGE
+

--- a/tests/klippy/afc_buffer_commands.test
+++ b/tests/klippy/afc_buffer_commands.test
@@ -1,0 +1,35 @@
+# AFC buffer commands integration test
+#
+# Verifies that AFC_buffer GCode commands register and execute correctly
+# in a Klipper environment with one TurtleNeck-style buffer (buf1) configured.
+# No lane needs to be loaded — commands that depend on an active lane are
+# safe no-ops when get_current_lane_obj() returns None.
+#
+# Prerequisites:
+#   - tests/dict/stm32h723.dict must exist
+#   - KLIPPER_PATH must point to a Klipper clone with chelper built
+
+DICTIONARY stm32h723.dict
+CONFIG afc_with_buffer.cfg
+
+# --- Query buffer state ---
+# Reports current enable state, last_state, and fault-detection info.
+QUERY_BUFFER BUFFER=buf1
+
+# --- Enable / disable buffer ---
+# No active lane, so the internal set_multiplier call is a no-op.
+ENABLE_BUFFER BUFFER=buf1 LANE=lane1
+DISABLE_BUFFER BUFFER=buf1 LANE=lane1
+
+# --- Fault detection sensitivity transitions ---
+# 0 → 5: registers extruder position timer and starts fault detection.
+AFC_SET_ERROR_SENSITIVITY BUFFER=buf1 SENSITIVITY=5.0
+# 5 → 7: both non-zero — updates filament error position threshold only.
+AFC_SET_ERROR_SENSITIVITY BUFFER=buf1 SENSITIVITY=7.0
+# 7 → 0: stops the fault detection timer.
+AFC_SET_ERROR_SENSITIVITY BUFFER=buf1 SENSITIVITY=0
+
+# --- Multiplier adjustment ---
+# Buffer is disabled and no lane is loaded, so these are logged no-ops.
+SET_BUFFER_MULTIPLIER BUFFER=buf1 MULTIPLIER=HIGH FACTOR=1.15
+SET_BUFFER_MULTIPLIER BUFFER=buf1 MULTIPLIER=LOW FACTOR=0.85

--- a/tests/klippy/afc_commands.test
+++ b/tests/klippy/afc_commands.test
@@ -1,0 +1,47 @@
+# AFC GCode commands integration test — no lanes/units required
+#
+# Verifies that AFC configuration/state commands work correctly in a minimal
+# environment with no BoxTurtle units or stepper lanes configured.
+#
+# Prerequisites:
+#   - test/dict/stm32h723.dict must exist (built from test/klippy/stm32h723.config)
+#   - KLIPPER_PATH must point to a Klipper clone with chelper built
+
+DICTIONARY stm32h723.dict
+CONFIG afc_base.cfg
+
+# --- Tip forming configuration commands ---
+# Read current tip forming config (no hardware required)
+GET_TIP_FORMING
+# Modify tip forming parameters
+SET_TIP_FORMING COOLING_TUBE_POSITION=40 COOLING_MOVES=6
+# Verify the change applied
+GET_TIP_FORMING
+
+# --- Quiet mode ---
+# Enable quiet mode at a custom speed
+AFC_QUIET_MODE SPEED=75 ENABLE=1
+# Disable quiet mode (restore default)
+AFC_QUIET_MODE ENABLE=0
+
+# --- Macro toggle flags ---
+# Toggle tool_cut on then off (just sets boolean flags, no hardware)
+AFC_TOGGLE_MACRO TOOL_CUT=1
+AFC_TOGGLE_MACRO TOOL_CUT=0
+
+# --- Toolchange counter ---
+SET_AFC_TOOLCHANGES TOOLCHANGES=5
+
+# --- Message queue ---
+# Clear from an empty message queue — should succeed silently
+AFC_CLEAR_MESSAGE
+
+# --- Error state reset ---
+RESET_FAILURE
+
+# --- Spool ID state ---
+SET_NEXT_SPOOL_ID SPOOL_ID=12345
+
+# --- Stats reset with no EXTRUDER/LANE specified ---
+# Command logs a message and returns cleanly without error
+AFC_RESET_STATS

--- a/tests/klippy/afc_lane_commands.test
+++ b/tests/klippy/afc_lane_commands.test
@@ -1,0 +1,28 @@
+# AFC lane-specific commands integration test
+#
+# Verifies GCode commands that require at least one AFC lane to be configured.
+# Uses a minimal BoxTurtle unit (unit_1) with one lane (lane1) and one hub
+# (hub_1), all wired to simulated STM32H723 pins (PC0–PC5).
+#
+# Prerequisites:
+#   - test/dict/stm32h723.dict must exist
+#   - KLIPPER_PATH must point to a Klipper clone with chelper built
+
+DICTIONARY stm32h723.dict
+CONFIG afc_with_lane.cfg
+
+AFC_CLEAR_MESSAGE
+
+# --- Per-lane metadata commands ---
+# SET_COLOR / SET_MATERIAL / SET_WEIGHT: update lane state then call save_vars
+# (save_vars returns early when prep_done=False) and send_lane_data
+# (which is a no-op when lane.map is None — no moonraker call).
+SET_COLOR LANE=lane1 COLOR=FF0000
+SET_MATERIAL LANE=lane1 MATERIAL=PLA
+SET_WEIGHT LANE=lane1 WEIGHT=500
+
+AFC_STEPPER_HOME STEPPER=lane1 ENABLE=1 SPEED=100 ACCEL=100 STOP_ON_ENDSTOP=1 DIST=500 ENDSTOP=load SYNC=1
+
+# Test non-homing move
+AFC_STEPPER_HOME STEPPER=lane1 ENABLE=1 SPEED=100 ACCEL=100 STOP_ON_ENDSTOP=0 DIST=500 ENDSTOP=load SYNC=1
+AFC_STEPPER_HOME STEPPER=lane1 ENABLE=1 SPEED=100 ACCEL=100 STOP_ON_ENDSTOP=0 DIST=500 ENDSTOP=load SYNC=0

--- a/tests/klippy/afc_vivid_commands.test
+++ b/tests/klippy/afc_vivid_commands.test
@@ -1,0 +1,33 @@
+# AFC lane-specific commands integration test
+#
+# Verifies GCode commands that require at least one AFC lane to be configured.
+# Uses a minimal BoxTurtle unit (unit_1) with one lane (lane1) and one hub
+# (hub_1), all wired to simulated STM32H723 pins (PC0–PC5).
+#
+# Prerequisites:
+#   - test/dict/stm32h723.dict must exist
+#   - KLIPPER_PATH must point to a Klipper clone with chelper built
+
+DICTIONARY stm32h723.dict
+CONFIG afc_vivid_unit.cfg
+
+# --- Per-lane metadata commands ---
+# SET_COLOR / SET_MATERIAL / SET_WEIGHT: update lane state then call save_vars
+# (save_vars returns early when prep_done=False) and send_lane_data
+# (which is a no-op when lane.map is None — no moonraker call).
+SET_COLOR LANE=lane1 COLOR=FF0000
+SET_MATERIAL LANE=lane1 MATERIAL=PLA
+SET_WEIGHT LANE=lane1 WEIGHT=500
+
+# Set position extremely negative so that homing endstop in kalico does not halt the test
+AFC_STEPPER_HOME STEPPER=Vivid_1_drive ENABLE=1 SPEED=100 ACCEL=100 STOP_ON_ENDSTOP=1 DIST=500 ENDSTOP=lane1_load SYNC=1
+AFC_STEPPER_HOME STEPPER=Vivid_1_selector ENABLE=1 SPEED=100 ACCEL=100 STOP_ON_ENDSTOP=1 DIST=500 ENDSTOP=lane1_selector SYNC=1
+
+# Test non-homing move
+AFC_STEPPER_HOME STEPPER=Vivid_1_drive ENABLE=1 SPEED=100 ACCEL=100 STOP_ON_ENDSTOP=0 DIST=500 ENDSTOP=load SYNC=1
+AFC_STEPPER_HOME STEPPER=Vivid_1_drive ENABLE=1 SPEED=100 ACCEL=100 STOP_ON_ENDSTOP=0 DIST=500 ENDSTOP=load SYNC=0
+
+AFC_RECOVER_LANE LANE=lane1
+AFC_UNSELECT_LANE UNIT=Vivid_1 FORCE=0
+AFC_UNSELECT_LANE UNIT=Vivid_1 FORCE=1
+AFC_UNSELECT_LANE UNIT=Vivid_1 FORCE=1 MOVE_DIST=200

--- a/tests/klippy/afc_vivid_unit.cfg
+++ b/tests/klippy/afc_vivid_unit.cfg
@@ -1,0 +1,202 @@
+
+# Minimal Klipper + AFC configuration with one BoxTurtle unit and lane.
+# Extends the base configuration by adding a simulated AFC_BoxTurtle unit,
+# one AFC_stepper lane, and one AFC_hub — all using free STM32H723 pins
+# not consumed by the base printer kinematics (PA*/PB* are already used).
+#
+# Free pin bank used here: PC0–PC5
+#
+# This file duplicates the base printer/AFC config so that klippy can load it
+# as a standalone config without needing an include directive.
+
+# ---------------------------------------------------------------------------
+# MCU — path is irrelevant in dict/simulation mode
+# ---------------------------------------------------------------------------
+[mcu]
+serial: /dev/null
+
+# ---------------------------------------------------------------------------
+# Printer kinematics (required by Klipper)
+# ---------------------------------------------------------------------------
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100
+
+[stepper_x]
+step_pin: PA0
+dir_pin: PA1
+enable_pin: !PA2
+microsteps: 16
+rotation_distance: 40
+endstop_pin: PA3
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_y]
+step_pin: PA4
+dir_pin: PA5
+enable_pin: !PA6
+microsteps: 16
+rotation_distance: 40
+endstop_pin: PA7
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_z]
+step_pin: PB0
+dir_pin: PB1
+enable_pin: !PB2
+microsteps: 16
+rotation_distance: 8
+endstop_pin: PB3
+position_endstop: 0
+position_max: 200
+
+[extruder]
+step_pin: PB4
+dir_pin: PB5
+enable_pin: !PB6
+microsteps: 16
+rotation_distance: 33.5
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PB7
+sensor_type: temperature_host
+min_temp: 0
+max_temp: 250
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+
+[heater_bed]
+heater_pin: PB8
+sensor_type: temperature_host
+min_temp: 0
+max_temp: 130
+control: pid
+pid_Kp: 54.027
+pid_Ki: 0.770
+pid_Kd: 948.182
+
+# save_variables is required by AFC to persist spool/lane state.
+[save_variables]
+filename: /tmp/afc_klippy_lane_test.cfg
+
+# pause_resume is required by AFC_error
+[pause_resume]
+
+# ---------------------------------------------------------------------------
+# AFC core
+# ---------------------------------------------------------------------------
+
+[testing]
+
+[AFC]
+VarFile: /tmp/afc_klippy_lane_test.var
+long_moves_speed: 150
+long_moves_accel: 250
+short_moves_speed: 50
+short_moves_accel: 300
+short_move_dis: 10
+enable_sensors_in_gui: False
+load_to_hub: False
+z_hop: 5
+resume_speed: 120
+resume_z_speed: 30
+error_timeout: 36000
+tool_cut: False
+park: False
+poop: False
+kick: False
+wipe: False
+form_tip: False
+
+[AFC_prep]
+enable: False
+
+[AFC_form_tip]
+cooling_tube_position: 35
+cooling_tube_length: 10
+cooling_moves: 4
+
+# ---------------------------------------------------------------------------
+# One BoxTurtle unit with a single lane — uses PC0–PC5 (all free)
+# ---------------------------------------------------------------------------
+
+# AFC extruder wrapper (required so AFC_stepper can link to an extruder object)
+[AFC_extruder extruder]
+# No tool_start / tool_end sensor pins — keep config minimal.
+
+[AFC_vivid Vivid_1]
+hub: Vivid_1
+extruder: extruder
+buffer: Vivid_1_buffer
+drive_stepper: Vivid_1_drive
+selector_stepper: Vivid_1_selector
+long_moves_speed: 120
+long_moves_accel:50
+
+[AFC_stepper Vivid_1_drive]
+unit: Vivid_1
+step_pin: PC0
+dir_pin: PC1
+enable_pin: PC2
+microsteps: 16
+rotation_distance: 360
+gear_ratio: 43:1
+
+[tmc2209 AFC_stepper Vivid_1_drive]
+uart_pin: PC3
+uart_address: 0
+run_current: 0.8
+sense_resistor: 0.110
+
+[AFC_stepper Vivid_1_selector]
+unit: Vivid_1
+step_pin: PD0
+dir_pin: PD1
+enable_pin: PD2
+microsteps: 16
+rotation_distance: 400
+gear_ratio: 2.5:1
+
+[tmc2209 AFC_stepper Vivid_1_selector]
+uart_pin: PD3
+uart_address: 0
+run_current: 0.8
+sense_resistor: 0.110
+
+[AFC_lane lane1]
+unit: Vivid_1:1
+dist_hub: 2000
+led_index: AFC_Indicator_1:1-7
+load: PC4
+prep: PC5
+selector: PC6
+
+[AFC_buffer Vivid_1_buffer]
+advance_pin: PD4
+trailing_pin: PD5
+multiplier_high: 1.15
+multiplier_low: 0.90
+
+[AFC_hub Vivid_1]
+afc_bowden_length: 2000     # Length of the Bowden tube from the hub to the toolhead sensor in mm.
+move_dis: 20                   # Distance to move the filament within the hub in mm.
+hub_clear_move_dis: 20
+switch_pin: virtual
+
+[AFC_led AFC_Indicator_1]
+pin: PD6
+chain_count: 14
+color_order: GRB
+initial_RED: 0.0
+initial_GREEN: 0.0
+initial_BLUE: 0.0
+initial_WHITE: 0.0

--- a/tests/klippy/afc_with_buffer.cfg
+++ b/tests/klippy/afc_with_buffer.cfg
@@ -1,0 +1,168 @@
+
+# Minimal Klipper + AFC configuration with one BoxTurtle unit, one lane, and
+# one TurtleNeck-style AFC_buffer.
+#
+# Pin assignment summary:
+#   PA0–PA7  stepper_x + stepper_y (step/dir/enable/endstop)
+#   PB0–PB8  stepper_z + extruder + heater_bed
+#   PC0–PC5  AFC lane + hub switch  (from afc_with_lane.cfg)
+#   PC6      AFC_buffer buf1 advance (expanded) pin
+#   PC7      AFC_buffer buf1 trailing (compressed) pin
+#
+# This file is self-contained — it duplicates the printer/AFC base so that
+# klippy can load it standalone without an include directive.
+
+# ---------------------------------------------------------------------------
+# MCU — path is irrelevant in dict/simulation mode
+# ---------------------------------------------------------------------------
+[mcu]
+serial: /dev/null
+
+# ---------------------------------------------------------------------------
+# Printer kinematics (required by Klipper)
+# ---------------------------------------------------------------------------
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100
+
+[stepper_x]
+step_pin: PA0
+dir_pin: PA1
+enable_pin: !PA2
+microsteps: 16
+rotation_distance: 40
+endstop_pin: PA3
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_y]
+step_pin: PA4
+dir_pin: PA5
+enable_pin: !PA6
+microsteps: 16
+rotation_distance: 40
+endstop_pin: PA7
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_z]
+step_pin: PB0
+dir_pin: PB1
+enable_pin: !PB2
+microsteps: 16
+rotation_distance: 8
+endstop_pin: PB3
+position_endstop: 0
+position_max: 200
+
+[extruder]
+step_pin: PB4
+dir_pin: PB5
+enable_pin: !PB6
+microsteps: 16
+rotation_distance: 33.5
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PB7
+sensor_type: temperature_host
+min_temp: 0
+max_temp: 250
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+
+[heater_bed]
+heater_pin: PB8
+sensor_type: temperature_host
+min_temp: 0
+max_temp: 130
+control: pid
+pid_Kp: 54.027
+pid_Ki: 0.770
+pid_Kd: 948.182
+
+# save_variables is required by AFC to persist spool/lane state.
+[save_variables]
+filename: /tmp/afc_klippy_buffer_test.cfg
+
+# pause_resume is required by AFC_error
+[pause_resume]
+
+# ---------------------------------------------------------------------------
+# AFC core
+# ---------------------------------------------------------------------------
+
+[testing]
+
+[AFC]
+VarFile: /tmp/afc_klippy_buffer_test.var
+long_moves_speed: 150
+long_moves_accel: 250
+short_moves_speed: 50
+short_moves_accel: 300
+short_move_dis: 10
+enable_sensors_in_gui: False
+load_to_hub: False
+z_hop: 5
+resume_speed: 120
+resume_z_speed: 30
+error_timeout: 36000
+tool_cut: False
+park: False
+poop: False
+kick: False
+wipe: False
+form_tip: False
+
+[AFC_prep]
+enable: False
+
+[AFC_form_tip]
+cooling_tube_position: 35
+cooling_tube_length: 10
+cooling_moves: 4
+
+# ---------------------------------------------------------------------------
+# One BoxTurtle unit with a single lane — uses PC0–PC5
+# ---------------------------------------------------------------------------
+
+[AFC_extruder extruder]
+
+[AFC_BoxTurtle unit_1]
+hub: hub_1
+extruder: extruder
+buffer: buf1
+
+[AFC_hub hub_1]
+switch_pin: PC5
+afc_bowden_length: 900
+move_dis: 75
+cut: False
+
+[AFC_stepper lane1]
+unit: unit_1:1
+step_pin: PC0
+dir_pin: PC1
+enable_pin: !PC2
+microsteps: 16
+rotation_distance: 4.65
+dist_hub: 155.0
+park_dist: 10
+prep: PC3
+load: PC4
+
+# ---------------------------------------------------------------------------
+# TurtleNeck-style buffer — uses PC6 (advance/expanded) and PC7 (trailing/compressed)
+# ---------------------------------------------------------------------------
+
+[AFC_buffer buf1]
+advance_pin: PC6
+trailing_pin: PC7
+multiplier_high: 1.05
+multiplier_low: 0.95

--- a/tests/klippy/afc_with_lane.cfg
+++ b/tests/klippy/afc_with_lane.cfg
@@ -1,0 +1,156 @@
+
+# Minimal Klipper + AFC configuration with one BoxTurtle unit and lane.
+# Extends the base configuration by adding a simulated AFC_BoxTurtle unit,
+# one AFC_stepper lane, and one AFC_hub — all using free STM32H723 pins
+# not consumed by the base printer kinematics (PA*/PB* are already used).
+#
+# Free pin bank used here: PC0–PC5
+#
+# This file duplicates the base printer/AFC config so that klippy can load it
+# as a standalone config without needing an include directive.
+
+# ---------------------------------------------------------------------------
+# MCU — path is irrelevant in dict/simulation mode
+# ---------------------------------------------------------------------------
+[mcu]
+serial: /dev/null
+
+# ---------------------------------------------------------------------------
+# Printer kinematics (required by Klipper)
+# ---------------------------------------------------------------------------
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100
+
+[stepper_x]
+step_pin: PA0
+dir_pin: PA1
+enable_pin: !PA2
+microsteps: 16
+rotation_distance: 40
+endstop_pin: PA3
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_y]
+step_pin: PA4
+dir_pin: PA5
+enable_pin: !PA6
+microsteps: 16
+rotation_distance: 40
+endstop_pin: PA7
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_z]
+step_pin: PB0
+dir_pin: PB1
+enable_pin: !PB2
+microsteps: 16
+rotation_distance: 8
+endstop_pin: PB3
+position_endstop: 0
+position_max: 200
+
+[extruder]
+step_pin: PB4
+dir_pin: PB5
+enable_pin: !PB6
+microsteps: 16
+rotation_distance: 33.5
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PB7
+sensor_type: temperature_host
+min_temp: 0
+max_temp: 250
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+
+[heater_bed]
+heater_pin: PB8
+sensor_type: temperature_host
+min_temp: 0
+max_temp: 130
+control: pid
+pid_Kp: 54.027
+pid_Ki: 0.770
+pid_Kd: 948.182
+
+# save_variables is required by AFC to persist spool/lane state.
+[save_variables]
+filename: /tmp/afc_klippy_lane_test.cfg
+
+# pause_resume is required by AFC_error
+[pause_resume]
+
+# ---------------------------------------------------------------------------
+# AFC core
+# ---------------------------------------------------------------------------
+
+[testing]
+
+[AFC]
+VarFile: /tmp/afc_klippy_lane_test.var
+long_moves_speed: 150
+long_moves_accel: 250
+short_moves_speed: 50
+short_moves_accel: 300
+short_move_dis: 10
+enable_sensors_in_gui: False
+load_to_hub: False
+z_hop: 5
+resume_speed: 120
+resume_z_speed: 30
+error_timeout: 36000
+tool_cut: False
+park: False
+poop: False
+kick: False
+wipe: False
+form_tip: False
+
+[AFC_prep]
+enable: False
+
+[AFC_form_tip]
+cooling_tube_position: 35
+cooling_tube_length: 10
+cooling_moves: 4
+
+# ---------------------------------------------------------------------------
+# One BoxTurtle unit with a single lane — uses PC0–PC5 (all free)
+# ---------------------------------------------------------------------------
+
+# AFC extruder wrapper (required so AFC_stepper can link to an extruder object)
+[AFC_extruder extruder]
+# No tool_start / tool_end sensor pins — keep config minimal.
+
+[AFC_BoxTurtle unit_1]
+hub: hub_1
+extruder: extruder
+
+[AFC_hub hub_1]
+switch_pin: PC5
+afc_bowden_length: 900
+move_dis: 75
+cut: False
+
+[AFC_stepper lane1]
+unit: unit_1:1
+step_pin: PC0
+dir_pin: PC1
+enable_pin: !PC2
+microsteps: 16
+rotation_distance: 4.65
+dist_hub: 155.0
+park_dist: 10
+prep: PC3
+load: PC4

--- a/tests/klippy/conftest.py
+++ b/tests/klippy/conftest.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+# pytest plugin that collects *.test files as Klipper integration tests.
+# Adapted from KalicoCrew/kalico/test/klippy/conftest.py.
+#
+# Each .test file describes:
+#   DICTIONARY <fname>   - MCU dict file (looked up in DICTDIR / test/dict/)
+#   CONFIG    <fname>    - Klipper config file (relative to the .test file)
+#   SHOULD_FAIL          - mark the test as expected to fail (xfail)
+#   <anything else>      - treated as a GCode line to execute
+#
+# Usage:
+#   KLIPPER_PATH=/path/to/klipper pytest tests/klippy/
+#   DICTDIR=/path/to/dicts pytest tests/klippy/
+#
+# Debugging options:
+#   pytest tests/klippy/ --klippy-keep      Keep temp files after test completion
+
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+
+import pytest
+
+ROOT = pathlib.Path(__file__).parent.parent.parent
+KLIPPER_PATH = pathlib.Path(
+    os.environ.get("KLIPPER_PATH", str(ROOT / "klipper"))
+)
+DICT_DIR = pathlib.Path(
+    os.environ.get("DICTDIR", str(ROOT / "tests" / "dict"))
+)
+LOG_DIR = ROOT / "tests" / "logs"
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--klippy-keep", action="store_true", default=False,
+        help="Keep temporary files (logs, gcode) after test completion",
+    )
+
+
+def pytest_collect_file(parent, file_path):
+    if file_path.suffix == ".test":
+        if not KLIPPER_PATH.exists():
+            return None  # Klipper not available; skip integration tests
+        return KlippyTest.from_parent(parent, path=file_path)
+
+
+class KlippyTest(pytest.File):
+    def _resolve(self, fname, root=None):
+        base = root if root else self.path.parent
+        return base.joinpath(fname).resolve()
+
+    def collect(self):
+        should_fail = False
+        gcode: list[str] = []
+        config_file = None
+        dictionaries: list[str] = []
+
+        with self.path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                parts = line.strip().split()
+                if not parts or line.strip().startswith("#"):
+                    continue
+
+                if parts[0] == "SHOULD_FAIL":
+                    should_fail = True
+
+                elif parts[0] == "DICTIONARY":
+                    dictionaries = [str(self._resolve(parts[1], root=DICT_DIR))]
+                    # Optional extra MCUs: mcu_name=dict_file
+                    for extra in parts[2:]:
+                        mcu, fname = extra.split("=", maxsplit=1)
+                        dictionaries.append(
+                            f"{mcu}={self._resolve(fname, root=DICT_DIR)}"
+                        )
+
+                elif parts[0] == "CONFIG":
+                    config_file = self._resolve(parts[1])
+
+                else:
+                    gcode.append(line.strip())
+
+        keepfiles = self.config.getoption("--klippy-keep")
+
+        yield KlippyTestItem.from_parent(
+            self,
+            name=str(config_file),
+            gcode=gcode,
+            config_file=config_file,
+            dictionaries=dictionaries,
+            should_fail=should_fail,
+            klipper_path=KLIPPER_PATH,
+            keepfiles=keepfiles,
+        )
+
+
+class KlippyTestItem(pytest.Item):
+    def __init__(
+        self,
+        *,
+        config_file,
+        dictionaries,
+        gcode,
+        should_fail=False,
+        klipper_path,
+        keepfiles=False,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.config_file = config_file
+        self.dictionaries = dictionaries
+        self.gcode = gcode
+        self.klipper_path = klipper_path
+        self.keepfiles = keepfiles
+        if should_fail:
+            self.add_marker(pytest.mark.xfail)
+
+    def setup(self):
+        # Build a descriptive directory name from the firmware, .test file, and config.
+        firmware = self.klipper_path.name                     # e.g. "klipper" or "kalico"
+        test_file = pathlib.Path(self.parent.path).stem       # e.g. "afc_buffer_commands"
+        config_name = pathlib.Path(self.config_file).stem     # e.g. "afc_with_buffer"
+        prefix = f"{firmware}_{test_file}_{config_name}_"
+
+        LOG_DIR.mkdir(parents=True, exist_ok=True)
+        self.tmp_dir = pathlib.Path(tempfile.mkdtemp(prefix=prefix, dir=LOG_DIR))
+        # AFC_logger writes to AFC.log in the same directory as klippy.log.
+        self.afc_log_path = self.tmp_dir / "AFC.log"
+
+    def teardown(self):
+        if self.keepfiles:
+            sys.stderr.write(f"  Keeping temp files in: {self.tmp_dir}\n")
+            return
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    def runtest(self):
+        gcode_file = self.tmp_dir / "_test_.gcode"
+        output_file = self.tmp_dir / "_test_.output"
+        log_file = self.tmp_dir / "klippy.log"
+
+        gcode_file.write_text("\n".join(self.gcode) + "\n")
+
+        # Run klippy via the launcher so that QueueListener's bg_thread is
+        # daemonised, allowing klippy to exit cleanly when -l is passed.
+        launcher = pathlib.Path(__file__).parent / "klippy_launcher.py"
+        klippy_script = self.klipper_path / "klippy" / "klippy.py"
+        args = [sys.executable, str(launcher), str(klippy_script), str(self.config_file)]
+        args += ["-i", str(gcode_file)]
+        args += ["-o", str(output_file)]
+        args += ["-l", str(log_file)]  # enables AFC.log in the same directory
+        args += ["-v"]
+        for df in self.dictionaries:
+            args += ["-d", df]
+
+        # Add Klipper root to PYTHONPATH so "python -m klippy" resolves.
+        env = dict(os.environ)
+        existing_pp = env.get("PYTHONPATH", "")
+        klipper_str = str(self.klipper_path)
+        env["PYTHONPATH"] = (
+            f"{klipper_str}{os.pathsep}{existing_pp}"
+            if existing_pp
+            else klipper_str
+        )
+
+        result = subprocess.run(
+            args,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            env=env,
+        )
+
+        if result.returncode != 0:
+            raise KlippyTestError(result.returncode, args, result.stdout)
+
+    def repr_failure(self, excinfo, style=None):
+        if isinstance(excinfo.value, KlippyTestError):
+            err = excinfo.value
+            output = err.output or ""
+            tail = output[-4000:] if len(output) > 4000 else output
+            lines = [
+                f"Klippy test failed (exit {err.returncode}): {self.name}",
+                f"  Config:       {self.config_file}",
+                f"  Dictionaries: {', '.join(self.dictionaries)}",
+            ]
+            if tail:
+                lines += ["", tail]
+            # Include klippy.log — with -l, klippy writes its detailed log here
+            # rather than to stdout, so stdout is mostly empty on failure.
+            klippy_log_path = self.tmp_dir / "klippy.log"
+            if klippy_log_path.exists():
+                klippy_content = klippy_log_path.read_text(errors="replace")
+                if klippy_content:
+                    klippy_tail = klippy_content[-4000:] if len(klippy_content) > 4000 else klippy_content
+                    lines += [
+                        "",
+                        "─── klippy.log ────────────────────────────────────────────",
+                        klippy_tail,
+                    ]
+            # Include AFC.log when it was written (requires -l to have been passed).
+            if self.afc_log_path.exists():
+                afc_content = self.afc_log_path.read_text(errors="replace")
+                if afc_content:
+                    afc_tail = afc_content[-4000:] if len(afc_content) > 4000 else afc_content
+                    lines += [
+                        "",
+                        "─── AFC.log ───────────────────────────────────────────────",
+                        afc_tail,
+                    ]
+            return "\n".join(lines)
+        return super().repr_failure(excinfo=excinfo, style=style)
+
+
+class KlippyTestError(Exception):
+    def __init__(self, returncode, args, output):
+        super().__init__(f"klippy exited with {returncode}")
+        self.returncode = returncode
+        self.args_ = args
+        self.output = output

--- a/tests/klippy/klippy_launcher.py
+++ b/tests/klippy/klippy_launcher.py
@@ -1,0 +1,30 @@
+"""
+Wraps klippy.py to prevent it hanging on exit when -l (file logging) is active.
+
+klipper's queuelogger.QueueListener starts a non-daemon background thread.
+Non-daemon threads block Python's threading shutdown, which prevents atexit
+handlers (including AFC_logger.shutdown) from running, causing a deadlock.
+Patching threading.Thread.__init__ before any threads are created resolves it.
+"""
+
+import sys
+import threading
+import runpy
+from pathlib import Path
+
+_orig_thread_init = threading.Thread.__init__
+
+
+def _patched_thread_init(self, *args, **kwargs):
+    _orig_thread_init(self, *args, **kwargs)
+    self.daemon = True
+
+
+threading.Thread.__init__ = _patched_thread_init
+
+sys.argv = sys.argv[1:]
+# Mirror what Python does when running a script directly: add the script's
+# directory to sys.path[0] so klippy's relative imports (util, reactor, etc.)
+# resolve correctly.
+sys.path.insert(0, str(Path(sys.argv[0]).parent))
+runpy.run_path(sys.argv[0], run_name="__main__")

--- a/tests/klippy/stm32h723.config
+++ b/tests/klippy/stm32h723.config
@@ -1,0 +1,17 @@
+#
+# Klipper firmware build configuration for STM32H723 (AFC Lite / BTT boards).
+# Requires arm-none-eabi-gcc cross-compiler.
+# Used to generate test/dict/stm32h723.dict for AFC integration tests.
+#
+# To regenerate the dict manually:
+#   cp test/klippy/stm32h723.config klipper/.config
+#   make -C klipper
+#   cp klipper/out/klipper.dict test/dict/stm32h723.dict
+#
+CONFIG_LOW_LEVEL_OPTIONS=y
+CONFIG_MACH_STM32=y
+CONFIG_MACH_STM32H723=y
+CONFIG_STM32_CLOCK_REF_25M=y
+CONFIG_STM32_FLASH_START_20000=y
+CONFIG_USBSERIAL=y
+CONFIG_STM32_USB_PA11_PA12=y

--- a/tests/klippy_testing_plugin.py
+++ b/tests/klippy_testing_plugin.py
@@ -1,0 +1,57 @@
+import ast
+import logging
+
+from extras import gcode_macro
+
+
+class KlippyTestingPlugin:
+    def __init__(self, config):
+        self.config = config
+        self.printer = config.get_printer()
+        self.gcode = self.printer.lookup_object("gcode")
+        self.gcode_macro = self.printer.load_object(config, "gcode_macro")
+
+        self.printer.register_event_handler(
+            "gcode:command_error", self._command_error
+        )
+        self.printer.register_event_handler(
+            "gcode:unknown_command", self._unknown_command
+        )
+
+        self.gcode.register_command("ASSERT", self.cmd_ASSERT)
+
+    def _command_error(self):
+        self.printer.request_exit("error_exit")
+        self.printer.invoke_shutdown("Exception during testing")
+
+    def _unknown_command(self, cmd):
+        logging.error(f"Unknown command during test execution: {cmd}")
+        self.printer.request_exit("error_exit")
+        self.printer.invoke_shutdown(
+            f"Unknown command during test execution: {cmd}"
+        )
+
+    def cmd_ASSERT(self, gcmd):
+        "Evaluate an expression, raising an error if the return value is False"
+        expression = gcmd.get("TEST")
+
+        try:
+            template = gcode_macro.Template(
+                self.printer,
+                self.gcode_macro.env,
+                "ASSERT:runtime_expression",
+                expression,
+            )
+        except:
+            raise gcmd.error(f"ASSERT: Failed to parse '{expression}'")
+
+        context = self.gcode_macro.create_template_context()
+        statement = template.render(context)
+        value = ast.literal_eval(statement) if statement else None
+
+        if not value:
+            raise gcmd.error(f"ASSERT: {expression} == {value}")
+
+
+def load_config(config):
+    return KlippyTestingPlugin(config)

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -1,0 +1,377 @@
+"""
+Unit tests for extras/AFC.py
+
+Covers:
+  - State: string constants
+  - AFC_VERSION: version string format
+  - afc._remove_after_last: string helper
+  - afc._get_message: message queue peek and pop
+  - afc.get_status: returns required keys
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+import pytest
+
+from extras.AFC import afc, State, AFC_VERSION
+
+
+# ── State constants ───────────────────────────────────────────────────────────
+
+class TestStateConstants:
+    def test_init_value(self):
+        assert State.INIT == "Initialized"
+
+    def test_idle_value(self):
+        assert State.IDLE == "Idle"
+
+    def test_error_value(self):
+        assert State.ERROR == "Error"
+
+    def test_loading_value(self):
+        assert State.LOADING == "Loading"
+
+    def test_unloading_value(self):
+        assert State.UNLOADING == "Unloading"
+
+    def test_ejecting_lane_value(self):
+        assert State.EJECTING_LANE == "Ejecting"
+
+    def test_moving_lane_value(self):
+        assert State.MOVING_LANE == "Moving"
+
+    def test_restoring_pos_value(self):
+        assert State.RESTORING_POS == "Restoring"
+
+    def test_all_constants_are_strings(self):
+        attrs = [a for a in dir(State) if not a.startswith("_")]
+        for attr in attrs:
+            assert isinstance(getattr(State, attr), str)
+
+    def test_all_constants_unique(self):
+        attrs = [a for a in dir(State) if not a.startswith("_")]
+        values = [getattr(State, a) for a in attrs]
+        assert len(values) == len(set(values))
+
+
+# ── AFC_VERSION ───────────────────────────────────────────────────────────────
+
+class TestAfcVersion:
+    def test_version_is_string(self):
+        assert isinstance(AFC_VERSION, str)
+
+    def test_version_has_dots(self):
+        assert "." in AFC_VERSION
+
+    def test_version_parts_are_numeric(self):
+        parts = AFC_VERSION.split(".")
+        for part in parts:
+            assert part.isdigit(), f"Non-numeric version part: {part!r}"
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_afc():
+    """Build an afc instance bypassing __init__."""
+    obj = afc.__new__(afc)
+
+    from tests.conftest import MockAFC, MockLogger, MockPrinter
+
+    inner = MockAFC()
+    printer = MockPrinter(afc=inner)
+    obj.printer = printer
+    obj.logger = MockLogger()
+    obj.reactor = inner.reactor
+    obj.moonraker = None
+    obj.function = MagicMock()
+    obj.message_queue = []
+    # obj.current = MagicMock()
+    obj.current_loading = None
+    obj.next_lane_load = None
+    obj.current_state = State.IDLE
+    obj.error_state = False
+    obj.position_saved = False
+    obj.spoolman = None
+    obj._td1_present = False
+    obj.lane_data_enabled = False
+    obj.units = {}
+    obj.lanes = {}
+    obj.tools = {}
+    obj.hubs = {}
+    obj.buffers = {}
+    obj.tool_cmds = {}
+    obj.led_state = True
+    obj.current_toolchange = 0
+    obj.number_of_toolchanges = 0
+    obj.temp_wait_tolerance = 5
+    obj._get_bypass_state = MagicMock(return_value=False)
+    obj._get_quiet_mode = MagicMock(return_value=False)
+    return obj
+
+
+# ── _remove_after_last ────────────────────────────────────────────────────────
+
+class TestRemoveAfterLast:
+    def test_removes_after_last_slash(self):
+        obj = _make_afc()
+        result = obj._remove_after_last("/home/user/file.txt", "/")
+        assert result == "/home/user/"
+
+    def test_no_char_returns_original(self):
+        obj = _make_afc()
+        result = obj._remove_after_last("nodots", ".")
+        assert result == "nodots"
+
+    def test_char_at_end(self):
+        obj = _make_afc()
+        result = obj._remove_after_last("trailing/", "/")
+        assert result == "trailing/"
+
+    def test_single_char_string(self):
+        obj = _make_afc()
+        result = obj._remove_after_last("/", "/")
+        assert result == "/"
+
+    def test_multiple_occurrences_uses_last(self):
+        obj = _make_afc()
+        result = obj._remove_after_last("a/b/c/d", "/")
+        assert result == "a/b/c/"
+
+
+# ── _get_message ──────────────────────────────────────────────────────────────
+
+class TestGetMessage:
+    def test_empty_queue_returns_empty_strings(self):
+        obj = _make_afc()
+        msg = obj._get_message()
+        assert msg["message"] == ""
+        assert msg["type"] == ""
+
+    def test_peek_does_not_remove(self):
+        obj = _make_afc()
+        obj.message_queue = [("hello", "info")]
+        obj._get_message(clear=False)
+        assert len(obj.message_queue) == 1
+
+    def test_peek_returns_message(self):
+        obj = _make_afc()
+        obj.message_queue = [("hello", "info")]
+        msg = obj._get_message(clear=False)
+        assert msg["message"] == "hello"
+        assert msg["type"] == "info"
+
+    def test_clear_removes_first_item(self):
+        obj = _make_afc()
+        obj.message_queue = [("first", "error"), ("second", "warning")]
+        obj._get_message(clear=True)
+        assert len(obj.message_queue) == 1
+        assert obj.message_queue[0][0] == "second"
+
+    def test_clear_returns_popped_message(self):
+        obj = _make_afc()
+        obj.message_queue = [("popped", "error")]
+        msg = obj._get_message(clear=True)
+        assert msg["message"] == "popped"
+        assert msg["type"] == "error"
+
+    def test_clear_on_empty_returns_empty(self):
+        obj = _make_afc()
+        msg = obj._get_message(clear=True)
+        assert msg["message"] == ""
+        assert msg["type"] == ""
+
+
+# ── get_status ────────────────────────────────────────────────────────────────
+
+class TestGetStatus:
+    def test_returns_required_keys(self):
+        obj = _make_afc()
+        status = obj.get_status()
+        required = {
+            "current_load", "current_state", "error_state",
+            "lanes", "extruders", "hubs", "buffers", "units",
+            "message", "position_saved",
+        }
+        for key in required:
+            assert key in status, f"Missing key: {key}"
+
+    def test_lanes_is_list(self):
+        obj = _make_afc()
+        assert isinstance(obj.get_status()["lanes"], list)
+
+    def test_extruders_is_list(self):
+        obj = _make_afc()
+        assert isinstance(obj.get_status()["extruders"], list)
+
+    def test_hubs_is_list(self):
+        obj = _make_afc()
+        assert isinstance(obj.get_status()["hubs"], list)
+
+    def test_units_is_list(self):
+        obj = _make_afc()
+        assert isinstance(obj.get_status()["units"], list)
+
+    def test_error_state_reflects_attribute(self):
+        obj = _make_afc()
+        obj.error_state = True
+        assert obj.get_status()["error_state"] is True
+
+    def test_current_load_none_when_nothing_loaded(self):
+        obj = _make_afc()
+        obj.function.get_current_lane.return_value = None
+        assert obj.get_status()["current_load"] is None
+
+    def test_message_from_queue(self):
+        obj = _make_afc()
+        obj.message_queue = [("test msg", "warning")]
+        msg = obj.get_status()["message"]
+        assert msg["message"] == "test msg"
+
+
+# ── _check_extruder_temp ──────────────────────────────────────────────────────
+
+def _make_afc_for_check_extruder_temp(
+    heater_target_temp,
+    actual_temp,
+    target_material_temp,
+    lower_extruder_temp_on_change=True,
+    using_min_value=False,
+):
+    from tests.test_AFC_lane import _make_afc_lane
+    """Build an afc instance wired up for _check_extruder_temp tests."""
+    obj = _make_afc()
+    obj.lower_extruder_temp_on_change = lower_extruder_temp_on_change
+    obj._wait_for_temp_within_tolerance = MagicMock()
+
+    heater = MagicMock()
+    heater.target_temp = heater_target_temp
+    heater.can_extrude = False
+    heater.get_temp = MagicMock(return_value=(actual_temp, 0.0))
+
+    extruder = MagicMock()
+    extruder.get_heater.return_value = heater
+
+    lane = _make_afc_lane()
+    lane.extruder_obj.toolhead_extruder = MagicMock()
+    lane.extruder_obj.toolhead_extruder = extruder
+
+    obj.toolhead = MagicMock()
+    obj.toolhead.get_extruder.return_value = extruder
+
+    pheaters = MagicMock()
+    obj.printer._objects["heaters"] = pheaters
+
+    obj.function.is_printing.return_value = False
+    obj._get_default_material_temps = MagicMock(
+        return_value=(float(target_material_temp), using_min_value)
+    )
+
+    return obj, heater, extruder, pheaters, lane
+
+
+class TestCheckExtruderTemp:
+    """Tests for afc._check_extruder_temp().
+
+    Covers the two-action logic:
+      need_lower: set temp > target+5 → lower without waiting
+      need_heat:  set temp < target-5 → heat and wait
+      skip_lower: need_lower AND lower_extruder_temp_on_change=False
+                  AND actual temp already sufficient → skip the lower call
+    """
+
+    # ── Default behaviour (lower_extruder_temp_on_change=True) ───────────────
+
+    def test_lowers_to_target_when_above(self):
+        
+        """Set temp more than 5° above target → lower to target, no wait."""
+        obj, heater, extruder, pheaters, lane = _make_afc_for_check_extruder_temp(
+            heater_target_temp=250, actual_temp=248, target_material_temp=210
+        )
+        result = obj._check_extruder_temp(lane)
+        pheaters.set_temperature.assert_called_once_with(heater, 210.0)
+        obj._wait_for_temp_within_tolerance.assert_not_called()
+        assert result is False
+
+    def test_heats_to_target_when_below(self):
+        """Set temp more than 5° below target → heat to target and wait."""
+        obj, heater, extruder, pheaters, lane = _make_afc_for_check_extruder_temp(
+            heater_target_temp=150, actual_temp=148, target_material_temp=210
+        )
+        result = obj._check_extruder_temp(lane)
+        pheaters.set_temperature.assert_called_once_with(heater, 210.0)
+        obj._wait_for_temp_within_tolerance.assert_called_once_with(obj.heater, 210,
+                                                                    obj.temp_wait_tolerance*2)
+        assert result is True
+
+    def test_no_change_when_within_range(self):
+        """Set temp within ±5° of target → no set_temperature call."""
+        obj, heater, extruder, pheaters, lane = _make_afc_for_check_extruder_temp(
+            heater_target_temp=212, actual_temp=210, target_material_temp=210
+        )
+        result = obj._check_extruder_temp(lane)
+        pheaters.set_temperature.assert_not_called()
+        obj._wait_for_temp_within_tolerance.assert_not_called()
+        assert result is False
+
+    def test_no_lower_when_using_min_extrude_temp(self):
+        """When using min_extrude_temp fallback, do not lower even if above target+5."""
+        obj, heater, extruder, pheaters, lane = _make_afc_for_check_extruder_temp(
+            heater_target_temp=250, actual_temp=248, target_material_temp=210,
+            using_min_value=True,
+        )
+        result = obj._check_extruder_temp(lane)
+        pheaters.set_temperature.assert_not_called()
+        obj._wait_for_temp_within_tolerance.assert_not_called()
+        assert result is False
+
+    # ── lower_extruder_temp_on_change=False ──────────────────────────────────
+
+    def test_skip_lower_when_disabled_and_actual_sufficient(self):
+        """lower=False, actual ≥ target-5 → lowering is skipped entirely."""
+        obj, heater, extruder, pheaters, lane = _make_afc_for_check_extruder_temp(
+            heater_target_temp=250, actual_temp=248, target_material_temp=210,
+            lower_extruder_temp_on_change=False,
+        )
+        result = obj._check_extruder_temp(lane)
+        pheaters.set_temperature.assert_not_called()
+        obj._wait_for_temp_within_tolerance.assert_not_called()
+        assert result is False
+
+    def test_lower_not_skipped_when_actual_insufficient(self):
+        """lower=False but actual < target-5 → skip_lower stays False, lower fires."""
+        obj, heater, extruder, pheaters, lane = _make_afc_for_check_extruder_temp(
+            heater_target_temp=250, actual_temp=200, target_material_temp=210,
+            lower_extruder_temp_on_change=False,
+        )
+        result = obj._check_extruder_temp(lane)
+        pheaters.set_temperature.assert_any_call(heater, 210.0)
+        obj._wait_for_temp_within_tolerance.assert_not_called()
+        assert result is False
+
+    def test_heating_unaffected_by_lower_flag(self):
+        """lower=False does not suppress heating up to a higher target."""
+        obj, heater, extruder, pheaters, lane = _make_afc_for_check_extruder_temp(
+            heater_target_temp=150, actual_temp=148, target_material_temp=210,
+            lower_extruder_temp_on_change=False,
+        )
+        result = obj._check_extruder_temp(lane)
+        pheaters.set_temperature.assert_called_once_with(heater, 210.0)
+        obj._wait_for_temp_within_tolerance.assert_called_once_with(obj.heater, 210,
+                                                                    obj.temp_wait_tolerance*2)
+        assert result is True
+
+    # ── Early-return guard ────────────────────────────────────────────────────
+
+    def test_no_change_when_printing(self):
+        """can_extrude=True + is_printing=True → early return, no temp change."""
+        obj, heater, extruder, pheaters, lane = _make_afc_for_check_extruder_temp(
+            heater_target_temp=150, actual_temp=148, target_material_temp=210
+        )
+        heater.can_extrude = True
+        obj.function.is_printing.return_value = True
+        result = obj._check_extruder_temp(lane)
+        pheaters.set_temperature.assert_not_called()
+        obj._wait_for_temp_within_tolerance.assert_not_called()
+        assert result is None
+    # TODO: add passing in a no_wait variable

--- a/tests/test_AFC_BoxTurtle.py
+++ b/tests/test_AFC_BoxTurtle.py
@@ -1,0 +1,183 @@
+"""
+Unit tests for extras/AFC_BoxTurtle.py
+
+Covers:
+  - afcBoxTurtle: MAX_NUM_MOVES constant
+  - system_Test: LED logic for each lane state combination
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+import pytest
+
+from extras.AFC_BoxTurtle import afcBoxTurtle
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_box_turtle(name="Turtle_1"):
+    """Build an afcBoxTurtle bypassing the complex __init__."""
+    unit = afcBoxTurtle.__new__(afcBoxTurtle)
+
+    from tests.conftest import MockAFC, MockPrinter, MockLogger, MockReactor
+
+    afc = MockAFC()
+    reactor = MockReactor()
+    afc.reactor = reactor
+    afc.logger = MockLogger()
+    printer = MockPrinter(afc=afc)
+
+    unit.printer = printer
+    unit.afc = afc
+    unit.logger = afc.logger
+    unit.reactor = reactor
+    unit.name = name
+    unit.full_name = ["AFC_BoxTurtle", name]
+    unit.lanes = {}
+    unit.hub_obj = None
+    unit.extruder_obj = None
+    unit.buffer_obj = None
+    unit.hub = None
+    unit.extruder = None
+    unit.buffer_name = None
+    unit.td1_defined = False
+    unit.type = "Box_Turtle"
+    unit.gcode = afc.gcode
+
+    return unit
+
+
+def _make_lane(prep_state=False, load_state=False, tool_loaded=False):
+    lane = MagicMock()
+    lane.move = MagicMock()
+    lane.name = "lane1"
+    lane.prep_state = prep_state
+    lane.load_state = load_state
+    lane.tool_loaded = tool_loaded
+    lane.map = "T0"
+    lane.led_ready = "0,1,0,0"
+    lane.led_not_ready = "0,0,0,0.25"
+    lane.led_fault = "1,0,0,0"
+    lane.led_loading = "0,0,1,0"
+    lane.led_spool_illum = "1,1,1,0"
+    lane.led_index = "1"
+    lane.led_spool_index = "2"
+    lane.status = None
+    return lane
+
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+class TestConstants:
+    def test_max_num_moves(self):
+        assert afcBoxTurtle.MAX_NUM_MOVES == 40
+
+
+# ── system_Test: empty lane (prep=F, load=F) ──────────────────────────────────
+
+class TestSystemTestEmptyLane:
+    def test_empty_lane_sets_not_ready_led(self):
+        """prep=False, load=False → LED set to led_not_ready."""
+        unit = _make_box_turtle()
+        lane = _make_lane(prep_state=False, load_state=False)
+        unit.system_Test(lane, delay=0.0, assignTcmd=True, enable_movement=False)
+        unit.afc.function.afc_led.assert_any_call(lane.led_not_ready, lane.led_index)
+
+    def test_empty_lane_does_not_set_fault_led(self):
+        unit = _make_box_turtle()
+        lane = _make_lane(prep_state=False, load_state=False)
+        unit.system_Test(lane, delay=0.0, assignTcmd=True, enable_movement=False)
+        for c in unit.afc.function.afc_led.call_args_list:
+            assert c[0][0] != lane.led_fault
+
+
+# ── system_Test: fault lane (prep=F, load=T) ─────────────────────────────────
+
+class TestSystemTestFaultLane:
+    def test_fault_state_sets_fault_led(self):
+        """prep=False, load=True → LED set to led_fault."""
+        unit = _make_box_turtle()
+        lane = _make_lane(prep_state=False, load_state=True)
+        unit.system_Test(lane, delay=0.0, assignTcmd=True, enable_movement=False)
+        unit.afc.function.afc_led.assert_any_call(lane.led_fault, lane.led_index)
+
+    def test_fault_state_calls_do_enable_false(self):
+        """Faulted lane should disable stepper."""
+        unit = _make_box_turtle()
+        lane = _make_lane(prep_state=False, load_state=True)
+        unit.system_Test(lane, delay=0.0, assignTcmd=True, enable_movement=False)
+        lane.do_enable.assert_called_with(False)
+
+
+# ── system_Test: loaded (prep=T, load=T) ──────────────────────────────────────
+
+class TestSystemTestLoadedLane:
+    def test_loaded_sets_ready_led(self):
+        """prep=True, load=True → LED set to led_ready."""
+        unit = _make_box_turtle()
+        lane = _make_lane(prep_state=True, load_state=True)
+        unit.system_Test(lane, delay=0.0, assignTcmd=True, enable_movement=False)
+        unit.afc.function.afc_led.assert_any_call(lane.led_ready, lane.led_index)
+
+    def test_loaded_sets_status_to_loaded(self):
+        from extras.AFC_lane import AFCLaneState
+        unit = _make_box_turtle()
+        lane = _make_lane(prep_state=True, load_state=True)
+        unit.system_Test(lane, delay=0.0, assignTcmd=True, enable_movement=False)
+        assert lane.status == AFCLaneState.LOADED
+
+
+# ── system_Test: locked not loaded (prep=T, load=F) ──────────────────────────
+
+class TestSystemTestLockedNotLoaded:
+    def test_locked_not_loaded_sets_not_ready_led(self):
+        """prep=True, load=False → LED set to led_not_ready."""
+        unit = _make_box_turtle()
+        lane = _make_lane(prep_state=True, load_state=False)
+        unit.system_Test(lane, delay=0.0, assignTcmd=True, enable_movement=False)
+        unit.afc.function.afc_led.assert_any_call(lane.led_not_ready, lane.led_index)
+
+
+# ── system_Test: reactor pause called when no movement ───────────────────────
+
+class TestSystemTestReactorPause:
+    def test_reactor_pause_called_when_no_movement(self):
+        unit = _make_box_turtle()
+        lane = _make_lane()
+        pause_mock = MagicMock()
+        unit.afc.reactor.pause = pause_mock
+        unit.system_Test(lane, delay=0.0, assignTcmd=True, enable_movement=False)
+        pause_mock.assert_called()
+
+# ── _move_lane ──────────────────────────────────────────────────
+class Test_MoveLane:
+    def test_returns_not_enable_movement_loaded(self):
+        from unittest.mock import PropertyMock
+        unit = _make_box_turtle()
+        lane = _make_lane()
+        type(lane).load_state = PropertyMock(side_effect=[True])
+
+        result = unit._move_lane(lane, delay=1, enable_movement=False)
+        assert result is True
+    
+    def test_returns_not_enable_movement_not_loaded(self):
+        from unittest.mock import PropertyMock
+        unit = _make_box_turtle()
+        lane = _make_lane()
+        type(lane).load_state = PropertyMock(side_effect=[False])
+
+        result = unit._move_lane(lane, delay=1, enable_movement=False)
+        assert result is False
+    
+    def test_returns_enable_movement_not_loaded(self):
+        from unittest.mock import PropertyMock
+        unit = _make_box_turtle()
+        lane = _make_lane()
+        pause_mock = MagicMock()
+        unit.afc.reactor.pause = pause_mock
+        type(lane).load_state = PropertyMock(side_effect=[False])
+
+        result = unit._move_lane(lane, delay=1, enable_movement=True)
+        assert result is False
+        pause_mock.assert_called()

--- a/tests/test_AFC_HTLF.py
+++ b/tests/test_AFC_HTLF.py
@@ -1,0 +1,99 @@
+"""
+Unit tests for extras/AFC_HTLF.py
+
+Covers:
+  - AFC_HTLF: class constants
+  - AFC_HTLF.home_callback: sets home_state from button event
+  - AFC_HTLF: is subclass of afcBoxTurtle
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+import pytest
+
+from extras.AFC_HTLF import AFC_HTLF
+from extras.AFC_BoxTurtle import afcBoxTurtle
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_htlf(name="HTLF_1"):
+    """Build an AFC_HTLF bypassing the complex __init__."""
+    unit = AFC_HTLF.__new__(AFC_HTLF)
+
+    from tests.conftest import MockAFC, MockPrinter, MockLogger, MockReactor
+
+    afc = MockAFC()
+    reactor = MockReactor()
+    afc.reactor = reactor
+    afc.logger = MockLogger()
+    printer = MockPrinter(afc=afc)
+
+    unit.printer = printer
+    unit.afc = afc
+    unit.logger = afc.logger
+    unit.reactor = reactor
+    unit.name = name
+    unit.full_name = ["AFC_HTLF", name]
+    unit.lanes = {}
+    unit.hub_obj = None
+    unit.extruder_obj = None
+    unit.buffer_obj = None
+    unit.hub = None
+    unit.extruder = None
+    unit.buffer_name = None
+    unit.td1_defined = False
+    unit.type = "HTLF"
+    unit.gcode = afc.gcode
+    unit.drive_stepper = "drive"
+    unit.selector_stepper = "selector"
+    unit.drive_stepper_obj = MagicMock()
+    unit.selector_stepper_obj = MagicMock()
+    unit.current_selected_lane = None
+    unit.home_state = False
+    unit.mm_move_per_rotation = 32
+    unit.cam_angle = 60
+    unit.home_pin = "PA1"
+    unit.MAX_ANGLE_MOVEMENT = 215
+    unit.enable_sensors_in_gui = False
+    unit.prep_homed = False
+    unit.failed_to_home = False
+    unit.lobe_current_pos = 0
+
+    return unit
+
+
+# ── Inheritance ───────────────────────────────────────────────────────────────
+
+class TestHTLFInheritance:
+    def test_is_subclass_of_box_turtle(self):
+        assert issubclass(AFC_HTLF, afcBoxTurtle)
+
+
+# ── Class constants ───────────────────────────────────────────────────────────
+
+class TestHTLFConstants:
+    def test_valid_cam_angles(self):
+        assert AFC_HTLF.VALID_CAM_ANGLES == [30, 45, 60]
+
+
+# ── home_callback ─────────────────────────────────────────────────────────────
+
+class TestHomeCallback:
+    def test_home_callback_sets_home_state_true(self):
+        unit = _make_htlf()
+        unit.home_callback(eventtime=100.0, state=True)
+        assert unit.home_state is True
+
+    def test_home_callback_sets_home_state_false(self):
+        unit = _make_htlf()
+        unit.home_state = True
+        unit.home_callback(eventtime=100.0, state=False)
+        assert unit.home_state is False
+
+    def test_home_callback_state_reflects_input(self):
+        unit = _make_htlf()
+        for state in [True, False, True]:
+            unit.home_callback(eventtime=0.0, state=state)
+            assert unit.home_state is state

--- a/tests/test_AFC_NightOwl.py
+++ b/tests/test_AFC_NightOwl.py
@@ -1,0 +1,86 @@
+"""
+Unit tests for extras/AFC_NightOwl.py
+
+Covers:
+  - afcNightOwl: is a subclass of afcBoxTurtle
+  - handle_connect: sets Night Owl logo strings
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+import pytest
+
+from extras.AFC_NightOwl import afcNightOwl
+from extras.AFC_BoxTurtle import afcBoxTurtle
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_night_owl(name="NightOwl_1"):
+    """Build an afcNightOwl bypassing the complex __init__."""
+    unit = afcNightOwl.__new__(afcNightOwl)
+
+    from tests.conftest import MockAFC, MockPrinter, MockLogger, MockReactor
+
+    afc = MockAFC()
+    reactor = MockReactor()
+    afc.reactor = reactor
+    afc.logger = MockLogger()
+    printer = MockPrinter(afc=afc)
+
+    unit.printer = printer
+    unit.afc = afc
+    unit.logger = afc.logger
+    unit.reactor = reactor
+    unit.name = name
+    unit.full_name = ["AFC_NightOwl", name]
+    unit.lanes = {}
+    unit.hub_obj = None
+    unit.extruder_obj = None
+    unit.buffer_obj = None
+    unit.hub = None
+    unit.extruder = None
+    unit.buffer_name = None
+    unit.td1_defined = False
+    unit.type = "Night_Owl"
+    unit.gcode = afc.gcode
+    unit.logo = ""
+    unit.logo_error = ""
+
+    return unit
+
+
+# ── Inheritance ───────────────────────────────────────────────────────────────
+
+class TestNightOwlInheritance:
+    def test_is_subclass_of_box_turtle(self):
+        assert issubclass(afcNightOwl, afcBoxTurtle)
+
+    def test_instance_is_box_turtle(self):
+        unit = _make_night_owl()
+        assert isinstance(unit, afcBoxTurtle)
+
+
+# ── handle_connect logos ──────────────────────────────────────────────────────
+
+class TestNightOwlHandleConnect:
+    def test_logo_set_after_connect(self):
+        unit = _make_night_owl()
+        # Manually call the portion that sets logos (bypassing super().__init__)
+        # We re-call just the handle_connect body:
+        # afcNightOwl.handle_connect calls super().handle_connect() then sets logo
+        # Since we can't easily call super here, we test that type attribute is set
+        assert unit.type == "Night_Owl"
+
+    def test_logo_contains_night_owl_text(self):
+        """After handle_connect, the logo should reference Night Owl."""
+        unit = _make_night_owl()
+        # Simulate what handle_connect does (just the logo part)
+        unit.logo = '<span class=success--text>Night Owl Ready</span>'
+        assert "Night Owl" in unit.logo or "night" in unit.logo.lower()
+
+    def test_logo_error_contains_night_owl(self):
+        unit = _make_night_owl()
+        unit.logo_error = '<span class=error--text>Night Owl Not Ready</span>\n'
+        assert "Night Owl" in unit.logo_error

--- a/tests/test_AFC_QuattroBox.py
+++ b/tests/test_AFC_QuattroBox.py
@@ -1,0 +1,187 @@
+"""
+Unit tests for extras/AFC_QuattroBox.py
+
+Covers:
+  - afcQuattroBox: is subclass of afcNightOwl
+  - lane_loaded: calls super().lane_loaded() then sets spool illumination LED
+  - lane_unloaded: calls afc_led with led_off for spool index
+  - lane_loading: calls super().lane_loading() then set_logo_color
+  - lane_tool_loaded: calls super().lane_tool_loaded() then set_logo_color with lane color
+  - lane_tool_unloaded: calls super().lane_tool_unloaded() then resets logo color
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, call, patch
+import pytest
+
+from extras.AFC_QuattroBox import afcQuattroBox
+from extras.AFC_NightOwl import afcNightOwl
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_quattro(name="Quattro_1"):
+    """Build an afcQuattroBox bypassing the complex __init__."""
+    unit = afcQuattroBox.__new__(afcQuattroBox)
+
+    from tests.conftest import MockAFC, MockPrinter, MockLogger, MockReactor
+
+    afc = MockAFC()
+    reactor = MockReactor()
+    afc.reactor = reactor
+    afc.logger = MockLogger()
+    printer = MockPrinter(afc=afc)
+
+    unit.printer = printer
+    unit.afc = afc
+    unit.logger = afc.logger
+    unit.reactor = reactor
+    unit.name = name
+    unit.full_name = ["AFC_QuattroBox", name]
+    unit.lanes = {}
+    unit.hub_obj = None
+    unit.extruder_obj = None
+    unit.buffer_obj = None
+    unit.hub = None
+    unit.extruder = None
+    unit.buffer_name = None
+    unit.td1_defined = False
+    unit.type = "Quattro_Box"
+    unit.gcode = afc.gcode
+    unit.led_logo_index = "0"
+    unit.led_logo_color = "0,0,0,0"
+    unit.led_logo_loading = "0,0,1,0"
+
+    return unit
+
+
+def _make_lane(name="lane1", color="#FF0000"):
+    lane = MagicMock()
+    lane.name = name
+    lane.color = color
+    lane.led_ready = "0,1,0,0"
+    lane.led_not_ready = "0,0,0,0.25"
+    lane.led_fault = "1,0,0,0"
+    lane.led_loading = "0,0,1,0"
+    lane.led_spool_illum = "1,1,1,0"
+    lane.led_tool_loaded = "0,1,0.5,0"
+    lane.led_index = "1"
+    lane.led_spool_index = "2"
+    lane.use_filament_color = False
+    return lane
+
+
+# ── Inheritance ───────────────────────────────────────────────────────────────
+
+class TestQuattroBoxInheritance:
+    def test_is_subclass_of_night_owl(self):
+        assert issubclass(afcQuattroBox, afcNightOwl)
+
+
+# ── lane_loaded ───────────────────────────────────────────────────────────────
+
+class TestLaneLoaded:
+    def test_calls_spool_illum_led(self):
+        """lane_loaded should set spool illumination LED in addition to lane LED."""
+        unit = _make_quattro()
+        lane = _make_lane()
+        unit.lane_loaded(lane)
+        unit.afc.function.afc_led.assert_any_call(lane.led_spool_illum, lane.led_spool_index)
+
+    def test_calls_lane_ready_led(self):
+        unit = _make_quattro()
+        lane = _make_lane()
+        unit.lane_loaded(lane)
+        unit.afc.function.afc_led.assert_any_call(lane.led_ready, lane.led_index)
+
+
+# ── lane_unloaded ─────────────────────────────────────────────────────────────
+
+class TestLaneUnloaded:
+    def test_calls_led_off_for_spool(self):
+        """lane_unloaded should turn off spool LEDs."""
+        unit = _make_quattro()
+        lane = _make_lane()
+        unit.lane_unloaded(lane)
+        unit.afc.function.afc_led.assert_any_call(unit.afc.led_off, lane.led_spool_index)
+
+
+# ── lane_loading ──────────────────────────────────────────────────────────────
+
+class TestLaneLoading:
+    def test_calls_set_logo_color_with_loading_color(self):
+        unit = _make_quattro()
+        lane = _make_lane()
+        unit.set_logo_color = MagicMock()
+        unit.lane_loading(lane)
+        unit.set_logo_color.assert_called_with(unit.led_logo_loading)
+
+    def test_calls_afc_led_for_lane(self):
+        unit = _make_quattro()
+        lane = _make_lane()
+        unit.lane_loading(lane)
+        unit.afc.function.afc_led.assert_any_call(lane.led_loading, lane.led_index)
+
+
+# ── lane_tool_loaded ──────────────────────────────────────────────────────────
+
+class TestLaneToolLoaded:
+    def test_calls_set_logo_color_with_lane_color(self):
+        unit = _make_quattro()
+        lane = _make_lane(color="#FF0000")
+        unit.set_logo_color = MagicMock()
+        unit.lane_tool_loaded(lane)
+        unit.set_logo_color.assert_called_with(lane.color)
+
+    def test_calls_afc_led_for_lane(self):
+        unit = _make_quattro()
+        lane = _make_lane()
+        unit.lane_tool_loaded(lane)
+        unit.afc.function.afc_led.assert_any_call(lane.led_tool_loaded, lane.led_index)
+
+
+# ── lane_tool_unloaded ────────────────────────────────────────────────────────
+
+class TestLaneToolUnloaded:
+    def test_calls_set_logo_color_with_logo_color(self):
+        unit = _make_quattro()
+        lane = _make_lane()
+        unit.set_logo_color = MagicMock()
+        unit.lane_tool_unloaded(lane)
+        unit.set_logo_color.assert_called_with(unit.led_logo_color)
+
+    def test_calls_afc_led_for_lane(self):
+        unit = _make_quattro()
+        lane = _make_lane()
+        unit.lane_tool_unloaded(lane)
+        # lane_tool_unloaded calls super() which calls afc_led with led_ready
+        unit.afc.function.afc_led.assert_any_call(lane.led_ready, lane.led_index)
+
+
+# ── handle_connect ────────────────────────────────────────────────────────────
+
+class TestHandleConnect:
+    def test_handle_connect_sets_logo_html(self):
+        unit = _make_quattro()
+        unit.set_logo_color = MagicMock()
+        unit.handle_connect()
+        assert "Quattro Box Ready" in unit.logo
+
+    def test_handle_connect_sets_logo_error_html(self):
+        unit = _make_quattro()
+        unit.set_logo_color = MagicMock()
+        unit.handle_connect()
+        assert "Quattro Box Not Ready" in unit.logo_error
+
+    def test_handle_connect_calls_set_logo_color_with_logo_color(self):
+        unit = _make_quattro()
+        unit.set_logo_color = MagicMock()
+        unit.handle_connect()
+        unit.set_logo_color.assert_called_once_with(unit.led_logo_color)
+
+    def test_handle_connect_registers_unit_in_afc_units(self):
+        unit = _make_quattro(name="quattro_test")
+        unit.set_logo_color = MagicMock()
+        unit.handle_connect()
+        assert unit.afc.units.get("quattro_test") is unit

--- a/tests/test_AFC_assist.py
+++ b/tests/test_AFC_assist.py
@@ -1,0 +1,267 @@
+"""
+Unit tests for extras/AFC_assist.py
+
+Covers:
+  - AFCassistMotor: attribute initialization
+  - _set_pin: pin state changes, same-value skip, is_resend, PWM vs digital
+  - get_status: returns correct dict
+  - EspoolerDir: direction constants
+  - AFCEspoolerStats: direction/start_time/end_time setters, reset, update
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+import pytest
+
+from extras.AFC_assist import AFCassistMotor, EspoolerDir, AFCEspoolerStats
+
+PIN_MIN_TIME = 0.100  # Must match source constant
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_assist_motor(is_pwm=False):
+    """Build an AFCassistMotor bypassing the complex __init__."""
+    motor = AFCassistMotor.__new__(AFCassistMotor)
+    motor.is_pwm = is_pwm
+    motor.scale = 1.0
+    motor.mcu_pin = MagicMock()
+    motor.last_value = 0.0
+    motor.last_print_time = 0.0
+    motor.resend_interval = 0.0
+    motor.resend_timer = None
+    motor.reactor = MagicMock()
+    motor.shutdown_value = 0.0
+    return motor
+
+
+def _make_espooler_stats():
+    """Build an AFCEspoolerStats bypassing __init__."""
+    from tests.conftest import MockLogger
+    stats = AFCEspoolerStats.__new__(AFCEspoolerStats)
+    stats._n20_runtime_fwd = MagicMock()
+    stats._n20_runtime_rwd = MagicMock()
+    stats._n20_runtime_fwd.value = 0
+    stats._n20_runtime_rwd.value = 0
+    stats._fwd_updated = False
+    stats._rwd_updated = False
+    stats._direction = None
+    stats._direction_start = None
+    stats._direction_end = None
+    stats._delta = None
+    stats.logger = MockLogger()
+    return stats
+
+
+# ── Initialization ────────────────────────────────────────────────────────────
+
+class TestAFCassistMotorInit:
+    def test_last_value_initially_zero(self):
+        motor = _make_assist_motor()
+        assert motor.last_value == 0.0
+
+    def test_last_print_time_initially_zero(self):
+        motor = _make_assist_motor()
+        assert motor.last_print_time == 0.0
+
+    def test_resend_interval_initially_zero(self):
+        motor = _make_assist_motor()
+        assert motor.resend_interval == 0.0
+
+    def test_is_pwm_stored(self):
+        motor = _make_assist_motor(is_pwm=True)
+        assert motor.is_pwm is True
+
+    def test_scale_default_one(self):
+        motor = _make_assist_motor()
+        assert motor.scale == 1.0
+
+
+# ── _set_pin ──────────────────────────────────────────────────────────────────
+
+class TestSetPin:
+    def test_same_value_no_resend_skips_pin(self):
+        """When value matches last_value and is_resend=False, pin is not touched."""
+        motor = _make_assist_motor(is_pwm=False)
+        motor.last_value = 0.5
+        motor._set_pin(0.0, 0.5, is_resend=False)
+        motor.mcu_pin.set_digital.assert_not_called()
+        motor.mcu_pin.set_pwm.assert_not_called()
+
+    def test_same_value_with_resend_calls_digital_pin(self):
+        """When is_resend=True, pin is called even if value is the same."""
+        motor = _make_assist_motor(is_pwm=False)
+        motor.last_value = 1.0
+        motor._set_pin(1.0, 1.0, is_resend=True)
+        motor.mcu_pin.set_digital.assert_called()
+
+    def test_digital_pin_called_when_not_pwm(self):
+        motor = _make_assist_motor(is_pwm=False)
+        motor._set_pin(0.0, 1.0)
+        motor.mcu_pin.set_digital.assert_called()
+        motor.mcu_pin.set_pwm.assert_not_called()
+
+    def test_pwm_pin_called_when_pwm(self):
+        motor = _make_assist_motor(is_pwm=True)
+        motor._set_pin(0.0, 0.75)
+        motor.mcu_pin.set_pwm.assert_called()
+        motor.mcu_pin.set_digital.assert_not_called()
+
+    def test_last_value_updated_after_set(self):
+        motor = _make_assist_motor()
+        motor._set_pin(0.0, 1.0)
+        assert motor.last_value == 1.0
+
+    def test_last_print_time_updated_after_set(self):
+        motor = _make_assist_motor()
+        motor._set_pin(1.5, 1.0)
+        # print_time = max(1.5, 0.0 + 0.1) = 1.5
+        assert motor.last_print_time == 1.5
+
+    def test_print_time_minimum_enforced(self):
+        """print_time is clamped to max(requested, last + PIN_MIN_TIME)."""
+        motor = _make_assist_motor(is_pwm=False)
+        motor.last_print_time = 5.0
+        motor._set_pin(0.0, 1.0)  # 0.0 < 5.0 + 0.1 = 5.1 → clamped
+        call_args = motor.mcu_pin.set_digital.call_args
+        actual_time = call_args[0][0]
+        assert actual_time >= 5.0 + PIN_MIN_TIME
+
+
+# ── get_status ────────────────────────────────────────────────────────────────
+
+class TestGetStatus:
+    def test_returns_dict_with_value_key(self):
+        motor = _make_assist_motor()
+        motor.last_value = 0.42
+        status = motor.get_status(0.0)
+        assert "value" in status
+
+    def test_value_reflects_last_value(self):
+        motor = _make_assist_motor()
+        motor.last_value = 0.75
+        status = motor.get_status(0.0)
+        assert status["value"] == 0.75
+
+
+# ── EspoolerDir ───────────────────────────────────────────────────────────────
+
+class TestEspoolerDir:
+    def test_fwd_constant(self):
+        assert EspoolerDir.FWD == "Forwards"
+
+    def test_rwd_constant(self):
+        assert EspoolerDir.RWD == "Reverse"
+
+
+# ── AFCEspoolerStats: direction setter ────────────────────────────────────────
+
+class TestAFCEspoolerStatsDirection:
+    def test_direction_set_when_none(self):
+        stats = _make_espooler_stats()
+        stats.direction = EspoolerDir.FWD
+        assert stats._direction == EspoolerDir.FWD
+
+    def test_direction_not_overwritten_when_already_set(self):
+        stats = _make_espooler_stats()
+        stats._direction = EspoolerDir.FWD
+        stats.direction = EspoolerDir.RWD
+        assert stats._direction == EspoolerDir.FWD
+
+
+# ── AFCEspoolerStats: start_time setter ───────────────────────────────────────
+
+class TestAFCEspoolerStatsStartTime:
+    def test_start_time_set_when_none(self):
+        stats = _make_espooler_stats()
+        stats.start_time = 100.0
+        assert stats._direction_start == 100.0
+
+    def test_start_time_not_overwritten_when_set(self):
+        stats = _make_espooler_stats()
+        stats._direction_start = 50.0
+        stats.start_time = 200.0
+        assert stats._direction_start == 50.0
+
+
+# ── AFCEspoolerStats: end_time setter ─────────────────────────────────────────
+
+class TestAFCEspoolerStatsEndTime:
+    def test_end_time_when_no_direction_does_nothing(self):
+        """If _direction is None, end_time setter returns early (no delta calc)."""
+        stats = _make_espooler_stats()
+        stats.end_time = 200.0
+        assert stats._direction is None  # nothing changed
+
+    def test_fwd_runtime_incremented(self):
+        stats = _make_espooler_stats()
+        stats._direction = EspoolerDir.FWD
+        stats._direction_start = 100.0
+        stats._n20_runtime_fwd.value = 0
+        stats.end_time = 105.0
+        assert stats._fwd_updated is True
+
+    def test_rwd_runtime_incremented(self):
+        stats = _make_espooler_stats()
+        stats._direction = EspoolerDir.RWD
+        stats._direction_start = 100.0
+        stats._n20_runtime_rwd.value = 0
+        stats.end_time = 108.0
+        assert stats._rwd_updated is True
+
+    def test_state_reset_after_end_time_set(self):
+        stats = _make_espooler_stats()
+        stats._direction = EspoolerDir.FWD
+        stats._direction_start = 100.0
+        stats.end_time = 105.0
+        assert stats._direction is None
+        assert stats._direction_start is None
+        assert stats._direction_end is None
+
+    def test_no_delta_when_end_not_after_start(self):
+        """When end_time <= start_time, no delta is applied."""
+        stats = _make_espooler_stats()
+        stats._direction = EspoolerDir.FWD
+        stats._direction_start = 100.0
+        stats._n20_runtime_fwd.value = 0
+        stats.end_time = 99.0  # end < start → no update
+        assert stats._fwd_updated is False
+
+
+# ── AFCEspoolerStats: reset_runtimes ─────────────────────────────────────────
+
+class TestResetRuntimes:
+    def test_fwd_reset_called(self):
+        stats = _make_espooler_stats()
+        stats.reset_runtimes()
+        stats._n20_runtime_fwd.reset_count.assert_called_once()
+
+    def test_rwd_reset_called(self):
+        stats = _make_espooler_stats()
+        stats.reset_runtimes()
+        stats._n20_runtime_rwd.reset_count.assert_called_once()
+
+
+# ── AFCEspoolerStats: update_database ────────────────────────────────────────
+
+class TestUpdateDatabase:
+    def test_fwd_database_updated_when_flag_set(self):
+        stats = _make_espooler_stats()
+        stats._fwd_updated = True
+        stats.update_database()
+        stats._n20_runtime_fwd.update_database.assert_called_once()
+        assert stats._fwd_updated is False
+
+    def test_rwd_database_updated_when_flag_set(self):
+        stats = _make_espooler_stats()
+        stats._rwd_updated = True
+        stats.update_database()
+        stats._n20_runtime_rwd.update_database.assert_called_once()
+        assert stats._rwd_updated is False
+
+    def test_no_update_when_neither_flag_set(self):
+        stats = _make_espooler_stats()
+        stats.update_database()
+        stats._n20_runtime_fwd.update_database.assert_not_called()
+        stats._n20_runtime_rwd.update_database.assert_not_called()

--- a/tests/test_AFC_buffer.py
+++ b/tests/test_AFC_buffer.py
@@ -1,0 +1,541 @@
+"""
+Unit tests for extras/AFC_buffer.py
+
+Covers:
+  - get_fault_sensitivity: formula validation
+  - fault_detection_enabled / disable / restore
+  - buffer_status: returns last_state
+  - disable_buffer / enable_buffer: toggles enable flag
+  - advance_callback / trailing_callback: state tracking
+  - pause_on_error: respects enable and min_event_systime
+  - update_filament_error_pos / get_extruder_pos
+  - start/stop fault timers
+  - cmd_QUERY_BUFFER string construction
+  - cmd_ENABLE_BUFFER / cmd_DISABLE_BUFFER GCode commands
+  - cmd_AFC_SET_ERROR_SENSITIVITY GCode command
+  - TRAILING_STATE_NAME / ADVANCING_STATE_NAME constants
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+import pytest
+
+from extras.AFC_buffer import (
+    AFCTrigger,
+    TRAILING_STATE_NAME,
+    ADVANCING_STATE_NAME,
+    CHECK_RUNOUT_TIMEOUT,
+)
+from tests.test_AFC_lane import _make_afc_lane
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_buffer(name="TN", error_sensitivity=0.0):
+    """Build an AFCTrigger by bypassing __init__ and setting attributes."""
+    buf = AFCTrigger.__new__(AFCTrigger)
+
+    from tests.conftest import MockAFC, MockReactor, MockLogger
+
+    afc = MockAFC()
+    reactor = MockReactor()
+
+    buf.printer = MagicMock()
+    buf.printer.state_message = "Printer is ready"
+    buf.afc = afc
+    buf.reactor = reactor
+    buf.gcode = afc.gcode
+    buf.logger = afc.logger
+    buf.name = name
+    buf.lanes = {}
+    buf.last_state = "Unknown"
+    buf.enable = False
+    buf.current = ""
+    buf.advance_state = False
+    buf.trailing_state = False
+
+    buf.error_sensitivity = error_sensitivity
+    buf.fault_sensitivity = buf.get_fault_sensitivity(error_sensitivity)
+    buf.filament_error_pos = None
+    buf.past_extruder_position = None
+    buf.extruder_pos_timer = None
+    buf.fault_timer = None
+
+    buf.multiplier_high = 1.1
+    buf.multiplier_low = 0.9
+
+    buf.led = False
+    buf.led_index = None
+    buf.led_advancing = "0,0,1,0"
+    buf.led_trailing = "0,1,0,0"
+    buf.led_buffer_disabled = "0,0,0,0.25"
+
+    buf.min_event_systime = 0.0
+
+    return buf
+
+def _make_lane(buf):
+    lane = _make_afc_lane()
+    lane.buffer_obj = buf
+    buf.lanes[lane.name] = lane
+    return lane
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+class TestConstants:
+    def test_trailing_state_name(self):
+        assert TRAILING_STATE_NAME == "Trailing"
+
+    def test_advancing_state_name(self):
+        assert ADVANCING_STATE_NAME == "Advancing"
+
+    def test_check_runout_timeout_positive(self):
+        assert CHECK_RUNOUT_TIMEOUT > 0
+
+
+# ── get_fault_sensitivity ─────────────────────────────────────────────────────
+
+class TestGetFaultSensitivity:
+    def test_zero_sensitivity_returns_zero(self):
+        buf = _make_buffer()
+        assert buf.get_fault_sensitivity(0) == 0
+
+    def test_min_sensitivity_one(self):
+        buf = _make_buffer()
+        # (11 - 1) * 10 = 100
+        assert buf.get_fault_sensitivity(1) == 100.0
+
+    def test_max_sensitivity_ten(self):
+        buf = _make_buffer()
+        # (11 - 10) * 10 = 10
+        assert buf.get_fault_sensitivity(10) == 10.0
+
+    def test_mid_sensitivity_five(self):
+        buf = _make_buffer()
+        # (11 - 5) * 10 = 60
+        assert buf.get_fault_sensitivity(5) == 60.0
+
+    def test_higher_sensitivity_means_smaller_fault_distance(self):
+        buf = _make_buffer()
+        low = buf.get_fault_sensitivity(2)
+        high = buf.get_fault_sensitivity(8)
+        assert high < low
+
+
+# ── fault_detection_enabled / disable / restore ───────────────────────────────
+
+class TestFaultDetection:
+    def test_enabled_when_sensitivity_positive(self):
+        buf = _make_buffer(error_sensitivity=5.0)
+        assert buf.fault_detection_enabled() is True
+
+    def test_disabled_when_sensitivity_zero(self):
+        buf = _make_buffer(error_sensitivity=0.0)
+        assert buf.fault_detection_enabled() is False
+
+    def test_disable_fault_sensitivity_sets_to_zero(self):
+        buf = _make_buffer(error_sensitivity=5.0)
+        buf.disable_fault_sensitivity()
+        assert buf.fault_sensitivity == 0
+
+    def test_restore_fault_sensitivity_restores_from_error_sensitivity(self):
+        buf = _make_buffer(error_sensitivity=5.0)
+        buf.disable_fault_sensitivity()
+        buf.restore_fault_sensitivity()
+        expected = buf.get_fault_sensitivity(5.0)
+        assert buf.fault_sensitivity == expected
+
+
+# ── buffer_status ─────────────────────────────────────────────────────────────
+
+class TestBufferStatus:
+    def test_returns_last_state(self):
+        buf = _make_buffer()
+        buf.last_state = TRAILING_STATE_NAME
+        assert buf.buffer_status() == TRAILING_STATE_NAME
+
+    def test_returns_unknown_when_unset(self):
+        buf = _make_buffer()
+        assert buf.buffer_status() == "Unknown"
+
+
+# ── disable_buffer / enable_buffer ───────────────────────────────────────────
+
+class TestBufferToggle:
+    def test_disable_buffer_sets_enable_false(self):
+        lane = _make_afc_lane()
+        buf = _make_buffer()
+        lane = _make_lane(buf)
+        buf.current_lane = lane
+        buf.enable = True
+        buf.lane = lane
+        buf.reset_multiplier = MagicMock()
+        buf.disable_buffer()
+        assert buf.enable is False
+
+    def test_disable_buffer_calls_reset_multiplier(self):
+        buf = _make_buffer()
+        lane = _make_lane(buf)
+        buf.current_lane = lane
+        buf.enable = True
+        buf.reset_multiplier = MagicMock()
+        buf.disable_buffer()
+        buf.reset_multiplier.assert_called_once()
+
+    def test_enable_buffer_sets_enable_true(self):
+        buf = _make_buffer()
+        lane = _make_lane(buf)
+        buf.set_multiplier = MagicMock()
+        buf.enable_buffer(lane)
+        assert buf.enable is True
+    
+    def test_enable_buffer_sets_current_lane(self):
+        buf = _make_buffer()
+        lane = _make_lane(buf)
+        buf.set_multiplier = MagicMock()
+        buf.enable_buffer(lane)
+        assert buf.current_lane == lane
+
+    def test_enable_buffer_applies_multiplier_trailing(self):
+        buf = _make_buffer()
+        lane = _make_lane(buf)
+        buf.set_multiplier = MagicMock()
+        buf.last_state = TRAILING_STATE_NAME
+        buf.enable_buffer(lane)
+        call_arg = buf.set_multiplier.call_args[0][0]
+        assert call_arg < 1.0  # should be multiplier_low or derivative
+
+    def test_enable_buffer_applies_multiplier_advancing(self):
+        buf = _make_buffer()
+        buf.set_multiplier = MagicMock()
+        lane = _make_lane(buf)
+        buf.last_state = ADVANCING_STATE_NAME
+        buf.enable_buffer(lane)
+        call_arg = buf.set_multiplier.call_args[0][0]
+        assert call_arg > 1.0  # should be multiplier_high or derivative
+
+
+# ── advance_callback / trailing_callback ─────────────────────────────────────
+
+class TestCallbacks:
+    def test_advance_callback_records_advance_state(self):
+        buf = _make_buffer()
+        buf.advance_callback(100.0, True)
+        assert buf.advance_state is True
+
+    def test_advance_callback_records_false_state(self):
+        buf = _make_buffer()
+        buf.advance_state = True
+        buf.advance_callback(100.0, False)
+        assert buf.advance_state is False
+
+    def test_advance_callback_sets_last_state_trailing(self):
+        """After an advance event, last_state → TRAILING_STATE_NAME."""
+        buf = _make_buffer()
+        buf.advance_callback(100.0, True)
+        assert buf.last_state == TRAILING_STATE_NAME
+
+    def test_trailing_callback_records_trailing_state(self):
+        buf = _make_buffer()
+        buf.trailing_callback(100.0, True)
+        assert buf.trailing_state is True
+
+    def test_trailing_callback_sets_last_state_advancing(self):
+        """After a trailing event, last_state → ADVANCING_STATE_NAME."""
+        buf = _make_buffer()
+        buf.trailing_callback(100.0, True)
+        assert buf.last_state == ADVANCING_STATE_NAME
+
+
+# ── pause_on_error ────────────────────────────────────────────────────────────
+
+class TestPauseOnError:
+    def test_does_not_pause_when_disabled(self):
+        buf = _make_buffer()
+        buf.enable = False
+        buf.afc.error = MagicMock()
+        buf.pause_on_error("fault", pause=True)
+        buf.afc.error.AFC_error.assert_not_called()
+
+    def test_does_not_pause_before_min_event_systime(self):
+        buf = _make_buffer()
+        buf.enable = True
+        buf.min_event_systime = 9_999_999.0  # far in the future
+        buf.afc.error = MagicMock()
+        buf.afc.function.is_paused.return_value = False
+        buf.pause_on_error("fault", pause=True)
+        buf.afc.error.AFC_error.assert_not_called()
+
+    def test_does_not_pause_when_already_paused(self):
+        buf = _make_buffer()
+        buf.enable = True
+        buf.min_event_systime = 0.0
+        buf.afc.error = MagicMock()
+        buf.afc.function.is_paused.return_value = True
+        buf.pause_on_error("fault", pause=True)
+        buf.afc.error.AFC_error.assert_not_called()
+
+    def test_pauses_when_all_conditions_met(self):
+        buf = _make_buffer()
+        buf.enable = True
+        buf.min_event_systime = 0.0
+        buf.afc.error = MagicMock()
+        buf.afc.function.is_paused.return_value = False
+        buf.last_state = TRAILING_STATE_NAME
+        buf.pause_on_error("Something went wrong", pause=True)
+        buf.afc.error.AFC_error.assert_called_once()
+
+    def test_clog_message_appended_when_trailing(self):
+        buf = _make_buffer()
+        buf.enable = True
+        buf.min_event_systime = 0.0
+        buf.afc.error = MagicMock()
+        buf.afc.function.is_paused.return_value = False
+        buf.last_state = TRAILING_STATE_NAME
+        buf.pause_on_error("Base message", pause=True)
+        call_msg = buf.afc.error.AFC_error.call_args[0][0]
+        assert "CLOG" in call_msg
+
+    def test_not_feeding_message_appended_when_advancing(self):
+        buf = _make_buffer()
+        buf.enable = True
+        buf.min_event_systime = 0.0
+        buf.afc.error = MagicMock()
+        buf.afc.function.is_paused.return_value = False
+        buf.last_state = ADVANCING_STATE_NAME
+        buf.pause_on_error("Base message", pause=True)
+        call_msg = buf.afc.error.AFC_error.call_args[0][0]
+        assert "NOT FEEDING" in call_msg
+
+
+# ── fault timer helpers ───────────────────────────────────────────────────────
+
+class TestFaultTimers:
+    def test_start_fault_timer_sets_fault_timer_running(self):
+        buf = _make_buffer()
+        buf.extruder_pos_timer = MagicMock()
+        buf.start_fault_timer(100.0)
+        assert buf.fault_timer == "Running"
+
+    def test_stop_fault_timer_sets_fault_timer_stopped(self):
+        buf = _make_buffer()
+        buf.extruder_pos_timer = MagicMock()
+        buf.stop_fault_timer(100.0)
+        assert buf.fault_timer == "Stopped"
+
+
+# ── extruder_pos_update_event ─────────────────────────────────────────────────
+
+class TestExtruderPosUpdateEvent:
+    def test_returns_eventtime_plus_timeout(self):
+        buf = _make_buffer()
+        buf.get_extruder_pos = MagicMock(return_value=None)
+        buf.afc.function.is_printing.return_value = False
+        result = buf.extruder_pos_update_event(50.0)
+        assert result == 50.0 + CHECK_RUNOUT_TIMEOUT
+
+    def test_triggers_pause_when_extruder_pos_exceeds_threshold(self):
+        buf = _make_buffer(error_sensitivity=5.0)
+        buf.enable = True
+        buf.min_event_systime = 0.0
+        buf.filament_error_pos = 50.0
+        buf.afc.error = MagicMock()
+        buf.afc.function.is_paused.return_value = False
+        buf.afc.function.is_printing.return_value = True
+        buf.get_extruder_pos = MagicMock(return_value=55.0)  # > 50.0
+        buf.update_filament_error_pos = MagicMock()
+        buf.extruder_pos_update_event(100.0)
+        buf.afc.error.AFC_error.assert_called()
+
+
+# ── get_status ────────────────────────────────────────────────────────────────
+
+class TestGetStatus:
+    def test_returns_dict_with_expected_keys(self):
+        buf = _make_buffer()
+        buf.afc.function.get_current_lane_obj.return_value = None
+        result = buf.get_status()
+        for key in ("state", "lanes", "enabled", "rotation_distance",
+                    "fault_detection_enabled", "error_sensitivity",
+                    "fault_timer", "distance_to_fault"):
+            assert key in result, f"Missing key: {key}"
+
+    def test_enabled_false_by_default(self):
+        buf = _make_buffer()
+        buf.afc.function.get_current_lane_obj.return_value = None
+        result = buf.get_status()
+        assert result["enabled"] is False
+
+    def test_rotation_distance_none_when_not_enabled(self):
+        buf = _make_buffer()
+        result = buf.get_status()
+        assert result["rotation_distance"] is None
+
+
+# ── cmd_ENABLE_BUFFER ─────────────────────────────────────────────────────────
+
+class TestCmdEnableBuffer:
+    def test_delegates_to_enable_buffer(self):
+        """cmd_ENABLE_BUFFER should call enable_buffer() exactly once."""
+        buf = _make_buffer()
+        lane = _make_lane(buf)
+        gcmd = MagicMock()
+        gcmd.get.return_value = "lane1"
+        buf.enable_buffer = MagicMock()
+        buf.cmd_ENABLE_BUFFER(gcmd)
+        buf.enable_buffer.assert_called_once()
+
+    def test_buffer_is_enabled_after_command(self):
+        """Issuing ENABLE_BUFFER leaves enable set to True."""
+        buf = _make_buffer()
+        lane = _make_lane(buf)
+        buf.set_multiplier = MagicMock()
+        gcmd = MagicMock()
+        gcmd.get.return_value = "lane1"
+        buf.cmd_ENABLE_BUFFER(gcmd)
+        assert buf.enable is True
+        assert buf.current_lane == lane
+
+
+# ── cmd_DISABLE_BUFFER ────────────────────────────────────────────────────────
+
+class TestCmdDisableBuffer:
+    def test_delegates_to_disable_buffer(self):
+        """cmd_DISABLE_BUFFER should call disable_buffer() exactly once."""
+        buf = _make_buffer()
+        lane = _make_lane(buf)
+        buf.current_lane = lane
+        buf.disable_buffer = MagicMock()
+        buf.cmd_DISABLE_BUFFER(MagicMock())
+        buf.disable_buffer.assert_called_once()
+
+    def test_buffer_is_disabled_after_command(self):
+        """Issuing DISABLE_BUFFER leaves enable set to False."""
+        buf = _make_buffer()
+        lane = _make_lane(buf)
+        buf.current_lane = lane
+        buf.enable = True
+        buf.reset_multiplier = MagicMock()
+        buf.cmd_DISABLE_BUFFER(MagicMock())
+        assert buf.enable is False
+
+
+# ── cmd_AFC_SET_ERROR_SENSITIVITY ─────────────────────────────────────────────
+
+def _gcmd(sensitivity):
+    """Return a mock gcmd whose get_float returns the given sensitivity."""
+    gcmd = MagicMock()
+    gcmd.get_float.return_value = sensitivity
+    return gcmd
+
+
+class TestCmdSetErrorSensitivity:
+    def test_updates_error_sensitivity(self):
+        """The new sensitivity value is stored on the buffer."""
+        buf = _make_buffer(error_sensitivity=0.0)
+        buf.setup_fault_timer = MagicMock()
+        buf.start_fault_detection = MagicMock()
+        buf.cmd_AFC_SET_ERROR_SENSITIVITY(_gcmd(5.0))
+        assert buf.error_sensitivity == 5.0
+
+    def test_updates_fault_sensitivity(self):
+        """fault_sensitivity is recalculated from the new error_sensitivity."""
+        buf = _make_buffer(error_sensitivity=0.0)
+        buf.setup_fault_timer = MagicMock()
+        buf.start_fault_detection = MagicMock()
+        buf.cmd_AFC_SET_ERROR_SENSITIVITY(_gcmd(5.0))
+        assert buf.fault_sensitivity == buf.get_fault_sensitivity(5.0)
+
+    # ── 0 → >0 transition ────────────────────────────────────────────────────
+
+    def test_disabled_to_enabled_calls_setup_fault_timer(self):
+        """Transitioning from 0 to >0 calls setup_fault_timer."""
+        buf = _make_buffer(error_sensitivity=0.0)
+        buf.setup_fault_timer = MagicMock()
+        buf.start_fault_detection = MagicMock()
+        buf.cmd_AFC_SET_ERROR_SENSITIVITY(_gcmd(5.0))
+        buf.setup_fault_timer.assert_called_once()
+
+    def test_disabled_to_enabled_calls_start_fault_detection(self):
+        """Transitioning from 0 to >0 calls start_fault_detection."""
+        buf = _make_buffer(error_sensitivity=0.0)
+        buf.setup_fault_timer = MagicMock()
+        buf.start_fault_detection = MagicMock()
+        buf.cmd_AFC_SET_ERROR_SENSITIVITY(_gcmd(5.0))
+        buf.start_fault_detection.assert_called_once()
+
+    def test_disabled_to_enabled_uses_multiplier_low_when_trailing(self):
+        """Transitioning 0 → >0 with trailing state passes multiplier_low."""
+        buf = _make_buffer(error_sensitivity=0.0)
+        buf.last_state = TRAILING_STATE_NAME
+        buf.setup_fault_timer = MagicMock()
+        buf.start_fault_detection = MagicMock()
+        buf.cmd_AFC_SET_ERROR_SENSITIVITY(_gcmd(5.0))
+        _, multiplier = buf.start_fault_detection.call_args[0]
+        assert multiplier == buf.multiplier_low
+
+    def test_disabled_to_enabled_uses_multiplier_high_when_advancing(self):
+        """Transitioning 0 → >0 with advancing state passes multiplier_high."""
+        buf = _make_buffer(error_sensitivity=0.0)
+        buf.last_state = ADVANCING_STATE_NAME
+        buf.setup_fault_timer = MagicMock()
+        buf.start_fault_detection = MagicMock()
+        buf.cmd_AFC_SET_ERROR_SENSITIVITY(_gcmd(5.0))
+        _, multiplier = buf.start_fault_detection.call_args[0]
+        assert multiplier == buf.multiplier_high
+
+    # ── >0 → 0 transition ────────────────────────────────────────────────────
+
+    def test_enabled_to_disabled_calls_stop_fault_timer(self):
+        """Transitioning from >0 to 0 calls stop_fault_timer."""
+        buf = _make_buffer(error_sensitivity=5.0)
+        buf.stop_fault_timer = MagicMock()
+        buf.cmd_AFC_SET_ERROR_SENSITIVITY(_gcmd(0.0))
+        buf.stop_fault_timer.assert_called_once()
+
+    def test_enabled_to_disabled_does_not_call_setup_fault_timer(self):
+        """Transitioning from >0 to 0 does not call setup_fault_timer."""
+        buf = _make_buffer(error_sensitivity=5.0)
+        buf.stop_fault_timer = MagicMock()
+        buf.setup_fault_timer = MagicMock()
+        buf.cmd_AFC_SET_ERROR_SENSITIVITY(_gcmd(0.0))
+        buf.setup_fault_timer.assert_not_called()
+
+    # ── >0 → >0 transition ───────────────────────────────────────────────────
+
+    def test_enabled_to_enabled_calls_update_filament_error_pos(self):
+        """Transitioning from >0 to another >0 calls update_filament_error_pos."""
+        buf = _make_buffer(error_sensitivity=3.0)
+        buf.update_filament_error_pos = MagicMock()
+        buf.cmd_AFC_SET_ERROR_SENSITIVITY(_gcmd(7.0))
+        buf.update_filament_error_pos.assert_called_once()
+
+    def test_enabled_to_enabled_does_not_call_stop_fault_timer(self):
+        """Transitioning from >0 to another >0 does not call stop_fault_timer."""
+        buf = _make_buffer(error_sensitivity=3.0)
+        buf.update_filament_error_pos = MagicMock()
+        buf.stop_fault_timer = MagicMock()
+        buf.cmd_AFC_SET_ERROR_SENSITIVITY(_gcmd(7.0))
+        buf.stop_fault_timer.assert_not_called()
+
+    def test_enabled_to_enabled_does_not_call_setup_fault_timer(self):
+        """Transitioning from >0 to another >0 does not call setup_fault_timer."""
+        buf = _make_buffer(error_sensitivity=3.0)
+        buf.update_filament_error_pos = MagicMock()
+        buf.setup_fault_timer = MagicMock()
+        buf.cmd_AFC_SET_ERROR_SENSITIVITY(_gcmd(7.0))
+        buf.setup_fault_timer.assert_not_called()
+
+    # ── logging ───────────────────────────────────────────────────────────────
+
+    def test_logs_info_with_new_sensitivity(self):
+        """Setting sensitivity logs an info message containing the new value."""
+        buf = _make_buffer(error_sensitivity=0.0)
+        buf.setup_fault_timer = MagicMock()
+        buf.start_fault_detection = MagicMock()
+        buf.logger = MagicMock()
+        buf.cmd_AFC_SET_ERROR_SENSITIVITY(_gcmd(5.0))
+        buf.logger.info.assert_called_once()
+        msg = buf.logger.info.call_args[0][0]
+        assert "5.0" in msg

--- a/tests/test_AFC_button.py
+++ b/tests/test_AFC_button.py
@@ -1,0 +1,232 @@
+"""
+Unit tests for extras/AFC_button.py
+
+Covers:
+  - AFCButton._button_callback: press/release tracking, short/long press logic
+  - AFCButton._handle_ready: validates lane_obj lookup
+  - Integration: correct actions taken for short vs long press
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+import pytest
+
+from extras.AFC_button import AFCButton
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_button(lane_id="lane1", long_press_duration=1.2):
+    """Build an AFCButton bypassing __init__."""
+    btn = AFCButton.__new__(AFCButton)
+
+    from tests.conftest import MockAFC, MockPrinter, MockReactor, MockLogger
+
+    afc = MockAFC()
+    afc.logger = MockLogger()
+    reactor = MockReactor()
+    printer = MockPrinter(afc=afc)
+    printer._reactor = reactor
+
+    btn.printer = printer
+    btn.gcode = printer._gcode
+    btn.reactor = reactor
+    btn.afc = afc
+    btn.lane_id = lane_id
+    btn.lane_obj = None
+    btn.long_press_duration = long_press_duration
+    btn._press_time = None
+
+    # Set up a lane object
+    lane = MagicMock()
+    lane.name = lane_id
+    afc.lanes = {lane_id: lane}
+    btn.lane_obj = lane
+
+    return btn
+
+
+# ── _handle_ready ─────────────────────────────────────────────────────────────
+
+class TestHandleReady:
+    def test_handle_ready_sets_lane_obj_when_found(self):
+        btn = _make_button("lane1")
+        btn.lane_obj = None
+        btn._handle_ready()
+        assert btn.lane_obj is btn.afc.lanes["lane1"]
+
+    def test_handle_ready_raises_when_lane_not_found(self):
+        btn = _make_button("missing_lane")
+        btn.afc.lanes = {}  # No lanes defined
+        btn.lane_obj = None
+        from configfile import error as KlipperError
+        with pytest.raises(KlipperError):
+            btn._handle_ready()
+
+
+# ── _button_callback – state tracking ────────────────────────────────────────
+
+class TestButtonCallbackStateTracking:
+    def test_press_stores_time(self):
+        btn = _make_button()
+        btn._button_callback(100.0, True)
+        assert btn._press_time == 100.0
+
+    def test_release_with_no_press_does_nothing(self):
+        btn = _make_button()
+        btn._press_time = None
+        btn.afc.error = MagicMock()
+        btn._button_callback(101.0, False)
+        btn.afc.error.AFC_error.assert_not_called()
+
+    def test_too_fast_release_ignored(self):
+        btn = _make_button()
+        btn._press_time = 100.0
+        btn.afc.function.is_printing.return_value = False
+        btn.afc.function.get_current_lane_obj.return_value = None
+        btn.afc.CHANGE_TOOL = MagicMock()
+        btn._button_callback(100.03, False)  # 0.03s < 0.05s threshold
+        btn.afc.CHANGE_TOOL.assert_not_called()
+
+    def test_press_time_cleared_after_release(self):
+        btn = _make_button()
+        btn._press_time = 100.0
+        btn.afc.function.is_printing.return_value = False
+        btn.afc.function.get_current_lane_obj.return_value = None
+        btn.afc.CHANGE_TOOL = MagicMock()
+        btn._button_callback(100.2, False)
+        assert btn._press_time is None
+
+
+# ── _button_callback – printing guard ────────────────────────────────────────
+
+class TestButtonCallbackPrintingGuard:
+    def test_error_logged_when_printing(self):
+        btn = _make_button()
+        btn._press_time = 100.0
+        btn.afc.function.is_printing.return_value = True
+        btn.afc.error = MagicMock()
+        btn._button_callback(101.0, False)
+        btn.afc.error.AFC_error.assert_called_once()
+
+    def test_press_time_not_cleared_when_printing_guard_fires(self):
+        """On printing guard, we return early; press_time may or may not clear."""
+        btn = _make_button()
+        btn._press_time = 100.0
+        btn.afc.function.is_printing.return_value = True
+        btn.afc.error = MagicMock()
+        btn._button_callback(100.5, False)
+        # Core assertion: error raised
+        btn.afc.error.AFC_error.assert_called_once()
+
+
+# ── _button_callback – short press ───────────────────────────────────────────
+
+class TestButtonCallbackShortPress:
+    def test_short_press_no_active_lane_loads_this_lane(self):
+        btn = _make_button("lane1")
+        btn._press_time = 100.0
+        btn.afc.function.is_printing.return_value = False
+        btn.afc.function.get_current_lane_obj.return_value = None
+        btn.afc.CHANGE_TOOL = MagicMock()
+        # 0.3s press < long_press_duration (1.2s)
+        btn._button_callback(100.3, False)
+        btn.afc.CHANGE_TOOL.assert_called_once_with(btn.lane_obj)
+
+    def test_short_press_with_this_lane_active_unloads(self):
+        btn = _make_button("lane1")
+        btn._press_time = 100.0
+        btn.afc.function.is_printing.return_value = False
+        cur_lane = MagicMock()
+        cur_lane.name = "lane1"  # Same as this button's lane
+        btn.afc.function.get_current_lane_obj.return_value = cur_lane
+        btn.afc.TOOL_UNLOAD = MagicMock()
+        btn._button_callback(100.3, False)
+        btn.afc.TOOL_UNLOAD.assert_called_once_with(cur_lane)
+
+    def test_short_press_with_different_lane_active_loads_this_lane(self):
+        btn = _make_button("lane1")
+        btn._press_time = 100.0
+        btn.afc.function.is_printing.return_value = False
+        cur_lane = MagicMock()
+        cur_lane.name = "lane2"  # Different lane
+        btn.afc.function.get_current_lane_obj.return_value = cur_lane
+        btn.afc.CHANGE_TOOL = MagicMock()
+        btn._button_callback(100.3, False)
+        btn.afc.CHANGE_TOOL.assert_called_once_with(btn.lane_obj)
+
+
+# ── _button_callback – long press ────────────────────────────────────────────
+
+class TestButtonCallbackLongPress:
+    def test_long_press_no_active_lane_ejects(self):
+        btn = _make_button("lane1", long_press_duration=1.0)
+        btn._press_time = 100.0
+        btn.afc.function.is_printing.return_value = False
+        btn.afc.function.get_current_lane_obj.return_value = None
+        btn.afc.LANE_UNLOAD = MagicMock()
+        # 1.5s press ≥ long_press_duration (1.0s)
+        btn._button_callback(101.5, False)
+        btn.afc.LANE_UNLOAD.assert_called_once_with(btn.lane_obj)
+
+    def test_long_press_with_this_lane_active_unloads_then_ejects(self):
+        btn = _make_button("lane1", long_press_duration=1.0)
+        btn._press_time = 100.0
+        btn.afc.function.is_printing.return_value = False
+        cur_lane = MagicMock()
+        cur_lane.name = "lane1"
+        btn.afc.function.get_current_lane_obj.return_value = cur_lane
+        btn.afc.TOOL_UNLOAD = MagicMock(return_value=True)
+        btn.afc.LANE_UNLOAD = MagicMock()
+        btn._button_callback(101.5, False)
+        btn.afc.TOOL_UNLOAD.assert_called_once()
+        btn.afc.LANE_UNLOAD.assert_called_once_with(btn.lane_obj)
+
+    def test_long_press_with_different_lane_active_ejects_only(self):
+        btn = _make_button("lane1", long_press_duration=1.0)
+        btn._press_time = 100.0
+        btn.afc.function.is_printing.return_value = False
+        cur_lane = MagicMock()
+        cur_lane.name = "lane2"
+        btn.afc.function.get_current_lane_obj.return_value = cur_lane
+        btn.afc.LANE_UNLOAD = MagicMock()
+        btn.afc.TOOL_UNLOAD = MagicMock()
+        btn._button_callback(101.5, False)
+        btn.afc.LANE_UNLOAD.assert_called_once_with(btn.lane_obj)
+        btn.afc.TOOL_UNLOAD.assert_not_called()
+
+
+# ── __init__ via MockConfig ───────────────────────────────────────────────────
+
+class TestAFCButtonInit:
+    def test_init_registers_ready_event_handler(self):
+        from tests.conftest import MockConfig, MockPrinter, MockAFC
+        afc = MockAFC()
+        printer = MockPrinter(afc=afc)
+        config = MockConfig(name="AFC_button lane1", printer=printer,
+                            values={"pin": "PA0", "long_press_duration": 1.2})
+        btn = AFCButton(config)
+        assert "klippy:ready" in printer._event_handlers
+
+    def test_init_sets_lane_id_from_config_name(self):
+        from tests.conftest import MockConfig, MockPrinter, MockAFC
+        afc = MockAFC()
+        printer = MockPrinter(afc=afc)
+        config = MockConfig(name="AFC_button lane_x", printer=printer,
+                            values={"pin": "PB1", "long_press_duration": 1.0})
+        btn = AFCButton(config)
+        assert btn.lane_id == "lane_x"
+
+    def test_init_registers_button_callback(self):
+        from tests.conftest import MockConfig, MockPrinter, MockAFC
+        afc = MockAFC()
+        printer = MockPrinter(afc=afc)
+        buttons_mock = MagicMock()
+        printer._objects["buttons"] = buttons_mock
+        config = MockConfig(name="AFC_button lane1", printer=printer,
+                            values={"pin": "PC2", "long_press_duration": 1.2})
+        btn = AFCButton(config)
+        buttons_mock.register_buttons.assert_called_once()
+        call_args = buttons_mock.register_buttons.call_args[0]
+        assert "PC2" in call_args[0]

--- a/tests/test_AFC_error.py
+++ b/tests/test_AFC_error.py
@@ -1,0 +1,702 @@
+"""
+Unit tests for extras/AFC_error.py
+
+Covers:
+  - set_error_state: sets error_state and current_state on AFC
+  - reset_failure: resets error_state, pause, position_saved, in_toolchange
+  - PauseUserIntervention: only pauses when homed and not already paused
+  - pause_print: calls PAUSE script
+  - handle_lane_failure: disables stepper, sets lane status, calls AFC_error
+  - AFC_error: logs error, optionally calls pause_print
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch, call
+import pytest
+
+from extras.AFC_error import afcError
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_afc_error():
+    """Create an afcError instance bypassing __init__ and wiring up mocks."""
+    from extras.AFC_error import afcError
+    from extras.AFC_lane import AFCLaneState
+    from extras.AFC import State
+    from tests.conftest import MockAFC, MockPrinter, MockLogger
+
+    afc = MockAFC()
+    afc.error_state = False
+    afc.current_state = State.IDLE
+    afc.function = MagicMock()
+    afc.function.is_homed = MagicMock(return_value=True)
+    afc.function.is_paused = MagicMock(return_value=False)
+    afc.save_pos = MagicMock()
+    afc.save_vars = MagicMock()
+
+    pause_resume = MagicMock()
+    idle_timeout = MagicMock()
+    idle_timeout.idle_timeout = 600
+
+    printer = MockPrinter(afc=afc)
+    printer._objects["pause_resume"] = pause_resume
+    printer._objects["idle_timeout"] = idle_timeout
+
+    # Build afcError without running __init__ (it needs a Klipper config)
+    err = afcError.__new__(afcError)
+    err.printer = printer
+    err.afc = afc
+    err.logger = MockLogger()
+    err.pause = False
+    err.pause_resume = pause_resume
+    err.error_timeout = 600
+    err.idle_timeout_obj = idle_timeout
+    err.idle_timeout_val = idle_timeout.idle_timeout
+    err.BASE_RESUME_NAME = "RESUME"
+    err.AFC_RENAME_RESUME_NAME = "_AFC_RENAMED_RESUME_"
+    err.BASE_PAUSE_NAME = "PAUSE"
+    err.AFC_RENAME_PAUSE_NAME = "_AFC_RENAMED_PAUSE_"
+    err.errorLog = {}
+
+    return err, afc
+
+
+# ── afcError.__init__ and handle_connect ──────────────────────────────────────
+
+class TestAfcErrorInit:
+    def test_init_sets_error_log_empty(self):
+        from tests.conftest import MockConfig, MockPrinter, MockAFC
+        afc = MockAFC()
+        printer = MockPrinter(afc=afc)
+        config = MockConfig(name="AFC_error", printer=printer)
+        err = afcError(config)
+        assert err.errorLog == {}
+
+    def test_init_sets_pause_false(self):
+        from tests.conftest import MockConfig, MockPrinter, MockAFC
+        afc = MockAFC()
+        printer = MockPrinter(afc=afc)
+        config = MockConfig(name="AFC_error", printer=printer)
+        err = afcError(config)
+        assert err.pause is False
+
+    def test_init_registers_klippy_connect_handler(self):
+        from tests.conftest import MockConfig, MockPrinter, MockAFC
+        afc = MockAFC()
+        printer = MockPrinter(afc=afc)
+        config = MockConfig(name="AFC_error", printer=printer)
+        err = afcError(config)
+        assert "klippy:connect" in printer._event_handlers
+
+
+class TestAfcErrorHandleConnect:
+    def test_handle_connect_sets_afc(self):
+        from tests.conftest import MockConfig, MockPrinter, MockAFC
+        afc = MockAFC()
+        printer = MockPrinter(afc=afc)
+        config = MockConfig(name="AFC_error", printer=printer)
+        err = afcError(config)
+        printer.send_event("klippy:connect")
+        assert err.afc is afc
+
+    def test_handle_connect_sets_logger(self):
+        from tests.conftest import MockConfig, MockPrinter, MockAFC
+        afc = MockAFC()
+        printer = MockPrinter(afc=afc)
+        config = MockConfig(name="AFC_error", printer=printer)
+        err = afcError(config)
+        printer.send_event("klippy:connect")
+        assert err.logger is afc.logger
+
+    def test_handle_connect_registers_reset_failure_command(self):
+        from tests.conftest import MockConfig, MockPrinter, MockAFC
+        afc = MockAFC()
+        printer = MockPrinter(afc=afc)
+        config = MockConfig(name="AFC_error", printer=printer)
+        err = afcError(config)
+        printer.send_event("klippy:connect")
+        assert "RESET_FAILURE" in afc.gcode._commands
+
+    def test_handle_connect_registers_afc_resume_command(self):
+        from tests.conftest import MockConfig, MockPrinter, MockAFC
+        afc = MockAFC()
+        printer = MockPrinter(afc=afc)
+        config = MockConfig(name="AFC_error", printer=printer)
+        err = afcError(config)
+        printer.send_event("klippy:connect")
+        assert "AFC_RESUME" in afc.gcode._commands
+
+    def test_handle_connect_sets_rename_macros(self):
+        from tests.conftest import MockConfig, MockPrinter, MockAFC
+        afc = MockAFC()
+        printer = MockPrinter(afc=afc)
+        config = MockConfig(name="AFC_error", printer=printer)
+        err = afcError(config)
+        printer.send_event("klippy:connect")
+        assert err.BASE_RESUME_NAME == "RESUME"
+        assert "_AFC_RENAMED_RESUME_" in err.AFC_RENAME_RESUME_NAME
+
+
+# ── set_error_state ───────────────────────────────────────────────────────────
+
+class TestSetErrorState:
+    def test_set_true_sets_error_state(self):
+        err, afc = _make_afc_error()
+        err.set_error_state(True)
+        assert afc.error_state is True
+
+    def test_set_true_changes_current_state_to_error(self):
+        from extras.AFC import State
+        err, afc = _make_afc_error()
+        err.set_error_state(True)
+        assert afc.current_state == State.ERROR
+
+    def test_set_false_clears_error_state(self):
+        err, afc = _make_afc_error()
+        afc.error_state = True
+        err.set_error_state(False)
+        assert afc.error_state is False
+
+    def test_set_false_changes_current_state_to_idle(self):
+        from extras.AFC import State
+        err, afc = _make_afc_error()
+        afc.error_state = True
+        err.set_error_state(False)
+        assert afc.current_state == State.IDLE
+
+    def test_set_true_when_not_yet_error_calls_save_pos(self):
+        err, afc = _make_afc_error()
+        afc.error_state = False
+        err.set_error_state(True)
+        afc.save_pos.assert_called_once()
+
+    def test_set_true_when_already_error_does_not_duplicate_save_pos(self):
+        err, afc = _make_afc_error()
+        afc.error_state = True
+        err.set_error_state(True)
+        afc.save_pos.assert_not_called()
+
+
+# ── reset_failure ─────────────────────────────────────────────────────────────
+
+class TestResetFailure:
+    def test_reset_failure_clears_error_state(self):
+        err, afc = _make_afc_error()
+        afc.error_state = True
+        err.reset_failure()
+        assert afc.error_state is False
+
+    def test_reset_failure_clears_pause_flag(self):
+        err, afc = _make_afc_error()
+        err.pause = True
+        err.reset_failure()
+        assert err.pause is False
+
+    def test_reset_failure_clears_position_saved(self):
+        err, afc = _make_afc_error()
+        afc.position_saved = True
+        err.reset_failure()
+        assert afc.position_saved is False
+
+    def test_reset_failure_clears_in_toolchange(self):
+        err, afc = _make_afc_error()
+        afc.in_toolchange = True
+        err.reset_failure()
+        assert afc.in_toolchange is False
+
+    def test_reset_failure_logs_debug(self):
+        err, afc = _make_afc_error()
+        err.reset_failure()
+        debug_msgs = [m for lvl, m in err.logger.messages if lvl == "debug"]
+        assert len(debug_msgs) > 0
+
+
+# ── PauseUserIntervention ─────────────────────────────────────────────────────
+
+class TestPauseUserIntervention:
+    def test_pause_when_homed_and_not_paused(self):
+        err, afc = _make_afc_error()
+        err.pause = True
+        err.pause_print = MagicMock()
+        afc.function.is_homed.return_value = True
+        afc.function.is_paused.return_value = False
+        err.PauseUserIntervention("Some message")
+        err.pause_print.assert_called_once()
+
+    def test_no_pause_when_not_homed(self):
+        err, afc = _make_afc_error()
+        err.pause = True
+        err.pause_print = MagicMock()
+        afc.function.is_homed.return_value = False
+        err.PauseUserIntervention("Some message")
+        err.pause_print.assert_not_called()
+
+    def test_no_pause_when_already_paused(self):
+        err, afc = _make_afc_error()
+        err.pause = True
+        err.pause_print = MagicMock()
+        afc.function.is_homed.return_value = True
+        afc.function.is_paused.return_value = True
+        err.PauseUserIntervention("Some message")
+        err.pause_print.assert_not_called()
+
+    def test_error_is_logged(self):
+        err, afc = _make_afc_error()
+        err.pause_print = MagicMock()
+        afc.function.is_homed.return_value = True
+        afc.function.is_paused.return_value = False
+        err.PauseUserIntervention("Bad thing happened")
+        error_msgs = [m for lvl, m in err.logger.messages if lvl == "error"]
+        assert any("Bad thing happened" in m for m in error_msgs)
+
+
+# ── pause_print ───────────────────────────────────────────────────────────────
+
+class TestPausePrint:
+    def test_pause_print_calls_gcode_pause(self):
+        err, afc = _make_afc_error()
+        err.set_error_state = MagicMock()
+        afc.function.log_toolhead_pos = MagicMock()
+        afc.gcode.run_script_from_command = MagicMock()
+        err.pause_print()
+        afc.gcode.run_script_from_command.assert_called()
+        script_arg = afc.gcode.run_script_from_command.call_args[0][0]
+        assert "PAUSE" in script_arg
+
+    def test_pause_print_sets_error_state(self):
+        err, afc = _make_afc_error()
+        err.set_error_state = MagicMock()
+        afc.function.log_toolhead_pos = MagicMock()
+        afc.gcode.run_script_from_command = MagicMock()
+        err.pause_print()
+        err.set_error_state.assert_called_once_with(True)
+
+
+# ── handle_lane_failure ───────────────────────────────────────────────────────
+
+class TestHandleLaneFailure:
+    def test_disables_lane_stepper(self):
+        from extras.AFC_lane import AFCLaneState
+        err, afc = _make_afc_error()
+        err.AFC_error = MagicMock()
+        cur_lane = MagicMock()
+        cur_lane.name = "lane1"
+        cur_lane.do_enable = MagicMock()
+        cur_lane.led_index = "1"
+        err.handle_lane_failure(cur_lane, "jammed", pause=False)
+        cur_lane.do_enable.assert_called_once_with(False)
+
+    def test_sets_lane_status_to_error(self):
+        from extras.AFC_lane import AFCLaneState
+        err, afc = _make_afc_error()
+        err.AFC_error = MagicMock()
+        cur_lane = MagicMock()
+        cur_lane.name = "lane1"
+        err.handle_lane_failure(cur_lane, "jammed", pause=False)
+        assert cur_lane.status == AFCLaneState.ERROR
+
+    def test_calls_afc_error_with_lane_name_in_message(self):
+        err, afc = _make_afc_error()
+        err.AFC_error = MagicMock()
+        cur_lane = MagicMock()
+        cur_lane.name = "lane2"
+        cur_lane.led_index = "2"
+        err.handle_lane_failure(cur_lane, "overheated", pause=False)
+        called_msg = err.AFC_error.call_args[0][0]
+        assert "lane2" in called_msg
+        assert "overheated" in called_msg
+
+
+# ── AFC_error (the method) ────────────────────────────────────────────────────
+
+class TestAFCErrorMethod:
+    def test_logs_error_message(self):
+        err, afc = _make_afc_error()
+        err.pause_print = MagicMock()
+        err.AFC_error("Catastrophic failure", pause=False)
+        error_msgs = [m for lvl, m in err.logger.messages if lvl == "error"]
+        assert any("Catastrophic failure" in m for m in error_msgs)
+
+    def test_pause_true_calls_pause_print(self):
+        err, afc = _make_afc_error()
+        err.pause_print = MagicMock()
+        err.AFC_error("Uh oh", pause=True)
+        err.pause_print.assert_called_once()
+
+    def test_pause_false_skips_pause_print(self):
+        err, afc = _make_afc_error()
+        err.pause_print = MagicMock()
+        err.AFC_error("Uh oh", pause=False)
+        err.pause_print.assert_not_called()
+
+
+# ── cmd_RESET_FAILURE ─────────────────────────────────────────────────────────
+
+class TestCmdResetFailure:
+    def test_delegates_to_reset_failure(self):
+        err, afc = _make_afc_error()
+        err.reset_failure = MagicMock()
+        gcmd = MagicMock()
+        err.cmd_RESET_FAILURE(gcmd)
+        err.reset_failure.assert_called_once()
+
+    def test_reset_failure_called_with_no_args(self):
+        err, afc = _make_afc_error()
+        err.reset_failure = MagicMock()
+        err.cmd_RESET_FAILURE(MagicMock())
+        err.reset_failure.assert_called_once_with()
+
+
+# ── fix ───────────────────────────────────────────────────────────────────────
+
+class TestFix:
+    def test_fix_sets_pause_true(self):
+        err, afc = _make_afc_error()
+        err.PauseUserIntervention = MagicMock()
+        err.ToolHeadFix = MagicMock(return_value=False)
+        lane = MagicMock()
+        err.fix("toolhead", lane)
+        assert err.pause is True
+
+    def test_fix_toolhead_calls_toolhead_fix(self):
+        err, afc = _make_afc_error()
+        err.PauseUserIntervention = MagicMock()
+        err.ToolHeadFix = MagicMock(return_value=True)
+        lane = MagicMock()
+        err.fix("toolhead", lane)
+        err.ToolHeadFix.assert_called_once_with(lane)
+
+    def test_fix_toolhead_success_skips_led_fault(self):
+        err, afc = _make_afc_error()
+        err.PauseUserIntervention = MagicMock()
+        err.ToolHeadFix = MagicMock(return_value=True)
+        lane = MagicMock()
+        err.fix("toolhead", lane)
+        afc.function.afc_led.assert_not_called()
+
+    def test_fix_toolhead_failure_calls_led_fault(self):
+        from extras.AFC_unit import afcUnit
+        err, afc = _make_afc_error()
+        err.PauseUserIntervention = MagicMock()
+        err.ToolHeadFix = MagicMock(return_value=False)
+        lane = MagicMock()
+        lane.led_index = "1"
+        lane.unit_obj = afcUnit.__new__(afcUnit)
+        lane.unit_obj.afc = afc
+        result = err.fix("toolhead", lane)
+        assert result is False
+        afc.function.afc_led.assert_called_with(lane.led_fault, lane.led_index)
+
+    def test_fix_other_problem_calls_pause_user_intervention(self):
+        err, afc = _make_afc_error()
+        err.PauseUserIntervention = MagicMock()
+        lane = MagicMock()
+        lane.led_index = "2"
+        err.fix("jam", lane)
+        err.PauseUserIntervention.assert_called_with("jam")
+
+    def test_fix_none_problem_calls_pause_user_intervention_with_unknown_message(self):
+        """Covers line 58: problem is None → PauseUserIntervention('Paused for unknown error')."""
+        err, afc = _make_afc_error()
+        err.PauseUserIntervention = MagicMock()
+        lane = MagicMock()
+        lane.led_index = "1"
+        err.fix(None, lane)
+        # Should be called with the 'unknown error' string
+        calls = [str(c) for c in err.PauseUserIntervention.call_args_list]
+        assert any("unknown" in c.lower() for c in calls)
+
+    def test_fix_returns_error_handled_from_toolhead_fix(self):
+        err, afc = _make_afc_error()
+        err.PauseUserIntervention = MagicMock()
+        err.ToolHeadFix = MagicMock(return_value=True)
+        lane = MagicMock()
+        result = err.fix("toolhead", lane)
+        assert result is True
+
+    def test_fix_returns_false_for_non_toolhead_problem(self):
+        err, afc = _make_afc_error()
+        err.PauseUserIntervention = MagicMock()
+        lane = MagicMock()
+        lane.led_index = "1"
+        result = err.fix("jam", lane)
+        assert result is False
+
+
+# ── ToolHeadFix ───────────────────────────────────────────────────────────────
+
+class TestToolHeadFix:
+    def test_toolhead_has_filament_matching_lane_but_not_loaded_pauses(self):
+        err, afc = _make_afc_error()
+        err.PauseUserIntervention = MagicMock()
+        lane = MagicMock()
+        lane.name = "lane1"
+        lane.get_toolhead_pre_sensor_state.return_value = True
+        lane.extruder_obj.lane_loaded = "lane1"
+        lane.raw_load_state = False  # load sensor not active
+        err.ToolHeadFix(lane)
+        err.PauseUserIntervention.assert_called_with("Filament not loaded in Lane")
+
+    def test_toolhead_has_filament_matching_lane_and_loaded_pauses_no_error(self):
+        err, afc = _make_afc_error()
+        err.PauseUserIntervention = MagicMock()
+        lane = MagicMock()
+        lane.name = "lane1"
+        lane.get_toolhead_pre_sensor_state.return_value = True
+        lane.extruder_obj.lane_loaded = "lane1"
+        lane.raw_load_state = True
+        err.ToolHeadFix(lane)
+        err.PauseUserIntervention.assert_called_with("no error detected")
+
+    def test_toolhead_has_filament_wrong_lane_pauses(self):
+        err, afc = _make_afc_error()
+        err.PauseUserIntervention = MagicMock()
+        lane = MagicMock()
+        lane.name = "lane1"
+        lane.get_toolhead_pre_sensor_state.return_value = True
+        lane.extruder_obj.lane_loaded = "lane2"  # Mismatch
+        err.ToolHeadFix(lane)
+        err.PauseUserIntervention.assert_called_with("laneloaded does not match extruder")
+
+    def test_toolhead_empty_with_lane_filament_returns_true_no_homing(self):
+        """Filament is retracted to lane and reloaded; returns True."""
+        from unittest.mock import PropertyMock
+        from tests.test_AFC_lane import _make_afc_lane
+        err, afc = _make_afc_error()
+        err.PauseUserIntervention = MagicMock()
+        afc.homing_enabled = False
+        lane = _make_afc_lane()
+        lane.get_toolhead_pre_sensor_state.return_value = False  # toolhead empty
+        # Sequence: if check(True→enter), while check(True→loop), while check(False→exit),
+        #           while-not check(False→enter), while-not check(True→exit)
+        type(lane).raw_load_state = PropertyMock(side_effect=[True, True, False, False, True])
+        result = err.ToolHeadFix(lane)
+        assert result is True
+        assert err.pause is False
+        afc.save_vars.assert_called_once()
+
+    def test_toolhead_empty_with_lane_filament_clears_flags_no_homing(self):
+        from unittest.mock import PropertyMock
+        from tests.test_AFC_lane import _make_afc_lane
+        err, afc = _make_afc_error()
+        err.PauseUserIntervention = MagicMock()
+        afc.homing_enabled = False
+        lane = _make_afc_lane()
+        lane.get_toolhead_pre_sensor_state.return_value = False
+        type(lane).raw_load_state = PropertyMock(side_effect=[True, True, False, False, True])
+        err.ToolHeadFix(lane)
+        assert lane.tool_loaded is False
+        assert lane.loaded_to_hub is False
+        assert lane.extruder_obj.lane_loaded == None
+    
+    def test_toolhead_empty_with_lane_filament_returns_true_homing(self):
+        """Filament is retracted to lane and reloaded; returns True."""
+        from unittest.mock import PropertyMock
+        from tests.test_AFC_lane import _make_afc_lane
+        err, afc = _make_afc_error()
+        err.PauseUserIntervention = MagicMock()
+        afc.homing_enabled = True
+        lane = _make_afc_lane()
+        lane.get_toolhead_pre_sensor_state.return_value = False  # toolhead empty
+        lane.hub_obj = MagicMock()
+        lane.hub_obj.afc_bowden_length = 1300
+        # Sequence: if check(True→enter), while check(True→loop), while check(False→exit),
+        #           while-not check(False→enter), while-not check(True→exit)
+        type(lane).raw_load_state = PropertyMock(side_effect=[True, True, False])
+        result = err.ToolHeadFix(lane)
+        assert result is True
+        assert err.pause is False
+        afc.save_vars.assert_called_once()
+
+    def test_toolhead_empty_with_lane_filament_clears_flags_homing(self):
+        from unittest.mock import PropertyMock
+        from tests.test_AFC_lane import _make_afc_lane
+        err, afc = _make_afc_error()
+        err.PauseUserIntervention = MagicMock()
+        afc.homing_enabled = True
+        lane = _make_afc_lane()
+        lane.hub_obj = MagicMock()
+        lane.hub_obj.afc_bowden_length = 1300
+        lane.get_toolhead_pre_sensor_state.return_value = False
+        type(lane).raw_load_state = PropertyMock(side_effect=[True, True, False])
+        err.ToolHeadFix(lane)
+        assert lane.tool_loaded is False
+        assert lane.loaded_to_hub is False
+        assert lane.extruder_obj.lane_loaded == None
+    
+    def test_toolhead_empty_with_lane_filament_returns_false_timed_out_homing(self):
+        """Filament is retracted to lane and reloaded; returns True."""
+        from unittest.mock import PropertyMock
+        from tests.test_AFC_lane import _make_afc_lane
+        err, afc = _make_afc_error()
+        err.PauseUserIntervention = MagicMock()
+        afc.homing_enabled = True
+        lane = _make_afc_lane()
+        lane.get_toolhead_pre_sensor_state.return_value = False  # toolhead empty
+        lane.hub_obj = MagicMock()
+        lane.hub_obj.afc_bowden_length = 1300
+        # Sequence: if check(True→enter), while check(True→loop), while check(False→exit),
+        #           while-not check(False→enter), while-not check(True→exit)
+        type(lane).raw_load_state = PropertyMock(side_effect=[True, True, True, True, True, True])
+        result = err.ToolHeadFix(lane)
+        assert result is False
+        assert err.pause is False
+        err.PauseUserIntervention.assert_called_with("Failed to retract lane1 to load sensor")
+
+
+
+# ── cmd_AFC_RESUME ────────────────────────────────────────────────────────────
+
+class TestCmdAfcResume:
+    def test_not_paused_sets_in_toolchange_false_and_returns_early(self):
+        err, afc = _make_afc_error()
+        afc.in_toolchange = True
+        afc.function.is_paused.return_value = False
+        gcmd = MagicMock()
+        err.cmd_AFC_RESUME(gcmd)
+        assert afc.in_toolchange is False
+        afc.gcode.run_script_from_command.assert_not_called()
+
+    def test_not_paused_logs_debug(self):
+        err, afc = _make_afc_error()
+        afc.function.is_paused.return_value = False
+        err.cmd_AFC_RESUME(MagicMock())
+        debug_msgs = [m for lvl, m in err.logger.messages if lvl == "debug"]
+        assert any("not paused" in m.lower() or "not executing" in m.lower() for m in debug_msgs)
+
+    def test_paused_calls_renamed_resume_macro(self):
+        err, afc = _make_afc_error()
+        afc.function.is_paused.return_value = True
+        afc.last_gcode_position = [0.0, 0.0, 0.0, 0.0]
+        afc.gcode_move.last_position = [0.0, 0.0, 0.0]
+        afc.move_z_pos = MagicMock()
+        afc.restore_pos = MagicMock()
+        gcmd = MagicMock()
+        gcmd.get_raw_command_parameters.return_value = ""
+        err.set_error_state = MagicMock()
+        err.cmd_AFC_RESUME(gcmd)
+        afc.gcode.run_script_from_command.assert_called_once()
+        call_arg = afc.gcode.run_script_from_command.call_args[0][0]
+        assert err.AFC_RENAME_RESUME_NAME in call_arg
+
+    def test_paused_z_below_threshold_calls_move_z_pos(self):
+        err, afc = _make_afc_error()
+        afc.function.is_paused.return_value = True
+        afc.last_gcode_position = [0.0, 0.0, 0.0, 0.0]
+        afc.z_hop = 0.5
+        afc.gcode_move.last_position = [0.0, 0.0, 0.0]  # z=0 ≤ 0+0.5
+        afc.move_z_pos = MagicMock()
+        afc.restore_pos = MagicMock()
+        gcmd = MagicMock()
+        gcmd.get_raw_command_parameters.return_value = ""
+        err.set_error_state = MagicMock()
+        err.cmd_AFC_RESUME(gcmd)
+        afc.move_z_pos.assert_called_once()
+
+    def test_paused_z_above_threshold_skips_move_z_pos(self):
+        err, afc = _make_afc_error()
+        afc.function.is_paused.return_value = True
+        afc.last_gcode_position = [0.0, 0.0, 0.0, 0.0]
+        afc.z_hop = 0.5
+        afc.gcode_move.last_position = [0.0, 0.0, 10.0]  # z=10 > 0+0.5
+        afc.move_z_pos = MagicMock()
+        afc.restore_pos = MagicMock()
+        gcmd = MagicMock()
+        gcmd.get_raw_command_parameters.return_value = ""
+        err.set_error_state = MagicMock()
+        err.cmd_AFC_RESUME(gcmd)
+        afc.move_z_pos.assert_not_called()
+
+    def test_paused_with_error_state_calls_restore_pos(self):
+        err, afc = _make_afc_error()
+        afc.function.is_paused.return_value = True
+        afc.error_state = True
+        afc.position_saved = False
+        afc.last_gcode_position = [0.0, 0.0, 0.0, 0.0]
+        afc.gcode_move.last_position = [0.0, 0.0, 0.0]
+        afc.move_z_pos = MagicMock()
+        afc.restore_pos = MagicMock()
+        gcmd = MagicMock()
+        gcmd.get_raw_command_parameters.return_value = ""
+        err.set_error_state = MagicMock()
+        err.cmd_AFC_RESUME(gcmd)
+        afc.restore_pos.assert_called_once_with(False)
+
+
+# ── cmd_AFC_PAUSE ─────────────────────────────────────────────────────────────
+
+class TestCmdAfcPause:
+    def test_not_paused_saves_position(self):
+        err, afc = _make_afc_error()
+        afc.function.is_paused.return_value = False
+        afc.save_pos = MagicMock()
+        afc.move_z_pos = MagicMock()
+        afc.last_gcode_position = [0.0, 0.0, 0.0, 0.0]
+        afc.gcode_move.last_position = [0.0, 0.0, 0.0]
+        err.cmd_AFC_PAUSE(MagicMock())
+        afc.save_pos.assert_called_once()
+
+    def test_not_paused_sends_pause_command(self):
+        err, afc = _make_afc_error()
+        afc.function.is_paused.return_value = False
+        afc.save_pos = MagicMock()
+        afc.move_z_pos = MagicMock()
+        afc.last_gcode_position = [0.0, 0.0, 0.0, 0.0]
+        afc.gcode_move.last_position = [0.0, 0.0, 0.0]
+        err.cmd_AFC_PAUSE(MagicMock())
+        err.pause_resume.send_pause_command.assert_called_once()
+
+    def test_not_paused_calls_renamed_pause_macro(self):
+        err, afc = _make_afc_error()
+        afc.function.is_paused.return_value = False
+        afc.save_pos = MagicMock()
+        afc.move_z_pos = MagicMock()
+        afc.last_gcode_position = [0.0, 0.0, 0.0, 0.0]
+        afc.gcode_move.last_position = [0.0, 0.0, 0.0]
+        gcmd = MagicMock()
+        gcmd.get_raw_command_parameters.return_value = ""
+        err.cmd_AFC_PAUSE(gcmd)
+        # run_script_from_command called at least twice: PAUSE macro + SET_IDLE_TIMEOUT
+        assert afc.gcode.run_script_from_command.call_count >= 1
+        calls = [c[0][0] for c in afc.gcode.run_script_from_command.call_args_list]
+        assert any(err.AFC_RENAME_PAUSE_NAME in c for c in calls)
+
+    def test_already_paused_logs_not_pausing(self):
+        err, afc = _make_afc_error()
+        afc.function.is_paused.return_value = True
+        err.cmd_AFC_PAUSE(MagicMock())
+        debug_msgs = [m for lvl, m in err.logger.messages if lvl == "debug"]
+        assert any("not pausing" in m.lower() for m in debug_msgs)
+
+    def test_already_paused_skips_pause_command(self):
+        err, afc = _make_afc_error()
+        afc.function.is_paused.return_value = True
+        err.cmd_AFC_PAUSE(MagicMock())
+        err.pause_resume.send_pause_command.assert_not_called()
+
+    def test_not_paused_z_below_threshold_calls_move_z_pos(self):
+        err, afc = _make_afc_error()
+        afc.function.is_paused.return_value = False
+        afc.save_pos = MagicMock()
+        afc.last_gcode_position = [0.0, 0.0, 0.0, 0.0]
+        afc.z_hop = 0.5
+        afc.gcode_move.last_position = [0.0, 0.0, 0.0]  # z=0 ≤ 0+0.5
+        afc.move_z_pos = MagicMock()
+        err.cmd_AFC_PAUSE(MagicMock())
+        afc.move_z_pos.assert_called_once()
+
+    def test_not_paused_z_above_threshold_skips_move_z_pos(self):
+        """Covers line 239: current z already above target → log debug, skip move_z_pos."""
+        err, afc = _make_afc_error()
+        afc.function.is_paused.return_value = False
+        afc.save_pos = MagicMock()
+        afc.last_gcode_position = [0.0, 0.0, 0.0, 0.0]  # saved z = 0
+        afc.z_hop = 0.5  # target = 0 + 0.5 = 0.5
+        afc.gcode_move.last_position = [0.0, 0.0, 1.0]  # current z = 1.0 > 0.5
+        afc.move_z_pos = MagicMock()
+        gcmd = MagicMock()
+        gcmd.get_raw_command_parameters.return_value = ""
+        err.cmd_AFC_PAUSE(gcmd)
+        afc.move_z_pos.assert_not_called()

--- a/tests/test_AFC_extruder.py
+++ b/tests/test_AFC_extruder.py
@@ -1,0 +1,601 @@
+"""
+Unit tests for extras/AFC_extruder.py
+
+Covers:
+  - AFCExtruderStats: cut threshold warning/error logic
+  - AFCExtruderStats.increase_cut_total: increments counts
+  - AFCExtruderStats.increase_toolcount_change: increments total
+  - AFCExtruderStats.reset_stats: resets all counts
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+import pytest
+
+from extras.AFC_extruder import AFCExtruderStats, AFCExtruder
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_extruder_obj(name="extruder"):
+    """Minimal AFCExtruder-like mock."""
+    from tests.conftest import MockAFC, MockLogger
+    afc = MockAFC()
+    afc.afc_stats = MagicMock()
+    obj = MagicMock()
+    obj.name = name
+    obj.afc = afc
+    obj.logger = MockLogger()
+    return obj
+
+
+def _make_stats(extruder_name="extruder", cut_threshold=200, cut_since_changed=0):
+    """Build an AFCExtruderStats bypassing heavy __init__ logic."""
+    obj = _make_extruder_obj(extruder_name)
+    stats = AFCExtruderStats.__new__(AFCExtruderStats)
+    stats.name = extruder_name
+    stats.obj = obj
+    logger = obj.logger
+    # AFC_extruder accesses self.logger.afc.message_queue; wire it up
+    from tests.conftest import MockAFC
+    afc_for_logger = MockAFC()
+    logger.afc = afc_for_logger
+    stats.logger = logger
+    stats.cut_threshold_for_warning = cut_threshold
+    stats.threshold_warning_sent = False
+    stats.threshold_error_sent = False
+
+    from tests.conftest import MockMoonraker
+    mr = MockMoonraker()
+    mr.update_afc_stats = MagicMock()
+    stats.moonraker = mr
+
+    # Create AFCStats_var mocks for the various stats
+    def _make_var(value=0):
+        v = MagicMock()
+        v.value = value
+        return v
+
+    stats.cut_total = _make_var(0)
+    stats.cut_total_since_changed = _make_var(cut_since_changed)
+    stats.last_blade_changed = _make_var(0)
+    stats.tc_total = _make_var(0)
+    stats.tc_tool_unload = _make_var(0)
+    stats.tc_tool_load = _make_var(0)
+    stats.tool_selected = _make_var(0)
+    stats.tool_unselected = _make_var(0)
+
+    return stats
+
+
+# ── AFCExtruderStats: initialization ──────────────────────────────────────────
+
+class TestAFCExtruderStatsInit:
+    def test_name_stored(self):
+        stats = _make_stats("extruder")
+        assert stats.name == "extruder"
+
+    def test_cut_threshold_stored(self):
+        stats = _make_stats(cut_threshold=300)
+        assert stats.cut_threshold_for_warning == 300
+
+    def test_threshold_warning_not_sent_initially(self):
+        stats = _make_stats()
+        assert stats.threshold_warning_sent is False
+
+    def test_threshold_error_not_sent_initially(self):
+        stats = _make_stats()
+        assert stats.threshold_error_sent is False
+
+
+# ── check_cut_threshold ───────────────────────────────────────────────────────
+
+class TestCheckCutThreshold:
+    def test_no_message_well_below_threshold(self):
+        """No message when cuts < threshold - 1000."""
+        stats = _make_stats(cut_threshold=2000, cut_since_changed=500)
+        stats.check_cut_threshold()
+        assert stats.threshold_warning_sent is False
+        assert stats.threshold_error_sent is False
+
+    def test_warning_sent_near_threshold(self):
+        """Warning sent when cuts >= threshold - 1000."""
+        stats = _make_stats(cut_threshold=2000, cut_since_changed=1001)
+        stats.check_cut_threshold()
+        assert stats.threshold_warning_sent is True
+
+    def test_warning_logged_near_threshold(self):
+        stats = _make_stats(cut_threshold=2000, cut_since_changed=1001)
+        stats.check_cut_threshold()
+        raw_msgs = [m for lvl, m in stats.logger.messages if lvl == "raw"]
+        assert len(raw_msgs) >= 1
+
+    def test_error_sent_at_threshold(self):
+        """Error logged when cuts >= threshold."""
+        stats = _make_stats(cut_threshold=200, cut_since_changed=200)
+        stats.check_cut_threshold()
+        assert stats.threshold_error_sent is True
+
+    def test_error_sent_above_threshold(self):
+        stats = _make_stats(cut_threshold=200, cut_since_changed=250)
+        stats.check_cut_threshold()
+        assert stats.threshold_error_sent is True
+
+    def test_warning_not_resent_when_already_sent(self):
+        """Warning should not spam logger if already sent."""
+        stats = _make_stats(cut_threshold=2000, cut_since_changed=1001)
+        stats.threshold_warning_sent = True
+        stats.check_cut_threshold()
+        raw_msgs = [m for lvl, m in stats.logger.messages if lvl == "raw"]
+        assert len(raw_msgs) == 0  # no new messages
+
+    def test_error_not_resent_when_already_sent(self):
+        stats = _make_stats(cut_threshold=200, cut_since_changed=250)
+        stats.threshold_error_sent = True
+        stats.check_cut_threshold()
+        raw_msgs = [m for lvl, m in stats.logger.messages if lvl == "raw"]
+        assert len(raw_msgs) == 0
+
+
+# ── increase_cut_total ────────────────────────────────────────────────────────
+
+class TestIncreaseCutTotal:
+    def test_increments_cut_total(self):
+        stats = _make_stats()
+        stats.check_cut_threshold = MagicMock()
+        stats.increase_cut_total()
+        stats.cut_total.increase_count.assert_called_once()
+
+    def test_increments_cut_total_since_changed(self):
+        stats = _make_stats()
+        stats.check_cut_threshold = MagicMock()
+        stats.increase_cut_total()
+        stats.cut_total_since_changed.increase_count.assert_called_once()
+
+    def test_calls_check_cut_threshold(self):
+        stats = _make_stats()
+        stats.check_cut_threshold = MagicMock()
+        stats.increase_cut_total()
+        stats.check_cut_threshold.assert_called_once()
+
+
+# ── increase_toolcount_change ──────────────────────────────────────────────────
+
+class TestIncreaseToolcountChange:
+    def test_increments_tc_total(self):
+        stats = _make_stats()
+        stats.increase_toolcount_change()
+        stats.tc_total.increase_count.assert_called_once()
+
+    def test_increments_toolchange_wo_error_on_afc_stats(self):
+        stats = _make_stats()
+        stats.increase_toolcount_change()
+        stats.obj.afc.afc_stats.increase_toolchange_wo_error.assert_called_once()
+
+
+# ── reset_stats ────────────────────────────────────────────────────────────────
+
+class TestResetStats:
+    def test_resets_tc_total(self):
+        stats = _make_stats()
+        stats.reset_stats()
+        stats.tc_total.reset_count.assert_called_once()
+
+    def test_resets_tc_tool_unload(self):
+        stats = _make_stats()
+        stats.reset_stats()
+        stats.tc_tool_unload.reset_count.assert_called_once()
+
+    def test_resets_tc_tool_load(self):
+        stats = _make_stats()
+        stats.reset_stats()
+        stats.tc_tool_load.reset_count.assert_called_once()
+
+    def test_resets_tool_selected(self):
+        stats = _make_stats()
+        stats.reset_stats()
+        stats.tool_selected.reset_count.assert_called_once()
+
+    def test_resets_tool_unselected(self):
+        stats = _make_stats()
+        stats.reset_stats()
+        stats.tool_unselected.reset_count.assert_called_once()
+
+
+# ── AFCExtruder helpers ────────────────────────────────────────────────────────
+
+def _make_afc_extruder(name="extruder"):
+    """Build an AFCExtruder bypassing __init__."""
+    from tests.conftest import MockAFC, MockPrinter, MockLogger, MockReactor
+
+    afc = MockAFC()
+    reactor = MockReactor()
+    printer = MockPrinter(afc=afc)
+    printer._reactor = reactor
+
+    ext = AFCExtruder.__new__(AFCExtruder)
+    ext.printer = printer
+    ext.afc = afc
+    ext.logger = MockLogger()
+    ext.reactor = reactor
+    ext.fullname = f"AFC_extruder {name}"
+    ext.name = name
+    ext.lane_loaded = None
+    ext.lanes = {}
+    ext.tool_start = None
+    ext.tool_end = None
+    ext.tool_start_state = False
+    ext.tool_end_state = False
+    ext.buffer_trailing = False
+    ext.tool_stn = 72.0
+    ext.tool_stn_unload = 100.0
+    ext.tool_sensor_after_extruder = 0.0
+    ext.tool_unload_speed = 25.0
+    ext.tool_load_speed = 25.0
+    ext.buffer_name = None
+    ext.common_save_msg = f"\nRun SAVE_EXTRUDER_VALUES EXTRUDER={name} once done."
+    ext.estats = MagicMock()
+    ext.function = afc.function
+
+    # Toolchanger stuff
+    ext.tool_obj = None
+    ext.tc_unit_name = None
+    ext.tool = None
+    ext.toolhead_leds = None
+    ext.mutex = MagicMock()
+    return ext
+
+
+# ── AFCExtruder.__str__ ────────────────────────────────────────────────────────
+
+class TestAFCExtruderStr:
+    def test_str_returns_name(self):
+        ext = _make_afc_extruder("my_extruder")
+        assert str(ext) == "my_extruder"
+
+
+# ── handle_connect ─────────────────────────────────────────────────────────────
+
+class TestAFCExtruderHandleConnect:
+    def test_handle_connect_stores_self_in_afc_tools(self):
+        ext = _make_afc_extruder("extruder")
+        ext.handle_connect()
+        assert ext.afc.tools["extruder"] is ext
+
+    def test_handle_connect_sets_reactor(self):
+        ext = _make_afc_extruder()
+        ext.reactor = None
+        ext.handle_connect()
+        assert ext.reactor is ext.afc.reactor
+
+
+# ── handle_moonraker_connect ───────────────────────────────────────────────────
+
+class TestAFCExtruderHandleMoonrakerConnect:
+    def test_delegates_to_estats(self):
+        ext = _make_afc_extruder()
+        ext.handle_moonraker_connect()
+        ext.estats.handle_moonraker_stats.assert_called_once()
+
+
+# ── _handle_toolhead_sensor_runout ─────────────────────────────────────────────
+
+class TestHandleToolheadSensorRunout:
+    def test_no_runout_when_state_true(self):
+        ext = _make_afc_extruder()
+        lane = MagicMock()
+        ext.lanes = {"lane1": lane}
+        ext.lane_loaded = "lane1"
+        ext._handle_toolhead_sensor_runout(True, "tool_start")
+        lane.handle_toolhead_runout.assert_not_called()
+
+    def test_no_runout_when_no_lane_loaded(self):
+        ext = _make_afc_extruder()
+        lane = MagicMock()
+        ext.lanes = {"lane1": lane}
+        ext.lane_loaded = None
+        ext._handle_toolhead_sensor_runout(False, "tool_start")
+        lane.handle_toolhead_runout.assert_not_called()
+
+    def test_no_runout_when_lane_not_in_lanes_dict(self):
+        ext = _make_afc_extruder()
+        ext.lanes = {}
+        ext.lane_loaded = "lane1"
+        ext._handle_toolhead_sensor_runout(False, "tool_start")
+        # no KeyError, just silently skips
+
+    def test_runout_calls_lane_handle_toolhead_runout(self):
+        ext = _make_afc_extruder()
+        lane = MagicMock()
+        ext.lanes = {"lane1": lane}
+        ext.lane_loaded = "lane1"
+        ext._handle_toolhead_sensor_runout(False, "tool_start")
+        lane.handle_toolhead_runout.assert_called_once_with(sensor="tool_start")
+
+    def test_runout_passes_sensor_name(self):
+        ext = _make_afc_extruder()
+        lane = MagicMock()
+        ext.lanes = {"lane1": lane}
+        ext.lane_loaded = "lane1"
+        ext._handle_toolhead_sensor_runout(False, "tool_end")
+        lane.handle_toolhead_runout.assert_called_once_with(sensor="tool_end")
+
+
+# ── tool_start_callback ────────────────────────────────────────────────────────
+
+class TestToolStartCallback:
+    def test_updates_state_true(self):
+        ext = _make_afc_extruder()
+        ext.tool_start_callback(100.0, True)
+        assert ext.tool_start_state is True
+
+    def test_updates_state_false(self):
+        ext = _make_afc_extruder()
+        ext.tool_start_state = True
+        ext.tool_start_callback(101.0, False)
+        assert ext.tool_start_state is False
+
+
+# ── tool_end_callback ──────────────────────────────────────────────────────────
+
+class TestToolEndCallback:
+    def test_updates_state_true(self):
+        ext = _make_afc_extruder()
+        ext.tool_end_callback(100.0, True)
+        assert ext.tool_end_state is True
+
+    def test_updates_state_false(self):
+        ext = _make_afc_extruder()
+        ext.tool_end_state = True
+        ext.tool_end_callback(101.0, False)
+        assert ext.tool_end_state is False
+
+
+# ── buffer_trailing_callback ───────────────────────────────────────────────────
+
+class TestBufferTrailingCallback:
+    def test_updates_buffer_trailing_true(self):
+        ext = _make_afc_extruder()
+        ext.buffer_trailing_callback(100.0, True)
+        assert ext.buffer_trailing is True
+
+    def test_updates_buffer_trailing_false(self):
+        ext = _make_afc_extruder()
+        ext.buffer_trailing = True
+        ext.buffer_trailing_callback(101.0, False)
+        assert ext.buffer_trailing is False
+
+
+# ── handle_start_runout ────────────────────────────────────────────────────────
+
+class TestHandleStartRunout:
+    def test_updates_min_event_systime(self):
+        ext = _make_afc_extruder()
+        ext._handle_toolhead_sensor_runout = MagicMock()
+        ext.fila_tool_start = MagicMock()
+        ext.fila_tool_start.runout_helper.min_event_systime = 0.0
+        ext.fila_tool_start.runout_helper.event_delay = 0.5
+        ext.handle_start_runout(100.0)
+        assert ext.fila_tool_start.runout_helper.min_event_systime != 0.0
+
+    def test_calls_handle_toolhead_sensor_runout_with_tool_start(self):
+        ext = _make_afc_extruder()
+        ext._handle_toolhead_sensor_runout = MagicMock()
+        ext.fila_tool_start = MagicMock()
+        ext.fila_tool_start.runout_helper.filament_present = False
+        ext.fila_tool_start.runout_helper.event_delay = 0.5
+        ext.handle_start_runout(100.0)
+        ext._handle_toolhead_sensor_runout.assert_called_once_with(False, "tool_start")
+
+
+# ── handle_end_runout ──────────────────────────────────────────────────────────
+
+class TestHandleEndRunout:
+    def test_updates_min_event_systime(self):
+        ext = _make_afc_extruder()
+        ext._handle_toolhead_sensor_runout = MagicMock()
+        ext.fila_tool_end = MagicMock()
+        ext.fila_tool_end.runout_helper.min_event_systime = 0.0
+        ext.fila_tool_end.runout_helper.event_delay = 0.5
+        ext.handle_end_runout(100.0)
+        assert ext.fila_tool_end.runout_helper.min_event_systime != 0.0
+
+    def test_calls_handle_toolhead_sensor_runout_with_tool_end(self):
+        ext = _make_afc_extruder()
+        ext._handle_toolhead_sensor_runout = MagicMock()
+        ext.fila_tool_end = MagicMock()
+        ext.fila_tool_end.runout_helper.filament_present = True
+        ext.fila_tool_end.runout_helper.event_delay = 0.5
+        ext.handle_end_runout(100.0)
+        ext._handle_toolhead_sensor_runout.assert_called_once_with(True, "tool_end")
+
+
+# ── _update_tool_stn ──────────────────────────────────────────────────────────
+
+class TestUpdateToolStn:
+    def test_positive_value_updates_tool_stn(self):
+        ext = _make_afc_extruder()
+        ext._update_tool_stn(80.0)
+        assert ext.tool_stn == 80.0
+
+    def test_zero_value_logs_error(self):
+        ext = _make_afc_extruder()
+        ext._update_tool_stn(0.0)
+        error_msgs = [m for lvl, m in ext.logger.messages if lvl == "error"]
+        assert any("greater than zero" in m for m in error_msgs)
+
+    def test_zero_value_does_not_update(self):
+        ext = _make_afc_extruder()
+        ext._update_tool_stn(0.0)
+        assert ext.tool_stn == 72.0  # unchanged
+
+    def test_positive_value_logs_info(self):
+        ext = _make_afc_extruder()
+        ext._update_tool_stn(90.0)
+        info_msgs = [m for lvl, m in ext.logger.messages if lvl == "info"]
+        assert any("tool_stn" in m for m in info_msgs)
+
+
+# ── _update_tool_stn_unload ───────────────────────────────────────────────────
+
+class TestUpdateToolStnUnload:
+    def test_zero_value_is_accepted(self):
+        ext = _make_afc_extruder()
+        ext._update_tool_stn_unload(0.0)
+        assert ext.tool_stn_unload == 0.0
+
+    def test_positive_value_updates(self):
+        ext = _make_afc_extruder()
+        ext._update_tool_stn_unload(50.0)
+        assert ext.tool_stn_unload == 50.0
+
+    def test_negative_value_logs_error(self):
+        ext = _make_afc_extruder()
+        ext._update_tool_stn_unload(-1.0)
+        error_msgs = [m for lvl, m in ext.logger.messages if lvl == "error"]
+        assert any("greater than or equal to zero" in m for m in error_msgs)
+
+    def test_negative_value_does_not_update(self):
+        ext = _make_afc_extruder()
+        ext._update_tool_stn_unload(-5.0)
+        assert ext.tool_stn_unload == 100.0  # unchanged
+
+
+# ── _update_tool_after_extr ───────────────────────────────────────────────────
+
+class TestUpdateToolAfterExtr:
+    def test_positive_value_updates(self):
+        ext = _make_afc_extruder()
+        ext._update_tool_after_extr(10.0)
+        assert ext.tool_sensor_after_extruder == 10.0
+
+    def test_zero_value_logs_error(self):
+        ext = _make_afc_extruder()
+        ext._update_tool_after_extr(0.0)
+        error_msgs = [m for lvl, m in ext.logger.messages if lvl == "error"]
+        assert any("greater than zero" in m for m in error_msgs)
+
+    def test_positive_value_logs_info(self):
+        ext = _make_afc_extruder()
+        ext._update_tool_after_extr(15.0)
+        info_msgs = [m for lvl, m in ext.logger.messages if lvl == "info"]
+        assert any("tool_sensor_after_extruder" in m for m in info_msgs)
+
+
+# ── cmd_UPDATE_TOOLHEAD_SENSORS ───────────────────────────────────────────────
+
+class TestCmdUpdateToolheadSensors:
+    def _make_gcmd(self, tool_stn=None, tool_stn_unload=None, tool_after=None,
+                   ext=None):
+        gcmd = MagicMock()
+        gcmd.get_float.side_effect = lambda key, default: {
+            "TOOL_STN": tool_stn if tool_stn is not None else (ext.tool_stn if ext else default),
+            "TOOL_STN_UNLOAD": tool_stn_unload if tool_stn_unload is not None else (ext.tool_stn_unload if ext else default),
+            "TOOL_AFTER_EXTRUDER": tool_after if tool_after is not None else (ext.tool_sensor_after_extruder if ext else default),
+        }[key]
+        return gcmd
+
+    def test_changed_tool_stn_calls_update(self):
+        ext = _make_afc_extruder()
+        ext._update_tool_stn = MagicMock()
+        gcmd = self._make_gcmd(tool_stn=90.0, tool_stn_unload=100.0, tool_after=0.0, ext=ext)
+        ext.cmd_UPDATE_TOOLHEAD_SENSORS(gcmd)
+        ext._update_tool_stn.assert_called_once_with(90.0)
+
+    def test_unchanged_tool_stn_skips_update(self):
+        ext = _make_afc_extruder()
+        ext._update_tool_stn = MagicMock()
+        gcmd = self._make_gcmd(tool_stn=72.0, tool_stn_unload=100.0, tool_after=0.0, ext=ext)
+        ext.cmd_UPDATE_TOOLHEAD_SENSORS(gcmd)
+        ext._update_tool_stn.assert_not_called()
+
+    def test_changed_tool_stn_unload_calls_update(self):
+        ext = _make_afc_extruder()
+        ext._update_tool_stn_unload = MagicMock()
+        gcmd = self._make_gcmd(tool_stn=72.0, tool_stn_unload=50.0, tool_after=0.0, ext=ext)
+        ext.cmd_UPDATE_TOOLHEAD_SENSORS(gcmd)
+        ext._update_tool_stn_unload.assert_called_once_with(50.0)
+
+    def test_changed_tool_after_extr_calls_update(self):
+        ext = _make_afc_extruder()
+        ext._update_tool_after_extr = MagicMock()
+        gcmd = self._make_gcmd(tool_stn=72.0, tool_stn_unload=100.0, tool_after=5.0, ext=ext)
+        ext.cmd_UPDATE_TOOLHEAD_SENSORS(gcmd)
+        ext._update_tool_after_extr.assert_called_once_with(5.0)
+
+
+# ── cmd_SAVE_EXTRUDER_VALUES ──────────────────────────────────────────────────
+
+class TestCmdSaveExtruderValues:
+    def test_saves_all_three_values(self):
+        ext = _make_afc_extruder()
+        ext.afc.function.ConfigRewrite = MagicMock()
+        ext.cmd_SAVE_EXTRUDER_VALUES(MagicMock())
+        calls = ext.afc.function.ConfigRewrite.call_args_list
+        keys = [c[0][1] for c in calls]
+        assert "tool_stn" in keys
+        assert "tool_stn_unload" in keys
+        assert "tool_sensor_after_extruder" in keys
+
+    def test_saves_with_correct_fullname(self):
+        ext = _make_afc_extruder("extruder")
+        ext.afc.function.ConfigRewrite = MagicMock()
+        ext.cmd_SAVE_EXTRUDER_VALUES(MagicMock())
+        for call in ext.afc.function.ConfigRewrite.call_args_list:
+            assert call[0][0] == "AFC_extruder extruder"
+
+
+# ── get_status ────────────────────────────────────────────────────────────────
+
+class TestGetStatus:
+    def test_returns_dict(self):
+        ext = _make_afc_extruder()
+        result = ext.get_status()
+        assert isinstance(result, dict)
+
+    def test_contains_tool_stn(self):
+        ext = _make_afc_extruder()
+        ext.tool_stn = 80.0
+        result = ext.get_status()
+        assert result["tool_stn"] == 80.0
+
+    def test_contains_tool_stn_unload(self):
+        ext = _make_afc_extruder()
+        ext.tool_stn_unload = 120.0
+        result = ext.get_status()
+        assert result["tool_stn_unload"] == 120.0
+
+    def test_contains_tool_sensor_after_extruder(self):
+        ext = _make_afc_extruder()
+        ext.tool_sensor_after_extruder = 5.0
+        result = ext.get_status()
+        assert result["tool_sensor_after_extruder"] == 5.0
+
+    def test_contains_speeds(self):
+        ext = _make_afc_extruder()
+        result = ext.get_status()
+        assert "tool_unload_speed" in result
+        assert "tool_load_speed" in result
+
+    def test_contains_sensor_states(self):
+        ext = _make_afc_extruder()
+        ext.tool_start_state = True
+        ext.tool_end_state = False
+        result = ext.get_status()
+        assert result["tool_start_status"] is True
+        assert result["tool_end_status"] is False
+
+    def test_contains_lane_loaded(self):
+        ext = _make_afc_extruder()
+        ext.lane_loaded = "lane1"
+        result = ext.get_status()
+        assert result["lane_loaded"] == "lane1"
+
+    def test_lanes_list_contains_lane_names(self):
+        ext = _make_afc_extruder()
+        lane = MagicMock()
+        lane.name = "lane1"
+        ext.lanes = {"lane1": lane}
+        result = ext.get_status()
+        assert "lane1" in result["lanes"]

--- a/tests/test_AFC_form_tip.py
+++ b/tests/test_AFC_form_tip.py
@@ -1,0 +1,322 @@
+"""
+Unit tests for extras/AFC_form_tip.py
+
+Covers:
+  - afc_tip_form attribute initialization
+  - cmd_GET_TIP_FORMING: output contains all config key names
+  - cmd_SET_TIP_FORMING: updates attributes from gcmd
+  - afc_extrude: delegates to afc.move_e_pos
+  - tip_form: calls afc_extrude the correct number of times based on config
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+import pytest
+
+from extras.AFC_form_tip import afc_tip_form
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_tip_form(values=None):
+    """Build an afc_tip_form instance by bypassing __init__."""
+    tip = afc_tip_form.__new__(afc_tip_form)
+
+    from tests.conftest import MockAFC, MockLogger
+
+    afc = MockAFC()
+    afc.logger = MockLogger()
+    afc.move_e_pos = MagicMock()
+
+    tip.printer = MagicMock()
+    tip.reactor = MagicMock()
+    tip.afc = afc
+    tip.gcode = afc.gcode
+    tip.logger = afc.logger
+
+    # Defaults matching the config defaults in afc_tip_form.__init__
+    tip.ramming_volume = 0.0
+    tip.toolchange_temp = 0.0
+    tip.unloading_speed_start = 80.0
+    tip.unloading_speed = 18.0
+    tip.cooling_tube_position = 35.0
+    tip.cooling_tube_length = 10.0
+    tip.initial_cooling_speed = 10.0
+    tip.final_cooling_speed = 50.0
+    tip.cooling_moves = 4
+    tip.use_skinnydip = False
+    tip.skinnydip_distance = 4.0
+    tip.dip_insertion_speed = 4.0
+    tip.dip_extraction_speed = 4.0
+    tip.melt_zone_pause = 4.0
+    tip.cooling_zone_pause = 4.0
+
+    if values:
+        for k, v in values.items():
+            setattr(tip, k, v)
+
+    return tip
+
+
+def _make_gcmd(**kwargs):
+    gcmd = MagicMock()
+    gcmd.get_float = lambda key, default: kwargs.get(key, default)
+    gcmd.get_int = lambda key, default: int(kwargs.get(key, default))
+    gcmd.get = lambda key, default: str(kwargs.get(key, default))
+    return gcmd
+
+
+# ── Attribute initialization ──────────────────────────────────────────────────
+
+class TestInitDefaults:
+    def test_ramming_volume_default(self):
+        tip = _make_tip_form()
+        assert tip.ramming_volume == 0.0
+
+    def test_cooling_moves_default(self):
+        tip = _make_tip_form()
+        assert tip.cooling_moves == 4
+
+    def test_use_skinnydip_default(self):
+        tip = _make_tip_form()
+        assert tip.use_skinnydip is False
+
+    def test_unloading_speed_default(self):
+        tip = _make_tip_form()
+        assert tip.unloading_speed == 18.0
+
+
+# ── cmd_GET_TIP_FORMING ───────────────────────────────────────────────────────
+
+class TestGetTipForming:
+    EXPECTED_KEYS = [
+        "ramming_volume",
+        "toolchange_temp",
+        "unloading_speed_start",
+        "unloading_speed",
+        "cooling_tube_position",
+        "cooling_tube_length",
+        "initial_cooling_speed",
+        "final_cooling_speed",
+        "cooling_moves",
+        "use_skinnydip",
+        "skinnydip_distance",
+        "dip_insertion_speed",
+        "dip_extraction_speed",
+        "melt_zone_pause",
+        "cooling_zone_pause",
+    ]
+
+    def test_all_keys_in_output(self):
+        tip = _make_tip_form()
+        gcmd = MagicMock()
+        tip.cmd_GET_TIP_FORMING(gcmd)
+        raw_msgs = [m for lvl, m in tip.logger.messages if lvl == "raw"]
+        combined = "\n".join(raw_msgs)
+        for key in self.EXPECTED_KEYS:
+            assert key in combined, f"Key '{key}' missing from GET_TIP_FORMING output"
+
+    def test_values_are_reflected(self):
+        tip = _make_tip_form({"ramming_volume": 42.0})
+        gcmd = MagicMock()
+        tip.cmd_GET_TIP_FORMING(gcmd)
+        raw_msgs = [m for lvl, m in tip.logger.messages if lvl == "raw"]
+        combined = "\n".join(raw_msgs)
+        assert "42.0" in combined
+
+
+# ── cmd_SET_TIP_FORMING ───────────────────────────────────────────────────────
+
+class TestSetTipForming:
+    def test_sets_ramming_volume(self):
+        tip = _make_tip_form()
+        gcmd = _make_gcmd(RAMMING_VOLUME=25.0)
+        tip.cmd_SET_TIP_FORMING(gcmd)
+        assert tip.ramming_volume == 25.0
+
+    def test_sets_cooling_moves(self):
+        tip = _make_tip_form()
+        gcmd = _make_gcmd(COOLING_MOVES=6)
+        tip.cmd_SET_TIP_FORMING(gcmd)
+        assert tip.cooling_moves == 6
+
+    def test_use_skinnydip_true_string(self):
+        tip = _make_tip_form()
+        gcmd = _make_gcmd(USE_SKINNYDIP="true")
+        tip.cmd_SET_TIP_FORMING(gcmd)
+        assert tip.use_skinnydip is True
+
+    def test_use_skinnydip_false_string(self):
+        tip = _make_tip_form()
+        tip.use_skinnydip = True
+        gcmd = _make_gcmd(USE_SKINNYDIP="False")
+        tip.cmd_SET_TIP_FORMING(gcmd)
+        assert tip.use_skinnydip is False
+
+    def test_sets_unloading_speed(self):
+        tip = _make_tip_form()
+        gcmd = _make_gcmd(UNLOADING_SPEED=20.0)
+        tip.cmd_SET_TIP_FORMING(gcmd)
+        assert tip.unloading_speed == 20.0
+
+    def test_unchanged_if_not_in_gcmd(self):
+        tip = _make_tip_form({"cooling_tube_length": 12.0})
+        gcmd = _make_gcmd()
+        tip.cmd_SET_TIP_FORMING(gcmd)
+        assert tip.cooling_tube_length == 12.0
+
+
+# ── afc_extrude ───────────────────────────────────────────────────────────────
+
+class TestAFCExtrude:
+    def test_delegates_to_afc_move_e_pos(self):
+        tip = _make_tip_form()
+        tip.afc_extrude(10.0, 5.0)
+        tip.afc.move_e_pos.assert_called_once_with(10.0, 5.0, "form tip")
+
+    def test_negative_distance_passes_through(self):
+        tip = _make_tip_form()
+        tip.afc_extrude(-20.0, 15.0)
+        tip.afc.move_e_pos.assert_called_once_with(-20.0, 15.0, "form tip")
+
+
+# ── tip_form ──────────────────────────────────────────────────────────────────
+
+class TestTipForm:
+    def _setup_toolhead(self, tip):
+        """Wire up toolhead and heaters mocks for tip_form()."""
+        toolhead = MagicMock()
+        extruder = MagicMock()
+        heater = MagicMock()
+        heater.target_temp = 200.0
+        extruder.get_heater.return_value = heater
+        toolhead.get_extruder.return_value = extruder
+        tip.afc.toolhead = toolhead
+        pheaters = MagicMock()
+        tip.printer.lookup_object = MagicMock(return_value=pheaters)
+        return pheaters, heater
+
+    def test_no_ramming_when_volume_zero(self):
+        tip = _make_tip_form()
+        tip.afc_extrude = MagicMock()
+        self._setup_toolhead(tip)
+        tip.tip_form()
+        # Without ramming_volume, only retraction + cooling moves happen
+        # Cooling moves: cooling_moves * 2 extrude calls
+        # Plus initial retraction calls
+        calls = tip.afc_extrude.call_count
+        assert calls > 0
+
+    def test_ramming_steps_called_when_volume_set(self):
+        tip = _make_tip_form({"ramming_volume": 23.0})
+        tip.afc_extrude = MagicMock()
+        self._setup_toolhead(tip)
+        tip.tip_form()
+        # 14 ramming steps + retraction + cooling moves
+        assert tip.afc_extrude.call_count > 14
+
+    def test_cooling_moves_call_count(self):
+        tip = _make_tip_form({"cooling_moves": 2})
+        tip.afc_extrude = MagicMock()
+        self._setup_toolhead(tip)
+        tip.tip_form()
+        # 2 cooling moves × 2 calls (forward + backward) = 4 cooling calls
+        # Plus at least 4 retraction calls
+        assert tip.afc_extrude.call_count >= 4
+
+    def test_skinnydip_called_when_enabled(self):
+        tip = _make_tip_form({"use_skinnydip": True})
+        tip.afc_extrude = MagicMock()
+        tip.reactor = MagicMock()
+        self._setup_toolhead(tip)
+        tip.tip_form()
+        # Skinnydip adds 2 more extrude calls
+        # Verify reactor.pause was called for melt and cooling zones
+        assert tip.reactor.pause.call_count >= 2
+
+    def test_logs_done_at_end(self):
+        tip = _make_tip_form()
+        tip.afc_extrude = MagicMock()
+        self._setup_toolhead(tip)
+        tip.tip_form()
+        info_msgs = [m for lvl, m in tip.logger.messages if lvl == "info"]
+        assert any("Done" in m for m in info_msgs)
+
+    def test_toolchange_temp_set_when_positive_no_skinnydip(self):
+        tip = _make_tip_form({"toolchange_temp": 150.0, "use_skinnydip": False})
+        tip.afc_extrude = MagicMock()
+        pheaters, heater = self._setup_toolhead(tip)
+        tip.tip_form()
+        # set_temperature should be called with toolchange_temp and wait=True
+        calls = pheaters.set_temperature.call_args_list
+        temp_calls = [c for c in calls if c[0][1] == 150.0]
+        assert len(temp_calls) >= 1
+        assert temp_calls[0][0][2] is True  # wait=True
+
+    def test_toolchange_temp_no_wait_when_skinnydip_enabled(self):
+        tip = _make_tip_form({"toolchange_temp": 150.0, "use_skinnydip": True})
+        tip.afc_extrude = MagicMock()
+        tip.reactor = MagicMock()
+        pheaters, heater = self._setup_toolhead(tip)
+        tip.tip_form()
+        calls = pheaters.set_temperature.call_args_list
+        temp_calls = [c for c in calls if c[0][1] == 150.0]
+        assert len(temp_calls) >= 1
+        assert temp_calls[0][0][2] is False  # wait=False
+
+    def test_temp_restored_when_heater_target_changed_during_tip_form(self):
+        tip = _make_tip_form({"toolchange_temp": 150.0})
+        tip.afc_extrude = MagicMock()
+        initial_temp = 200.0
+        heater = MagicMock()
+        heater.target_temp = initial_temp
+        extruder = MagicMock()
+        extruder.get_heater.return_value = heater
+        tip.afc.toolhead = MagicMock()
+        tip.afc.toolhead.get_extruder.return_value = extruder
+        pheaters = MagicMock()
+
+        def update_temp(heater_obj, temp, wait=True):
+            heater_obj.target_temp = temp
+
+        pheaters.set_temperature.side_effect = update_temp
+        tip.printer.lookup_object = MagicMock(return_value=pheaters)
+        tip.tip_form()
+        # Last set_temperature call should restore original temp
+        assert pheaters.set_temperature.call_count >= 2
+        last_call = pheaters.set_temperature.call_args_list[-1]
+        assert last_call[0][1] == initial_temp
+
+    def test_cmd_test_tip_forming_calls_tip_form(self):
+        tip = _make_tip_form()
+        tip.tip_form = MagicMock()
+        gcmd = MagicMock()
+        tip.cmd_TEST_AFC_TIP_FORMING(gcmd)
+        tip.tip_form.assert_called_once()
+
+
+# ── __init__ via MockConfig ───────────────────────────────────────────────────
+
+class TestFormTipInit:
+    def test_init_from_config_sets_defaults(self):
+        from tests.conftest import MockConfig, MockPrinter, MockAFC
+        afc = MockAFC()
+        printer = MockPrinter(afc=afc)
+        config = MockConfig(printer=printer)
+        tip = afc_tip_form(config)
+        assert tip.ramming_volume == 0.0
+        assert tip.cooling_moves == 4
+        assert tip.use_skinnydip is False
+
+    def test_init_from_config_reads_custom_values(self):
+        from tests.conftest import MockConfig, MockPrinter, MockAFC
+        afc = MockAFC()
+        printer = MockPrinter(afc=afc)
+        config = MockConfig(printer=printer, values={
+            "ramming_volume": 15.0,
+            "cooling_moves": 6,
+        })
+        tip = afc_tip_form(config)
+        assert tip.ramming_volume == 15.0
+        assert tip.cooling_moves == 6

--- a/tests/test_AFC_functions.py
+++ b/tests/test_AFC_functions.py
@@ -1,0 +1,329 @@
+"""
+Unit tests for extras/AFC_functions.py
+
+Covers:
+  - HexConvert: comma-separated RGBA float string → "#rrggbb"
+  - HexToLedString: hex string → comma-separated float list
+  - _get_led_indexes: "1-4,9,10" → [1,2,3,4,9,10]
+  - _calc_length: bowden length arithmetic (reset / +/- / direct)
+  - check_macro_present: detects macro in gcode handlers
+  - get_filament_status: returns correct status string for lane state
+  - afcDeltaTime: timing delta helper class
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+import pytest
+
+from extras.AFC_functions import afcFunction, afcDeltaTime
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_func():
+    """Build an afcFunction instance bypassing __init__."""
+    func = afcFunction.__new__(afcFunction)
+
+    from tests.conftest import MockAFC, MockLogger
+
+    afc = MockAFC()
+    func.afc = afc
+    func.logger = MockLogger()
+    func.printer = MagicMock()
+    func.config = MagicMock()
+    func.auto_var_file = None
+    func.errorLog = {}
+    func.pause = False
+    func.mcu = MagicMock()
+    return func
+
+
+# ── HexConvert ────────────────────────────────────────────────────────────────
+
+class TestHexConvert:
+    def test_full_brightness_red(self):
+        func = _make_func()
+        result = func.HexConvert("1,0,0")
+        assert result == "#ff0000"
+
+    def test_full_brightness_green(self):
+        func = _make_func()
+        result = func.HexConvert("0,1,0")
+        assert result == "#00ff00"
+
+    def test_full_brightness_blue(self):
+        func = _make_func()
+        result = func.HexConvert("0,0,1")
+        assert result == "#0000ff"
+
+    def test_all_zeros_black(self):
+        func = _make_func()
+        result = func.HexConvert("0,0,0")
+        assert result == "#000000"
+
+    def test_half_red(self):
+        func = _make_func()
+        result = func.HexConvert("0.5,0,0")
+        # 0.5 * 255 = 127 → 0x7f
+        assert result == "#7f0000"
+
+    def test_white_no_w_channel(self):
+        func = _make_func()
+        # Only first 3 channels used in HexConvert
+        result = func.HexConvert("1,1,1")
+        assert result == "#ffffff"
+
+    def test_returns_string_starting_with_hash(self):
+        func = _make_func()
+        result = func.HexConvert("1,0.5,0")
+        assert result.startswith("#")
+        assert len(result) == 7
+
+
+# ── HexToLedString ────────────────────────────────────────────────────────────
+
+class TestHexToLedString:
+    def test_black_returns_all_zeros(self):
+        func = _make_func()
+        result = func.HexToLedString("000000")
+        assert result[0] == pytest.approx(0.0)
+        assert result[1] == pytest.approx(0.0)
+        assert result[2] == pytest.approx(0.0)
+
+    def test_white_sets_w_channel(self):
+        func = _make_func()
+        result = func.HexToLedString("FFFFFF")
+        assert result[3] == 1.0
+
+    def test_red_channel(self):
+        func = _make_func()
+        result = func.HexToLedString("FF0000")
+        assert result[0] == pytest.approx(1.0)
+        assert result[1] == pytest.approx(0.0)
+        assert result[2] == pytest.approx(0.0)
+
+    def test_non_white_sets_w_zero(self):
+        func = _make_func()
+        result = func.HexToLedString("FF0000")
+        assert result[3] == 0.0
+
+    def test_returns_four_values(self):
+        func = _make_func()
+        result = func.HexToLedString("123456")
+        assert len(result) == 4
+
+
+# ── _get_led_indexes ──────────────────────────────────────────────────────────
+
+class TestGetLedIndexes:
+    def test_single_index(self):
+        func = _make_func()
+        assert func._get_led_indexes("5") == [5]
+
+    def test_range_expands(self):
+        func = _make_func()
+        assert func._get_led_indexes("1-4") == [1, 2, 3, 4]
+
+    def test_comma_separated(self):
+        func = _make_func()
+        assert func._get_led_indexes("9,10") == [9, 10]
+
+    def test_range_and_singles(self):
+        func = _make_func()
+        assert func._get_led_indexes("1-4,9,10") == [1, 2, 3, 4, 9, 10]
+
+    def test_single_element_range(self):
+        func = _make_func()
+        assert func._get_led_indexes("3-3") == [3]
+
+
+# ── _calc_length ──────────────────────────────────────────────────────────────
+
+class TestCalcLength:
+    def test_reset_returns_config_length(self):
+        func = _make_func()
+        result = func._calc_length(500.0, 600.0, "reset")
+        assert result == 500.0
+
+    def test_reset_case_insensitive(self):
+        func = _make_func()
+        result = func._calc_length(500.0, 600.0, "RESET")
+        assert result == 500.0
+
+    def test_positive_delta(self):
+        func = _make_func()
+        result = func._calc_length(500.0, 600.0, "+50")
+        assert result == pytest.approx(650.0)
+
+    def test_negative_delta(self):
+        func = _make_func()
+        result = func._calc_length(500.0, 600.0, "-100")
+        assert result == pytest.approx(500.0)
+
+    def test_direct_value(self):
+        func = _make_func()
+        result = func._calc_length(500.0, 600.0, "750")
+        assert result == pytest.approx(750.0)
+
+    def test_invalid_delta_returns_current(self):
+        func = _make_func()
+        result = func._calc_length(500.0, 600.0, "+abc")
+        assert result == 600.0
+
+
+# ── check_macro_present ───────────────────────────────────────────────────────
+
+class TestCheckMacroPresentFunction:
+    def test_returns_true_when_macro_exists(self):
+        func = _make_func()
+        func.afc.gcode.ready_gcode_handlers = {"MY_MACRO": MagicMock()}
+        assert func.check_macro_present("MY_MACRO") is True
+
+    def test_returns_false_when_macro_missing(self):
+        func = _make_func()
+        func.afc.gcode.ready_gcode_handlers = {}
+        assert func.check_macro_present("MISSING_MACRO") is False
+
+    def test_returns_false_when_no_handlers_attr(self):
+        func = _make_func()
+        # gcode has no ready_gcode_handlers attr
+        if hasattr(func.afc.gcode, "ready_gcode_handlers"):
+            del func.afc.gcode.ready_gcode_handlers
+        assert func.check_macro_present("ANYTHING") is False
+
+
+# ── get_filament_status ───────────────────────────────────────────────────────
+
+class TestGetFilamentStatus:
+    def _make_lane(self, prep=False, load=False, tool_loaded=False):
+        lane = MagicMock()
+        lane.prep_state = prep
+        lane.load_state = load
+        lane.name = "lane1"
+        lane.led_tool_loaded = "0,1,0,0"
+        lane.led_ready = "0,1,0,0"
+        lane.led_prep_loaded = "0,0.5,0,0"
+        lane.led_not_ready = "0,0,0,0.25"
+        lane.material = "PLA"
+        if tool_loaded:
+            ext = MagicMock()
+            ext.lane_loaded = "lane1"
+            lane.extruder_obj = ext
+        else:
+            if lane.extruder_obj:
+                lane.extruder_obj.lane_loaded = ""
+        return lane
+
+    def test_not_ready_when_not_prep(self):
+        func = _make_func()
+        lane = self._make_lane(prep=False, load=False)
+        status = func.get_filament_status(lane)
+        assert "Not Ready" in status
+
+    def test_prep_only_when_prep_no_load(self):
+        func = _make_func()
+        lane = self._make_lane(prep=True, load=False)
+        status = func.get_filament_status(lane)
+        assert "Prep" in status
+
+    def test_ready_when_prep_and_load(self):
+        func = _make_func()
+        lane = self._make_lane(prep=True, load=True, tool_loaded=False)
+        lane.extruder_obj = MagicMock()
+        lane.extruder_obj.lane_loaded = "other_lane"
+        status = func.get_filament_status(lane)
+        assert "Ready" in status
+
+    def test_in_tool_when_tool_loaded(self):
+        func = _make_func()
+        lane = self._make_lane(prep=True, load=True, tool_loaded=True)
+        status = func.get_filament_status(lane)
+        assert "In Tool" in status
+
+
+# ── afcDeltaTime ──────────────────────────────────────────────────────────────
+
+class TestAfcDeltaTime:
+    def _make_delta(self):
+        from tests.conftest import MockAFC
+        afc = MockAFC()
+        return afcDeltaTime(afc)
+
+    def test_set_start_time_sets_start(self):
+        dt = self._make_delta()
+        dt.set_start_time()
+        assert dt.start_time is not None
+
+    def test_set_start_time_sets_last_time(self):
+        dt = self._make_delta()
+        dt.set_start_time()
+        assert dt.last_time is not None
+
+    def test_log_with_time_logs_message(self):
+        dt = self._make_delta()
+        dt.set_start_time()
+        dt.log_with_time("test message", debug=True)
+        debug_msgs = [m for lvl, m in dt.logger.messages if lvl == "debug"]
+        assert any("test message" in m for m in debug_msgs)
+
+    def test_log_with_time_includes_delta(self):
+        dt = self._make_delta()
+        dt.set_start_time()
+        dt.log_with_time("delta check", debug=False)
+        info_msgs = [m for lvl, m in dt.logger.messages if lvl == "info"]
+        assert any("delta check" in m for m in info_msgs)
+
+    def test_log_total_time_returns_float(self):
+        dt = self._make_delta()
+        dt.set_start_time()
+        result = dt.log_total_time("total")
+        assert isinstance(result, float)
+        assert result >= 0.0
+
+    def test_log_major_delta_returns_float(self):
+        dt = self._make_delta()
+        dt.set_start_time()
+        result = dt.log_major_delta("major delta")
+        assert isinstance(result, float)
+        assert result >= 0.0
+
+    def test_log_with_time_before_set_start_does_not_raise(self):
+        dt = self._make_delta()
+        dt.start_time = None
+        dt.last_time = None
+        # Should not raise (caught internally)
+        dt.log_with_time("safe call")
+
+
+# ── _rename ───────────────────────────────────────────────────────────────────
+
+class TestRename:
+    def test_rename_calls_register_command_for_base(self):
+        func = _make_func()
+        func.afc.gcode.register_command = MagicMock(return_value=MagicMock())
+        mock_func = MagicMock()
+        func._rename("RESUME", "_AFC_RENAMED_RESUME_", mock_func, "help text")
+        calls = func.afc.gcode.register_command.call_args_list
+        # Should call at least: register_command("RESUME", None) and
+        # register_command("RESUME", mock_func, ...)
+        names = [c[0][0] for c in calls]
+        assert "RESUME" in names
+
+    def test_rename_registers_afc_function_under_base_name(self):
+        func = _make_func()
+        mock_func = MagicMock()
+        prev_cmd = MagicMock()
+        # _rename calls register_command 3 times: unregister, re-register old, register new
+        func.afc.gcode.register_command = MagicMock(side_effect=[prev_cmd, None, None])
+        func._rename("RESUME", "_AFC_RENAMED_RESUME_", mock_func, "help")
+        final_call = func.afc.gcode.register_command.call_args_list[-1]
+        assert final_call[0][1] is mock_func
+
+    def test_rename_logs_debug_when_command_not_found(self):
+        func = _make_func()
+        func.afc.gcode.register_command = MagicMock(return_value=None)
+        func._rename("RESUME", "_AFC_RENAMED_RESUME_", MagicMock(), "help")
+        debug_msgs = [m for lvl, m in func.logger.messages if lvl == "debug"]
+        assert any("RESUME" in m for m in debug_msgs)

--- a/tests/test_AFC_hub.py
+++ b/tests/test_AFC_hub.py
@@ -1,0 +1,392 @@
+"""
+Unit tests for extras/AFC_hub.py
+
+Covers:
+  - afc_hub.get_status: returns dict with expected keys and correct values
+  - afc_hub.state property: physical vs virtual hub sensor
+  - afc_hub.switch_pin_callback: updates internal _state
+  - afc_hub.__str__: returns name
+  - afc_hub.handle_runout: only triggers for the currently-loaded lane
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+import pytest
+
+from extras.AFC_hub import afc_hub
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_hub(switch_pin="PA0", name="test_hub", extra_values=None):
+    """Build an afc_hub instance by bypassing __init__ and setting attrs."""
+    hub = afc_hub.__new__(afc_hub)
+
+    from tests.conftest import MockAFC, MockPrinter, MockReactor, MockLogger
+
+    afc = MockAFC()
+    reactor = MockReactor()
+    printer = MockPrinter(afc=afc)
+    printer._reactor = reactor
+
+    hub.printer = printer
+    hub.afc = afc
+    hub.reactor = reactor
+    hub.gcode = afc.gcode
+
+    hub.fullname = f"AFC_hub {name}"
+    hub.name = name
+    hub.unit = None
+    hub.lanes = {}
+    hub._state = False
+    hub.switch_pin = switch_pin
+
+    # Default config values
+    hub.hub_clear_move_dis = 65.0
+    hub.afc_bowden_length = 900.0
+    hub.td1_bowden_length = 850.0
+    hub.afc_unload_bowden_length = 900.0
+    hub.assisted_retract = False
+    hub.move_dis = 75.0
+    hub.cut = False
+    hub.cut_cmd = None
+    hub.cut_servo_name = "cut"
+    hub.cut_dist = 50.0
+    hub.cut_clear = 120.0
+    hub.cut_min_length = 200.0
+    hub.cut_servo_pass_angle = 0.0
+    hub.cut_servo_clip_angle = 160.0
+    hub.cut_servo_prep_angle = 75.0
+    hub.cut_confirm = False
+    hub.config_bowden_length = hub.afc_bowden_length
+    hub.config_unload_bowden_length = hub.afc_unload_bowden_length
+    hub.enable_sensors_in_gui = False
+    hub.debounce_delay = 0.1
+    hub.enable_runout = False
+
+    # Filament sensor mock (used in handle_runout)
+    hub.fila = MagicMock()
+    hub.fila.runout_helper.min_event_systime = 0.0
+    hub.fila.runout_helper.event_delay = 0.5
+    hub.debounce_button = MagicMock()
+
+    if extra_values:
+        for k, v in extra_values.items():
+            setattr(hub, k, v)
+
+    return hub
+
+
+# ── __str__ ───────────────────────────────────────────────────────────────────
+
+class TestAFCHubStr:
+    def test_str_returns_name(self):
+        hub = _make_hub(name="hub1")
+        assert str(hub) == "hub1"
+
+
+# ── switch_pin_callback ───────────────────────────────────────────────────────
+
+class TestSwitchPinCallback:
+    def test_callback_sets_state_true(self):
+        hub = _make_hub()
+        hub.switch_pin_callback(100.0, True)
+        assert hub._state is True
+
+    def test_callback_sets_state_false(self):
+        hub = _make_hub()
+        hub._state = True
+        hub.switch_pin_callback(101.0, False)
+        assert hub._state is False
+
+
+# ── state property ────────────────────────────────────────────────────────────
+
+class TestStateProperty:
+    def test_physical_switch_returns_internal_state(self):
+        hub = _make_hub(switch_pin="PA0")
+        hub._state = True
+        assert hub.state is True
+
+    def test_physical_switch_false(self):
+        hub = _make_hub(switch_pin="PA0")
+        hub._state = False
+        assert hub.state is False
+
+    def test_virtual_hub_true_when_any_lane_load_state_true(self):
+        hub = _make_hub(switch_pin="virtual")
+        lane1 = MagicMock()
+        lane1.raw_load_state = False
+        lane2 = MagicMock()
+        lane2.raw_load_state = True
+        hub.lanes = {"lane1": lane1, "lane2": lane2}
+        assert hub.state is True
+
+    def test_virtual_hub_false_when_all_lanes_not_loaded(self):
+        hub = _make_hub(switch_pin="virtual")
+        lane1 = MagicMock()
+        lane1.raw_load_state = False
+        lane2 = MagicMock()
+        lane2.raw_load_state = False
+        hub.lanes = {"lane1": lane1, "lane2": lane2}
+        assert hub.state is False
+
+    def test_virtual_hub_false_when_no_lanes(self):
+        hub = _make_hub(switch_pin="virtual")
+        hub.lanes = {}
+        assert hub.state is False
+
+
+# ── get_status ────────────────────────────────────────────────────────────────
+
+class TestGetStatus:
+    def test_get_status_returns_dict(self):
+        hub = _make_hub()
+        result = hub.get_status()
+        assert isinstance(result, dict)
+
+    def test_get_status_contains_state(self):
+        hub = _make_hub()
+        hub._state = False
+        result = hub.get_status()
+        assert "state" in result
+        assert result["state"] is False
+
+    def test_get_status_cut_flag(self):
+        hub = _make_hub()
+        hub.cut = True
+        result = hub.get_status()
+        assert result["cut"] is True
+
+    def test_get_status_cut_cmd_default_none(self):
+        hub = _make_hub()
+        result = hub.get_status()
+        assert result["cut_cmd"] is None
+
+    def test_get_status_bowden_length(self):
+        hub = _make_hub()
+        hub.afc_bowden_length = 1200.0
+        result = hub.get_status()
+        assert result["afc_bowden_length"] == 1200.0
+
+    def test_get_status_lanes_list(self):
+        hub = _make_hub()
+        lane1 = MagicMock()
+        lane1.name = "lane1"
+        lane2 = MagicMock()
+        lane2.name = "lane2"
+        hub.lanes = {"lane1": lane1, "lane2": lane2}
+        result = hub.get_status()
+        assert set(result["lanes"]) == {"lane1", "lane2"}
+
+    def test_get_status_servo_angles(self):
+        hub = _make_hub()
+        hub.cut_servo_pass_angle = 10.0
+        hub.cut_servo_clip_angle = 170.0
+        hub.cut_servo_prep_angle = 80.0
+        result = hub.get_status()
+        assert result["cut_servo_pass_angle"] == 10.0
+        assert result["cut_servo_clip_angle"] == 170.0
+        assert result["cut_servo_prep_angle"] == 80.0
+
+    def test_get_status_cut_distances(self):
+        hub = _make_hub()
+        hub.cut_dist = 60.0
+        hub.cut_clear = 130.0
+        hub.cut_min_length = 250.0
+        result = hub.get_status()
+        assert result["cut_dist"] == 60.0
+        assert result["cut_clear"] == 130.0
+        assert result["cut_min_length"] == 250.0
+
+
+# ── handle_runout ─────────────────────────────────────────────────────────────
+
+class TestHandleRunout:
+    def test_runout_triggers_current_lane_in_hub(self):
+        hub = _make_hub()
+        lane = MagicMock()
+        hub.lanes = {"lane1": lane}
+        hub.afc.current = "lane1"
+        hub.handle_runout(100.0)
+        lane.handle_hub_runout.assert_called_once_with(sensor=hub.name)
+
+    def test_runout_does_not_trigger_if_current_lane_not_in_hub(self):
+        hub = _make_hub()
+        lane = MagicMock()
+        hub.lanes = {"lane1": lane}
+        hub.afc.current = "lane2"  # Different lane
+        hub.handle_runout(100.0)
+        lane.handle_hub_runout.assert_not_called()
+
+    def test_runout_does_not_trigger_when_no_current(self):
+        hub = _make_hub()
+        lane = MagicMock()
+        hub.lanes = {"lane1": lane}
+        hub.afc.current = None
+        hub.handle_runout(100.0)
+        lane.handle_hub_runout.assert_not_called()
+
+    def test_runout_updates_min_event_systime(self):
+        hub = _make_hub()
+        hub.lanes = {}
+        hub.afc.current = None
+        initial_time = hub.fila.runout_helper.min_event_systime
+        hub.handle_runout(150.0)
+        # min_event_systime should be updated to monotonic + event_delay
+        assert hub.fila.runout_helper.min_event_systime != initial_time
+
+
+# ── handle_connect ────────────────────────────────────────────────────────────
+
+class TestHandleConnect:
+    def test_physical_hub_handle_connect_does_not_raise(self):
+        hub = _make_hub(switch_pin="PA0")
+        # physical pin — no lane validation needed
+        hub.handle_connect()  # should not raise
+        assert hub.gcode is hub.afc.gcode
+
+    def test_virtual_hub_raises_when_lanes_have_no_load_sensor(self):
+        from configparser import Error as config_error
+        hub = _make_hub(switch_pin="virtual")
+        lane = MagicMock()
+        lane.fullname = "AFC_stepper lane1"
+        lane.load = None  # no load sensor
+        hub.lanes = {"lane1": lane}
+        with pytest.raises(config_error):
+            hub.handle_connect()
+
+    def test_virtual_hub_no_error_when_all_lanes_have_load_sensor(self):
+        hub = _make_hub(switch_pin="virtual")
+        lane = MagicMock()
+        lane.fullname = "AFC_stepper lane1"
+        lane.load = MagicMock()  # has load sensor
+        hub.lanes = {"lane1": lane}
+        hub.handle_connect()  # should not raise
+
+    def test_handle_connect_sends_register_macros_event(self):
+        hub = _make_hub(switch_pin="PA0")
+        hub.handle_connect()
+        # Verify the event was dispatched (MockPrinter records handlers)
+        # send_event on MockPrinter calls registered handlers — no assert needed
+        # if we got here without error, the event path ran
+        assert True
+
+
+# ── afc_hub.__init__ ──────────────────────────────────────────────────────────
+
+class TestAFCHubInit:
+    def test_virtual_hub_init_does_not_call_add_filament_switch(self):
+        from tests.conftest import MockConfig, MockPrinter, MockAFC
+        afc = MockAFC()
+        printer = MockPrinter(afc=afc)
+        config = MockConfig(
+            name="AFC_hub test_hub", printer=printer,
+            values={"switch_pin": "virtual", "afc_bowden_length": 900.0}
+        )
+        with patch("extras.AFC_hub.add_filament_switch") as mock_afs:
+            hub = afc_hub(config)
+        mock_afs.assert_not_called()
+
+    def test_virtual_hub_init_registers_hub_in_afc(self):
+        from tests.conftest import MockConfig, MockPrinter, MockAFC
+        afc = MockAFC()
+        printer = MockPrinter(afc=afc)
+        config = MockConfig(
+            name="AFC_hub my_hub", printer=printer,
+            values={"switch_pin": "virtual"}
+        )
+        hub = afc_hub(config)
+        assert "my_hub" in afc.hubs
+
+    def test_virtual_hub_sets_name_from_config(self):
+        from tests.conftest import MockConfig, MockPrinter, MockAFC
+        afc = MockAFC()
+        printer = MockPrinter(afc=afc)
+        config = MockConfig(
+            name="AFC_hub hub_one", printer=printer,
+            values={"switch_pin": "virtual"}
+        )
+        hub = afc_hub(config)
+        assert hub.name == "hub_one"
+
+    def test_physical_hub_init_calls_add_filament_switch(self):
+        from tests.conftest import MockConfig, MockPrinter, MockAFC
+        afc = MockAFC()
+        printer = MockPrinter(afc=afc)
+        config = MockConfig(
+            name="AFC_hub phys_hub", printer=printer,
+            values={"switch_pin": "PA0"}
+        )
+        with patch("extras.AFC_hub.add_filament_switch") as mock_afs:
+            mock_afs.return_value = (MagicMock(), MagicMock())
+            hub = afc_hub(config)
+        mock_afs.assert_called_once()
+
+    def test_physical_hub_registers_button_callback(self):
+        from tests.conftest import MockConfig, MockPrinter, MockAFC
+        afc = MockAFC()
+        printer = MockPrinter(afc=afc)
+        buttons_mock = MagicMock()
+        printer._objects["buttons"] = buttons_mock
+        config = MockConfig(
+            name="AFC_hub phys_hub", printer=printer,
+            values={"switch_pin": "PA0"}
+        )
+        with patch("extras.AFC_hub.add_filament_switch") as mock_afs:
+            mock_afs.return_value = (MagicMock(), MagicMock())
+            hub = afc_hub(config)
+        buttons_mock.register_buttons.assert_called_once()
+
+
+# ── hub_cut ───────────────────────────────────────────────────────────────────
+
+class TestHubCut:
+    def test_hub_cut_no_confirm_runs_servo_commands(self):
+        from unittest.mock import PropertyMock
+        hub = _make_hub(switch_pin="PA0")
+        hub.cut_confirm = False
+        cur_lane = MagicMock()
+        # Sequence: loop1 enter(F), loop1 exit(T), loop2 enter(T), loop2 exit(F),
+        #           loop3 enter(F), loop3 exit(T)
+        type(hub).state = PropertyMock(side_effect=[False, True, True, False, False, True])
+        hub.hub_cut(cur_lane)
+        # Should call run_script_from_command for prep, clip, and pass angles
+        calls = hub.gcode.run_script_from_command.call_args_list
+        assert len(calls) >= 3  # prep + clip + pass
+
+    def test_hub_cut_no_confirm_calls_correct_servo_angles(self):
+        from unittest.mock import PropertyMock
+        hub = _make_hub(switch_pin="PA0")
+        hub.cut_confirm = False
+        cur_lane = MagicMock()
+        type(hub).state = PropertyMock(side_effect=[False, True, True, False, False, True])
+        hub.hub_cut(cur_lane)
+        calls = [c[0][0] for c in hub.gcode.run_script_from_command.call_args_list]
+        assert any(str(hub.cut_servo_prep_angle) in c for c in calls)
+        assert any(str(hub.cut_servo_clip_angle) in c for c in calls)
+        assert any(str(hub.cut_servo_pass_angle) in c for c in calls)
+
+    def test_hub_cut_with_confirm_runs_extra_servo_commands(self):
+        from unittest.mock import PropertyMock
+        hub = _make_hub(switch_pin="PA0")
+        hub.cut_confirm = True
+        cur_lane = MagicMock()
+        type(hub).state = PropertyMock(side_effect=[False, True, True, False, False, True])
+        hub.hub_cut(cur_lane)
+        # With confirm: prep + clip + prep + clip + pass = 5 calls
+        calls = hub.gcode.run_script_from_command.call_args_list
+        assert len(calls) >= 5
+
+    def test_hub_cut_retracts_filament_after_cut(self):
+        from unittest.mock import PropertyMock
+        hub = _make_hub(switch_pin="PA0")
+        hub.cut_confirm = False
+        cur_lane = MagicMock()
+        type(hub).state = PropertyMock(side_effect=[False, True, True, False, False, True])
+        hub.hub_cut(cur_lane)
+        # Last move should be negative (retract by cut_clear)
+        all_move_calls = cur_lane.move.call_args_list
+        last_call_dist = all_move_calls[-1][0][0]
+        assert last_call_dist < 0  # negative = retract

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -1,0 +1,827 @@
+"""
+Unit tests for extras/AFC_lane.py
+
+Covers:
+  - SpeedMode enum values
+  - AssistActive enum values
+  - MoveDirection float constants
+  - AFCLaneState string constants
+  - AFCHomingPoints string constants
+  - AFCLane instantiation and attribute initialization
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+import pytest
+
+from extras.AFC_lane import (
+    SpeedMode,
+    AssistActive,
+    MoveDirection,
+    AFCLaneState,
+    AFCHomingPoints,
+    AFCLane,
+    EXCLUDE_TYPES,
+    AFCMoveWarning
+)
+from extras.AFC_stepper import AFCExtruderStepper
+
+
+# ── SpeedMode ─────────────────────────────────────────────────────────────────
+
+class TestSpeedMode:
+    def test_none_value_is_python_none(self):
+        assert SpeedMode.NONE.value is None
+
+    def test_long_value(self):
+        assert SpeedMode.LONG.value == 1
+
+    def test_short_value(self):
+        assert SpeedMode.SHORT.value == 2
+
+    def test_hub_value(self):
+        assert SpeedMode.HUB.value == 3
+
+    def test_night_value(self):
+        assert SpeedMode.NIGHT.value == 4
+
+    def test_calibration_value(self):
+        assert SpeedMode.CALIBRATION.value == 5
+    
+    def test_dist_hub_value(self):
+        assert SpeedMode.DIST_HUB.value == 6
+
+    def test_all_members_unique(self):
+        values = [m.value for m in SpeedMode if m.value is not None]
+        assert len(values) == len(set(values))
+
+    def test_comparison_equal(self):
+        assert SpeedMode.LONG == SpeedMode.LONG
+
+    def test_comparison_not_equal(self):
+        assert SpeedMode.LONG != SpeedMode.SHORT
+
+
+# ── AssistActive ──────────────────────────────────────────────────────────────
+
+class TestAssistActive:
+    def test_yes_value(self):
+        assert AssistActive.YES.value == 1
+
+    def test_no_value(self):
+        assert AssistActive.NO.value == 2
+
+    def test_dynamic_value(self):
+        assert AssistActive.DYNAMIC.value == 3
+
+    def test_members_count(self):
+        assert len(list(AssistActive)) == 3
+
+
+# ── MoveDirection ─────────────────────────────────────────────────────────────
+
+class TestMoveDirection:
+    def test_pos_is_positive_one(self):
+        assert MoveDirection.POS == 1.0
+
+    def test_neg_is_negative_one(self):
+        assert MoveDirection.NEG == -1.0
+
+    def test_pos_is_float_subclass(self):
+        assert isinstance(MoveDirection.POS, float)
+
+    def test_neg_is_float_subclass(self):
+        assert isinstance(MoveDirection.NEG, float)
+
+    def test_multiplication_with_distance(self):
+        dist = 50.0
+        assert dist * MoveDirection.POS == 50.0
+        assert dist * MoveDirection.NEG == -50.0
+
+
+# ── AFCLaneState ──────────────────────────────────────────────────────────────
+
+class TestAFCLaneState:
+    def test_none_constant(self):
+        assert AFCLaneState.NONE == "None"
+
+    def test_error_constant(self):
+        assert AFCLaneState.ERROR == "Error"
+
+    def test_loaded_constant(self):
+        assert AFCLaneState.LOADED == "Loaded"
+
+    def test_tooled_constant(self):
+        assert AFCLaneState.TOOLED == "Tooled"
+
+    def test_tool_loaded_constant(self):
+        assert AFCLaneState.TOOL_LOADED == "Tool Loaded"
+
+    def test_tool_loading_constant(self):
+        assert AFCLaneState.TOOL_LOADING == "Tool Loading"
+
+    def test_tool_unloading_constant(self):
+        assert AFCLaneState.TOOL_UNLOADING == "Tool Unloading"
+
+    def test_hub_loading_constant(self):
+        assert AFCLaneState.HUB_LOADING == "HUB Loading"
+
+    def test_ejecting_constant(self):
+        assert AFCLaneState.EJECTING == "Ejecting"
+
+    def test_calibrating_constant(self):
+        assert AFCLaneState.CALIBRATING == "Calibrating"
+
+    def test_all_constants_are_strings(self):
+        attrs = [a for a in dir(AFCLaneState) if not a.startswith("_")]
+        for attr in attrs:
+            assert isinstance(getattr(AFCLaneState, attr), str)
+
+    def test_all_constants_unique(self):
+        attrs = [a for a in dir(AFCLaneState) if not a.startswith("_")]
+        values = [getattr(AFCLaneState, a) for a in attrs]
+        assert len(values) == len(set(values))
+
+
+# ── AFCHomingPoints ───────────────────────────────────────────────────────────
+
+class TestAFCHomingPoints:
+    def test_none_constant(self):
+        assert AFCHomingPoints.NONE is None
+
+    def test_hub_constant(self):
+        assert AFCHomingPoints.HUB == "hub"
+
+    def test_load_constant(self):
+        assert AFCHomingPoints.LOAD == "load"
+
+    def test_tool_constant(self):
+        assert AFCHomingPoints.TOOL == "tool"
+
+    def test_tool_start_constant(self):
+        assert AFCHomingPoints.TOOL_START == "tool_start"
+
+    def test_buffer_constant(self):
+        assert AFCHomingPoints.BUFFER == "buffer"
+
+    def test_buffer_trail_constant(self):
+        assert AFCHomingPoints.BUFFER_TRAIL == "buffer_trailing"
+
+
+# ── EXCLUDE_TYPES ──────────────────────────────────────────────────────────────
+
+class TestExcludeTypes:
+    def test_htlf_in_exclude_types(self):
+        assert "HTLF" in EXCLUDE_TYPES
+
+    def test_vivid_in_exclude_types(self):
+        assert "ViViD" in EXCLUDE_TYPES
+
+
+# ── AFCLane initialization ────────────────────────────────────────────────────
+# AFCLane.__init__ is tightly coupled to Klipper's runtime; we bypass it with
+# __new__ and set attributes to their documented initial values.
+
+def _make_afc_lane(fullname="AFC_stepper lane1"):
+    """Build an AFCLane bypassing the complex __init__."""
+    lane = AFCLane.__new__(AFCLane)
+    parts = fullname.split()
+    lane.fullname = fullname
+    lane.name = parts[-1]
+    lane.afc = MagicMock()
+    lane.unit = "Turtle_1"
+    lane.unit_obj = MagicMock()
+    lane.hub_obj = None
+    lane.buffer_obj = None
+    lane.extruder_obj = MagicMock()
+    lane.endstops = {}
+    lane.espooler = MagicMock()
+    lane.espooler.assist.return_value = False
+    lane.hub = "PB1"
+    lane.get_toolhead_pre_sensor_state = MagicMock()
+    lane.weight = 1000
+    lane.empty_spool_weight = 200
+    lane.filament_density = 1.24
+    lane.filament_diameter = 1.75
+    lane.inner_diameter = 75
+    lane.outer_diameter = 200
+    lane.max_motor_rpm = 500
+    lane.rwd_speed_multi = 0.5
+    lane.fwd_speed_multi = 0.5
+    lane.drive_stepper = None
+    lane.dist_hub = 900
+    lane.remember_spool = False
+    lane.short_moves_speed = 50
+    lane.short_moves_accel = 100
+    return lane
+
+
+class TestAFCLaneInit:
+    def test_lane_name_extracted_from_fullname(self):
+        lane = _make_afc_lane("AFC_stepper lane1")
+        assert lane.name == "lane1"
+
+    def test_lane_fullname_stored(self):
+        lane = _make_afc_lane("AFC_stepper lane1")
+        assert lane.fullname == "AFC_stepper lane1"
+
+    def test_initial_unit_obj_is_not_none(self):
+        lane = _make_afc_lane()
+        assert lane.unit_obj is not None
+
+    def test_initial_hub_obj_is_none(self):
+        lane = _make_afc_lane()
+        assert lane.hub_obj is None
+
+    def test_initial_buffer_obj_is_none(self):
+        lane = _make_afc_lane()
+        assert lane.buffer_obj is None
+
+    def test_initial_extruder_obj_is_not_none(self):
+        lane = _make_afc_lane()
+        assert lane.extruder_obj is not None
+
+    def test_update_weight_delay_class_constant(self):
+        assert AFCLane.UPDATE_WEIGHT_DELAY == 10.0
+
+
+# ── __str__ ───────────────────────────────────────────────────────────────────
+
+class TestAFCLaneStr:
+    def test_str_returns_name(self):
+        lane = _make_afc_lane("AFC_stepper lane1")
+        assert str(lane) == "lane1"
+
+    def test_str_matches_name_attribute(self):
+        lane = _make_afc_lane("AFC_stepper myLane")
+        assert str(lane) == lane.name
+
+
+# ── material property ─────────────────────────────────────────────────────────
+
+def _make_lane_with_afc(fullname="AFC_stepper lane1", density_values=None):
+    """Build an AFCLane with a minimal MockAFC for material/density tests."""
+    from tests.conftest import MockAFC
+    lane = _make_afc_lane(fullname)
+    lane.afc = MockAFC()
+    lane.afc.common_density_values = density_values or [
+        "PLA:1.24",
+        "PETG:1.27",
+        "ABS:1.04",
+        "TPU:1.21",
+    ]
+    lane.filament_density = 1.24
+    lane._material = None
+    return lane
+
+
+class TestAFCLaneMaterial:
+    def test_getter_returns_material(self):
+        lane = _make_lane_with_afc()
+        lane._material = "PLA"
+        assert lane.material == "PLA"
+
+    def test_getter_returns_none_when_unset(self):
+        lane = _make_lane_with_afc()
+        lane._material = None
+        assert lane.material is None
+
+    def test_setter_stores_value(self):
+        lane = _make_lane_with_afc()
+        lane.material = "PETG"
+        assert lane._material == "PETG"
+
+    def test_setter_none_resets_density_to_default(self):
+        lane = _make_lane_with_afc()
+        lane.filament_density = 1.27
+        lane.material = None
+        assert lane.filament_density == 1.24
+
+    def test_setter_empty_string_resets_density(self):
+        lane = _make_lane_with_afc()
+        lane.filament_density = 1.27
+        lane.material = ""
+        assert lane.filament_density == 1.24
+
+    def test_setter_known_material_sets_density(self):
+        lane = _make_lane_with_afc()
+        lane.material = "PETG"
+        assert lane.filament_density == 1.27
+
+    def test_setter_abs_sets_correct_density(self):
+        lane = _make_lane_with_afc()
+        lane.material = "ABS"
+        assert lane.filament_density == 1.04
+
+    def test_setter_unknown_material_keeps_existing_density(self):
+        lane = _make_lane_with_afc()
+        lane.filament_density = 1.24
+        lane.material = "NYLONX"  # not in density list
+        assert lane.filament_density == 1.24
+
+    def test_setter_partial_match(self):
+        """'PLA+' should match 'PLA' entry."""
+        lane = _make_lane_with_afc()
+        lane.material = "PLA+"
+        assert lane.filament_density == 1.24
+
+
+# ── load_es property ──────────────────────────────────────────────────────────
+
+class TestAFCLaneLoadEs:
+    def test_only_lane_false_returns_load_homing_point(self):
+        lane = _make_afc_lane()
+        lane.only_lane = False
+        assert lane.load_es == AFCHomingPoints.LOAD
+
+    def test_only_lane_true_returns_endstop_name(self):
+        lane = _make_afc_lane()
+        lane.only_lane = True
+        lane.endstops.update({AFCHomingPoints.LOAD: {"endstop" : "PIN123", "endstop_name": "lane1_load"}})
+        assert lane.load_es == "lane1_load"
+
+    def test_only_lane_true_unique_endstop_per_lane(self):
+        lane_a = _make_afc_lane("AFC_stepper laneA")
+        lane_a.only_lane = True
+        lane_a.endstops.update({AFCHomingPoints.LOAD: {"endstop" : "PIN123", "endstop_name": "laneA_load"}})
+
+        lane_b = _make_afc_lane("AFC_stepper laneB")
+        lane_b.only_lane = True
+        lane_a.endstops.update({AFCHomingPoints.LOAD: {"endstop" : "PIN123", "endstop_name": "laneB_load"}})
+
+        assert lane_a.load_es != lane_b.load_es
+
+
+# ── get_color ─────────────────────────────────────────────────────────────────
+
+class TestAFCLaneGetColor:
+    def test_returns_color_when_no_td1_data(self):
+        lane = _make_afc_lane()
+        lane.color = "#FF0000"
+        lane.td1_data = {}
+        assert lane.get_color() == "#FF0000"
+
+    def test_returns_td1_color_when_present(self):
+        lane = _make_afc_lane()
+        lane.color = "#FF0000"
+        lane.td1_data = {"color": "00FF00"}
+        assert lane.get_color() == "#00FF00"
+
+    def test_none_color_with_no_td1(self):
+        lane = _make_afc_lane()
+        lane.color = None
+        lane.td1_data = {}
+        assert lane.get_color() is None
+
+    def test_td1_color_overrides_manual_color(self):
+        lane = _make_afc_lane()
+        lane.color = "manual_color"
+        lane.td1_data = {"color": "TD1Color"}
+        assert lane.get_color() == "#TD1Color"
+
+
+# ── get_active_assist ─────────────────────────────────────────────────────────
+
+class TestAFCLaneGetActiveAssist:
+    def test_no_returns_false(self):
+        lane = _make_afc_lane()
+        assert lane.get_active_assist(100.0, AssistActive.NO) is False
+
+    def test_yes_returns_true(self):
+        lane = _make_afc_lane()
+        assert lane.get_active_assist(100.0, AssistActive.YES) is True
+
+    def test_yes_returns_true_regardless_of_distance(self):
+        lane = _make_afc_lane()
+        assert lane.get_active_assist(5.0, AssistActive.YES) is True
+
+    def test_dynamic_short_distance_returns_false(self):
+        lane = _make_afc_lane()
+        assert lane.get_active_assist(100.0, AssistActive.DYNAMIC) is False
+
+    def test_dynamic_long_distance_returns_true(self):
+        lane = _make_afc_lane()
+        assert lane.get_active_assist(201.0, AssistActive.DYNAMIC) is True
+
+    def test_dynamic_exactly_200_returns_false(self):
+        """200 mm is NOT > 200, so dynamic assist is inactive."""
+        lane = _make_afc_lane()
+        assert lane.get_active_assist(200.0, AssistActive.DYNAMIC) is False
+
+    def test_dynamic_negative_long_distance_returns_true(self):
+        lane = _make_afc_lane()
+        assert lane.get_active_assist(-250.0, AssistActive.DYNAMIC) is True
+
+
+# ── calculate_effective_diameter ──────────────────────────────────────────────
+
+def _make_lane_for_weight(name="lane1"):
+    """Build a minimal AFCLane with weight/diameter attributes set."""
+    lane = _make_afc_lane(f"AFC_stepper {name}")
+    lane.filament_density = 1.24          # g/cm³ → g/1000 mm³
+    lane.inner_diameter   = 75.0          # mm
+    lane.outer_diameter   = 200.0         # mm
+    lane.filament_diameter = 1.75         # mm
+    lane.empty_spool_weight = 190.0       # g
+    lane.max_motor_rpm    = 465.0
+    lane.fwd_speed_multi  = 0.5
+    lane.rwd_speed_multi  = 0.5
+    lane.weight           = 1000.0        # g remaining filament
+    return lane
+
+
+class TestCalculateEffectiveDiameter:
+    def test_returns_float(self):
+        lane = _make_lane_for_weight()
+        result = lane.calculate_effective_diameter(500)
+        assert isinstance(result, float)
+
+    def test_more_filament_gives_larger_diameter(self):
+        lane = _make_lane_for_weight()
+        d_small = lane.calculate_effective_diameter(100)
+        d_large = lane.calculate_effective_diameter(1000)
+        assert d_large > d_small
+
+    def test_result_at_least_inner_diameter(self):
+        """Effective spool outer diameter should always exceed the inner core."""
+        lane = _make_lane_for_weight()
+        result = lane.calculate_effective_diameter(1)
+        assert result >= lane.inner_diameter
+
+    def test_result_is_positive(self):
+        lane = _make_lane_for_weight()
+        assert lane.calculate_effective_diameter(250) > 0
+
+    def test_wider_spool_gives_smaller_diameter(self):
+        """Same mass spread over a wider spool → smaller outer diameter."""
+        lane = _make_lane_for_weight()
+        d_narrow = lane.calculate_effective_diameter(500, spool_width_mm=30)
+        d_wide   = lane.calculate_effective_diameter(500, spool_width_mm=90)
+        assert d_narrow > d_wide
+
+
+# ── calculate_rpm ─────────────────────────────────────────────────────────────
+
+class TestCalculateRpm:
+    def test_returns_float(self):
+        lane = _make_lane_for_weight()
+        assert isinstance(lane.calculate_rpm(50.0), float)
+
+    def test_higher_feed_rate_gives_higher_rpm(self):
+        lane = _make_lane_for_weight()
+        rpm_low  = lane.calculate_rpm(10.0)
+        rpm_high = lane.calculate_rpm(100.0)
+        assert rpm_high > rpm_low
+
+    def test_rpm_clamped_to_max_motor_rpm(self):
+        lane = _make_lane_for_weight()
+        # Very high feed rate should be clamped
+        rpm = lane.calculate_rpm(10_000.0)
+        assert rpm == lane.max_motor_rpm
+
+    def test_rpm_positive_for_positive_feed(self):
+        lane = _make_lane_for_weight()
+        assert lane.calculate_rpm(50.0) > 0
+
+
+# ── calculate_pwm_value ───────────────────────────────────────────────────────
+
+class TestCalculatePwmValue:
+    def test_returns_value_between_0_and_1(self):
+        lane = _make_lane_for_weight()
+        pwm = lane.calculate_pwm_value(50.0)
+        assert 0.0 <= pwm <= 1.0
+
+    def test_higher_feed_rate_gives_higher_pwm(self):
+        lane = _make_lane_for_weight()
+        pwm_low  = lane.calculate_pwm_value(10.0)
+        pwm_high = lane.calculate_pwm_value(200.0)
+        assert pwm_high >= pwm_low
+
+    def test_rewind_flag_changes_pwm(self):
+        lane = _make_lane_for_weight()
+        pwm_fwd = lane.calculate_pwm_value(50.0, rewind=False)
+        pwm_rwd = lane.calculate_pwm_value(50.0, rewind=True)
+        # They use different formulas; the values should differ
+        assert pwm_fwd != pwm_rwd
+
+    def test_clamped_at_zero(self):
+        """PWM should never be negative."""
+        lane = _make_lane_for_weight()
+        assert lane.calculate_pwm_value(0.0) >= 0.0
+
+    def test_clamped_at_one(self):
+        """PWM should never exceed 1.0."""
+        lane = _make_lane_for_weight()
+        assert lane.calculate_pwm_value(100_000.0) <= 1.0
+
+
+# ── update_remaining_weight ───────────────────────────────────────────────────
+
+import math as _math
+
+
+class TestUpdateRemainingWeight:
+    def test_weight_decreases_after_move(self):
+        lane = _make_lane_for_weight()
+        lane.weight = 500.0
+        lane.update_remaining_weight(100.0)
+        assert lane.weight < 500.0
+
+    def test_weight_does_not_go_negative(self):
+        lane = _make_lane_for_weight()
+        lane.weight = 0.1
+        lane.update_remaining_weight(1000.0)
+        assert lane.weight == 0.0
+
+    def test_zero_distance_no_weight_change(self):
+        lane = _make_lane_for_weight()
+        lane.weight = 500.0
+        lane.update_remaining_weight(0.0)
+        assert lane.weight == 500.0
+
+    def test_weight_change_matches_formula(self):
+        lane = _make_lane_for_weight()
+        lane.weight = 500.0
+        dist = 100.0
+        expected_vol = _math.pi * (lane.filament_diameter / 2) ** 2 * dist
+        expected_change = expected_vol * lane.filament_density / 1000.0
+        lane.update_remaining_weight(dist)
+        assert abs(lane.weight - (500.0 - expected_change)) < 1e-9
+
+    def test_larger_diameter_removes_more_weight(self):
+        lane1 = _make_lane_for_weight()
+        lane1.filament_diameter = 1.75
+        lane1.weight = 500.0
+
+        lane2 = _make_lane_for_weight()
+        lane2.filament_diameter = 2.85
+        lane2.weight = 500.0
+
+        lane1.update_remaining_weight(100.0)
+        lane2.update_remaining_weight(100.0)
+
+        assert lane2.weight < lane1.weight
+
+
+# ── _is_normal_printing_state ─────────────────────────────────────────────────
+
+class TestIsNormalPrintingState:
+    def _make_lane(self, status, in_toolchange=False):
+        lane = _make_lane_with_afc()
+        lane.status = status
+        lane.afc.in_toolchange = in_toolchange
+        return lane
+
+    def test_tooled_state_returns_true(self):
+        from extras.AFC_lane import AFCLaneState
+        lane = self._make_lane(AFCLaneState.TOOLED)
+        assert lane._is_normal_printing_state() is True
+
+    def test_loaded_state_returns_true(self):
+        from extras.AFC_lane import AFCLaneState
+        lane = self._make_lane(AFCLaneState.LOADED)
+        assert lane._is_normal_printing_state() is True
+
+    def test_error_state_returns_false(self):
+        from extras.AFC_lane import AFCLaneState
+        lane = self._make_lane(AFCLaneState.ERROR)
+        assert lane._is_normal_printing_state() is False
+
+    def test_none_state_returns_false(self):
+        from extras.AFC_lane import AFCLaneState
+        lane = self._make_lane(AFCLaneState.NONE)
+        assert lane._is_normal_printing_state() is False
+
+    def test_in_toolchange_returns_false_even_if_tooled(self):
+        from extras.AFC_lane import AFCLaneState
+        lane = self._make_lane(AFCLaneState.TOOLED, in_toolchange=True)
+        assert lane._is_normal_printing_state() is False
+
+    def test_tool_loading_state_returns_false(self):
+        from extras.AFC_lane import AFCLaneState
+        lane = self._make_lane(AFCLaneState.TOOL_LOADING)
+        assert lane._is_normal_printing_state() is False
+
+
+# ── set_afc_prep_done ─────────────────────────────────────────────────────────
+
+class TestSetAfcPrepDone:
+    def test_initially_false(self):
+        lane = _make_afc_lane()
+        lane._afc_prep_done = False
+        assert lane._afc_prep_done is False
+
+    def test_set_afc_prep_done_sets_flag(self):
+        lane = _make_afc_lane()
+        lane._afc_prep_done = False
+        lane.set_afc_prep_done()
+        assert lane._afc_prep_done is True
+
+    def test_set_afc_prep_done_idempotent(self):
+        lane = _make_afc_lane()
+        lane._afc_prep_done = True
+        lane.set_afc_prep_done()
+        assert lane._afc_prep_done is True
+
+
+# ── load_callback ─────────────────────────────────────────────────────────────
+
+class TestLoadCallback:
+    def test_stores_load_state(self):
+        lane = _make_afc_lane()
+        lane._load_state = False
+        lane.unit_obj = MagicMock()
+        lane.unit_obj.type = "BoxTurtle"
+        lane.printer = MagicMock()
+        lane.printer.state_message = "Starting"
+        lane.load_callback(100.0, True)
+        assert lane._load_state is True
+
+    def test_htlf_sets_prep_state(self):
+        lane = _make_afc_lane()
+        lane._load_state = False
+        lane.prep_state = False
+        lane.unit_obj = MagicMock()
+        lane.unit_obj.type = "HTLF"
+        lane.printer = MagicMock()
+        lane.printer.state_message = "Printer is ready"
+        lane.load_callback(100.0, True)
+        assert lane.prep_state is True
+
+    def test_non_htlf_does_not_set_prep_state(self):
+        lane = _make_afc_lane()
+        lane._load_state = False
+        lane.prep_state = False
+        lane.unit_obj = MagicMock()
+        lane.unit_obj.type = "BoxTurtle"
+        lane.printer = MagicMock()
+        lane.printer.state_message = "Printer is ready"
+        lane.load_callback(100.0, True)
+        assert lane.prep_state is False
+
+# ── move_to ───────────────────────────────────────────────────────────────────
+
+class TestMoveTo:
+    def test_no_drive_stepper_no_extruder_stepper(self):
+        lane = _make_afc_lane()
+        lane.drive_stepper = None
+        lane.extruder_stepper = None
+        homed, dist, warn = lane.move_to(100, SpeedMode.SHORT, AFCHomingPoints.BUFFER,
+                                          False, False)
+        assert homed == False
+        assert dist == 0
+        assert warn == AFCMoveWarning.ERROR
+    
+    def test_drive_stepper_no_extruder_stepper_no_homing(self):
+        lane = _make_afc_lane()
+        lane.drive_stepper = AFCExtruderStepper.__new__(AFCExtruderStepper)
+        lane.move_advanced = MagicMock()
+        homed, dist, warn = lane.move_to(100, SpeedMode.SHORT, AFCHomingPoints.BUFFER,
+                                          False, False)
+        assert homed == True
+        assert dist == 0
+        assert warn == AFCMoveWarning.NONE
+    
+    def test_drive_stepper_no_extruder_stepper_homing_pos_movement(self):
+        HOMING_OVERSHOOT = 50
+        HOMING_DELTA = 300
+        MOVE_DISTANCE = 1000
+        ASSIST_ACTIVE = AssistActive.NO
+        HOMING = True
+        lane = _make_afc_lane()
+        lane.homing_overshoot = HOMING_OVERSHOOT
+        lane.homing_delta = HOMING_DELTA
+        lane.drive_stepper = AFCExtruderStepper.__new__(AFCExtruderStepper)
+        home_to = MagicMock()
+        lane.drive_stepper.home_to = home_to
+        lane.move_advanced = MagicMock()
+        home_to.return_value = (True, MOVE_DISTANCE, False)
+        homed, dist, warn = lane.move_to(MOVE_DISTANCE, SpeedMode.SHORT, AFCHomingPoints.BUFFER,
+                                         ASSIST_ACTIVE, HOMING)
+        call_args = home_to.call_args[0]
+        kwargs = home_to.call_args[1]
+        assert homed == True
+        assert dist == abs(MOVE_DISTANCE)
+        assert warn == AFCMoveWarning.NONE
+        assert call_args[0] == AFCHomingPoints.BUFFER
+        assert call_args[1] == MOVE_DISTANCE + HOMING_OVERSHOOT
+        assert call_args[2] == lane.short_moves_speed
+        assert call_args[3] == lane.short_moves_accel
+        assert call_args[4] == bool(MOVE_DISTANCE > 0)
+        assert kwargs["assist_active"] == False
+    
+    def test_drive_stepper_no_extruder_stepper_homing_neg_movement(self):
+        HOMING_OVERSHOOT = 50
+        HOMING_DELTA = 300
+        MOVE_DISTANCE = -1000
+        ASSIST_ACTIVE = AssistActive.NO
+        HOMING = True
+        lane = _make_afc_lane()
+        lane.homing_overshoot = HOMING_OVERSHOOT
+        lane.homing_delta = HOMING_DELTA
+        lane.drive_stepper = AFCExtruderStepper.__new__(AFCExtruderStepper)
+        home_to = MagicMock()
+        lane.drive_stepper.home_to = home_to
+        lane.move_advanced = MagicMock()
+        home_to.return_value = (True, abs(MOVE_DISTANCE), False)
+        homed, dist, warn = lane.move_to(MOVE_DISTANCE, SpeedMode.SHORT, AFCHomingPoints.BUFFER,
+                                         ASSIST_ACTIVE, HOMING)
+        call_args = home_to.call_args[0]
+        kwargs = home_to.call_args[1]
+        assert homed == True
+        assert dist == abs(MOVE_DISTANCE)
+        assert warn == AFCMoveWarning.NONE
+        assert call_args[0] == AFCHomingPoints.BUFFER
+        assert call_args[1] == MOVE_DISTANCE - HOMING_OVERSHOOT
+        assert call_args[2] == lane.short_moves_speed
+        assert call_args[3] == lane.short_moves_accel
+        assert call_args[4] == bool(MOVE_DISTANCE > 0)
+        assert kwargs["assist_active"] == False
+
+    def test_drive_stepper_no_extruder_stepper_homing_neg_movement_homing_error(self):
+        HOMING_OVERSHOOT = 50
+        HOMING_DELTA = 300
+        MOVE_DISTANCE = -1000
+        ASSIST_ACTIVE = AssistActive.NO
+        HOMING = True
+        lane = _make_afc_lane()
+        lane.homing_overshoot = HOMING_OVERSHOOT
+        lane.homing_delta = HOMING_DELTA
+        lane.drive_stepper = AFCExtruderStepper.__new__(AFCExtruderStepper)
+        home_to = MagicMock()
+        lane.drive_stepper.home_to = home_to
+        lane.move_advanced = MagicMock()
+        home_to.return_value = (False, 0, True)
+        homed, dist, warn = lane.move_to(MOVE_DISTANCE, SpeedMode.SHORT, AFCHomingPoints.BUFFER,
+                                         ASSIST_ACTIVE, HOMING)
+        call_args = home_to.call_args[0]
+        kwargs = home_to.call_args[1]
+        assert homed == False
+        assert dist == 0
+        assert warn == AFCMoveWarning.ERROR
+        assert call_args[0] == AFCHomingPoints.BUFFER
+        assert call_args[1] == MOVE_DISTANCE - HOMING_OVERSHOOT
+        assert call_args[2] == lane.short_moves_speed
+        assert call_args[3] == lane.short_moves_accel
+        assert call_args[4] == bool(MOVE_DISTANCE > 0)
+        assert kwargs["assist_active"] == False
+
+    def test_drive_stepper_no_extruder_stepper_homing_pos_movement_short(self):
+        HOMING_OVERSHOOT = 50
+        HOMING_DELTA = 300
+        MOVE_DISTANCE = 1000
+        ASSIST_ACTIVE = AssistActive.NO
+        HOMING = True
+        MOVE_SHORT = 300
+        lane = _make_afc_lane()
+        lane.homing_overshoot = HOMING_OVERSHOOT
+        lane.homing_delta = HOMING_DELTA
+        lane.drive_stepper = AFCExtruderStepper.__new__(AFCExtruderStepper)
+        home_to = MagicMock()
+        lane.drive_stepper.home_to = home_to
+        lane.move_advanced = MagicMock()
+        home_to.return_value = (False, MOVE_SHORT, False)
+        homed, dist, warn = lane.move_to(MOVE_DISTANCE, SpeedMode.SHORT, AFCHomingPoints.BUFFER,
+                                         ASSIST_ACTIVE, HOMING)
+        call_args = home_to.call_args[0]
+        kwargs = home_to.call_args[1]
+        assert homed == False
+        assert dist == MOVE_SHORT
+        assert warn == AFCMoveWarning.WARN
+        assert call_args[0] == AFCHomingPoints.BUFFER
+        assert call_args[1] == MOVE_DISTANCE + HOMING_OVERSHOOT
+        assert call_args[2] == lane.short_moves_speed
+        assert call_args[3] == lane.short_moves_accel
+        assert call_args[4] == HOMING
+        assert kwargs["assist_active"] == False
+    
+    def test_extruder_stepper_no_drive_stepper_homing_pos_movement_short(self):
+        HOMING_OVERSHOOT = 50
+        HOMING_DELTA = 300
+        MOVE_DISTANCE = 1000
+        ASSIST_ACTIVE = AssistActive.NO
+        HOMING = True
+        MOVE_SHORT = 300
+        lane = _make_afc_lane()
+        lane.homing_overshoot = HOMING_OVERSHOOT
+        lane.homing_delta = HOMING_DELTA
+        lane.extruder_stepper = AFCExtruderStepper.__new__(AFCExtruderStepper)
+        home_to = MagicMock()
+        lane.home_to = home_to
+        lane.move_advanced = MagicMock()
+        home_to.return_value = (False, MOVE_SHORT, False)
+        homed, dist, warn = lane.move_to(MOVE_DISTANCE, SpeedMode.SHORT, AFCHomingPoints.BUFFER,
+                                         ASSIST_ACTIVE, HOMING)
+        call_args = home_to.call_args[0]
+        kwargs = home_to.call_args[1]
+        assert homed == False
+        assert dist == MOVE_SHORT
+        assert warn == AFCMoveWarning.WARN
+        assert call_args[0] == AFCHomingPoints.BUFFER
+        assert call_args[1] == MOVE_DISTANCE + HOMING_OVERSHOOT
+        assert call_args[2] == lane.short_moves_speed
+        assert call_args[3] == lane.short_moves_accel
+        assert call_args[4] == HOMING
+        assert kwargs["assist_active"] == False

--- a/tests/test_AFC_led.py
+++ b/tests/test_AFC_led.py
@@ -1,0 +1,214 @@
+"""
+Unit tests for extras/AFC_led.py
+
+Covers:
+  - AFCled.led_change: single index, range string, list
+  - AFCled.set_color_fn: respects keep_leds_off
+  - AFCled.turn_off_leds: sets keep_leds_off, updates all LEDs to black
+  - AFCled.turn_on_leds: clears keep_leds_off, restores last colours
+  - AFCled.update_color_data: maps LED state through color_map
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch, call
+import pytest
+
+from extras.AFC_led import AFCled
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_led(chain_count=4, color_order="RGB"):
+    """Build an AFCled instance by bypassing __init__ and setting attrs."""
+    led = AFCled.__new__(AFCled)
+
+    from tests.conftest import MockAFC, MockPrinter, MockReactor
+
+    afc = MockAFC()
+    printer = MockPrinter(afc=afc)
+
+    led.printer = printer
+    led.afc = afc
+    led.fullname = f"AFC_led test_led"
+    led.name = "test_led"
+    led.mutex = MagicMock()
+    led.mutex.__enter__ = MagicMock(return_value=None)
+    led.mutex.__exit__ = MagicMock(return_value=False)
+
+    led.last_led_color = {}
+    led.keep_leds_off = False
+    led.chain_count = chain_count
+
+    # Build a color_map for RGB chain
+    # color_map: list of (cdidx, (lidx, cidx))
+    # For RGB, each LED has 3 entries
+    led.color_map = []
+    for lidx in range(chain_count):
+        for cidx, c in enumerate("RGB"):
+            cdidx = lidx * 3 + cidx
+            led.color_map.append((cdidx, (lidx, cidx)))
+
+    led.color_data = bytearray(len(led.color_map))
+    led.old_color_data = bytearray(len(led.color_map))
+
+    # LED helper mock
+    led.led_helper = MagicMock()
+    led.led_helper.led_count = chain_count
+    led.led_helper.get_status.return_value = {
+        "color_data": [(0.0, 0.0, 0.0)] * chain_count
+    }
+
+    led.ledHelper_set_color_fn = MagicMock()
+    led.check_transmit_fn = MagicMock()
+
+    # MCU mock
+    led.mcu = MagicMock()
+    led.oid = 1
+    led.pin = "PA0"
+    led.neopixel_update_cmd = MagicMock()
+    led.neopixel_send_cmd = MagicMock()
+
+    return led
+
+
+# ── set_color_fn ──────────────────────────────────────────────────────────────
+
+class TestSetColorFn:
+    def test_updates_last_led_color_when_update_last_true(self):
+        led = _make_led()
+        color = [1.0, 0.0, 0.0]
+        led.set_color_fn(1, color, update_last=True)
+        assert led.last_led_color["1"] == color
+
+    def test_does_not_update_last_led_color_when_false(self):
+        led = _make_led()
+        color = [1.0, 0.0, 0.0]
+        led.set_color_fn(1, color, update_last=False)
+        assert "1" not in led.last_led_color
+
+    def test_skips_set_color_when_keep_leds_off(self):
+        led = _make_led()
+        led.keep_leds_off = True
+        led.set_color_fn(1, [1.0, 0.0, 0.0])
+        led.ledHelper_set_color_fn.assert_not_called()
+
+    def test_calls_led_helper_when_keep_off_false(self):
+        led = _make_led()
+        led.keep_leds_off = False
+        color = [0.0, 1.0, 0.0]
+        led.set_color_fn(2, color)
+        led.ledHelper_set_color_fn.assert_called_once_with(2, color)
+
+
+# ── led_change ────────────────────────────────────────────────────────────────
+
+class TestLedChange:
+    def test_single_integer_index(self):
+        led = _make_led()
+        led.set_color_fn = MagicMock()
+        # Toolhead mock needed for lookahead callback
+        led.printer._objects["toolhead"] = MagicMock()
+        led.led_change(1, [1.0, 0.0, 0.0])
+        led.set_color_fn.assert_called_once_with(1, [1.0, 0.0, 0.0], True)
+
+    def test_string_color_parsed_to_list(self):
+        led = _make_led()
+        led.set_color_fn = MagicMock()
+        led.printer._objects["toolhead"] = MagicMock()
+        led.led_change(0, "0.5,0.5,0.5,0.0")
+        args = led.set_color_fn.call_args[0]
+        assert args[1] == [0.5, 0.5, 0.5, 0.0]
+
+    def test_range_index_calls_set_color_for_each(self):
+        led = _make_led(chain_count=6)
+        led.set_color_fn = MagicMock()
+        led.printer._objects["toolhead"] = MagicMock()
+        # Range "1-3" → LED indices 1, 2, 3
+        led.led_change("1-3", [0.0, 0.0, 1.0])
+        assert led.set_color_fn.call_count == 3
+        indices = [c[0][0] for c in led.set_color_fn.call_args_list]
+        assert sorted(indices) == [1, 2, 3]
+
+    def test_list_index_calls_set_color_for_each(self):
+        led = _make_led()
+        led.set_color_fn = MagicMock()
+        led.printer._objects["toolhead"] = MagicMock()
+        led.led_change([0, 2], [1.0, 1.0, 0.0])
+        assert led.set_color_fn.call_count == 2
+
+    def test_keep_leds_off_skips_lookahead(self):
+        """When keep_leds_off is True, led_change should return early."""
+        led = _make_led()
+        led.keep_leds_off = True
+        toolhead = MagicMock()
+        led.printer._objects["toolhead"] = toolhead
+        led.led_change(0, [1.0, 0.0, 0.0])
+        toolhead.register_lookahead_callback.assert_not_called()
+
+
+# ── turn_off_leds / turn_on_leds ─────────────────────────────────────────────
+
+class TestLedPower:
+    def test_turn_off_sets_keep_leds_off_true(self):
+        led = _make_led(chain_count=2)
+        led.printer._objects["toolhead"] = MagicMock()
+        led.turn_off_leds()
+        assert led.keep_leds_off is True
+
+    def test_turn_off_calls_led_change_for_each_led(self):
+        led = _make_led(chain_count=3)
+        led.led_change = MagicMock()
+        led.turn_off_leds()
+        # 3 LEDs → 3 calls; each call passes "0,0,0,0"
+        assert led.led_change.call_count == 3
+        for c in led.led_change.call_args_list:
+            assert c[0][1] == "0,0,0,0"
+
+    def test_turn_on_clears_keep_leds_off(self):
+        led = _make_led()
+        led.keep_leds_off = True
+        led.turn_on_leds()
+        assert led.keep_leds_off is False
+
+    def test_turn_on_restores_last_colors(self):
+        led = _make_led()
+        led.keep_leds_off = True
+        led.last_led_color = {"0": [1.0, 0.0, 0.0], "1": [0.0, 1.0, 0.0]}
+        led.led_change = MagicMock()
+        led.turn_on_leds()
+        assert led.led_change.call_count == 2
+
+    def test_turn_on_with_no_saved_colors_does_nothing(self):
+        led = _make_led()
+        led.keep_leds_off = True
+        led.last_led_color = {}
+        led.led_change = MagicMock()
+        led.turn_on_leds()
+        led.led_change.assert_not_called()
+
+
+# ── update_color_data ─────────────────────────────────────────────────────────
+
+class TestUpdateColorData:
+    def test_full_brightness_maps_to_255(self):
+        led = _make_led(chain_count=1)
+        # For a 1-LED RGB chain: color_data has 3 bytes (R, G, B)
+        # Set LED 0 to full red: (1.0, 0.0, 0.0)
+        led_state = [(1.0, 0.0, 0.0)]
+        led.update_color_data(led_state)
+        assert led.color_data[0] == 255  # R=1.0 → 255
+
+    def test_zero_brightness_maps_to_zero(self):
+        led = _make_led(chain_count=1)
+        led_state = [(0.0, 0.0, 0.0)]
+        led.update_color_data(led_state)
+        for b in led.color_data:
+            assert b == 0
+
+    def test_half_brightness_maps_to_128(self):
+        led = _make_led(chain_count=1)
+        led_state = [(0.5, 0.0, 0.0)]
+        led.update_color_data(led_state)
+        # 0.5 * 255 + 0.5 = 128.0 → int 128
+        assert led.color_data[0] == 128

--- a/tests/test_AFC_logger.py
+++ b/tests/test_AFC_logger.py
@@ -1,0 +1,324 @@
+"""
+Unit tests for extras/AFC_logger.py
+
+Covers:
+  - AFC_logger instantiation (with and without log_file start arg)
+  - _remove_tags: strips HTML-like tags
+  - _add_monotonic: prepends reactor time
+  - set_debug: toggles print_debug_console
+  - send_callback: only calls GCodeHelper callbacks
+  - info / warning / debug / error / raw: verify log routing
+  - shutdown: stops queue listener
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch, call
+import pytest
+
+from extras.AFC_logger import AFC_logger
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_afc_obj(message_queue=None):
+    """Minimal afc stand-in for AFC_logger."""
+    afc = MagicMock()
+    afc.message_queue = message_queue if message_queue is not None else []
+    afc.log_frame_data = True
+    return afc
+
+
+def _make_printer(monotonic_val=42.0, log_file=None):
+    from tests.conftest import MockPrinter, MockReactor
+
+    printer = MockPrinter()
+    reactor = MockReactor(monotonic_value=monotonic_val)
+    printer._reactor = reactor
+    printer.reactor = reactor  # keep public attribute in sync
+    printer.start_args = {"log_file": log_file} if log_file else {}
+    # gcode.output_callbacks is used by send_callback
+    printer._gcode.output_callbacks = []
+    return printer
+
+
+def _make_logger(log_file=None):
+    printer = _make_printer(log_file=log_file)
+    afc = _make_afc_obj()
+    return AFC_logger(printer, afc), afc, printer
+
+
+# ── Instantiation ─────────────────────────────────────────────────────────────
+
+class TestAFCLoggerInit:
+    def test_init_without_log_file(self):
+        logger, _, _ = _make_logger(log_file=None)
+        assert logger.afc_ql is None
+        assert logger.print_debug_console is False
+        assert logger.adaptive_padding == 0
+
+    def test_init_sets_reactor(self):
+        printer = _make_printer(monotonic_val=77.0)
+        afc = _make_afc_obj()
+        lg = AFC_logger(printer, afc)
+        assert lg.reactor is printer._reactor
+
+    def test_set_debug_true(self):
+        logger, _, _ = _make_logger()
+        logger.set_debug(True)
+        assert logger.print_debug_console is True
+
+    def test_set_debug_false(self):
+        logger, _, _ = _make_logger()
+        logger.set_debug(True)
+        logger.set_debug(False)
+        assert logger.print_debug_console is False
+
+
+# ── _remove_tags ──────────────────────────────────────────────────────────────
+
+class TestRemoveTags:
+    def test_removes_span_tags(self):
+        logger, _, _ = _make_logger()
+        result = logger._remove_tags("<span class=error--text>hello</span>")
+        assert result == "hello"
+
+    def test_removes_nested_tags(self):
+        logger, _, _ = _make_logger()
+        result = logger._remove_tags("<b><i>bold italic</i></b>")
+        assert result == "bold italic"
+
+    def test_no_tags_unchanged(self):
+        logger, _, _ = _make_logger()
+        result = logger._remove_tags("plain text")
+        assert result == "plain text"
+
+    def test_empty_string(self):
+        logger, _, _ = _make_logger()
+        assert logger._remove_tags("") == ""
+
+
+# ── _add_monotonic ────────────────────────────────────────────────────────────
+
+class TestAddMonotonic:
+    def test_prepends_monotonic_time(self):
+        printer = _make_printer(monotonic_val=123.456)
+        afc = _make_afc_obj()
+        lg = AFC_logger(printer, afc)
+        result = lg._add_monotonic("hello")
+        assert "123.456" in result
+        assert "hello" in result
+
+
+# ── send_callback ──────────────────────────────────────────────────────────────
+
+class TestSendCallback:
+    def test_send_callback_calls_gcode_helper(self):
+        """Only GCodeHelper instances should receive the callback."""
+        from webhooks import GCodeHelper
+
+        printer = _make_printer()
+        afc = _make_afc_obj()
+        lg = AFC_logger(printer, afc)
+
+        # Attach a mock callback that looks like a GCodeHelper method
+        mock_cb = MagicMock()
+        mock_cb.__self__ = GCodeHelper()  # Simulate being bound to a GCodeHelper
+        printer._gcode.output_callbacks.append(mock_cb)
+
+        lg.send_callback("test message")
+        mock_cb.assert_called_once_with("test message")
+
+    def test_send_callback_skips_non_gcode_helper(self):
+        """Non-GCodeHelper callbacks must be ignored."""
+        printer = _make_printer()
+        afc = _make_afc_obj()
+        lg = AFC_logger(printer, afc)
+
+        other_cb = MagicMock()
+        other_cb.__self__ = object()  # NOT a GCodeHelper
+        printer._gcode.output_callbacks.append(other_cb)
+
+        lg.send_callback("test")
+        other_cb.assert_not_called()
+
+
+# ── Logging methods ───────────────────────────────────────────────────────────
+
+class TestLoggingMethods:
+    def _make_lg_with_mocked_logger(self):
+        logger, afc, printer = _make_logger()
+        logger.logger = MagicMock()  # replace stdlib logger with mock
+        return logger, afc
+
+    def test_info_calls_logger_info(self):
+        lg, afc = self._make_lg_with_mocked_logger()
+        lg.send_callback = MagicMock()
+        lg.info("Hello info")
+        lg.logger.info.assert_called()
+
+    def test_info_console_only_skips_logger(self):
+        lg, afc = self._make_lg_with_mocked_logger()
+        lg.send_callback = MagicMock()
+        lg.info("Console only", console_only=True)
+        lg.logger.info.assert_not_called()
+
+    def test_warning_calls_logger_debug(self):
+        lg, afc = self._make_lg_with_mocked_logger()
+        lg.send_callback = MagicMock()
+        lg.warning("Watch out")
+        lg.logger.debug.assert_called()
+
+    def test_warning_appends_to_message_queue(self):
+        lg, afc = self._make_lg_with_mocked_logger()
+        lg.send_callback = MagicMock()
+        lg.warning("A warning")
+        warnings = [m for m, lvl in afc.message_queue if lvl == "warning"]
+        assert len(warnings) == 1
+
+    def test_debug_calls_logger_debug(self):
+        lg, afc = self._make_lg_with_mocked_logger()
+        lg.debug("Debug info")
+        lg.logger.debug.assert_called()
+
+    def test_debug_with_traceback_logs_traceback(self):
+        lg, afc = self._make_lg_with_mocked_logger()
+        lg.debug("Uh-oh", traceback="Traceback line 1\nTraceback line 2")
+        # logger.debug must have been called at least twice
+        assert lg.logger.debug.call_count >= 2
+
+    def test_error_calls_logger_error(self):
+        lg, afc = self._make_lg_with_mocked_logger()
+        lg.send_callback = MagicMock()
+        lg.error("Something broke")
+        lg.logger.error.assert_called()
+
+    def test_error_appends_to_message_queue(self):
+        lg, afc = self._make_lg_with_mocked_logger()
+        lg.send_callback = MagicMock()
+        lg.error("Fatal error")
+        errors = [m for m, lvl in afc.message_queue if lvl == "error"]
+        assert len(errors) == 1
+
+    def test_error_with_stack_name_formats_message(self):
+        lg, afc = self._make_lg_with_mocked_logger()
+        lg.send_callback = MagicMock()
+        lg.error("Broke", stack_name="my_func")
+        formatted = lg.logger.error.call_args[0][0]
+        assert "my_func" in formatted
+
+    def test_error_with_traceback_logs_each_line(self):
+        lg, afc = self._make_lg_with_mocked_logger()
+        lg.send_callback = MagicMock()
+        lg.error("Something broke", traceback="Traceback line 1\nTraceback line 2")
+        # Called once for the message + once per traceback line (2)
+        assert lg.logger.error.call_count >= 3
+
+    def test_debug_with_print_debug_sends_callback(self):
+        lg, afc = self._make_lg_with_mocked_logger()
+        lg.print_debug_console = True
+        lg.send_callback = MagicMock()
+        lg.debug("debug message")
+        lg.send_callback.assert_called()
+
+    def test_raw_sends_callback(self):
+        lg, _ = self._make_lg_with_mocked_logger()
+        lg.send_callback = MagicMock()
+        lg.raw("raw output")
+        lg.send_callback.assert_called()
+
+    def test_raw_calls_logger_info(self):
+        lg, _ = self._make_lg_with_mocked_logger()
+        lg.send_callback = MagicMock()
+        lg.raw("raw output")
+        lg.logger.info.assert_called()
+
+
+# ── shutdown ──────────────────────────────────────────────────────────────────
+
+class TestShutdown:
+    def test_shutdown_stops_queue_listener(self):
+        logger, _, _ = _make_logger()
+        logger.afc_ql = MagicMock()
+        logger.shutdown()
+        logger.afc_ql.stop.assert_called_once()
+
+    def test_shutdown_no_queue_listener_does_not_raise(self):
+        logger, _, _ = _make_logger()
+        assert logger.afc_ql is None
+        logger.shutdown()  # should not raise
+
+
+# ── AFC_QueueListener ─────────────────────────────────────────────────────────
+
+class TestAFCQueueListener:
+    def test_queue_listener_init_calls_file_handler_init(self, tmp_path):
+        from extras.AFC_logger import AFC_QueueListener
+        filename = str(tmp_path / "afc_test.log")
+        with patch("logging.handlers.TimedRotatingFileHandler.__init__", return_value=None):
+            ql = AFC_QueueListener(filename)
+        assert ql is not None
+
+    def test_queue_listener_has_bg_queue_after_init(self, tmp_path):
+        import queue as _queue
+        from extras.AFC_logger import AFC_QueueListener
+        filename = str(tmp_path / "afc_test.log")
+        with patch("logging.handlers.TimedRotatingFileHandler.__init__", return_value=None):
+            ql = AFC_QueueListener(filename)
+        assert hasattr(ql, "bg_queue")
+        assert isinstance(ql.bg_queue, _queue.Queue)
+
+
+# ── AFC_logger init with log_file ─────────────────────────────────────────────
+
+class TestAFCLoggerInitWithLogFile:
+    def test_init_with_log_file_creates_afc_ql(self, tmp_path):
+        import queue as _queue
+        log_path = str(tmp_path / "klippy.log")
+        printer = _make_printer(log_file=log_path)
+        afc = _make_afc_obj()
+        with patch("extras.AFC_logger.AFC_QueueListener") as mock_ql_cls:
+            instance = MagicMock()
+            instance.bg_queue = _queue.Queue()
+            mock_ql_cls.return_value = instance
+            lg = AFC_logger(printer, afc)
+        assert lg.afc_ql is instance
+        mock_ql_cls.assert_called_once()
+
+    def test_init_with_log_file_adds_queue_handler(self, tmp_path):
+        import queue as _queue
+        import logging
+        # Clear any handlers added by previous tests on the singleton "AFC" logger
+        logging.getLogger("AFC").handlers.clear()
+        log_path = str(tmp_path / "klippy.log")
+        printer = _make_printer(log_file=log_path)
+        afc = _make_afc_obj()
+        with patch("extras.AFC_logger.AFC_QueueListener") as mock_ql_cls:
+            instance = MagicMock()
+            instance.bg_queue = _queue.Queue()
+            mock_ql_cls.return_value = instance
+            lg = AFC_logger(printer, afc)
+        assert hasattr(lg, "afc_queue_handler")
+
+    def test_init_with_log_file_does_not_create_ql_when_handler_exists(self, tmp_path):
+        """When logger already has a QueueHandler, afc_ql is not created again."""
+        import queue as _queue
+        from queuelogger import QueueHandler
+        log_path = str(tmp_path / "klippy.log")
+        printer = _make_printer(log_file=log_path)
+        afc = _make_afc_obj()
+        # Pre-add a QueueHandler so the `if not any(...)` branch is False
+        q = _queue.Queue()
+        existing_handler = QueueHandler(q)
+        logger_name = "AFC"
+        import logging
+        logging.getLogger(logger_name).addHandler(existing_handler)
+        try:
+            with patch("extras.AFC_logger.AFC_QueueListener") as mock_ql_cls:
+                lg = AFC_logger(printer, afc)
+            # afc_ql should remain None since handler already existed
+            assert lg.afc_ql is None
+            mock_ql_cls.assert_not_called()
+        finally:
+            logging.getLogger(logger_name).removeHandler(existing_handler)

--- a/tests/test_AFC_poop.py
+++ b/tests/test_AFC_poop.py
@@ -1,0 +1,197 @@
+"""
+Unit tests for extras/AFC_poop.py
+
+Covers:
+  - afc_poop attribute initialization from config
+  - poop(): movement sequence, fan commands, iteration logic
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, call
+import pytest
+
+from extras.AFC_poop import afc_poop
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_poop(values=None):
+    """Build an afc_poop instance bypassing __init__."""
+    poop = afc_poop.__new__(afc_poop)
+
+    from tests.conftest import MockAFC, MockLogger
+
+    afc = MockAFC()
+    afc.logger = MockLogger()
+
+    poop.printer = MagicMock()
+    poop.reactor = MagicMock()
+    poop.afc = afc
+    poop.gcode = afc.gcode
+    poop.logger = afc.logger
+
+    # Config defaults
+    poop.verbose = False
+    poop.purge_loc_xy = "10,10"
+    poop.purge_start = 20.0
+    poop.purge_spd = 6.5
+    poop.fast_z = 200.0
+    poop.z_lift = 20.0
+    poop.restore_position = False
+    poop.full_fan = False
+    poop.purge_length = 70.111
+    poop.purge_length_min = 60.999
+    poop.max_iteration_length = 40.0
+    poop.iteration_z_raise = 6.0
+    poop.iteration_z_change = 0.6
+
+    if values:
+        for k, v in values.items():
+            setattr(poop, k, v)
+
+    return poop
+
+
+def _make_toolhead_pos(x=0.0, y=0.0, z=0.0, e=0.0):
+    """Return a mutable position list (gcode_move.last_position style)."""
+    return [x, y, z, e]
+
+
+# ── Initialization ────────────────────────────────────────────────────────────
+
+class TestPoopInit:
+    def test_default_purge_spd(self):
+        p = _make_poop()
+        assert p.purge_spd == 6.5
+
+    def test_default_max_iteration_length(self):
+        p = _make_poop()
+        assert p.max_iteration_length == 40.0
+
+    def test_default_full_fan_false(self):
+        p = _make_poop()
+        assert p.full_fan is False
+
+    def test_default_verbose_false(self):
+        p = _make_poop()
+        assert p.verbose is False
+
+
+# ── poop() ────────────────────────────────────────────────────────────────────
+
+class TestPoopMethod:
+    def _run_poop(self, poop_obj):
+        """Wire up toolhead and gcode_move mocks then call poop()."""
+        toolhead = MagicMock()
+        poop_obj.printer.lookup_object.return_value = toolhead
+        pos = _make_toolhead_pos(5.0, 5.0, 0.0, 0.0)
+        poop_obj.afc.gcode_move = MagicMock()
+        poop_obj.afc.gcode_move.last_position = pos
+        # move_with_transform should just update the pos we gave it
+        poop_obj.afc.gcode_move.move_with_transform = MagicMock()
+        poop_obj.poop()
+        return poop_obj.afc.gcode_move
+
+    def test_moves_to_purge_xy(self):
+        p = _make_poop({"purge_loc_xy": "100,50"})
+        gm = self._run_poop(p)
+        calls = gm.move_with_transform.call_args_list
+        # First move_with_transform call should set position to purge XY
+        first_call_pos = calls[0][0][0]
+        assert first_call_pos[0] == 100.0
+        assert first_call_pos[1] == 50.0
+
+    def test_fan_commands_when_full_fan(self):
+        p = _make_poop({"full_fan": True, "purge_length": 40.0, "max_iteration_length": 40.0})
+        self._run_poop(p)
+        scripts = [
+            c[0][0] for c in p.gcode.run_script_from_command.call_args_list
+        ]
+        # Fan on + fan off
+        assert any("M106" in s for s in scripts)
+        assert any("S255" in s for s in scripts)
+        assert any("S0" in s for s in scripts)
+
+    def test_no_fan_commands_when_full_fan_false(self):
+        p = _make_poop({"full_fan": False})
+        self._run_poop(p)
+        scripts = [
+            c[0][0] for c in p.gcode.run_script_from_command.call_args_list
+        ]
+        assert not any("M106" in s for s in scripts)
+
+    def test_move_with_transform_called(self):
+        p = _make_poop()
+        gm = self._run_poop(p)
+        assert gm.move_with_transform.call_count > 0
+
+    def test_verbose_logs_info(self):
+        p = _make_poop({"verbose": True, "purge_length": 40.0, "max_iteration_length": 40.0})
+        self._run_poop(p)
+        info_msgs = [m for lvl, m in p.logger.messages if lvl == "info"]
+        assert len(info_msgs) > 0
+
+    def test_iteration_count_matches_purge_length(self):
+        """Number of extrude iterations equals floor(purge_length / max_iter)."""
+        purge_length = 80.0
+        max_iter = 40.0
+        p = _make_poop({"purge_length": purge_length, "max_iteration_length": max_iter})
+        gm = self._run_poop(p)
+        # At least 2 iterations of purge moves
+        assert gm.move_with_transform.call_count >= 3  # xy + z + iterations
+
+    def test_z_lift_at_end(self):
+        """Last Z movement should be to z_lift value."""
+        p = _make_poop({"z_lift": 25.0})
+        gm = self._run_poop(p)
+        # Last call to move_with_transform should use the fast_z speed
+        last_call = gm.move_with_transform.call_args_list[-1]
+        speed = last_call[0][1]
+        assert speed == p.fast_z
+
+    def test_verbose_fan_messages_logged_when_full_fan_and_verbose(self):
+        """verbose=True + full_fan=True should log fan-related info messages."""
+        p = _make_poop({
+            "verbose": True,
+            "full_fan": True,
+            "purge_length": 40.0,
+            "max_iteration_length": 40.0,
+        })
+        self._run_poop(p)
+        info_msgs = [m for lvl, m in p.logger.messages if lvl == "info"]
+        fan_msgs = [m for m in info_msgs if "fan" in m.lower() or "Fan" in m]
+        assert len(fan_msgs) >= 2  # "Set Cooling Fan" + "Restore fan speed"
+
+
+# ── __init__ via MockConfig ───────────────────────────────────────────────────
+
+class TestPoopInitFromConfig:
+    def test_init_reads_config_values(self):
+        from tests.conftest import MockConfig, MockPrinter, MockAFC
+        afc = MockAFC()
+        printer = MockPrinter(afc=afc)
+        config = MockConfig(
+            printer=printer,
+            values={
+                "purge_loc_xy": "50,75",
+                "purge_start": 5.0,
+                "purge_spd": 8.0,
+                "fast_z": 150.0,
+                "z_lift": 30.0,
+                "restore_position": False,
+                "full_fan": True,
+                "purge_length": 80.0,
+                "purge_length_min": 60.0,
+                "max_iteration_length": 35.0,
+                "iteration_z_raise": 5.0,
+                "iteration_z_change": 0.5,
+                "verbose": False,
+                "comment": False,
+            },
+        )
+        p = afc_poop(config)
+        assert p.purge_loc_xy == "50,75"
+        assert p.fast_z == 150.0
+        assert p.full_fan is True
+        assert p.purge_length == 80.0

--- a/tests/test_AFC_prep.py
+++ b/tests/test_AFC_prep.py
@@ -1,0 +1,170 @@
+"""
+Unit tests for extras/AFC_prep.py
+
+Covers:
+  - afcPrep attribute initialization
+  - _rename: delegates to gcode.register_command
+  - _rename_macros: only renames once, respects dis_unload_macro flag
+  - PREP: error when unit file missing or malformed JSON
+  - _td1_prep: logic branches for TD-1 presence
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from unittest.mock import MagicMock, patch, call
+import pytest
+
+from extras.AFC_prep import afcPrep
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_prep(values=None):
+    """Build an afcPrep instance bypassing __init__."""
+    prep = afcPrep.__new__(afcPrep)
+
+    from tests.conftest import MockAFC, MockPrinter, MockLogger
+
+    afc = MockAFC()
+    printer = MockPrinter(afc=afc)
+
+    prep.printer = printer
+    prep.afc = afc
+    prep.logger = afc.logger
+    prep.delay = 0.1
+    prep.enable = False
+    prep.dis_unload_macro = False
+    prep.get_td1_data = False
+    prep.rename_occurred = False
+    prep.assignTcmd = True
+
+    if values:
+        for k, v in values.items():
+            setattr(prep, k, v)
+
+    return prep
+
+
+# ── Initialization defaults ───────────────────────────────────────────────────
+
+class TestPrepInit:
+    def test_rename_occurred_initially_false(self):
+        p = _make_prep()
+        assert p.rename_occurred is False
+
+    def test_assign_tcmd_initially_true(self):
+        p = _make_prep()
+        assert p.assignTcmd is True
+
+    def test_delay_default(self):
+        p = _make_prep()
+        assert p.delay == 0.1
+
+# ── _rename_macros ────────────────────────────────────────────────────────────
+
+class TestRenameMacros:
+    def _setup_error_obj(self, prep):
+        prep.afc.error.BASE_RESUME_NAME = "RESUME"
+        prep.afc.error.AFC_RENAME_RESUME_NAME = "_AFC_RENAMED_RESUME_"
+        prep.afc.error.cmd_AFC_RESUME = MagicMock()
+        prep.afc.error.cmd_AFC_RESUME_help = "help"
+        prep.afc.error.BASE_PAUSE_NAME = "PAUSE"
+        prep.afc.error.AFC_RENAME_PAUSE_NAME = "_AFC_RENAMED_PAUSE_"
+        prep.afc.error.cmd_AFC_PAUSE = MagicMock()
+
+    def test_rename_macros_only_runs_once(self):
+        """Second call to _rename_macros should be a no-op (rename_occurred guard)."""
+        prep = _make_prep({"dis_unload_macro": True})  # skip UNLOAD_FILAMENT rename
+        self._setup_error_obj(prep)
+        prep.afc.function._rename = MagicMock()
+        prep._rename_macros()
+        count_after_first = prep.afc.function._rename.call_count
+        prep._rename_macros()  # Second call should be a no-op
+        assert prep.afc.function._rename.call_count == count_after_first  # no additional calls
+
+    def test_rename_occurred_set_after_first_call(self):
+        prep = _make_prep({"dis_unload_macro": True})
+        self._setup_error_obj(prep)
+        prep.afc.function._rename = MagicMock()
+        prep._rename_macros()
+        assert prep.rename_occurred is True
+
+    def test_unload_filament_renamed_by_default(self):
+        prep = _make_prep()
+        self._setup_error_obj(prep)
+        prep.afc.BASE_UNLOAD_FILAMENT = "UNLOAD_FILAMENT"
+        prep.afc.RENAMED_UNLOAD_FILAMENT = "_AFC_RENAMED_UNLOAD_FILAMENT_"
+        prep.afc.cmd_TOOL_UNLOAD = MagicMock()
+        prep.afc.cmd_TOOL_UNLOAD_help = "help"
+        prep.afc.function._rename = MagicMock()
+        prep._rename_macros()
+        # Expect 3 renames: RESUME, PAUSE, UNLOAD_FILAMENT
+        assert prep.afc.function._rename.call_count == 3
+
+    def test_unload_filament_not_renamed_when_disabled(self):
+        prep = _make_prep({"dis_unload_macro": True})
+        self._setup_error_obj(prep)
+        prep.afc.BASE_UNLOAD_FILAMENT = "UNLOAD_FILAMENT"
+        prep.afc.function._rename = MagicMock()
+        prep._rename_macros()
+        # Expect only 2 renames: RESUME + PAUSE
+        assert prep.afc.function._rename.call_count == 2
+    
+    def test_rename_occurred(self):
+        prep = _make_prep({"rename_occurred": True})
+        self._setup_error_obj(prep)
+        prep.afc.function._rename = MagicMock()
+        prep._rename_macros()
+        # Expect only 2 renames: RESUME + PAUSE
+        assert prep.afc.function._rename.call_count == 0
+
+
+# ── _td1_prep ─────────────────────────────────────────────────────────────────
+
+class TestTd1Prep:
+    def test_no_td1_skips_data_capture(self):
+        prep = _make_prep()
+        prep.afc.td1_present = False
+        prep.afc.function.get_current_lane_obj.return_value = None
+        # Should not raise or try to iterate lanes
+        prep._td1_prep(overrall_status=True)
+
+    def test_td1_present_no_current_lane_no_error_captures_data(self):
+        prep = _make_prep({"get_td1_data": True})
+        prep.afc.td1_present = True
+        prep.afc.function.get_current_lane_obj.return_value = None
+        prep.afc.function.check_for_td1_error.return_value = (False, None)
+        lane = MagicMock()
+        lane.load_state = True
+        lane.prep_state = True
+        lane.get_td1_data.return_value = (True, "data")
+        prep.afc.lanes = {"lane1": lane}
+        prep._td1_prep(overrall_status=True)
+        lane.get_td1_data.assert_called()
+
+    def test_td1_present_with_current_lane_skips_capture(self):
+        prep = _make_prep({"get_td1_data": True})
+        prep.afc.td1_present = True
+        cur_lane = MagicMock()
+        cur_lane.unit_obj = MagicMock()
+        prep.afc.function.get_current_lane_obj.return_value = cur_lane
+        prep.afc.function.check_for_td1_error.return_value = (False, None)
+        lane = MagicMock()
+        lane.get_td1_data = MagicMock()
+        prep.afc.lanes = {"lane1": lane}
+        prep._td1_prep(overrall_status=True)
+        lane.get_td1_data.assert_not_called()
+
+    def test_overall_status_false_skips_capture(self):
+        prep = _make_prep({"get_td1_data": True})
+        prep.afc.td1_present = True
+        prep.afc.function.get_current_lane_obj.return_value = None
+        prep.afc.function.check_for_td1_error.return_value = (False, None)
+        lane = MagicMock()
+        lane.get_td1_data = MagicMock()
+        prep.afc.lanes = {"lane1": lane}
+        prep._td1_prep(overrall_status=False)
+        lane.get_td1_data.assert_not_called()

--- a/tests/test_AFC_respond.py
+++ b/tests/test_AFC_respond.py
@@ -1,0 +1,263 @@
+"""
+Unit tests for extras/AFC_respond.py
+
+Covers every public method of AFCprompt:
+  p_begin, p_text, p_button, p_footer_button, p_cancel_button,
+  p_show, p_end, p_button_group_start, p_button_group_end,
+  create_custom_p (all combinations of args)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, call
+import pytest
+
+from extras.AFC_respond import AFCprompt
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def make_prompt():
+    """Return an AFCprompt whose logger.raw() calls are captured."""
+    gcmd = MagicMock()
+    from tests.conftest import MockLogger
+    logger = MockLogger()
+    return AFCprompt(gcmd, logger)
+
+
+def raw_messages(prompt):
+    return [m for lvl, m in prompt.logger.messages if lvl == "raw"]
+
+
+# ── Basic protocol methods ────────────────────────────────────────────────────
+
+class TestAFCpromptBasicMethods:
+    def test_p_begin_formats_correctly(self):
+        p = make_prompt()
+        p.p_begin("My Prompt")
+        assert any("prompt_begin My Prompt" in m for m in raw_messages(p))
+
+    def test_p_show_sends_action(self):
+        p = make_prompt()
+        p.p_show()
+        assert any("prompt_show" in m for m in raw_messages(p))
+
+    def test_p_end_sends_action(self):
+        p = make_prompt()
+        p.p_end()
+        assert any("prompt_end" in m for m in raw_messages(p))
+
+    def test_p_button_group_start(self):
+        p = make_prompt()
+        p.p_button_group_start()
+        assert any("prompt_button_group_start" in m for m in raw_messages(p))
+
+    def test_p_button_group_end(self):
+        p = make_prompt()
+        p.p_button_group_end()
+        assert any("prompt_button_group_end" in m for m in raw_messages(p))
+
+
+# ── p_text ────────────────────────────────────────────────────────────────────
+
+class TestAFCpromptText:
+    def test_p_text_single_line(self):
+        p = make_prompt()
+        p.p_text("Hello world")
+        msgs = raw_messages(p)
+        assert any("prompt_text Hello world" in m for m in msgs)
+
+    def test_p_text_multiline_sends_separate_messages(self):
+        p = make_prompt()
+        p.p_text("Line 1\nLine 2\nLine 3")
+        msgs = raw_messages(p)
+        assert any("Line 1" in m for m in msgs)
+        assert any("Line 2" in m for m in msgs)
+        assert any("Line 3" in m for m in msgs)
+
+
+# ── p_button ──────────────────────────────────────────────────────────────────
+
+class TestAFCpromptButton:
+    def test_p_button_without_style(self):
+        p = make_prompt()
+        p.p_button("Load", "LOAD_LANE LANE=lane1")
+        msgs = raw_messages(p)
+        assert any("Load|LOAD_LANE LANE=lane1" in m for m in msgs)
+        # Style must NOT be appended
+        assert not any("|primary" in m or "|secondary" in m for m in msgs)
+
+    def test_p_button_with_style(self):
+        p = make_prompt()
+        p.p_button("Load", "LOAD_LANE LANE=lane1", style="primary")
+        msgs = raw_messages(p)
+        assert any("Load|LOAD_LANE LANE=lane1|primary" in m for m in msgs)
+
+    def test_p_footer_button_without_style(self):
+        p = make_prompt()
+        p.p_footer_button("Cancel", "CANCEL")
+        msgs = raw_messages(p)
+        assert any("prompt_footer_button Cancel|CANCEL" in m for m in msgs)
+        assert not any("|primary" in m for m in msgs)
+
+    def test_p_footer_button_with_style(self):
+        p = make_prompt()
+        p.p_footer_button("Cancel", "CANCEL", style="warning")
+        msgs = raw_messages(p)
+        assert any("Cancel|CANCEL|warning" in m for m in msgs)
+
+    def test_p_cancel_button_uses_warning_style(self):
+        p = make_prompt()
+        p.p_cancel_button()
+        msgs = raw_messages(p)
+        assert any("warning" in m for m in msgs)
+        assert any("Cancel" in m for m in msgs)
+        assert any("prompt_end" in m for m in msgs)
+
+
+# ── create_custom_p ───────────────────────────────────────────────────────────
+
+class TestCreateCustomPrompt:
+    def test_minimal_call_begin_and_show(self):
+        p = make_prompt()
+        p.create_custom_p("My Title")
+        msgs = raw_messages(p)
+        assert any("prompt_begin My Title" in m for m in msgs)
+        assert any("prompt_show" in m for m in msgs)
+
+    def test_with_text(self):
+        p = make_prompt()
+        p.create_custom_p("Title", text="Some instructions")
+        msgs = raw_messages(p)
+        assert any("Some instructions" in m for m in msgs)
+
+    def test_with_cancel_footer(self):
+        p = make_prompt()
+        p.create_custom_p("Title", cancel=True)
+        msgs = raw_messages(p)
+        assert any("Cancel" in m for m in msgs)
+
+    def test_with_buttons(self):
+        p = make_prompt()
+        buttons = [
+            ("Button A", "CMD_A", "primary"),
+            ("Button B", "CMD_B", "secondary"),
+        ]
+        p.create_custom_p("Title", buttons=buttons)
+        msgs = raw_messages(p)
+        assert any("Button A" in m for m in msgs)
+        assert any("Button B" in m for m in msgs)
+
+    def test_with_footer_buttons(self):
+        p = make_prompt()
+        footer = [("Back", "BACK_CMD", "info")]
+        p.create_custom_p("Title", footer_buttons=footer)
+        msgs = raw_messages(p)
+        assert any("Back" in m for m in msgs)
+        assert any("prompt_footer_button" in m for m in msgs)
+
+    def test_with_groups(self):
+        p = make_prompt()
+        groups = [
+            [("Lane 1", "LOAD_LANE LANE=1", "primary"),
+             ("Lane 2", "LOAD_LANE LANE=2", "secondary")],
+        ]
+        p.create_custom_p("Select Lane", groups=groups)
+        msgs = raw_messages(p)
+        assert any("prompt_button_group_start" in m for m in msgs)
+        assert any("prompt_button_group_end" in m for m in msgs)
+        assert any("Lane 1" in m for m in msgs)
+        assert any("Lane 2" in m for m in msgs)
+
+    def test_order_begin_text_buttons_show(self):
+        """begin must appear before show, text before buttons."""
+        p = make_prompt()
+        buttons = [("OK", "OK_CMD", None)]
+        p.create_custom_p("Order Test", text="instructions", buttons=buttons)
+        msgs = raw_messages(p)
+        begin_idx = next(i for i, m in enumerate(msgs) if "prompt_begin" in m)
+        text_idx = next(i for i, m in enumerate(msgs) if "instructions" in m)
+        btn_idx = next(i for i, m in enumerate(msgs) if "OK" in m)
+        show_idx = next(i for i, m in enumerate(msgs) if "prompt_show" in m)
+        assert begin_idx < text_idx < btn_idx < show_idx
+
+    def test_all_options_combined(self):
+        p = make_prompt()
+        groups = [[("G1", "G1_CMD", "primary")]]
+        buttons = [("B1", "B1_CMD", "secondary")]
+        footer = [("Back", "BACK", "info")]
+        p.create_custom_p(
+            "Full Prompt",
+            text="Details here",
+            buttons=buttons,
+            cancel=True,
+            groups=groups,
+            footer_buttons=footer,
+        )
+        msgs = raw_messages(p)
+        assert any("Full Prompt" in m for m in msgs)
+        assert any("Details here" in m for m in msgs)
+        assert any("G1" in m for m in msgs)
+        assert any("B1" in m for m in msgs)
+        assert any("Back" in m for m in msgs)
+        assert any("Cancel" in m for m in msgs)
+        assert any("prompt_show" in m for m in msgs)
+
+
+# ── example_prompt ────────────────────────────────────────────────────────────
+
+class TestExamplePrompt:
+    def _make_prompt_with_mock(self):
+        p = make_prompt()
+        p.prompt = MagicMock()  # example_prompt delegates to self.prompt
+        return p
+
+    def test_four_items_creates_one_group(self):
+        p = self._make_prompt_with_mock()
+        p.example_prompt(["a", "b", "c", "d"])
+        _, _, _, _, groups, _ = p.prompt.create_custom_p.call_args[0]
+        assert len(groups) == 1
+        assert len(groups[0]) == 4
+
+    def test_five_items_creates_two_groups(self):
+        p = self._make_prompt_with_mock()
+        p.example_prompt(["a", "b", "c", "d", "e"])
+        _, _, _, _, groups, _ = p.prompt.create_custom_p.call_args[0]
+        assert len(groups) == 2
+        assert len(groups[0]) == 4
+        assert len(groups[1]) == 1
+
+    def test_eight_items_creates_two_groups_of_four(self):
+        p = self._make_prompt_with_mock()
+        p.example_prompt(["a", "b", "c", "d", "e", "f", "g", "h"])
+        _, _, _, _, groups, _ = p.prompt.create_custom_p.call_args[0]
+        assert len(groups) == 2
+        assert all(len(g) == 4 for g in groups)
+
+    def test_button_styles_alternate_primary_secondary(self):
+        p = self._make_prompt_with_mock()
+        p.example_prompt(["x", "y"])
+        _, _, _, _, groups, _ = p.prompt.create_custom_p.call_args[0]
+        styles = [btn[2] for btn in groups[0]]
+        assert styles[0] == "primary"
+        assert styles[1] == "secondary"
+
+    def test_button_command_contains_item_name(self):
+        p = self._make_prompt_with_mock()
+        p.example_prompt(["lane1"])
+        _, _, _, _, groups, _ = p.prompt.create_custom_p.call_args[0]
+        cmd = groups[0][0][1]
+        assert "lane1" in cmd
+
+    def test_back_button_is_passed_as_footer(self):
+        p = self._make_prompt_with_mock()
+        p.example_prompt(["x"])
+        _, _, _, _, _, back = p.prompt.create_custom_p.call_args[0]
+        assert len(back) == 1
+        assert back[0][0] == "Back"
+
+    def test_cancel_is_enabled(self):
+        p = self._make_prompt_with_mock()
+        p.example_prompt(["x"])
+        _, _, _, cancel, _, _ = p.prompt.create_custom_p.call_args[0]
+        assert cancel is True

--- a/tests/test_AFC_spool.py
+++ b/tests/test_AFC_spool.py
@@ -1,0 +1,764 @@
+"""
+Unit tests for extras/AFC_spool.py
+
+Covers:
+  - AFCSpool: initialization
+  - cmd_SET_MAP: validates lane mapping
+  - cmd_SET_COLOR / cmd_SET_MATERIAL / cmd_SET_WEIGHT: attribute updates
+  - cmd_SET_SPOOL_ID: spoolman interaction
+  - cmd_SET_RUNOUT: runout lane assignment
+  - cmd_RESET_AFC_MAPPING: clears mappings
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+import pytest
+
+from extras.AFC_spool import AFCSpool
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_spool():
+    """Build an AFCSpool instance bypassing __init__."""
+    spool = AFCSpool.__new__(AFCSpool)
+
+    from tests.conftest import MockAFC, MockPrinter, MockLogger, MockGcode
+
+    afc = MockAFC()
+    printer = MockPrinter(afc=afc)
+    afc.logger = MockLogger()
+    afc.gcode = MockGcode()
+    afc.reactor = MagicMock()
+    afc.spoolman = None
+    afc.tool_cmds = {}
+    afc.lanes = {}
+
+    spool.printer = printer
+    spool.afc = afc
+    spool.error = afc.error
+    spool.reactor = afc.reactor
+    spool.gcode = afc.gcode
+    spool.logger = afc.logger
+    spool.disable_weight_check = False
+    spool.next_spool_id = None
+    spool.SPOOLMAN_REMOTE_METHOD = 'spoolman_set_active_spool'
+
+    return spool
+
+
+def _make_lane(name="lane1"):
+    lane = MagicMock()
+    lane.name = name
+    lane.map = None
+    lane.color = ""
+    lane.material = ""
+    lane.weight = 0
+    lane.spool_id = None
+    lane.runout_lane = None
+    lane.unit_obj = MagicMock()
+    lane.hub_obj = MagicMock()
+    lane.extruder_obj = MagicMock()
+    return lane
+
+
+def _make_gcmd(**kwargs):
+    """Build a gcmd mock that returns values from kwargs."""
+    gcmd = MagicMock()
+    gcmd.get = lambda key, default=None: kwargs.get(key, default)
+    def _get_float(key, default=0.0, **kw):
+        val = kwargs.get(key, default)
+        return float(val) if val is not None else None
+    gcmd.get_float = _get_float
+    gcmd.get_int = lambda key, default=0, **kw: int(kwargs.get(key, default))
+    return gcmd
+
+
+# ── cmd_SET_MAP ────────────────────────────────────────────────────────────────
+
+class TestSetMap:
+    def test_set_map_assigns_lane_mapping(self):
+        spool = _make_spool()
+        lane1 = _make_lane("lane1")
+        lane2 = _make_lane("lane2")
+        lane2.map = "T0"
+        # T0 is currently mapped to lane2; we want to remap it to lane1
+        spool.afc.tool_cmds = {"T0": "lane2"}
+        spool.afc.lanes = {"lane1": lane1, "lane2": lane2}
+        gcmd = _make_gcmd(LANE="lane1", MAP="T0")
+        spool.cmd_SET_MAP(gcmd)
+        assert lane1.map == "T0"
+        assert spool.afc.tool_cmds.get("T0") == "lane1"
+
+    def test_set_map_invalid_lane_logs_error(self):
+        spool = _make_spool()
+        spool.afc.lanes = {}
+        gcmd = _make_gcmd(LANE="nonexistent", MAP="T1")
+        spool.cmd_SET_MAP(gcmd)
+        # Should log an error about invalid lane
+        error_msgs = [m for lvl, m in spool.logger.messages if lvl == "error"]
+        assert len(error_msgs) > 0
+
+    def test_no_lane_param_logs_info(self):
+        """Covers lines 66-68: lane is None → log info + return."""
+        spool = _make_spool()
+        gcmd = _make_gcmd()  # no LANE key → returns None
+        spool.cmd_SET_MAP(gcmd)
+        info_msgs = [m for lvl, m in spool.logger.messages if lvl == "info"]
+        assert any("LANE" in m for m in info_msgs)
+
+    def test_no_map_param_logs_info(self):
+        """Covers lines 72-74: map_cmd is None → log info + return."""
+        spool = _make_spool()
+        gcmd = _make_gcmd(LANE="lane1")  # no MAP key → returns None
+        spool.cmd_SET_MAP(gcmd)
+        info_msgs = [m for lvl, m in spool.logger.messages if lvl == "info"]
+        assert any("MAP" in m for m in info_msgs)
+
+    def test_lane_not_in_lanes_with_valid_tool_cmd_logs_info(self):
+        """Covers lines 84-86: MAP in tool_cmds, lane not in lanes → log info + return."""
+        spool = _make_spool()
+        spool.afc.tool_cmds = {"T0": "lane2"}
+        spool.afc.lanes = {}  # lane1 not present
+        gcmd = _make_gcmd(LANE="lane1", MAP="T0")
+        spool.cmd_SET_MAP(gcmd)
+        info_msgs = [m for lvl, m in spool.logger.messages if lvl == "info"]
+        assert any("lane1" in m for m in info_msgs)
+
+
+# ── cmd_SET_COLOR ──────────────────────────────────────────────────────────────
+
+class TestSetColor:
+    def test_set_color_updates_lane_color(self):
+        spool = _make_spool()
+        lane = _make_lane("lane1")
+        spool.afc.lanes = {"lane1": lane}
+        gcmd = _make_gcmd(LANE="lane1", COLOR="#FF0000")
+        spool.cmd_SET_COLOR(gcmd)
+        assert lane.color == "#FF0000"
+
+    def test_set_color_saves_vars(self):
+        spool = _make_spool()
+        lane = _make_lane("lane1")
+        spool.afc.lanes = {"lane1": lane}
+        spool.afc.save_vars = MagicMock()
+        gcmd = _make_gcmd(LANE="lane1", COLOR="red")
+        spool.cmd_SET_COLOR(gcmd)
+        spool.afc.save_vars.assert_called()
+
+    def test_no_lane_param_logs_info(self):
+        """Covers lines 117-119: lane is None → log info + return."""
+        spool = _make_spool()
+        gcmd = _make_gcmd()  # no LANE key
+        spool.cmd_SET_COLOR(gcmd)
+        info_msgs = [m for lvl, m in spool.logger.messages if lvl == "info"]
+        assert any("LANE" in m for m in info_msgs)
+
+    def test_lane_not_in_lanes_logs_info(self):
+        """Covers lines 121-123: lane not in lanes dict → log info + return."""
+        spool = _make_spool()
+        spool.afc.lanes = {}
+        gcmd = _make_gcmd(LANE="ghost", COLOR="FF0000")
+        spool.cmd_SET_COLOR(gcmd)
+        info_msgs = [m for lvl, m in spool.logger.messages if lvl == "info"]
+        assert any("ghost" in m for m in info_msgs)
+
+
+# ── cmd_SET_MATERIAL ───────────────────────────────────────────────────────────
+
+class TestSetMaterial:
+    def test_set_material_updates_lane_material(self):
+        spool = _make_spool()
+        lane = _make_lane("lane1")
+        spool.afc.lanes = {"lane1": lane}
+        gcmd = _make_gcmd(LANE="lane1", MATERIAL="PLA")
+        spool.cmd_SET_MATERIAL(gcmd)
+        assert lane.material == "PLA"
+
+    def test_set_material_saves_vars(self):
+        spool = _make_spool()
+        lane = _make_lane("lane1")
+        spool.afc.lanes = {"lane1": lane}
+        spool.afc.save_vars = MagicMock()
+        gcmd = _make_gcmd(LANE="lane1", MATERIAL="ABS")
+        spool.cmd_SET_MATERIAL(gcmd)
+        spool.afc.save_vars.assert_called()
+
+    def test_no_lane_param_logs_info(self):
+        """Covers lines 185-187: lane is None → log info + return."""
+        spool = _make_spool()
+        gcmd = _make_gcmd()  # no LANE key
+        spool.cmd_SET_MATERIAL(gcmd)
+        info_msgs = [m for lvl, m in spool.logger.messages if lvl == "info"]
+        assert any("LANE" in m for m in info_msgs)
+
+    def test_lane_not_in_lanes_logs_info(self):
+        """Covers lines 188-190: lane not in lanes → log info + return."""
+        spool = _make_spool()
+        spool.afc.lanes = {}
+        gcmd = _make_gcmd(LANE="ghost", MATERIAL="PLA")
+        spool.cmd_SET_MATERIAL(gcmd)
+        info_msgs = [m for lvl, m in spool.logger.messages if lvl == "info"]
+        assert any("ghost" in m for m in info_msgs)
+
+    def test_with_density_sets_filament_density(self):
+        """Covers lines 200-201: density is not None → sets cur_lane.filament_density."""
+        spool = _make_spool()
+        lane = _make_lane("lane1")
+        spool.afc.lanes = {"lane1": lane}
+        gcmd = _make_gcmd(LANE="lane1", MATERIAL="PLA", DENSITY=1.24)
+        spool.cmd_SET_MATERIAL(gcmd)
+        assert lane.filament_density == 1.24
+
+
+# ── cmd_SET_WEIGHT ─────────────────────────────────────────────────────────────
+
+class TestSetWeight:
+    def test_set_weight_updates_lane_weight(self):
+        spool = _make_spool()
+        lane = _make_lane("lane1")
+        spool.afc.lanes = {"lane1": lane}
+        gcmd = _make_gcmd(LANE="lane1", WEIGHT=250)
+        spool.cmd_SET_WEIGHT(gcmd)
+        assert lane.weight == 250
+
+    def test_set_weight_invalid_lane_logs_info(self):
+        spool = _make_spool()
+        spool.afc.lanes = {}
+        gcmd = _make_gcmd(LANE="missing", WEIGHT=100)
+        spool.cmd_SET_WEIGHT(gcmd)
+        info_msgs = [m for lvl, m in spool.logger.messages if lvl == "info"]
+        assert len(info_msgs) > 0
+
+    def test_no_lane_param_logs_info(self):
+        """Covers lines 146-148: lane is None → log info + return."""
+        spool = _make_spool()
+        gcmd = _make_gcmd()  # no LANE key
+        spool.cmd_SET_WEIGHT(gcmd)
+        info_msgs = [m for lvl, m in spool.logger.messages if lvl == "info"]
+        assert any("LANE" in m for m in info_msgs)
+
+
+# ── cmd_SET_RUNOUT ─────────────────────────────────────────────────────────────
+
+class TestSetRunout:
+    def test_set_runout_assigns_runout_lane(self):
+        spool = _make_spool()
+        lane1 = _make_lane("lane1")
+        lane2 = _make_lane("lane2")
+        spool.afc.lanes = {"lane1": lane1, "lane2": lane2}
+        gcmd = _make_gcmd(LANE="lane1", RUNOUT="lane2")
+        spool.cmd_SET_RUNOUT(gcmd)
+        assert lane1.runout_lane == "lane2"
+
+    def test_set_runout_saves_vars(self):
+        spool = _make_spool()
+        lane1 = _make_lane("lane1")
+        lane2 = _make_lane("lane2")
+        spool.afc.lanes = {"lane1": lane1, "lane2": lane2}
+        spool.afc.save_vars = MagicMock()
+        gcmd = _make_gcmd(LANE="lane1", RUNOUT="lane2")
+        spool.cmd_SET_RUNOUT(gcmd)
+        spool.afc.save_vars.assert_called()
+
+    def test_no_lane_param_logs_info(self):
+        """Covers lines 373-375: lane is None → log info + return."""
+        spool = _make_spool()
+        gcmd = _make_gcmd()  # no LANE key
+        spool.cmd_SET_RUNOUT(gcmd)
+        info_msgs = [m for lvl, m in spool.logger.messages if lvl == "info"]
+        assert any("LANE" in m for m in info_msgs)
+
+    def test_lane_equals_runout_logs_error(self):
+        """Covers lines 379-381: lane == runout → log error + return."""
+        spool = _make_spool()
+        lane1 = _make_lane("lane1")
+        spool.afc.lanes = {"lane1": lane1}
+        gcmd = _make_gcmd(LANE="lane1", RUNOUT="lane1")
+        spool.cmd_SET_RUNOUT(gcmd)
+        error_msgs = [m for lvl, m in spool.logger.messages if lvl == "error"]
+        assert any("lane1" in m for m in error_msgs)
+
+    def test_lane_not_in_lanes_logs_error(self):
+        """Covers lines 383-385: lane not in lanes → log error + return."""
+        spool = _make_spool()
+        spool.afc.lanes = {}
+        gcmd = _make_gcmd(LANE="ghost", RUNOUT="lane2")
+        spool.cmd_SET_RUNOUT(gcmd)
+        error_msgs = [m for lvl, m in spool.logger.messages if lvl == "error"]
+        assert any("ghost" in m for m in error_msgs)
+
+    def test_runout_not_in_lanes_logs_error(self):
+        """Covers lines 387-389: runout != 'NONE' but not in lanes → log error + return."""
+        spool = _make_spool()
+        lane1 = _make_lane("lane1")
+        spool.afc.lanes = {"lane1": lane1}
+        gcmd = _make_gcmd(LANE="lane1", RUNOUT="no_such_lane")
+        spool.cmd_SET_RUNOUT(gcmd)
+        error_msgs = [m for lvl, m in spool.logger.messages if lvl == "error"]
+        assert any("no_such_lane" in m for m in error_msgs)
+
+
+# ── cmd_RESET_AFC_MAPPING ─────────────────────────────────────────────────────
+
+class TestResetAFCMapping:
+    def _make_reset_gcmd(self, runout="yes"):
+        gcmd = MagicMock()
+        gcmd.get = lambda key, default=None: runout if key == "RUNOUT" else default
+        return gcmd
+
+    def _make_lane_for_reset(self, name, map_cmd="T0"):
+        """Lane mock with explicit _map=None and map=map_cmd."""
+        lane = _make_lane(name)
+        lane.map = map_cmd
+        lane._map = None  # not manually assigned
+        lane.runout_lane = None
+        return lane
+
+    def test_reset_saves_vars(self):
+        spool = _make_spool()
+        lane1 = self._make_lane_for_reset("lane1", "T0")
+        spool.afc.lanes = {"lane1": lane1}
+        spool.afc.units = {}  # no units, loop skips mapping reassignment
+        gcmd = self._make_reset_gcmd()
+        spool.cmd_RESET_AFC_MAPPING(gcmd)
+        spool.afc.save_vars.assert_called()
+
+    def test_reset_clears_runout_lanes(self):
+        spool = _make_spool()
+        lane1 = self._make_lane_for_reset("lane1", "T0")
+        lane1.runout_lane = "lane2"
+        spool.afc.lanes = {"lane1": lane1}
+        spool.afc.units = {}
+        gcmd = self._make_reset_gcmd(runout="yes")
+        spool.cmd_RESET_AFC_MAPPING(gcmd)
+        assert lane1.runout_lane is None
+
+    def test_reset_skips_runout_when_no(self):
+        spool = _make_spool()
+        lane1 = self._make_lane_for_reset("lane1", "T0")
+        lane1.runout_lane = "lane2"
+        spool.afc.lanes = {"lane1": lane1}
+        spool.afc.units = {}
+        gcmd = self._make_reset_gcmd(runout="no")
+        spool.cmd_RESET_AFC_MAPPING(gcmd)
+        assert lane1.runout_lane == "lane2"  # not cleared
+
+    def test_reset_reassigns_map_without_manual_mapping(self):
+        """Covers lines 422-431 else branch: lane._map=None → pops from existing_cmds."""
+        spool = _make_spool()
+        # Set up a lane in afc.lanes used to build existing_cmds
+        lane1 = self._make_lane_for_reset("lane1", "T0")
+        spool.afc.lanes = {"lane1": lane1}
+        # Unit whose lane also has _map=None (else branch)
+        unit_lane = MagicMock()
+        unit_lane.name = "lane1"
+        unit_lane._map = None
+        unit = MagicMock()
+        unit.lanes = {"lane1": unit_lane}
+        spool.afc.units = {"unit_1": unit}
+        gcmd = self._make_reset_gcmd()
+        spool.cmd_RESET_AFC_MAPPING(gcmd)
+        # tool_cmds and lane.map must have been updated
+        assert spool.afc.tool_cmds.get("T0") == "lane1"
+        assert spool.afc.lanes["lane1"].map == "T0"
+
+    def test_reset_uses_manual_map_when_set(self):
+        """Covers lines 425-427 if branch: lane._map is not None → uses it directly."""
+        spool = _make_spool()
+        lane1 = self._make_lane_for_reset("lane1", "T0")
+        lane1._map = "T0"  # manually assigned
+        spool.afc.lanes = {"lane1": lane1}
+        unit_lane = MagicMock()
+        unit_lane.name = "lane1"
+        unit_lane._map = "T0"  # manual assignment
+        unit = MagicMock()
+        unit.lanes = {"lane1": unit_lane}
+        spool.afc.units = {"unit_1": unit}
+        gcmd = self._make_reset_gcmd()
+        spool.cmd_RESET_AFC_MAPPING(gcmd)
+        # The manually assigned T0 should be applied
+        assert spool.afc.tool_cmds.get("T0") == "lane1"
+
+
+# ── cmd_SET_NEXT_SPOOL_ID ─────────────────────────────────────────────────────
+
+class TestSetNextSpoolId:
+    def test_stores_next_spool_id(self):
+        spool = _make_spool()
+        gcmd = _make_gcmd(SPOOL_ID=42)
+        spool.cmd_SET_NEXT_SPOOL_ID(gcmd)
+        assert spool.next_spool_id == 42
+
+    def test_invalid_spool_id_logs_error_and_clears(self):
+        """Covers lines 466-468: ValueError → log error, next_spool_id stays None."""
+        spool = _make_spool()
+        gcmd = _make_gcmd(SPOOL_ID="not_a_number")
+        spool.cmd_SET_NEXT_SPOOL_ID(gcmd)
+        error_msgs = [m for lvl, m in spool.logger.messages if lvl == "error"]
+        assert len(error_msgs) > 0
+        assert spool.next_spool_id is None
+
+    def test_empty_spool_id_clears_next(self):
+        """Covers lines 469-470: SpoolID='' → next_spool_id set to None."""
+        spool = _make_spool()
+        spool.next_spool_id = 99
+        gcmd = _make_gcmd()  # no SPOOL_ID key → default ''
+        spool.cmd_SET_NEXT_SPOOL_ID(gcmd)
+        assert spool.next_spool_id is None
+
+    def test_overwrites_existing_spool_id_logs_overwrite(self):
+        """Covers lines 471-472: previous_id is set → log overwrite info message."""
+        spool = _make_spool()
+        spool.next_spool_id = 10  # existing
+        gcmd = _make_gcmd(SPOOL_ID=20)
+        spool.cmd_SET_NEXT_SPOOL_ID(gcmd)
+        assert spool.next_spool_id == 20
+        info_msgs = [m for lvl, m in spool.logger.messages if lvl == "info"]
+        assert any("10" in m for m in info_msgs)
+
+
+# ── handle_connect / register_lane_macros ─────────────────────────────────────
+
+class TestHandleConnect:
+    def test_handle_connect_stores_afc_references(self):
+        from tests.conftest import MockAFC, MockPrinter
+        afc = MockAFC()
+        printer = MockPrinter(afc=afc)
+        spool = AFCSpool.__new__(AFCSpool)
+        spool.printer = printer
+        spool.next_spool_id = None
+        spool.handle_connect()
+        assert spool.afc is afc
+        assert spool.gcode is afc.gcode
+        assert spool.logger is afc.logger
+
+    def test_handle_connect_registers_commands(self):
+        from tests.conftest import MockAFC, MockPrinter
+        afc = MockAFC()
+        printer = MockPrinter(afc=afc)
+        spool = AFCSpool.__new__(AFCSpool)
+        spool.printer = printer
+        spool.next_spool_id = None
+        spool.handle_connect()
+        assert "RESET_AFC_MAPPING" in afc.gcode._commands
+        assert "SET_NEXT_SPOOL_ID" in afc.gcode._commands
+
+
+class TestRegisterLaneMacros:
+    def test_registers_six_mux_commands(self):
+        spool = _make_spool()
+        spool.gcode.register_mux_command = MagicMock()
+        lane = _make_lane("lane1")
+        spool.register_lane_macros(lane)
+        assert spool.gcode.register_mux_command.call_count == 6
+
+    def test_all_commands_use_correct_lane_name(self):
+        spool = _make_spool()
+        calls_received = []
+        spool.gcode.register_mux_command = MagicMock(
+            side_effect=lambda cmd, key, val, *a, **kw: calls_received.append((cmd, val))
+        )
+        lane = _make_lane("lane_x")
+        spool.register_lane_macros(lane)
+        for _cmd, val in calls_received:
+            assert val == "lane_x"
+
+
+# ── set_active_spool ──────────────────────────────────────────────────────────
+
+class TestSetActiveSpool:
+    def test_no_op_when_spoolman_is_none(self):
+        spool = _make_spool()
+        spool.afc.spoolman = None
+        webhooks = MagicMock()
+        spool.printer._objects["webhooks"] = webhooks
+        spool.set_active_spool(42)
+        webhooks.call_remote_method.assert_not_called()
+
+    def test_calls_webhook_with_spool_id(self):
+        spool = _make_spool()
+        spool.afc.spoolman = MagicMock()
+        webhooks = MagicMock()
+        spool.printer.lookup_object = MagicMock(return_value=webhooks)
+        spool.set_active_spool(7)
+        webhooks.call_remote_method.assert_called_once_with(
+            spool.SPOOLMAN_REMOTE_METHOD, spool_id=7
+        )
+
+    def test_calls_webhook_with_none_when_id_is_none(self):
+        spool = _make_spool()
+        spool.afc.spoolman = MagicMock()
+        webhooks = MagicMock()
+        spool.printer.lookup_object = MagicMock(return_value=webhooks)
+        spool.set_active_spool(None)
+        webhooks.call_remote_method.assert_called_once_with(
+            spool.SPOOLMAN_REMOTE_METHOD, spool_id=None
+        )
+
+
+# ── _get_filament_values ──────────────────────────────────────────────────────
+
+class TestGetFilamentValues:
+    def test_returns_value_when_field_present(self):
+        spool = _make_spool()
+        filament = {"material": "PLA", "density": 1.24}
+        assert spool._get_filament_values(filament, "material") == "PLA"
+
+    def test_returns_default_when_field_missing(self):
+        spool = _make_spool()
+        assert spool._get_filament_values({}, "density", default=1.0) == 1.0
+
+    def test_returns_none_as_default_when_not_specified(self):
+        spool = _make_spool()
+        assert spool._get_filament_values({}, "missing_field") is None
+
+
+# ── clear_values ──────────────────────────────────────────────────────────────
+
+class TestClearValues:
+    def test_clears_all_spool_fields(self):
+        spool = _make_spool()
+        lane = _make_lane()
+        lane.spool_id = 42
+        lane.material = "PLA"
+        lane.color = "#FF0000"
+        lane.weight = 500
+        lane.extruder_temp = 210
+        lane.bed_temp = 60
+        lane.clear_lane_data = MagicMock()
+        spool.clear_values(lane)
+        assert lane.spool_id is None
+        assert lane.material == ""
+        assert lane.color == ""
+        assert lane.weight == 0
+        assert lane.extruder_temp is None
+        assert lane.bed_temp is None
+        lane.clear_lane_data.assert_called_once()
+
+
+# ── _set_values ───────────────────────────────────────────────────────────────
+
+class TestSetValues:
+    def test_sets_defaults_when_not_remember_spool(self):
+        spool = _make_spool()
+        lane = _make_lane()
+        lane.remember_spool = False
+        spool.afc.default_material_type = "PLA"
+        spool.set_spoolID = MagicMock()
+        spool._set_values(lane)
+        assert lane.material == "PLA"
+        assert lane.weight == 1000
+        spool.set_spoolID.assert_not_called()
+
+    def test_calls_set_spool_id_when_next_spool_id_set(self):
+        spool = _make_spool()
+        lane = _make_lane()
+        lane.remember_spool = False
+        spool.afc.default_material_type = "PLA"
+        spool.afc.spoolman = MagicMock()
+        spool.next_spool_id = 42
+        spool.set_spoolID = MagicMock()
+        spool._set_values(lane)
+        spool.set_spoolID.assert_called_once_with(lane, 42)
+        assert spool.next_spool_id is None  # consumed after use
+
+
+# ── set_spoolID ───────────────────────────────────────────────────────────────
+
+def _make_spool_result(material="PLA", color_hex="FF0000", weight=800.0):
+    return {
+        "filament": {
+            "material": material,
+            "settings_extruder_temp": 210,
+            "settings_bed_temp": 60,
+            "density": 1.24,
+            "diameter": 1.75,
+            "color_hex": color_hex,
+        },
+        "spool_weight": 190,
+        "remaining_weight": weight,
+        "initial_weight": 1000.0,
+    }
+
+
+class TestSetSpoolID:
+    def _make_spool_with_spoolman(self):
+        spool = _make_spool()
+        spool.afc.spoolman = MagicMock()
+        return spool
+
+    def test_no_spoolman_not_remember_spool_clears_values(self):
+        spool = _make_spool()
+        lane = _make_lane()
+        lane.remember_spool = False
+        spool.clear_values = MagicMock()
+        spool.set_spoolID(lane, "")
+        spool.clear_values.assert_called_once_with(lane)
+
+    def test_valid_spool_id_sets_lane_attributes(self):
+        spool = self._make_spool_with_spoolman()
+        lane = _make_lane()
+        lane.remember_spool = False
+        lane.espooler = MagicMock()
+        result = _make_spool_result()
+        spool.afc.moonraker.get_spool = MagicMock(return_value=result)
+        spool.set_spoolID(lane, 42)
+        assert lane.spool_id == 42
+        assert lane.material == "PLA"
+        assert lane.color == "#FF0000"
+
+    def test_zero_weight_triggers_error_when_check_enabled(self):
+        spool = self._make_spool_with_spoolman()
+        lane = _make_lane()
+        lane.remember_spool = False
+        lane.espooler = MagicMock()
+        result = _make_spool_result(weight=0.0)
+        spool.afc.moonraker.get_spool = MagicMock(return_value=result)
+        spool.disable_weight_check = False
+        spool.clear_values = MagicMock()
+        spool.set_spoolID(lane, 42)
+        spool.afc.error.AFC_error.assert_called()
+        spool.clear_values.assert_called()
+
+    def test_disable_weight_check_skips_validation(self):
+        spool = self._make_spool_with_spoolman()
+        lane = _make_lane()
+        lane.remember_spool = False
+        lane.espooler = MagicMock()
+        result = _make_spool_result(weight=0.0)
+        spool.afc.moonraker.get_spool = MagicMock(return_value=result)
+        spool.disable_weight_check = True
+        spool.set_spoolID(lane, 42)
+        spool.afc.error.AFC_error.assert_not_called()
+
+    def test_multi_color_takes_first_color(self):
+        spool = self._make_spool_with_spoolman()
+        lane = _make_lane()
+        lane.remember_spool = False
+        lane.espooler = MagicMock()
+        result = _make_spool_result()
+        result["filament"]["multi_color_hexes"] = "AABBCC,001122,334455"
+        spool.afc.moonraker.get_spool = MagicMock(return_value=result)
+        spool.set_spoolID(lane, 42)
+        assert lane.color == "#AABBCC"
+
+    def test_ignore_spoolman_material_temps_skips_extruder_temp(self):
+        spool = self._make_spool_with_spoolman()
+        spool.afc.ignore_spoolman_material_temps = True
+        lane = _make_lane()
+        lane.remember_spool = False
+        lane.extruder_temp = None  # explicitly set before call
+        lane.espooler = MagicMock()
+        result = _make_spool_result()
+        spool.afc.moonraker.get_spool = MagicMock(return_value=result)
+        spool.set_spoolID(lane, 42)
+        # extruder_temp should NOT be overwritten when the flag is True
+        assert lane.extruder_temp is None
+
+    def test_exception_in_get_spool_calls_afc_error(self):
+        """Covers lines 346-348: exception in get_spool → AFC_error called."""
+        spool = self._make_spool_with_spoolman()
+        lane = _make_lane()
+        lane.remember_spool = False
+        spool.afc.moonraker.get_spool = MagicMock(
+            side_effect=Exception("Connection refused")
+        )
+        spool.set_spoolID(lane, 42)
+        spool.afc.error.AFC_error.assert_called()
+
+    def test_empty_spool_id_with_spoolman_not_remember_spool_clears_values(self):
+        """Covers lines 348-349: spoolman not None + SpoolID='' + not remember_spool → clear_values."""
+        spool = self._make_spool_with_spoolman()
+        lane = _make_lane()
+        lane.remember_spool = False
+        spool.clear_values = MagicMock()
+        spool.set_spoolID(lane, "")
+        spool.clear_values.assert_called_once_with(lane)
+
+
+# ── cmd_SET_SPOOL_ID ──────────────────────────────────────────────────────────
+
+class TestCmdSetSpoolID:
+    def test_no_op_when_spoolman_is_none(self):
+        spool = _make_spool()
+        spool.afc.spoolman = None
+        lane = _make_lane("lane1")
+        spool.afc.lanes = {"lane1": lane}
+        gcmd = _make_gcmd(LANE="lane1", SPOOL_ID="42")
+        spool.set_spoolID = MagicMock()
+        spool.cmd_SET_SPOOL_ID(gcmd)
+        spool.set_spoolID.assert_not_called()
+
+    def test_invalid_spool_id_string_logs_error(self):
+        spool = _make_spool()
+        spool.afc.spoolman = MagicMock()
+        lane = _make_lane("lane1")
+        spool.afc.lanes = {"lane1": lane}
+        gcmd = _make_gcmd(LANE="lane1", SPOOL_ID="not_a_number")
+        spool.set_spoolID = MagicMock()
+        spool.cmd_SET_SPOOL_ID(gcmd)
+        errors = [m for lvl, m in spool.logger.messages if lvl == "error"]
+        assert len(errors) > 0
+        spool.set_spoolID.assert_not_called()
+
+    def test_spool_already_assigned_to_other_lane_logs_error(self):
+        spool = _make_spool()
+        spool.afc.spoolman = MagicMock()
+        lane1 = _make_lane("lane1")
+        lane1.spool_id = None
+        lane2 = _make_lane("lane2")
+        lane2.spool_id = 42
+        spool.afc.lanes = {"lane1": lane1, "lane2": lane2}
+        gcmd = _make_gcmd(LANE="lane1", SPOOL_ID="42")
+        spool.set_spoolID = MagicMock()
+        spool.cmd_SET_SPOOL_ID(gcmd)
+        errors = [m for lvl, m in spool.logger.messages if lvl == "error"]
+        assert len(errors) > 0
+        spool.set_spoolID.assert_not_called()
+
+    def test_valid_assignment_calls_set_spool_id(self):
+        spool = _make_spool()
+        spool.afc.spoolman = MagicMock()
+        lane1 = _make_lane("lane1")
+        lane1.spool_id = None
+        spool.afc.lanes = {"lane1": lane1}
+        spool.afc.current = None
+        gcmd = _make_gcmd(LANE="lane1", SPOOL_ID="5")
+        spool.set_spoolID = MagicMock()
+        spool.cmd_SET_SPOOL_ID(gcmd)
+        spool.set_spoolID.assert_called_once_with(lane1, 5)
+
+    def test_no_lane_param_logs_info(self):
+        """Covers lines 239-241: spoolman not None + lane=None → log info + return."""
+        spool = _make_spool()
+        spool.afc.spoolman = MagicMock()
+        gcmd = _make_gcmd()  # no LANE key
+        spool.cmd_SET_SPOOL_ID(gcmd)
+        info_msgs = [m for lvl, m in spool.logger.messages if lvl == "info"]
+        assert any("LANE" in m for m in info_msgs)
+
+    def test_lane_not_in_lanes_logs_info(self):
+        """Covers lines 243-245: spoolman not None + lane not in lanes → log info + return."""
+        spool = _make_spool()
+        spool.afc.spoolman = MagicMock()
+        spool.afc.lanes = {}
+        gcmd = _make_gcmd(LANE="ghost", SPOOL_ID="7")
+        spool.cmd_SET_SPOOL_ID(gcmd)
+        info_msgs = [m for lvl, m in spool.logger.messages if lvl == "info"]
+        assert any("ghost" in m for m in info_msgs)
+
+    def test_calls_set_active_spool_when_lane_is_current(self):
+        """Covers lines 264-265: cur_lane.name == afc.current → set_active_spool called."""
+        spool = _make_spool()
+        spool.afc.spoolman = MagicMock()
+        lane1 = _make_lane("lane1")
+        lane1.spool_id = None
+        spool.afc.lanes = {"lane1": lane1}
+        spool.afc.current = "lane1"  # lane1 is the active lane
+        gcmd = _make_gcmd(LANE="lane1", SPOOL_ID="9")
+        spool.set_spoolID = MagicMock()
+        spool.set_active_spool = MagicMock()
+        spool.cmd_SET_SPOOL_ID(gcmd)
+        spool.set_active_spool.assert_called_once_with(lane1.spool_id)

--- a/tests/test_AFC_stats.py
+++ b/tests/test_AFC_stats.py
@@ -1,0 +1,494 @@
+"""
+Unit tests for extras/AFC_stats.py
+
+Covers:
+  - AFCStats_var: init, value retrieval, increment, reset, average_time,
+    get_average, update_database, set_current_time, __str__, value property
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+import pytest
+
+from extras.AFC_stats import AFCStats_var, AFCStats
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def make_moonraker(stats_data=None):
+    from tests.conftest import MockMoonraker
+    mr = MockMoonraker()
+    mr._stats = stats_data or {}
+    return mr
+
+
+def make_var(parent_name, name, data=None, moonraker=None, new_parent_name="", new_average=False):
+    mr = moonraker or make_moonraker()
+    return AFCStats_var(parent_name, name, data, mr, new_parent_name, new_average)
+
+
+# ── AFCStats_var ──────────────────────────────────────────────────────────────
+
+class TestAFCStatsVarInit:
+    def test_init_no_data_defaults_to_zero(self):
+        var = make_var("extruder", "cut_total", data=None)
+        assert var.value == 0
+
+    def test_init_data_missing_parent_defaults_to_zero(self):
+        data = {"other_parent": {"cut_total": 5}}
+        var = make_var("extruder", "cut_total", data=data)
+        assert var.value == 0
+
+    def test_init_data_with_matching_parent_single_level(self):
+        data = {"extruder": {"cut_total": 42}}
+        var = make_var("extruder", "cut_total", data=data)
+        assert var.value == 42
+
+    def test_init_data_with_matching_parent_two_levels(self):
+        data = {"extruder": {"cut": {"cut_total": 7}}}
+        var = make_var("extruder.cut", "cut_total", data=data)
+        assert var.value == 7
+
+    def test_init_data_float_value(self):
+        data = {"timing": {"avg": "3.14"}}
+        var = make_var("timing", "avg", data=data)
+        assert abs(var.value - 3.14) < 1e-9
+
+    def test_init_data_int_value_as_string(self):
+        data = {"extruder": {"count": "5"}}
+        var = make_var("extruder", "count", data=data)
+        assert var.value == 5
+        assert isinstance(var.value, int)
+
+    def test_init_data_non_numeric_string(self):
+        data = {"extruder": {"date": "2024-01-01"}}
+        var = make_var("extruder", "date", data=data)
+        assert var.value == "2024-01-01"
+
+    def test_init_new_parent_renames_and_deletes_old(self):
+        mr = make_moonraker()
+        mr.remove_database_entry = MagicMock()
+        mr.update_afc_stats = MagicMock()
+        data = {"old_parent": {"count": 3}}
+        var = AFCStats_var("old_parent", "count", data, mr, new_parent_name="new_parent")
+        assert var.parent_name == "new_parent"
+        mr.update_afc_stats.assert_called()
+
+    def test_str_representation(self):
+        var = make_var("extruder", "cut_total", data={"extruder": {"cut_total": 10}})
+        assert str(var) == "10"
+
+    def test_value_property_getter(self):
+        var = make_var("extruder", "cut_total")
+        var.value = 99
+        assert var.value == 99
+
+    def test_value_property_setter(self):
+        var = make_var("extruder", "cut_total")
+        var.value = 55
+        assert var._value == 55
+
+
+class TestAFCStatsVarIncrement:
+    def test_increase_count_increments_by_one(self):
+        mr = make_moonraker()
+        mr.update_afc_stats = MagicMock()
+        var = make_var("extruder", "cut_total", moonraker=mr)
+        var.increase_count()
+        assert var.value == 1
+        mr.update_afc_stats.assert_called_once()
+
+    def test_increase_count_multiple_times(self):
+        mr = make_moonraker()
+        mr.update_afc_stats = MagicMock()
+        var = make_var("extruder", "cut_total", moonraker=mr)
+        for _ in range(5):
+            var.increase_count()
+        assert var.value == 5
+
+
+class TestAFCStatsVarReset:
+    def test_reset_count_sets_to_zero(self):
+        mr = make_moonraker()
+        mr.update_afc_stats = MagicMock()
+        var = make_var("extruder", "cut_total", moonraker=mr)
+        var._value = 100
+        var.reset_count()
+        assert var.value == 0
+
+    def test_reset_count_enables_new_average(self):
+        mr = make_moonraker()
+        mr.update_afc_stats = MagicMock()
+        var = make_var("extruder", "cut_total", moonraker=mr, new_average=False)
+        var._value = 50
+        var.reset_count()
+        assert var.new_average is True
+
+    def test_reset_count_calls_update_database(self):
+        mr = make_moonraker()
+        mr.update_afc_stats = MagicMock()
+        var = make_var("extruder", "cut_total", moonraker=mr)
+        var._value = 10
+        var.reset_count()
+        mr.update_afc_stats.assert_called()
+
+
+class TestAFCStatsVarAverageTime:
+    def test_average_time_first_value_sets_value(self):
+        mr = make_moonraker()
+        mr.update_afc_stats = MagicMock()
+        var = make_var("timing", "avg", moonraker=mr)
+        var.average_time(10.0)
+        assert var.value == 10.0
+
+    def test_average_time_old_method_divides_by_two(self):
+        mr = make_moonraker()
+        mr.update_afc_stats = MagicMock()
+        var = make_var("timing", "avg", moonraker=mr, new_average=False)
+        var._value = 10.0
+        var.average_time(20.0)
+        assert var.value == 15.0  # (10+20)/2
+
+    def test_average_time_new_method_sums(self):
+        mr = make_moonraker()
+        mr.update_afc_stats = MagicMock()
+        var = make_var("timing", "avg", moonraker=mr, new_average=True)
+        var._value = 10.0
+        var.average_time(20.0)
+        assert var.value == 30.0  # 10 + 20 (no division)
+
+    def test_get_average_new_method_divides_by_total(self):
+        var = make_var("timing", "avg", new_average=True)
+        var._value = 30.0
+        result = var.get_average(total=3)
+        assert result == 10.0
+
+    def test_get_average_new_method_zero_total(self):
+        var = make_var("timing", "avg", new_average=True)
+        var._value = 30.0
+        result = var.get_average(total=0)
+        assert result == 30.0
+
+    def test_get_average_old_method_returns_value(self):
+        var = make_var("timing", "avg", new_average=False)
+        var._value = 15.0
+        result = var.get_average(total=5)
+        assert result == 15.0
+
+
+class TestAFCStatsVarUpdateDatabase:
+    def test_update_database_calls_moonraker_with_correct_key(self):
+        mr = make_moonraker()
+        mr.update_afc_stats = MagicMock()
+        var = make_var("extruder", "cut_total", moonraker=mr)
+        var._value = 7
+        var.update_database()
+        mr.update_afc_stats.assert_called_once_with("extruder.cut_total", 7)
+
+    def test_update_database_two_level_parent(self):
+        mr = make_moonraker()
+        mr.update_afc_stats = MagicMock()
+        var = make_var("extruder.cut", "cut_total", moonraker=mr)
+        var._value = 3
+        var.update_database()
+        mr.update_afc_stats.assert_called_once_with("extruder.cut.cut_total", 3)
+
+
+class TestAFCStatsVarSetCurrentTime:
+    def test_set_current_time_updates_value_and_database(self):
+        mr = make_moonraker()
+        mr.update_afc_stats = MagicMock()
+        var = make_var("error_stats", "last_load_error", moonraker=mr)
+        var.set_current_time()
+        assert isinstance(var.value, str)
+        assert len(var.value) > 0
+        mr.update_afc_stats.assert_called()
+
+
+# ── _get_value edge cases ─────────────────────────────────────────────────────
+
+class TestGetValueEdgeCases:
+    def test_three_level_parent_logs_error(self):
+        """Three-level parent (a.b.c) triggers logger.error and returns 0."""
+        mr = make_moonraker()
+        mr.update_afc_stats = MagicMock()
+        data = {"a": {"b": {"c": 5}}}
+        var = make_var("a.b.c", "value", data=data, moonraker=mr)
+        # Value should be 0 (error path)
+        assert var.value == 0
+
+    def test_two_level_parent_missing_second_level_returns_zero(self):
+        """Two-level parent with missing second key returns 0."""
+        mr = make_moonraker()
+        data = {"extruder": {}}  # second level key "cut" missing
+        var = make_var("extruder.cut", "cut_total", data=data, moonraker=mr)
+        assert var.value == 0
+
+    def test_new_parent_with_no_data_does_not_remove(self):
+        """When data=None, the old-parent delete step is skipped."""
+        mr = make_moonraker()
+        mr.remove_database_entry = MagicMock()
+        mr.update_afc_stats = MagicMock()
+        var = AFCStats_var("old_parent", "count", None, mr, new_parent_name="new_parent")
+        assert var.parent_name == "new_parent"
+        mr.remove_database_entry.assert_not_called()
+
+
+# ── AFCStats ──────────────────────────────────────────────────────────────────
+
+def _make_afc_stats(multiple_tools=False, stats_data=None):
+    """Build an AFCStats instance with MockMoonraker and MockLogger."""
+    from tests.conftest import MockMoonraker, MockLogger
+    mr = MockMoonraker()
+    if stats_data is not None:
+        mr._stats = stats_data
+    mr.update_afc_stats = MagicMock()
+    mr.remove_database_entry = MagicMock()
+    logger = MockLogger()
+    afc_stats = AFCStats(mr, logger, multiple_tools)
+    return afc_stats, mr, logger
+
+
+class TestAFCStatsInit:
+    def test_creates_tc_without_error_var(self):
+        stats, _, _ = _make_afc_stats()
+        assert hasattr(stats, "tc_without_error")
+
+    def test_creates_tc_last_load_error_var(self):
+        stats, _, _ = _make_afc_stats()
+        assert hasattr(stats, "tc_last_load_error")
+
+    def test_last_load_error_set_to_na_when_zero(self):
+        stats, _, _ = _make_afc_stats()
+        assert stats.tc_last_load_error.value == "N/A"
+
+    def test_creates_average_time_vars(self):
+        stats, _, _ = _make_afc_stats()
+        assert hasattr(stats, "average_toolchange_time")
+        assert hasattr(stats, "average_tool_unload_time")
+        assert hasattr(stats, "average_tool_load_time")
+
+    def test_multiple_tools_creates_swap_var(self):
+        stats, _, _ = _make_afc_stats(multiple_tools=True)
+        assert stats.average_tool_swap_time is not None
+
+    def test_single_tool_swap_var_is_none(self):
+        stats, _, _ = _make_afc_stats(multiple_tools=False)
+        assert stats.average_tool_swap_time is None
+
+    def test_multiple_tools_logs_debug(self):
+        _, _, logger = _make_afc_stats(multiple_tools=True)
+        debug_msgs = [m for lvl, m in logger.messages if lvl == "debug"]
+        assert any("multiple" in m.lower() for m in debug_msgs)
+
+    def test_new_average_calc_set_to_one_when_no_existing_data(self):
+        stats, _, _ = _make_afc_stats()
+        assert stats.new_average_calc.value == 1
+
+    def test_new_average_calc_set_to_zero_when_average_time_in_db(self):
+        # When "average_time" key exists in stats data, new_average_calc stays 0
+        stats, mr, _ = _make_afc_stats(stats_data={"average_time": {"new_average_calc": 0}})
+        assert stats.new_average_calc.value == 0
+
+
+class TestAFCStatsIncreaseTcWoError:
+    def test_increase_toolchange_wo_error_calls_increase_count(self):
+        stats, _, _ = _make_afc_stats()
+        before = stats.tc_without_error.value
+        stats.increase_toolchange_wo_error()
+        assert stats.tc_without_error.value == before + 1
+
+
+class TestAFCStatsResetTcWoError:
+    def test_reset_clears_count(self):
+        stats, _, _ = _make_afc_stats()
+        stats.tc_without_error._value = 5
+        stats.reset_toolchange_wo_error()
+        assert stats.tc_without_error.value == 0
+
+    def test_reset_sets_last_error_time(self):
+        stats, _, _ = _make_afc_stats()
+        stats.reset_toolchange_wo_error()
+        # Should have a date string now
+        assert isinstance(stats.tc_last_load_error.value, str)
+        assert len(stats.tc_last_load_error.value) > 3
+
+
+class TestAFCStatsResetAverageTimes:
+    def test_reset_sets_toolchange_time_to_zero(self):
+        stats, _, _ = _make_afc_stats()
+        stats.average_toolchange_time._value = 10.0
+        stats.reset_average_times()
+        assert stats.average_toolchange_time.value == 0
+
+    def test_reset_sets_unload_time_to_zero(self):
+        stats, _, _ = _make_afc_stats()
+        stats.average_tool_unload_time._value = 5.0
+        stats.reset_average_times()
+        assert stats.average_tool_unload_time.value == 0
+
+    def test_reset_sets_load_time_to_zero(self):
+        stats, _, _ = _make_afc_stats()
+        stats.average_tool_load_time._value = 8.0
+        stats.reset_average_times()
+        assert stats.average_tool_load_time.value == 0
+
+    def test_reset_also_resets_swap_time_when_multiple_tools(self):
+        stats, _, _ = _make_afc_stats(multiple_tools=True)
+        stats.average_tool_swap_time._value = 3.0
+        stats.reset_average_times()
+        assert stats.average_tool_swap_time.value == 0
+
+    def test_reset_sets_new_average_calc_to_one(self):
+        stats, _, _ = _make_afc_stats()
+        stats.reset_average_times()
+        assert stats.new_average_calc.value == 1
+
+
+class TestAFCStatsPrintStats:
+    def _make_mock_afc(self):
+        afc_obj = MagicMock()
+        afc_obj.lanes = {}
+        afc_obj.tools = {}
+        return afc_obj
+
+    def test_print_stats_calls_logger_raw(self):
+        stats, _, logger = _make_afc_stats()
+        afc_obj = self._make_mock_afc()
+        stats.print_stats(afc_obj)
+        raw_msgs = [m for lvl, m in logger.messages if lvl == "raw"]
+        assert len(raw_msgs) >= 1
+
+    def test_print_stats_contains_overall_header(self):
+        stats, _, logger = _make_afc_stats()
+        afc_obj = self._make_mock_afc()
+        stats.print_stats(afc_obj)
+        raw_msgs = [m for lvl, m in logger.messages if lvl == "raw"]
+        output = "".join(raw_msgs)
+        assert "Overall Stats" in output
+
+    def test_print_stats_short_mode_calls_logger_raw(self):
+        stats, _, logger = _make_afc_stats()
+        afc_obj = self._make_mock_afc()
+        stats.print_stats(afc_obj, short=True)
+        raw_msgs = [m for lvl, m in logger.messages if lvl == "raw"]
+        assert len(raw_msgs) >= 1
+
+    def test_print_stats_with_extruder(self):
+        stats, _, logger = _make_afc_stats()
+        afc_obj = self._make_mock_afc()
+        ext = MagicMock()
+        ext.name = "extruder"
+        ext.estats.cut_total_since_changed.value = 5
+        ext.estats.cut_threshold_for_warning = 100
+        ext.estats.tc_total.value = 10
+        ext.estats.tc_tool_unload.value = 5
+        ext.estats.tc_tool_load.value = 5
+        ext.estats.cut_total.value = 5
+        ext.estats.last_blade_changed.value = "2024-01-01"
+        ext.estats.tool_selected.value = 0
+        ext.estats.tool_unselected.value = 0
+        afc_obj.tools = {"extruder": ext}
+        stats.print_stats(afc_obj)
+        raw_msgs = [m for lvl, m in logger.messages if lvl == "raw"]
+        output = "".join(raw_msgs)
+        assert "extruder" in output
+
+    def test_print_stats_with_multiple_tools_and_extruder(self):
+        stats, _, logger = _make_afc_stats(multiple_tools=True)
+        afc_obj = self._make_mock_afc()
+        ext = MagicMock()
+        ext.name = "extruder"
+        ext.estats.cut_total_since_changed.value = 5
+        ext.estats.cut_threshold_for_warning = 100
+        ext.estats.tc_total.value = 10
+        ext.estats.tc_tool_unload.value = 5
+        ext.estats.tc_tool_load.value = 5
+        ext.estats.cut_total.value = 5
+        ext.estats.last_blade_changed.value = "2024-01-01"
+        ext.estats.tool_selected.value = 2
+        ext.estats.tool_unselected.value = 1
+        afc_obj.tools = {"extruder": ext}
+        stats.print_stats(afc_obj)
+        raw_msgs = [m for lvl, m in logger.messages if lvl == "raw"]
+        output = "".join(raw_msgs)
+        assert "Overall Stats" in output
+
+    def _make_ext_mock(self, name="extruder"):
+        ext = MagicMock()
+        ext.name = name
+        ext.estats.cut_total_since_changed.value = 3
+        ext.estats.cut_threshold_for_warning = 50
+        ext.estats.tc_total.value = 7
+        ext.estats.tc_tool_unload.value = 3
+        ext.estats.tc_tool_load.value = 4
+        ext.estats.cut_total.value = 3
+        ext.estats.last_blade_changed.value = "N/A"
+        ext.estats.tool_selected.value = 5
+        ext.estats.tool_unselected.value = 5
+        return ext
+
+    def test_print_stats_short_mode_with_multiple_tools_and_extruder(self):
+        """Covers short=True + multiple_tools branches (lines 337, 340, 343-344)."""
+        stats, _, logger = _make_afc_stats(multiple_tools=True)
+        afc_obj = self._make_mock_afc()
+        afc_obj.tools = {"extruder": self._make_ext_mock()}
+        stats.print_stats(afc_obj, short=True)
+        raw_msgs = [m for lvl, m in logger.messages if lvl == "raw"]
+        output = "".join(raw_msgs)
+        assert "Overall Stats" in output
+
+    def test_print_stats_long_format_with_lane(self):
+        """Covers the lane loop body and end_string() call (lines 270-271, 282, 379-381, 392-399)."""
+        stats, _, logger = _make_afc_stats()
+        afc_obj = self._make_mock_afc()
+        lane = MagicMock()
+        lane.name = "lane1"
+        lane.espooler.get_spooler_stats.return_value = ""  # empty espooler
+        lane.lane_load_count.value = 3
+        afc_obj.lanes = {"lane1": lane}
+        stats.print_stats(afc_obj, short=False)
+        raw_msgs = [m for lvl, m in logger.messages if lvl == "raw"]
+        assert len(raw_msgs) >= 1
+
+    def test_print_stats_long_format_with_lane_espooler_stats(self):
+        """Covers espooler non-empty long-format branch (line 385)."""
+        stats, _, logger = _make_afc_stats()
+        afc_obj = self._make_mock_afc()
+        lane = MagicMock()
+        lane.name = "lane1"
+        lane.espooler.get_spooler_stats.return_value = "Spooler: 500g"  # non-empty
+        lane.lane_load_count.value = 5
+        afc_obj.lanes = {"lane1": lane}
+        stats.print_stats(afc_obj, short=False)
+        raw_msgs = [m for lvl, m in logger.messages if lvl == "raw"]
+        output = "".join(raw_msgs)
+        assert "lane1" in output
+
+    def test_print_stats_short_format_with_lane_and_espooler(self):
+        """Covers short=True lane formatting (lines 382, 383-384)."""
+        stats, _, logger = _make_afc_stats()
+        afc_obj = self._make_mock_afc()
+        lane = MagicMock()
+        lane.name = "lane1"
+        lane.espooler.get_spooler_stats.return_value = "Spooler: 250g"  # non-empty
+        lane.lane_load_count.value = 2
+        afc_obj.lanes = {"lane1": lane}
+        stats.print_stats(afc_obj, short=True)
+        raw_msgs = [m for lvl, m in logger.messages if lvl == "raw"]
+        assert len(raw_msgs) >= 1
+
+    def test_print_stats_long_string_lane_uses_direct_print(self):
+        """Covers lines 395-397: lane string > 60 chars goes directly to print_str."""
+        stats, _, logger = _make_afc_stats()
+        afc_obj = self._make_mock_afc()
+        lane = MagicMock()
+        lane.name = "lane1"
+        # Long espooler stats (>21 chars) pushes string length over 60
+        lane.espooler.get_spooler_stats.return_value = "x" * 25
+        lane.lane_load_count.value = 1
+        afc_obj.lanes = {"lane1": lane}
+        stats.print_stats(afc_obj, short=False)
+        raw_msgs = [m for lvl, m in logger.messages if lvl == "raw"]
+        assert len(raw_msgs) >= 1

--- a/tests/test_AFC_stepper.py
+++ b/tests/test_AFC_stepper.py
@@ -1,0 +1,331 @@
+"""
+Unit tests for extras/AFC_stepper.py
+
+Covers:
+  - AFCExtruderStepper: pure helper methods that don't need hardware
+  - dwell: increments next_cmd_time by max(0, delay)
+  - set_position: always sets _manual_axis_pos to 0.0
+  - get_position: delegates to stepper get_commanded_position
+  - _set_current: calls gcode script when tmc_print_current is set
+  - set_load_current / set_print_current: call _set_current with correct value
+  - update_rotation_distance: calls set_rotation_distance with base/multiplier
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+import pytest
+
+from extras.AFC_stepper import AFCExtruderStepper
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_stepper(name="lane1"):
+    """Build an AFCExtruderStepper bypassing the complex __init__."""
+    stepper = AFCExtruderStepper.__new__(AFCExtruderStepper)
+
+    from tests.conftest import MockAFC, MockPrinter, MockLogger, MockGcode
+
+    afc = MockAFC()
+    afc.logger = MockLogger()
+    printer = MockPrinter(afc=afc)
+
+    stepper.printer = printer
+    stepper.afc = afc
+    stepper.logger = afc.logger
+    stepper.name = name
+    stepper.fullname = name
+    stepper.next_cmd_time = 0.0
+    stepper._manual_axis_pos = 0.0
+
+    # Extruder stepper mock
+    stepper.extruder_stepper = MagicMock()
+    stepper.extruder_stepper.stepper.get_commanded_position.return_value = 42.0
+    stepper.extruder_stepper.stepper.get_rotation_distance.return_value = (8.0, 200)
+
+    stepper.base_rotation_dist = 8.0
+
+    # TMC / current settings
+    stepper.tmc_print_current = None
+    stepper.tmc_load_current = None
+
+    # Gcode mock
+    stepper.gcode = MockGcode()
+    stepper.gcode.run_script_from_command = MagicMock()
+
+    return stepper
+
+
+# ── dwell ─────────────────────────────────────────────────────────────────────
+
+class TestDwell:
+    def test_dwell_increments_next_cmd_time(self):
+        s = _make_stepper()
+        s.next_cmd_time = 10.0
+        s.dwell(0.5)
+        assert s.next_cmd_time == 10.5
+
+    def test_dwell_zero_delay_no_change(self):
+        s = _make_stepper()
+        s.next_cmd_time = 5.0
+        s.dwell(0.0)
+        assert s.next_cmd_time == 5.0
+
+    def test_dwell_negative_delay_no_change(self):
+        """Negative delay is clamped to 0 via max(0., delay)."""
+        s = _make_stepper()
+        s.next_cmd_time = 5.0
+        s.dwell(-1.0)
+        assert s.next_cmd_time == 5.0
+
+    def test_dwell_accumulates(self):
+        s = _make_stepper()
+        s.next_cmd_time = 0.0
+        s.dwell(1.0)
+        s.dwell(2.0)
+        assert s.next_cmd_time == 3.0
+
+
+# ── set_position ──────────────────────────────────────────────────────────────
+
+class TestSetPosition:
+    def test_set_position_always_zeros_manual_axis_pos(self):
+        s = _make_stepper()
+        s._manual_axis_pos = 99.0
+        s.set_position([10.0, 0., 0., 0.], "x")
+        assert s._manual_axis_pos == 0.0
+
+    def test_set_position_ignores_newpos(self):
+        """Regardless of newpos, _manual_axis_pos is reset to 0."""
+        s = _make_stepper()
+        s.set_position([500.0], "")
+        assert s._manual_axis_pos == 0.0
+
+# ── get_position ──────────────────────────────────────────────────────────────
+
+class TestGetPosition:
+    def test_returns_list_of_four_floats(self):
+        s = _make_stepper()
+        pos = s.get_position()
+        assert isinstance(pos, list)
+        assert len(pos) == 4
+
+    def test_first_element_is_stepper_position(self):
+        s = _make_stepper()
+        s.extruder_stepper.stepper.get_commanded_position.return_value = 123.0
+        pos = s.get_position()
+        assert pos[0] == 123.0
+
+    def test_other_elements_are_zero(self):
+        s = _make_stepper()
+        pos = s.get_position()
+        assert pos[1] == 0.0
+        assert pos[2] == 0.0
+        assert pos[3] == 0.0
+
+
+# ── _set_current ──────────────────────────────────────────────────────────────
+
+class TestSetCurrent:
+    def test_no_script_when_tmc_print_current_is_none(self):
+        s = _make_stepper()
+        s.tmc_print_current = None
+        s._set_current(1.0)
+        s.gcode.run_script_from_command.assert_not_called()
+
+    def test_no_script_when_current_arg_is_none(self):
+        s = _make_stepper()
+        s.tmc_print_current = 0.8
+        s._set_current(None)
+        s.gcode.run_script_from_command.assert_not_called()
+
+    def test_runs_script_when_both_set(self):
+        s = _make_stepper()
+        s.tmc_print_current = 0.8
+        s._set_current(0.6)
+        s.gcode.run_script_from_command.assert_called_once()
+
+    def test_script_contains_stepper_name(self):
+        s = _make_stepper(name="lane1")
+        s.tmc_print_current = 0.8
+        s._set_current(0.6)
+        script = s.gcode.run_script_from_command.call_args[0][0]
+        assert "lane1" in script
+
+    def test_script_contains_current_value(self):
+        s = _make_stepper()
+        s.tmc_print_current = 0.8
+        s._set_current(0.6)
+        script = s.gcode.run_script_from_command.call_args[0][0]
+        assert "0.6" in script
+
+
+# ── set_load_current / set_print_current ─────────────────────────────────────
+
+class TestCurrentHelpers:
+    def test_set_load_current_calls_set_current_with_load_value(self):
+        s = _make_stepper()
+        s.tmc_print_current = 0.8
+        s.tmc_load_current = 1.2
+        s._set_current = MagicMock()
+        s.set_load_current()
+        s._set_current.assert_called_once_with(1.2)
+
+    def test_set_print_current_calls_set_current_with_print_value(self):
+        s = _make_stepper()
+        s.tmc_print_current = 0.5
+        s.tmc_load_current = 1.0
+        s._set_current = MagicMock()
+        s.set_print_current()
+        s._set_current.assert_called_once_with(0.5)
+
+
+# ── update_rotation_distance ──────────────────────────────────────────────────
+
+class TestUpdateRotationDistance:
+    def test_sets_rotation_distance_to_base_divided_by_multiplier(self):
+        s = _make_stepper()
+        s.base_rotation_dist = 8.0
+        s.update_rotation_distance(2.0)
+        s.extruder_stepper.stepper.set_rotation_distance.assert_called_once_with(4.0)
+
+    def test_multiplier_of_one_restores_base(self):
+        s = _make_stepper()
+        s.base_rotation_dist = 8.0
+        s.update_rotation_distance(1.0)
+        s.extruder_stepper.stepper.set_rotation_distance.assert_called_once_with(8.0)
+
+    def test_multiplier_of_four_quarters_distance(self):
+        s = _make_stepper()
+        s.base_rotation_dist = 8.0
+        s.update_rotation_distance(4.0)
+        s.extruder_stepper.stepper.set_rotation_distance.assert_called_once_with(2.0)
+
+
+# ── get_kinematics / get_steppers / calc_position ────────────────────────────
+
+class TestKinematicsShims:
+    def test_get_kinematics_returns_self(self):
+        s = _make_stepper()
+        assert s.get_kinematics() is s
+
+    def test_get_steppers_returns_list_with_stepper(self):
+        s = _make_stepper()
+        steppers = s.get_steppers()
+        assert isinstance(steppers, list)
+        assert len(steppers) == 1
+        assert steppers[0] is s.extruder_stepper.stepper
+
+
+# ── sync_print_time ───────────────────────────────────────────────────────────
+
+def _make_stepper_with_toolhead(next_cmd_time=0.0, last_move_time=0.0):
+    """Build a stepper with a mocked toolhead for sync_print_time tests."""
+    s = _make_stepper()
+    s.next_cmd_time = next_cmd_time
+
+    toolhead = MagicMock()
+    toolhead.get_last_move_time.return_value = last_move_time
+    s.printer._objects["toolhead"] = toolhead
+    s.printer.lookup_object = lambda name, default=None: (
+        toolhead if name == "toolhead" else (s.afc if name == "AFC" else MagicMock())
+    )
+    s._toolhead = toolhead
+    return s
+
+
+class TestSyncPrintTime:
+    def test_no_dwell_when_next_cmd_time_is_behind(self):
+        """When next_cmd_time < print_time, update next_cmd_time to print_time."""
+        s = _make_stepper_with_toolhead(next_cmd_time=0.0, last_move_time=5.0)
+        s.sync_print_time()
+        assert s.next_cmd_time == 5.0
+
+    def test_dwell_called_when_next_cmd_time_is_ahead(self):
+        """When next_cmd_time > print_time, toolhead.dwell is called."""
+        s = _make_stepper_with_toolhead(next_cmd_time=10.0, last_move_time=5.0)
+        s.sync_print_time()
+        s._toolhead.dwell.assert_called_once_with(5.0)
+
+    def test_no_dwell_when_times_equal(self):
+        """When next_cmd_time == print_time, no dwell and no update needed."""
+        s = _make_stepper_with_toolhead(next_cmd_time=5.0, last_move_time=5.0)
+        s.sync_print_time()
+        s._toolhead.dwell.assert_not_called()
+        assert s.next_cmd_time == 5.0
+
+
+# ── flush_step_generation ─────────────────────────────────────────────────────
+
+class TestFlushStepGeneration:
+    def test_delegates_to_sync_print_time(self):
+        s = _make_stepper_with_toolhead(next_cmd_time=0.0, last_move_time=7.0)
+        s.flush_step_generation()
+        # After sync, next_cmd_time should be updated to print_time
+        assert s.next_cmd_time == 7.0
+
+
+# ── get_last_move_time ────────────────────────────────────────────────────────
+
+class TestGetLastMoveTime:
+    def test_returns_next_cmd_time_after_sync(self):
+        s = _make_stepper_with_toolhead(next_cmd_time=0.0, last_move_time=3.5)
+        result = s.get_last_move_time()
+        assert result == 3.5
+
+    def test_returns_next_cmd_time_when_ahead(self):
+        s = _make_stepper_with_toolhead(next_cmd_time=8.0, last_move_time=3.0)
+        result = s.get_last_move_time()
+        assert result == 8.0
+
+
+# ── sync_to_extruder / unsync_to_extruder ────────────────────────────────────
+
+class TestSyncUnsync:
+    def test_sync_calls_extruder_stepper_sync(self):
+        s = _make_stepper()
+        s.extruder_name = "extruder"
+        s._set_current = MagicMock()
+        s.set_print_current = MagicMock()
+        s.sync_to_extruder(update_current=False)
+        s.extruder_stepper.sync_to_extruder.assert_called_once_with("extruder")
+
+    def test_sync_calls_set_print_current_when_update_current(self):
+        s = _make_stepper()
+        s.extruder_name = "extruder"
+        s.set_print_current = MagicMock()
+        s.sync_to_extruder(update_current=True)
+        s.set_print_current.assert_called_once()
+
+    def test_sync_skips_set_print_current_when_update_current_false(self):
+        s = _make_stepper()
+        s.extruder_name = "extruder"
+        s.set_print_current = MagicMock()
+        s.sync_to_extruder(update_current=False)
+        s.set_print_current.assert_not_called()
+
+    def test_sync_uses_override_extruder_name(self):
+        s = _make_stepper()
+        s.extruder_name = "extruder"
+        s.set_print_current = MagicMock()
+        s.sync_to_extruder(update_current=False, extruder_name="extruder2")
+        s.extruder_stepper.sync_to_extruder.assert_called_once_with("extruder2")
+
+    def test_unsync_calls_sync_with_none(self):
+        s = _make_stepper()
+        s.set_load_current = MagicMock()
+        s.unsync_to_extruder(update_current=False)
+        s.extruder_stepper.sync_to_extruder.assert_called_once_with(None)
+
+    def test_unsync_calls_set_load_current_when_update_current(self):
+        s = _make_stepper()
+        s.set_load_current = MagicMock()
+        s.unsync_to_extruder(update_current=True)
+        s.set_load_current.assert_called_once()
+
+    def test_unsync_skips_set_load_current_when_update_current_false(self):
+        s = _make_stepper()
+        s.set_load_current = MagicMock()
+        s.unsync_to_extruder(update_current=False)
+        s.set_load_current.assert_not_called()

--- a/tests/test_AFC_unit.py
+++ b/tests/test_AFC_unit.py
@@ -1,0 +1,339 @@
+"""
+Unit tests for extras/AFC_unit.py
+
+Covers:
+  - afcUnit.__str__: returns name
+  - afcUnit._check_and_errorout: None vs non-None object
+  - afcUnit.get_status: correct keys and content
+  - afcUnit.check_runout: returns False
+  - afcUnit.return_to_home: returns None
+  - afcUnit.lane_loaded/unloaded/loading/tool_loaded/tool_unloaded: call afc_led
+  - afcUnit.set_logo_color: calls afc_led when color present, skips when None/empty
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, call
+import pytest
+
+from extras.AFC_unit import afcUnit
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_unit(name="Turtle_1"):
+    """Build an afcUnit bypassing the complex __init__."""
+    unit = afcUnit.__new__(afcUnit)
+
+    from tests.conftest import MockAFC, MockPrinter, MockLogger
+    from extras.AFC_error import afcError
+    afc = MockAFC()
+    printer = MockPrinter(afc=afc)
+    afc.logger = MockLogger()
+    afc.error = afcError.__new__(afcError)
+    afc.error.logger = afc.logger
+    unit.printer = printer
+    unit.afc = afc
+    unit.logger = afc.logger
+    unit.name = name
+    unit.full_name = ["AFC_BoxTurtle", name]
+    unit.lanes = {}
+    unit.hub_obj = None
+    unit.extruder_obj = None
+    unit.buffer_obj = None
+    unit.hub = None
+    unit.extruder = None
+    unit.buffer_name = None
+    unit.td1_defined = False
+    unit.type = "Box_Turtle"
+    unit.gcode = afc.gcode
+    unit.led_logo_index = None
+    unit.enable_buffer_tool_check = True
+
+    return unit
+
+
+def _make_lane(name="lane1", hub="hub1", extruder="ext1", buffer_name="buf1"):
+    from extras.AFC_lane import AFCLane
+    lane = AFCLane.__new__(AFCLane)
+    lane.unit_obj = MagicMock()
+    lane.name = name
+    lane.hub = hub
+    lane.extruder_name = extruder
+    lane.buffer_name = buffer_name
+    lane.led_ready = "0,1,0,0"
+    lane.led_not_ready = "0,0,0,0.25"
+    lane.led_loading = "0,0,1,0"
+    lane.led_tool_loaded = "0,1,0,0"
+    lane.led_tool_unloaded = "0,1,0,0"
+    lane.led_tool_loaded_idle = "0,1,0,0"
+    lane.led_index = "1"
+    lane.led_spool_illum = "1,1,1,0"
+    lane._load_state = True
+    lane.short_moves_speed = 50
+    lane.short_moves_accel = 50
+    lane.color = None
+    lane.use_filament_color = False
+    return lane
+
+
+# ── __str__ ───────────────────────────────────────────────────────────────────
+
+class TestStr:
+    def test_str_returns_name(self):
+        unit = _make_unit("Turtle_1")
+        assert str(unit) == "Turtle_1"
+
+    def test_str_reflects_different_name(self):
+        unit = _make_unit("NightOwl_2")
+        assert str(unit) == "NightOwl_2"
+
+
+# ── _check_and_errorout ────────────────────────────────────────────────────────
+
+class TestCheckAndErrorOut:
+    def test_returns_true_when_obj_is_none(self):
+        unit = _make_unit()
+        error, msg = unit._check_and_errorout(None, "AFC_hub testname", "hub")
+        assert error is True
+
+    def test_error_msg_not_empty_when_obj_none(self):
+        unit = _make_unit()
+        _, msg = unit._check_and_errorout(None, "AFC_hub testname", "hub")
+        assert len(msg) > 0
+
+    def test_error_msg_contains_config_name(self):
+        unit = _make_unit()
+        _, msg = unit._check_and_errorout(None, "AFC_hub testname", "hub")
+        assert "AFC_hub testname" in msg
+
+    def test_returns_false_when_obj_present(self):
+        unit = _make_unit()
+        obj = MagicMock()
+        error, msg = unit._check_and_errorout(obj, "AFC_hub", "hub")
+        assert error is False
+
+    def test_msg_empty_when_obj_present(self):
+        unit = _make_unit()
+        obj = MagicMock()
+        _, msg = unit._check_and_errorout(obj, "AFC_hub", "hub")
+        assert msg == ""
+
+
+# ── get_status ────────────────────────────────────────────────────────────────
+
+class TestGetStatus:
+    def test_has_lanes_key(self):
+        unit = _make_unit()
+        status = unit.get_status()
+        assert "lanes" in status
+
+    def test_has_extruders_key(self):
+        unit = _make_unit()
+        status = unit.get_status()
+        assert "extruders" in status
+
+    def test_has_hubs_key(self):
+        unit = _make_unit()
+        status = unit.get_status()
+        assert "hubs" in status
+
+    def test_has_buffers_key(self):
+        unit = _make_unit()
+        status = unit.get_status()
+        assert "buffers" in status
+
+    def test_lanes_list_contains_lane_name(self):
+        unit = _make_unit()
+        lane = _make_lane("lane1")
+        unit.lanes = {"lane1": lane}
+        status = unit.get_status()
+        assert "lane1" in status["lanes"]
+
+    def test_extruder_name_collected_from_lanes(self):
+        unit = _make_unit()
+        lane = _make_lane("lane1", extruder="my_extruder")
+        unit.lanes = {"lane1": lane}
+        status = unit.get_status()
+        assert "my_extruder" in status["extruders"]
+
+    def test_hub_name_collected_from_lanes(self):
+        unit = _make_unit()
+        lane = _make_lane("lane1", hub="my_hub")
+        unit.lanes = {"lane1": lane}
+        status = unit.get_status()
+        assert "my_hub" in status["hubs"]
+
+    def test_hub_name_collected_from_lanes_direct_hub(self):
+        unit = _make_unit()
+        lane = _make_lane("lane1", hub="direct")
+        unit.lanes = {"lane1": lane}
+        status = unit.get_status()
+        assert "direct" not in status["hubs"]
+
+    def test_hub_name_collected_from_lanes_direct_load_hub(self):
+        unit = _make_unit()
+        lane = _make_lane("lane1", hub="direct_load")
+        unit.lanes = {"lane1": lane}
+        status = unit.get_status()
+        assert "direct_load" not in status["hubs"]
+
+    def test_buffer_name_collected_from_lanes(self):
+        unit = _make_unit()
+        lane = _make_lane("lane1", buffer_name="my_buffer")
+        unit.lanes = {"lane1": lane}
+        status = unit.get_status()
+        assert "my_buffer" in status["buffers"]
+
+    def test_duplicate_extruder_not_repeated(self):
+        """Two lanes sharing the same extruder should appear only once."""
+        unit = _make_unit()
+        lane1 = _make_lane("lane1", extruder="shared_ext")
+        lane2 = _make_lane("lane2", extruder="shared_ext")
+        unit.lanes = {"lane1": lane1, "lane2": lane2}
+        status = unit.get_status()
+        assert status["extruders"].count("shared_ext") == 1
+
+    def test_empty_lanes_returns_empty_lists(self):
+        unit = _make_unit()
+        unit.lanes = {}
+        status = unit.get_status()
+        assert status["lanes"] == []
+        assert status["extruders"] == []
+        assert status["hubs"] == []
+        assert status["buffers"] == []
+
+
+# ── check_runout ──────────────────────────────────────────────────────────────
+
+class TestCheckRunout:
+    def test_returns_false(self):
+        unit = _make_unit()
+        assert unit.check_runout("lane") is False
+
+
+# ── return_to_home ────────────────────────────────────────────────────────────
+
+class TestReturnToHome:
+    def test_returns_none(self):
+        unit = _make_unit()
+        result = unit.return_to_home()
+        assert result is None
+
+
+# ── LED helpers ───────────────────────────────────────────────────────────────
+
+class TestLaneStatusLeds:
+    def test_lane_loaded_calls_afc_led_with_ready_color(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        unit.lane_loaded(lane)
+        unit.afc.function.afc_led.assert_called_once_with(lane.led_ready, lane.led_index)
+
+    def test_lane_unloaded_calls_afc_led_with_not_ready_color(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        unit.lane_unloaded(lane)
+        unit.afc.function.afc_led.assert_called_once_with(lane.led_not_ready, lane.led_index)
+
+    def test_lane_loading_calls_afc_led_with_loading_color(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        unit.lane_loading(lane)
+        unit.afc.function.afc_led.assert_called_once_with(lane.led_loading, lane.led_index)
+
+    def test_lane_tool_loaded_calls_afc_led_with_tool_loaded_color(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.extruder_obj = MagicMock()
+        unit.lane_tool_loaded(lane)
+        unit.afc.function.afc_led.assert_called_once_with(lane.led_tool_loaded, lane.led_index)
+        lane.extruder_obj.set_status_led.assert_called_once_with(lane.led_tool_loaded)
+
+    def test_lane_tool_unloaded_calls_afc_led_with_ready_color(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.extruder_obj = MagicMock()
+        unit.lane_tool_unloaded(lane)
+        unit.afc.function.afc_led.assert_called_once_with(lane.led_ready, lane.led_index)
+        lane.extruder_obj.set_status_led.assert_called_once_with(lane.led_tool_unloaded)
+
+
+# ── set_logo_color ────────────────────────────────────────────────────────────
+
+class TestSetLogoColor:
+    def test_calls_afc_led_when_color_present(self):
+        unit = _make_unit()
+        unit.led_logo_index = "0"
+        unit.afc.function.HexToLedString = MagicMock(return_value="0,0,0,0")
+        unit.set_logo_color("FF0000")
+        unit.afc.function.afc_led.assert_called()
+
+    def test_no_call_when_color_is_none(self):
+        unit = _make_unit()
+        unit.set_logo_color(None)
+        unit.afc.function.afc_led.assert_not_called()
+
+    def test_no_call_when_color_is_empty_string(self):
+        unit = _make_unit()
+        unit.set_logo_color("")
+        unit.afc.function.afc_led.assert_not_called()
+
+
+# ── _buffer_toolhead_load_check ────────────────────────────────────────────────────────────
+class TestBufferToolheadLoadCheck:
+    def test_homing_not_enabled_not_loaded(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        unit.afc.homing_enabled = False
+        lane.tool_loaded = False
+        result = unit._buffer_toolhead_load_check(lane)
+        assert result is False
+    
+    def test_homing_not_enabled_loaded(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        unit.afc.homing_enabled = False
+        lane.tool_loaded = True
+        result = unit._buffer_toolhead_load_check(lane)
+        assert result is True
+
+    def test_homing_enabled_disable_buffer_tool_check_loaded(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        unit.afc.homing_enabled = True
+        lane.tool_loaded = True
+        unit.enable_buffer_tool_check = False
+        result = unit._buffer_toolhead_load_check(lane)
+        assert result is True
+
+    def test_homing_enabled_loaded_fail_extend(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.buffer_obj = MagicMock()
+        unit.afc.homing_enabled = True
+        lane.tool_loaded = True
+        lane.buffer_obj.advance_state = False
+        lane.move_to = MagicMock()
+        lane.move_to.return_value = (False, 200, False)
+        result = unit._buffer_toolhead_load_check(lane)
+        assert result is False
+        error_msgs = [m for lvl, m in unit.logger.messages if lvl == "error"]
+        assert any(f"Buffer toolhead loaded check failed for {lane.name}. Please verify" in m for m in error_msgs)
+    
+    def test_homing_enabled_loaded_extended(self):
+        from extras.AFC_lane import MoveDirection
+        SIDE_EFFECT_DIST = 200
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.buffer_obj = MagicMock()
+        unit.afc.homing_enabled = True
+        lane.tool_loaded = True
+        lane.buffer_obj.advance_state = False
+        lane.move_to = MagicMock()
+        lane.move = MagicMock()
+        lane.move_to.side_effect = [(True, SIDE_EFFECT_DIST, False)]
+        result = unit._buffer_toolhead_load_check(lane)
+        call_args = lane.move.call_args[0]
+        assert result is True
+        assert call_args[0] == (SIDE_EFFECT_DIST * MoveDirection.NEG)

--- a/tests/test_AFC_utils.py
+++ b/tests/test_AFC_utils.py
@@ -1,0 +1,571 @@
+"""
+Unit tests for extras/AFC_utils.py
+
+Covers:
+  - check_and_return()
+  - section_in_config()
+  - DebounceButton
+  - AFC_moonraker
+"""
+
+from __future__ import annotations
+
+import configparser
+import json
+from io import StringIO
+from unittest.mock import MagicMock, patch, call
+import pytest
+
+# conftest installs Klipper mocks; extras is on sys.path via REPO_ROOT
+from extras.AFC_utils import check_and_return, section_in_config, DebounceButton, AFC_moonraker
+
+
+# ── check_and_return ──────────────────────────────────────────────────────────
+
+class TestCheckAndReturn:
+    def test_key_present_returns_value(self):
+        data = {"color": "red", "weight": 250}
+        assert check_and_return("color", data) == "red"
+
+    def test_key_present_numeric_string(self):
+        data = {"weight": "250"}
+        assert check_and_return("weight", data) == "250"
+
+    def test_key_missing_returns_zero_string(self):
+        data = {"color": "blue"}
+        assert check_and_return("weight", data) == "0"
+
+    def test_empty_dict_returns_zero_string(self):
+        assert check_and_return("anything", {}) == "0"
+
+    def test_key_with_none_value(self):
+        data = {"key": None}
+        assert check_and_return("key", data) is None
+
+    def test_key_with_zero_value(self):
+        data = {"key": 0}
+        assert check_and_return("key", data) == 0
+
+
+# ── section_in_config ─────────────────────────────────────────────────────────
+
+class TestSectionInConfig:
+    def _make_config(self, *sections):
+        """Return a MockConfig whose fileconfig contains the given sections."""
+        from tests.conftest import MockConfig, _make_fileconfig
+        cfg = MockConfig()
+        cfg.fileconfig = _make_fileconfig(*sections)
+        return cfg
+
+    def test_exact_section_found(self):
+        cfg = self._make_config("AFC_hub my_hub")
+        assert section_in_config(cfg, "AFC_hub my_hub") is True
+
+    def test_partial_section_name_found(self):
+        cfg = self._make_config("AFC_hub my_hub")
+        assert section_in_config(cfg, "my_hub") is True
+
+    def test_section_not_found(self):
+        cfg = self._make_config("AFC_hub my_hub")
+        assert section_in_config(cfg, "missing_section") is False
+
+    def test_empty_fileconfig_returns_false(self):
+        cfg = self._make_config()
+        assert section_in_config(cfg, "anything") is False
+
+    def test_multiple_sections_correct_one_found(self):
+        cfg = self._make_config("AFC_hub hub1", "AFC_hub hub2", "AFC_lane lane1")
+        assert section_in_config(cfg, "hub2") is True
+        assert section_in_config(cfg, "lane1") is True
+        assert section_in_config(cfg, "lane2") is False
+
+
+# ── DebounceButton ────────────────────────────────────────────────────────────
+
+class TestDebounceButton:
+    """DebounceButton wraps a filament sensor's note_filament_present method."""
+
+    def _make_filament_sensor(self, sig_params):
+        """
+        Build a minimal filament-sensor mock with the given parameter names
+        on its runout_helper.note_filament_present signature.
+        """
+        import inspect
+
+        # Construct a function with the desired signature dynamically
+        arg_list = ", ".join(sig_params)
+        exec_globals: dict = {}
+        exec(f"def note_filament_present({arg_list}): pass", exec_globals)
+        func = exec_globals["note_filament_present"]
+
+        helper = MagicMock()
+        helper.note_filament_present = func
+        sensor = MagicMock()
+        sensor.runout_helper = helper
+        return sensor
+
+    def _make_config(self, debounce_delay=0.0):
+        from tests.conftest import MockConfig, MockPrinter, MockReactor
+        reactor = MockReactor()
+        printer = MockPrinter()
+        printer._reactor = reactor
+        cfg = MockConfig(printer=printer, values={"debounce_delay": debounce_delay})
+        return cfg
+
+    def test_init_sets_debounce_delay(self):
+        cfg = self._make_config(debounce_delay=0.05)
+        sensor = self._make_filament_sensor(["self", "eventtime", "state"])
+        btn = DebounceButton(cfg, sensor)
+        assert btn.debounce_delay == 0.05
+
+    def test_initial_states_are_none(self):
+        cfg = self._make_config()
+        sensor = self._make_filament_sensor(["self", "eventtime", "state"])
+        btn = DebounceButton(cfg, sensor)
+        assert btn.logical_state is None
+        assert btn.physical_state is None
+        assert btn.latest_eventtime is None
+
+    def test_button_handler_records_state(self):
+        cfg = self._make_config()
+        sensor = self._make_filament_sensor(["self", "eventtime", "state"])
+        btn = DebounceButton(cfg, sensor)
+        btn._button_handler(100.0, True)
+        assert btn.physical_state is True
+        assert btn.latest_eventtime == 100.0
+
+    def test_same_state_does_not_re_register_callback(self):
+        cfg = self._make_config()
+        sensor = self._make_filament_sensor(["self", "eventtime", "state"])
+        btn = DebounceButton(cfg, sensor)
+        btn.logical_state = True
+        reactor = cfg.get_printer().get_reactor()
+        reactor.register_callback = MagicMock()
+        btn._button_handler(100.0, True)  # same as logical_state → no callback
+        reactor.register_callback.assert_not_called()
+
+    def test_state_change_registers_callback(self):
+        cfg = self._make_config()
+        sensor = self._make_filament_sensor(["self", "eventtime", "state"])
+        btn = DebounceButton(cfg, sensor)
+        btn.logical_state = False
+        reactor = cfg.get_printer().get_reactor()
+        reactor.register_callback = MagicMock()
+        btn._button_handler(100.0, True)  # transition False→True
+        reactor.register_callback.assert_called_once()
+
+    def test_debounce_event_ignored_if_no_transition(self):
+        cfg = self._make_config()
+        sensor = self._make_filament_sensor(["self", "eventtime", "state"])
+        btn = DebounceButton(cfg, sensor)
+        btn.logical_state = True
+        btn.physical_state = True
+        btn.button_action = MagicMock()
+        btn._debounce_event(100.0)
+        btn.button_action.assert_not_called()
+
+    def test_debounce_event_updates_logical_state(self):
+        cfg = self._make_config(debounce_delay=0.0)
+        sensor = self._make_filament_sensor(["self", "eventtime", "state"])
+        btn = DebounceButton(cfg, sensor)
+        btn.logical_state = False
+        btn.physical_state = True
+        btn.latest_eventtime = 100.0
+        btn.button_action = MagicMock()
+        btn._debounce_event(100.0)
+        assert btn.logical_state is True
+
+    def test_init_kalico_signature_uses_button_handler(self):
+        """Covers line 135: Kalico exact-match signature assigns _button_handler."""
+        cfg = self._make_config()
+        # Exact Kalico params (no 'self' since inspect works on function signature)
+        sensor = self._make_filament_sensor(
+            ["eventtime", "is_filament_present", "force", "immediate"]
+        )
+        btn = DebounceButton(cfg, sensor)
+        # The assignment to _button_handler was made; button_action should be set
+        assert btn.button_action is not None
+
+    def test_init_two_param_signature_uses_button_handler_else(self):
+        """Covers line 139: exactly 2 params → else branch assigns _button_handler."""
+        cfg = self._make_config()
+        # Only 2 parameters: eventtime, state (not > 2, not == 1)
+        sensor = self._make_filament_sensor(["eventtime", "state"])
+        btn = DebounceButton(cfg, sensor)
+        # Should still set button_action
+        assert btn.button_action is not None
+
+    def test_button_handler_delegates_to_internal_handler(self):
+        """Covers line 146: button_handler calls _button_handler with reactor time."""
+        cfg = self._make_config()
+        sensor = self._make_filament_sensor(["self", "eventtime", "state"])
+        btn = DebounceButton(cfg, sensor)
+        btn._button_handler = MagicMock()
+        btn.button_handler(True)
+        btn._button_handler.assert_called_once()
+
+    def test_debounce_event_ignores_stale_event(self):
+        """Covers line 163: stale event (more recent event exists) → returns early."""
+        cfg = self._make_config(debounce_delay=1.0)
+        sensor = self._make_filament_sensor(["self", "eventtime", "state"])
+        btn = DebounceButton(cfg, sensor)
+        btn.logical_state = False
+        btn.physical_state = True
+        btn.latest_eventtime = 100.0
+        btn.button_action = MagicMock()
+        # eventtime=100.5 → 100.5 - 1.0 = 99.5 < 100.0 → stale → returns early
+        btn._debounce_event(100.5)
+        btn.button_action.assert_not_called()
+
+    def test_debounce_event_falls_back_to_positional_args(self):
+        """Covers lines 169-170: button_action that doesn't accept kwargs → except branch."""
+        cfg = self._make_config(debounce_delay=0.0)
+        sensor = self._make_filament_sensor(["self", "eventtime", "state"])
+        btn = DebounceButton(cfg, sensor)
+        btn.logical_state = False
+        btn.physical_state = True
+        btn.latest_eventtime = 100.0
+
+        # A callback that only accepts positional args → raises TypeError on kwargs call
+        calls = []
+        def positional_only(eventtime, state):
+            calls.append((eventtime, state))
+
+        btn.button_action = positional_only
+        btn._debounce_event(101.0)
+        assert len(calls) == 1
+        assert calls[0] == (101.0, True)
+
+
+# ── AFC_moonraker ─────────────────────────────────────────────────────────────
+
+class TestAFCMoonraker:
+    def _make_moonraker(self, host="http://localhost", port="7125"):
+        from tests.conftest import MockLogger
+        logger = MockLogger()
+        return AFC_moonraker(host, port, logger)
+
+    def test_init_sets_host_with_port(self):
+        mr = self._make_moonraker("http://localhost", "7125")
+        assert "7125" in mr.host
+
+    def test_init_strips_trailing_slash(self):
+        mr = self._make_moonraker("http://localhost/", "7125")
+        assert not mr.host.endswith("//")
+
+    def test_init_default_stats_none(self):
+        mr = self._make_moonraker()
+        assert mr.afc_stats is None
+        assert mr.last_stats_time is None
+
+    def test_get_results_connection_error_returns_none(self):
+        mr = self._make_moonraker()
+        with patch("extras.AFC_utils.urlopen", side_effect=Exception("connection refused")):
+            result = mr._get_results("http://localhost:7125/server/info", print_error=False)
+        assert result is None
+
+    def test_get_results_bad_status_returns_none(self):
+        mr = self._make_moonraker()
+        mock_resp = MagicMock()
+        mock_resp.status = 500
+        mock_resp.reason = "Internal Server Error"
+        with patch("extras.AFC_utils.urlopen", return_value=mock_resp):
+            result = mr._get_results("http://localhost:7125/server/info", print_error=False)
+        assert result is None
+
+    def test_get_results_success_returns_data(self):
+        mr = self._make_moonraker()
+        payload = {"result": {"state": "ready"}}
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        with patch("extras.AFC_utils.urlopen", return_value=mock_resp), \
+             patch("extras.AFC_utils.json.load", return_value=payload):
+            result = mr._get_results("http://localhost:7125/server/info")
+        assert result == {"state": "ready"}
+
+    def test_check_and_return_helper(self):
+        # Ensure the standalone helper works (already tested above, but
+        # verify the moonraker module exports it correctly)
+        from extras.AFC_utils import check_and_return
+        assert check_and_return("x", {"x": 42}) == 42
+
+    def test_update_afc_stats_logs_on_failure(self):
+        mr = self._make_moonraker()
+        mr._get_results = MagicMock(return_value=None)
+        mr.update_afc_stats("some.key", 10)
+        errors = [m for lvl, m in mr.logger.messages if lvl == "error"]
+        assert len(errors) == 1
+
+    def test_get_spool_not_found_logs_info(self):
+        mr = self._make_moonraker()
+        mr._get_results = MagicMock(return_value=None)
+        result = mr.get_spool(42)
+        assert result is None
+        infos = [m for lvl, m in mr.logger.messages if lvl == "info"]
+        assert any("42" in m for m in infos)
+
+    def test_get_spoolman_server_returns_none_when_missing(self):
+        mr = self._make_moonraker()
+        mr._get_results = MagicMock(return_value={"orig": {}})
+        result = mr.get_spoolman_server()
+        assert result is None
+
+    def test_get_spoolman_server_returns_url_when_present(self):
+        mr = self._make_moonraker()
+        mr._get_results = MagicMock(
+            return_value={"orig": {"spoolman": {"server": "http://spoolman:7912"}}}
+        )
+        result = mr.get_spoolman_server()
+        assert result == "http://spoolman:7912"
+
+    def test_get_file_filament_change_count_default_zero(self):
+        mr = self._make_moonraker()
+        mr._get_results = MagicMock(return_value=None)
+        assert mr.get_file_filament_change_count("test.gcode") == 0
+
+    def test_get_file_filament_change_count_from_metadata(self):
+        mr = self._make_moonraker()
+        mr._get_results = MagicMock(return_value={"filament_change_count": 5})
+        assert mr.get_file_filament_change_count("test.gcode") == 5
+
+    def test_get_afc_stats_returns_none_on_empty_db(self):
+        mr = self._make_moonraker()
+        mr._get_results = MagicMock(return_value=None)
+        result = mr.get_afc_stats()
+        assert result is None
+
+    def test_get_afc_stats_returns_cached_after_first_call(self):
+        mr = self._make_moonraker()
+        payload = {"value": {"toolchange_count": {"total": 10}}}
+        mr._get_results = MagicMock(return_value=payload)
+        first = mr.get_afc_stats()
+        # Second call should use cache (but still calls _get_results when
+        # afc_stats is populated, unless last_stats_time is very recent)
+        assert first is not None
+
+    def test_check_for_td1_no_td1_in_config(self):
+        mr = self._make_moonraker()
+        mr._get_results = MagicMock(return_value={"orig": {}})
+        td1_defined, td1, lane_data = mr.check_for_td1()
+        assert td1_defined is False
+        assert td1 is False
+        assert lane_data is False
+
+    # ── wait_for_moonraker ────────────────────────────────────────────────────
+
+    def test_wait_for_moonraker_connects_immediately_returns_true(self):
+        mr = self._make_moonraker()
+        toolhead = MagicMock()
+        mr._get_results = MagicMock(return_value={"klippy": "ready"})
+        result = mr.wait_for_moonraker(toolhead, timeout=5)
+        assert result is True
+        toolhead.dwell.assert_not_called()
+
+    def test_wait_for_moonraker_connects_after_retries(self):
+        mr = self._make_moonraker()
+        toolhead = MagicMock()
+        mr._get_results = MagicMock(side_effect=[None, None, {"klippy": "ready"}])
+        result = mr.wait_for_moonraker(toolhead, timeout=5)
+        assert result is True
+        assert toolhead.dwell.call_count == 2
+
+    def test_wait_for_moonraker_timeout_returns_false(self):
+        mr = self._make_moonraker()
+        toolhead = MagicMock()
+        mr._get_results = MagicMock(return_value=None)
+        result = mr.wait_for_moonraker(toolhead, timeout=3)
+        assert result is False
+        warnings = [m for lvl, m in mr.logger.messages if lvl == "warning"]
+        assert len(warnings) == 1
+
+    # ── get_td1_data ──────────────────────────────────────────────────────────
+
+    def test_get_td1_data_returns_devices_on_success(self):
+        mr = self._make_moonraker()
+        mr._get_results = MagicMock(return_value={"devices": {"SN123": {}}})
+        result = mr.get_td1_data()
+        assert result == {"SN123": {}}
+
+    def test_get_td1_data_returns_none_when_no_devices_key(self):
+        mr = self._make_moonraker()
+        mr._get_results = MagicMock(return_value={"other": "data"})
+        result = mr.get_td1_data()
+        assert result is None
+
+    def test_get_td1_data_returns_none_on_failure(self):
+        mr = self._make_moonraker()
+        mr._get_results = MagicMock(return_value=None)
+        result = mr.get_td1_data()
+        assert result is None
+
+    # ── reboot_td1 ───────────────────────────────────────────────────────────
+
+    def test_reboot_td1_returns_response(self):
+        mr = self._make_moonraker()
+        mr._get_results = MagicMock(return_value={"status": "ok"})
+        result = mr.reboot_td1("SN12345")
+        assert result == {"status": "ok"}
+
+    def test_reboot_td1_returns_none_on_failure(self):
+        mr = self._make_moonraker()
+        mr._get_results = MagicMock(return_value=None)
+        result = mr.reboot_td1("SN12345")
+        assert result is None
+
+    # ── send_lane_data ────────────────────────────────────────────────────────
+
+    def test_send_lane_data_logs_error_on_failure(self):
+        mr = self._make_moonraker()
+        mr._get_results = MagicMock(return_value=None)
+        mr.send_lane_data({"lane1": {"color": "red"}})
+        errors = [m for lvl, m in mr.logger.messages if lvl == "error"]
+        assert len(errors) == 1
+
+    def test_send_lane_data_success_no_error(self):
+        mr = self._make_moonraker()
+        mr._get_results = MagicMock(return_value={"value": "ok"})
+        mr.send_lane_data({"lane1": {"color": "red"}})
+        errors = [m for lvl, m in mr.logger.messages if lvl == "error"]
+        assert len(errors) == 0
+
+    # ── remove_database_entry ─────────────────────────────────────────────────
+
+    def test_remove_database_entry_calls_urlopen(self):
+        mr = self._make_moonraker()
+        with patch("extras.AFC_utils.urlopen") as mock_urlopen:
+            mr.remove_database_entry("lane_data", "lane1")
+        mock_urlopen.assert_called_once()
+
+    def test_remove_database_entry_logs_debug_on_http_error(self):
+        from urllib.error import HTTPError
+        mr = self._make_moonraker()
+        with patch("extras.AFC_utils.urlopen",
+                   side_effect=HTTPError(None, 404, "Not Found", {}, None)):
+            mr.remove_database_entry("lane_data", "missing_key")
+        debug_msgs = [m for lvl, m in mr.logger.messages if lvl == "debug"]
+        assert len(debug_msgs) > 0
+
+    # ── delete_lane_data ──────────────────────────────────────────────────────
+
+    def test_delete_lane_data_calls_remove_for_each_key(self):
+        mr = self._make_moonraker()
+        mr._get_results = MagicMock(
+            return_value={"value": {"lane1": {}, "lane2": {}}}
+        )
+        mr.remove_database_entry = MagicMock()
+        mr.delete_lane_data()
+        assert mr.remove_database_entry.call_count == 2
+
+    def test_delete_lane_data_no_op_on_none_response(self):
+        mr = self._make_moonraker()
+        mr._get_results = MagicMock(return_value=None)
+        mr.remove_database_entry = MagicMock()
+        mr.delete_lane_data()
+        mr.remove_database_entry.assert_not_called()
+
+    # ── trigger_db_backup ─────────────────────────────────────────────────────
+
+    def test_trigger_db_backup_success_logs_path_and_returns_false(self):
+        mr = self._make_moonraker()
+        mr._get_results = MagicMock(return_value={"backup_path": "/tmp/backup.db"})
+        error = mr.trigger_db_backup()
+        assert error is False
+        infos = [m for lvl, m in mr.logger.messages if lvl == "info"]
+        assert any("/tmp/backup.db" in m for m in infos)
+
+    def test_trigger_db_backup_failure_returns_true(self):
+        mr = self._make_moonraker()
+        mr._get_results = MagicMock(return_value=None)
+        error = mr.trigger_db_backup()
+        assert error is True
+        errors = [m for lvl, m in mr.logger.messages if lvl == "error"]
+        assert len(errors) == 1
+
+    def test_get_spool_returns_resp_when_found(self):
+        """Covers line 352: if resp is not None → resp = resp branch in get_spool."""
+        mr = self._make_moonraker()
+        mr._get_results = MagicMock(return_value={"id": 42, "name": "PLA"})
+        result = mr.get_spool(42)
+        assert result == {"id": 42, "name": "PLA"}
+
+    def test_check_for_td1_with_td1_in_config_and_data(self):
+        """Covers lines 371-374: td1 in orig config and data returned."""
+        mr = self._make_moonraker()
+        mr._get_results = MagicMock(return_value={"orig": {"td1": True, "lane_data": True}})
+        mr.get_td1_data = MagicMock(return_value={"SN123": {}})
+        td1_defined, td1, lane_data = mr.check_for_td1()
+        assert td1_defined is True
+        assert td1 is True
+        assert lane_data is True
+
+    def test_check_for_td1_with_lane_data_only(self):
+        """Covers line 377: lane_data in orig config sets _lane_data True."""
+        mr = self._make_moonraker()
+        mr._get_results = MagicMock(return_value={"orig": {"lane_data": True}})
+        _, _, lane_data = mr.check_for_td1()
+        assert lane_data is True
+
+    def test_get_afc_stats_second_call_uses_cache_path(self):
+        """Covers lines 294-296: second call enters the last_stats_time is not None branch."""
+        mr = self._make_moonraker()
+        payload = {"value": {"tc": 5}}
+        mr._get_results = MagicMock(return_value=payload)
+        mr.get_afc_stats()        # first call: sets last_stats_time
+        mr.get_afc_stats()        # second call: last_stats_time is not None → cached path
+        # At least first call was made; second call may skip _get_results if cached
+        assert mr._get_results.call_count >= 1
+
+    def test_get_afc_stats_refetches_after_60_seconds(self):
+        """Covers lines 297-298: delta > 60s → refetch_data=True, update last_stats_time."""
+        from unittest.mock import patch
+        from datetime import datetime, timedelta
+        mr = self._make_moonraker()
+        payload = {"value": {"tc": 5}}
+        mr._get_results = MagicMock(return_value=payload)
+
+        t0 = datetime(2024, 1, 1, 12, 0, 0)
+        t1 = datetime(2024, 1, 1, 12, 1, 5)  # 65 seconds later
+
+        with patch("extras.AFC_utils.datetime") as mock_dt:
+            mock_dt.now.side_effect = [t0, t0, t1]  # first call: 2x now(), second call: once
+            mr.get_afc_stats()  # first call: sets last_stats_time to t0
+            mr.get_afc_stats()  # second call: delta = 65s > 60 → refetch
+        # Two _get_results calls: once per call since refetch was triggered
+        assert mr._get_results.call_count == 2
+
+    def test_send_lane_data_http_error_logs_error(self):
+        """Covers lines 432-435: HTTPError propagated from _get_results."""
+        from urllib.error import HTTPError
+        mr = self._make_moonraker()
+        mr._get_results = MagicMock(
+            side_effect=HTTPError(None, 500, "Internal Server Error", {}, None)
+        )
+        mr.send_lane_data({"lane1": {"color": "red"}})
+        errors = [m for lvl, m in mr.logger.messages if lvl == "error"]
+        assert len(errors) >= 1
+
+    def test_delete_lane_data_http_error_logs_debug(self):
+        """Covers lines 473-475: HTTPError raised by remove_database_entry."""
+        from urllib.error import HTTPError
+        mr = self._make_moonraker()
+        mr._get_results = MagicMock(return_value={"value": {"lane1": {}}})
+        mr.remove_database_entry = MagicMock(
+            side_effect=HTTPError(None, 500, "Error", {}, None)
+        )
+        mr.delete_lane_data()
+        debug_msgs = [m for lvl, m in mr.logger.messages if lvl == "debug"]
+        assert len(debug_msgs) >= 1
+
+    def test_trigger_db_backup_http_error_returns_true(self):
+        """Covers lines 491-495: HTTPError from _get_results in trigger_db_backup."""
+        from urllib.error import HTTPError
+        mr = self._make_moonraker()
+        mr._get_results = MagicMock(
+            side_effect=HTTPError(None, 503, "Service Unavailable", {}, None)
+        )
+        error = mr.trigger_db_backup()
+        assert error is True
+        errors = [m for lvl, m in mr.logger.messages if lvl == "error"]
+        assert len(errors) >= 1

--- a/tests/test_AFC_vivid.py
+++ b/tests/test_AFC_vivid.py
@@ -1,0 +1,628 @@
+"""
+Unit tests for extras/AFC_vivid.py
+
+Covers:
+  - AFC_vivid: class constants
+  - _get_lane_selector_state: returns correct bool from fila_selector
+  - _get_selector_enabled: returns stepper enabled status
+  - calibration_lane_message: returns informative string
+  - cmd_AFC_SELECT_LANE: dispatches to select_lane or gcmd.error
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+import pytest
+
+from extras.AFC_vivid import AFC_vivid
+from extras.AFC_BoxTurtle import afcBoxTurtle
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_vivid(name="ViViD_1"):
+    """Build an AFC_vivid bypassing the complex __init__."""
+    unit = AFC_vivid.__new__(AFC_vivid)
+
+    from tests.conftest import MockAFC, MockPrinter, MockLogger, MockReactor
+
+    afc = MockAFC()
+    reactor = MockReactor()
+    afc.reactor = reactor
+    afc.logger = MockLogger()
+    printer = MockPrinter(afc=afc)
+
+    unit.printer = printer
+    unit.afc = afc
+    unit.logger = afc.logger
+    unit.reactor = reactor
+    unit.name = name
+    unit.full_name = ["AFC_vivid", name]
+    unit.lanes = {}
+    unit.hub_obj = None
+    unit.extruder_obj = None
+    unit.buffer_obj = None
+    unit.hub = None
+    unit.extruder = None
+    unit.buffer_name = None
+    unit.td1_defined = False
+    unit.type = "ViViD"
+    unit.gcode = afc.gcode
+    unit.drive_stepper = "drive_stepper"
+    unit.selector_stepper = "selector_stepper"
+    unit.drive_stepper_obj = MagicMock()
+    unit.selector_stepper_obj = MagicMock()
+    unit.current_selected_lane = None
+    unit.home_state = False
+    unit.prep_homed = False
+    unit.failed_to_home = False
+    unit.selector_homing_speed = 150
+    unit.selector_homing_accel = 150
+    unit.max_selector_movement = 800
+
+    return unit
+
+
+def _make_lane(name="lane1", has_selector=True):
+    lane = MagicMock()
+    lane.name = name
+    lane.selector_endstop = "selector_pin" if has_selector else None
+    lane.selector_endstop_name = "lane1_selector"
+    lane.load_endstop_name = "lane1_load"
+    lane.prep_endstop_name = "lane1_prep"
+    lane.dist_hub = 200
+    lane.calibrated_lane = True
+    if has_selector:
+        lane.fila_selector = MagicMock()
+        lane.fila_selector.get_status.return_value = {"filament_detected": False}
+    else:
+        del lane.fila_selector  # make attribute not exist
+    return lane
+
+
+# ── Class constants ───────────────────────────────────────────────────────────
+
+class TestVivdConstants:
+    def test_valid_cam_angles(self):
+        assert AFC_vivid.VALID_CAM_ANGLES == [30, 45, 60]
+
+    def test_calibration_distance(self):
+        assert AFC_vivid.CALIBRATION_DISTANCE == 5000
+
+    def test_lane_overshoot(self):
+        assert AFC_vivid.LANE_OVERSHOOT == 200
+
+    def test_is_subclass_of_box_turtle(self):
+        assert issubclass(AFC_vivid, afcBoxTurtle)
+
+# ── _move_lane ──────────────────────────────────────────────────
+class Test_MoveLane:
+    def test_returns_prep_true_filament_loaded(self):
+        unit = _make_vivid()
+        lane = _make_lane(has_selector=True)
+        lane.prep_state = True
+        lane.spool_id = 10
+        lane.remember_spool = True
+        lane.tool_loaded = False
+        lane.move_to.return_value = (True, 100.0, False)
+        result = unit._move_lane(lane, 1, True)
+        assert result is True
+        assert lane.spool_id == 10
+    
+    def test_returns_prep_true_filament_not_loaded(self):
+        unit = _make_vivid()
+        lane = _make_lane(has_selector=True)
+        lane.prep_state = True
+        lane.loaded_to_hub = True
+        lane.spool_id = 10
+        lane.remember_spool = True
+        lane.tool_loaded = False
+        lane.move_to.return_value = (False, 100.0, False)
+        result = unit._move_lane(lane, 1, True)
+        assert result is False
+        assert lane.tool_loaded is False
+        assert lane.loaded_to_hub is False
+        assert lane.spool_id == 10
+    
+    def test_returns_prep_false_filament_not_loaded(self):
+        from extras.AFC_spool import AFCSpool
+        unit = _make_vivid()
+        lane = _make_lane(has_selector=True)
+        lane.afc.spool = AFCSpool.__new__(AFCSpool)
+        lane.prep_state = False
+        lane.loaded_to_hub = True
+        lane.spool_id = 10
+        lane.remember_spool = True
+        lane.tool_loaded = False
+        lane.move_to.return_value = (False, 100.0, False)
+        result = unit._move_lane(lane, 1, True)
+        assert result is False
+        assert lane.tool_loaded is False
+        assert lane.loaded_to_hub is False
+        assert lane.spool_id == 10
+    
+    def test_returns_prep_false_filament_not_loaded_not_remember_spool(self):
+        from extras.AFC_spool import AFCSpool
+        unit = _make_vivid()
+        lane = _make_lane(has_selector=True)
+        lane.afc.spool = AFCSpool.__new__(AFCSpool)
+        lane.prep_state = False
+        lane.loaded_to_hub = True
+        lane.spool_id = 10
+        lane.remember_spool = False
+        lane.tool_loaded = False
+        lane.move_to.return_value = (False, 100.0, False)
+        result = unit._move_lane(lane, 1, True)
+        assert result is False
+        assert lane.tool_loaded is False
+        assert lane.loaded_to_hub is False
+        assert lane.spool_id is None
+
+# ── _get_lane_selector_state ──────────────────────────────────────────────────
+
+class TestGetLaneSelectorState:
+    def test_returns_filament_detected_when_selector_present(self):
+        unit = _make_vivid()
+        lane = _make_lane(has_selector=True)
+        lane.fila_selector.get_status.return_value = {"filament_detected": True}
+        result = unit._get_lane_selector_state(lane)
+        assert result is True
+
+    def test_returns_false_when_selector_not_detected(self):
+        unit = _make_vivid()
+        lane = _make_lane(has_selector=True)
+        lane.fila_selector.get_status.return_value = {"filament_detected": False}
+        result = unit._get_lane_selector_state(lane)
+        assert result is False
+
+    def test_returns_false_when_no_selector_attribute(self):
+        unit = _make_vivid()
+        lane = MagicMock(spec=[])  # No attributes
+        result = unit._get_lane_selector_state(lane)
+        assert result is False
+
+
+# ── _get_selector_enabled ─────────────────────────────────────────────────────
+
+class TestGetSelectorEnabled:
+    def test_returns_true_when_stepper_enabled(self):
+        unit = _make_vivid()
+        stepper_enable = MagicMock()
+        stepper_enable.get_status.return_value = {
+            "steppers": {f"AFC_stepper {unit.selector_stepper}": True}
+        }
+        unit.printer._objects["stepper_enable"] = stepper_enable
+        result = unit._get_selector_enabled()
+        assert result is True
+
+    def test_returns_false_when_stepper_not_found(self):
+        unit = _make_vivid()
+        # No stepper_enable in printer objects → returns False
+        unit.printer._objects = {}
+        result = unit._get_selector_enabled()
+        assert result is False
+
+
+# ── calibration_lane_message ──────────────────────────────────────────────────
+
+class TestCalibrationLaneMessage:
+    def test_returns_non_empty_string(self):
+        unit = _make_vivid()
+        msg = unit.calibration_lane_message()
+        assert isinstance(msg, str)
+        assert len(msg) > 0
+
+    def test_message_mentions_reinsert(self):
+        unit = _make_vivid()
+        msg = unit.calibration_lane_message()
+        assert "reinsert" in msg.lower() or "insert" in msg.lower()
+
+    def test_message_mentions_vivid(self):
+        unit = _make_vivid()
+        msg = unit.calibration_lane_message()
+        assert "vivid" in msg.lower() or "ViViD" in msg
+
+
+# ── cmd_AFC_SELECT_LANE ────────────────────────────────────────────────────────
+
+class TestCmdAfcSelectLane:
+    def test_calls_select_lane_when_lane_found(self):
+        unit = _make_vivid()
+        lane = _make_lane("lane1")
+        unit.afc.lanes = {"lane1": lane}
+        unit.select_lane = MagicMock(return_value=(True, 15.0))
+        gcmd = MagicMock()
+        gcmd.get.return_value = "lane1"
+        unit.cmd_AFC_SELECT_LANE(gcmd)
+        unit.select_lane.assert_called_once_with(lane)
+
+    def test_logs_success_when_homed(self):
+        unit = _make_vivid()
+        lane = _make_lane("lane1")
+        unit.afc.lanes = {"lane1": lane}
+        unit.select_lane = MagicMock(return_value=(True, 15.0))
+        gcmd = MagicMock()
+        gcmd.get.return_value = "lane1"
+        unit.cmd_AFC_SELECT_LANE(gcmd)
+        info_msgs = [m for lvl, m in unit.logger.messages if lvl == "info"]
+        assert any("lane1" in m for m in info_msgs)
+
+    def test_logs_error_when_homing_fails(self):
+        unit = _make_vivid()
+        lane = _make_lane("lane1")
+        unit.afc.lanes = {"lane1": lane}
+        unit.select_lane = MagicMock(return_value=(False, 0))
+        gcmd = MagicMock()
+        gcmd.get.return_value = "lane1"
+        unit.cmd_AFC_SELECT_LANE(gcmd)
+        error_msgs = [m for lvl, m in unit.logger.messages if lvl == "error"]
+        assert any("lane1" in m for m in error_msgs)
+
+    def test_calls_gcmd_error_when_lane_not_found(self):
+        unit = _make_vivid()
+        unit.afc.lanes = {}
+        gcmd = MagicMock()
+        gcmd.get.return_value = "missing_lane"
+        unit.cmd_AFC_SELECT_LANE(gcmd)
+        gcmd.error.assert_called()
+
+
+# ── handle_connect ────────────────────────────────────────────────────────────
+
+class TestVividHandleConnect:
+    def test_handle_connect_sets_logo(self):
+        unit = _make_vivid()
+        unit.set_logo_color = MagicMock()
+        unit.handle_connect()
+        assert "ViViD Ready" in unit.logo
+
+    def test_handle_connect_sets_logo_error(self):
+        unit = _make_vivid()
+        unit.set_logo_color = MagicMock()
+        unit.handle_connect()
+        assert "ViViD Not Ready" in unit.logo_error
+
+    def test_handle_connect_registers_unit_in_afc(self):
+        unit = _make_vivid(name="vivid_1")
+        unit.set_logo_color = MagicMock()
+        unit.handle_connect()
+        assert unit.afc.units.get("vivid_1") is unit
+
+
+# ── system_Test ───────────────────────────────────────────────────────────────
+
+class TestVividSystemTest:
+    def test_system_test_calls_super_with_movement_disabled(self):
+        unit = _make_vivid()
+        lane = MagicMock()
+        with MagicMock() as super_mock:
+            from extras.AFC_BoxTurtle import afcBoxTurtle
+            with MagicMock() as patch_target:
+                from unittest.mock import patch
+                with patch.object(afcBoxTurtle, 'system_Test', return_value="ok") as mock_st:
+                    result = unit.system_Test(lane, 0.5, True, True)
+                    mock_st.assert_called_once_with(lane, 0.5, True, enable_movement=False)
+
+
+# ── prep_post_load ────────────────────────────────────────────────────────────
+
+class TestPrepPostLoad:
+    def test_returns_none(self):
+        unit = _make_vivid()
+        lane = MagicMock()
+        result = unit.prep_post_load(lane)
+        assert result is None
+
+
+# ── unselect_lane ─────────────────────────────────────────────────────────────
+
+class TestUnselectLane:
+    def test_calls_selector_stepper_move(self):
+        unit = _make_vivid()
+        unit.unselect_lane()
+        unit.selector_stepper_obj.move.assert_called_once_with(50, 100, 100, False)
+
+
+# ── move_to_hub ───────────────────────────────────────────────────────────────
+
+class TestMoveToHub:
+    def test_delegates_to_lane_move_to(self):
+        from extras.AFC_lane import SpeedMode, MoveDirection, AssistActive, AFCMoveWarning
+        unit = _make_vivid()
+        lane = MagicMock()
+        lane.move_to.return_value = (True, 100.0, AFCMoveWarning.NONE)
+        lane.load_es = "load_endstop"
+        result = unit.move_to_hub(lane, 100.0, MoveDirection.POS)
+        lane.move_to.assert_called_once()
+        assert result == (True, 100.0, AFCMoveWarning.NONE)
+
+    def test_returns_homed_distance_warn_tuple(self):
+        from extras.AFC_lane import SpeedMode, MoveDirection, AFCMoveWarning
+        unit = _make_vivid()
+        lane = MagicMock()
+        lane.move_to.return_value = (False, 50.0, AFCMoveWarning.WARN)
+        lane.load_es = "load_endstop"
+        homed, dist, warn = unit.move_to_hub(lane, 50.0, MoveDirection.NEG)
+        assert homed is False
+        assert warn is AFCMoveWarning.WARN
+
+
+# ── select_lane ───────────────────────────────────────────────────────────────
+
+class TestSelectLane:
+    def test_returns_none_when_no_selector_endstop(self):
+        unit = _make_vivid()
+        lane = _make_lane("lane1", has_selector=False)
+        lane.selector_endstop_name = None
+        result = unit.select_lane(lane)
+        assert result is None
+
+    def test_returns_true_and_zero_when_already_selected_and_enabled(self):
+        unit = _make_vivid()
+        lane = _make_lane("lane1", has_selector=True)
+        lane.fila_selector.get_status.return_value = {"filament_detected": True}
+        # stepper enabled
+        stepper_enable = MagicMock()
+        stepper_enable.get_status.return_value = {
+            "steppers": {f"AFC_stepper {unit.selector_stepper}": True}
+        }
+        unit.printer._objects["stepper_enable"] = stepper_enable
+        result = unit.select_lane(lane)
+        assert result == (True, 0.0)
+
+    def test_calls_homing_when_not_selected(self):
+        unit = _make_vivid()
+        lane = _make_lane("lane1", has_selector=True)
+        lane.fila_selector.get_status.return_value = {"filament_detected": False}
+        unit.printer._objects = {}  # no stepper_enable → enabled=False
+        unit.selector_stepper_obj.do_homing_move.return_value = (True, 15.0)
+        homed, dist = unit.select_lane(lane)
+        assert homed is True
+        assert dist == 15.0
+        unit.selector_stepper_obj.do_homing_move.assert_called_once()
+
+    def test_calls_unselect_lane_when_disabled_but_selector_triggered(self):
+        """When stepper not enabled but selector triggered, unselect_lane is called first."""
+        unit = _make_vivid()
+        lane = _make_lane("lane1", has_selector=True)
+        lane.fila_selector.get_status.return_value = {"filament_detected": True}
+        # stepper disabled (no stepper_enable object)
+        unit.printer._objects = {}
+        unit.unselect_lane = MagicMock()
+        unit.selector_stepper_obj.do_homing_move.return_value = (True, 10.0)
+        unit.select_lane(lane)
+        unit.unselect_lane.assert_called_once()
+
+
+# ── calibrate_lane ────────────────────────────────────────────────────────────
+
+class TestCalibrateLane:
+    def test_returns_correct_tuple(self):
+        from extras.AFC_lane import AFCLaneState
+        unit = _make_vivid()
+        lane = MagicMock()
+        unit.eject_lane = MagicMock()
+        result = unit.calibrate_lane(lane, 0)
+        assert result == (True, "calibration_lane", 0)
+
+    def test_sets_loaded_to_hub_false(self):
+        unit = _make_vivid()
+        lane = MagicMock()
+        unit.eject_lane = MagicMock()
+        unit.calibrate_lane(lane, 0)
+        assert lane.loaded_to_hub is False
+
+    def test_sets_calibrated_lane_false(self):
+        unit = _make_vivid()
+        lane = MagicMock()
+        unit.eject_lane = MagicMock()
+        unit.calibrate_lane(lane, 0)
+        assert lane.calibrated_lane is False
+
+    def test_calls_eject_lane(self):
+        unit = _make_vivid()
+        lane = MagicMock()
+        unit.eject_lane = MagicMock()
+        unit.calibrate_lane(lane, 5.0)
+        unit.eject_lane.assert_called_once_with(lane)
+
+
+# ── _get_selector_enabled except branch ───────────────────────────────────────
+
+class TestGetSelectorEnabledExceptBranch:
+    def test_returns_false_when_stepper_key_missing_from_steppers(self):
+        """Covers the except branch when the specific stepper key is absent."""
+        unit = _make_vivid()
+        stepper_enable = MagicMock()
+        stepper_enable.get_status.return_value = {"steppers": {}}  # key not present
+        unit.printer._objects["stepper_enable"] = stepper_enable
+        result = unit._get_selector_enabled()
+        assert result is False
+
+
+# ── prep_load ─────────────────────────────────────────────────────────────────
+
+class TestPrepLoad:
+    def test_calibrated_lane_sets_loaded_to_hub(self):
+        from unittest.mock import PropertyMock
+        unit = _make_vivid()
+        lane = MagicMock()
+        lane.calibrated_lane = True
+        lane.dist_hub = 200.0
+        lane.move_to.return_value = (True, 200.0, False)
+        unit.lane_loading = MagicMock()
+        unit.select_lane = MagicMock()
+        unit.lane_loaded = MagicMock()
+        type(lane).raw_load_state = PropertyMock(side_effect=[False, True])
+
+        unit.prep_load(lane)
+
+        assert lane.loaded_to_hub is True
+        unit.lane_loading.assert_called_once_with(lane)
+        unit.select_lane.assert_called_once_with(lane, sel_prep=True)
+        unit.lane_loaded.assert_called_once_with(lane)
+
+    def test_disables_steppers_and_selects_loaded_lane(self):
+        unit = _make_vivid()
+        lane = MagicMock()
+        lane.calibrated_lane = True
+        lane.dist_hub = 200.0
+        lane.move_to.return_value = (True, 200.0, False)
+        unit.lane_loading = MagicMock()
+        unit.select_lane = MagicMock()
+        unit.lane_loaded = MagicMock()
+
+        unit.prep_load(lane)
+
+        unit.selector_stepper_obj.do_enable.assert_called_with(False)
+        unit.drive_stepper_obj.do_enable.assert_called_with(False)
+        unit.afc.function.select_loaded_lane.assert_called_once()
+
+    def test_uncalibrated_lane_updates_dist_hub_and_config(self):
+        from unittest.mock import PropertyMock
+        unit = _make_vivid()
+        lane = MagicMock()
+        lane.calibrated_lane = False
+        lane.prep_state = True
+        lane.move_to.return_value = (True, 300.0, False)
+        unit.lane_loading = MagicMock()
+        unit.select_lane = MagicMock()
+        unit.lane_loaded = MagicMock()
+        type(lane).raw_load_state = PropertyMock(side_effect=[False, True])
+
+        unit.prep_load(lane)
+
+        assert lane.calibrated_lane is True
+        assert lane.dist_hub == round(300.0, 2) + AFC_vivid.LANE_OVERSHOOT
+        unit.afc.function.ConfigRewrite.assert_called()
+    
+    def test_uncalibrated_lane_updates_dist_hub_and_config_two_tries(self):
+        from unittest.mock import PropertyMock
+        unit = _make_vivid()
+        lane = MagicMock()
+        lane.calibrated_lane = False
+        lane.prep_state = True
+        lane.move_to.return_value = (True, 300.0, False)
+        unit.lane_loading = MagicMock()
+        unit.select_lane = MagicMock()
+        unit.lane_loaded = MagicMock()
+        type(lane).raw_load_state = PropertyMock(side_effect=[False, False, True])
+
+        unit.prep_load(lane)
+
+        assert lane.calibrated_lane is True
+        assert lane.dist_hub == round(300.0, 2) + AFC_vivid.LANE_OVERSHOOT
+        unit.afc.function.ConfigRewrite.assert_called()
+    
+    def test_uncalibrated_lane_updates_dist_hub_and_config_failed(self):
+        from unittest.mock import PropertyMock
+        unit = _make_vivid()
+        lane = MagicMock()
+        lane.calibrated_lane = False
+        lane.prep_state = True
+        lane.move_to.return_value = (False, 300.0, False)
+        lane.dist_hub = 0.0
+        unit.lane_loading = MagicMock()
+        unit.select_lane = MagicMock()
+        unit.lane_loaded = MagicMock()
+        type(lane).raw_load_state = PropertyMock(side_effect=[False, False, False])
+
+        unit.prep_load(lane)
+
+        assert lane.calibrated_lane is False
+        assert lane.dist_hub == 0.0
+        unit.afc.function.ConfigRewrite.assert_not_called()
+        # Failure should be reported/logged
+        error_msgs = [m for lvl, m in unit.logger.messages if lvl == "error"]
+        assert error_msgs
+    
+    def test_uncalibrated_lane_updates_dist_hub_no_prep(self):
+        from unittest.mock import PropertyMock
+        unit = _make_vivid()
+        lane = MagicMock()
+        lane.calibrated_lane = False
+        lane.prep_state = False
+        lane.move_to.return_value = (True, 300.0, False)
+        unit.lane_loading = MagicMock()
+        unit.select_lane = MagicMock()
+        unit.lane_loaded = MagicMock()
+        type(lane).raw_load_state = PropertyMock(side_effect=[False])
+
+        unit.prep_load(lane)
+
+        assert lane.calibrated_lane is False
+
+    def test_not_homed_skips_lane_loaded(self):
+        unit = _make_vivid()
+        lane = MagicMock()
+        lane.calibrated_lane = True
+        lane.dist_hub = 200.0
+        lane.move_to.return_value = (False, 0.0, False)
+        unit.lane_loading = MagicMock()
+        unit.select_lane = MagicMock()
+        unit.lane_loaded = MagicMock()
+
+        unit.prep_load(lane)
+
+        unit.lane_loaded.assert_not_called()
+        # Steppers are disabled regardless of homing result
+        unit.selector_stepper_obj.do_enable.assert_called_with(False)
+
+
+# ── eject_lane ────────────────────────────────────────────────────────────────
+
+class TestEjectLane:
+    def test_calls_select_and_unselect(self):
+        unit = _make_vivid()
+        lane = MagicMock()
+        lane.dist_hub = 200.0
+        unit.select_lane = MagicMock()
+        unit.unselect_lane = MagicMock()
+
+        unit.eject_lane(lane)
+
+        unit.select_lane.assert_called_once_with(lane)
+        unit.unselect_lane.assert_called_once()
+
+    def test_disables_steppers(self):
+        unit = _make_vivid()
+        lane = MagicMock()
+        lane.dist_hub = 200.0
+        unit.select_lane = MagicMock()
+        unit.unselect_lane = MagicMock()
+
+        unit.eject_lane(lane)
+
+        unit.selector_stepper_obj.do_enable.assert_called_with(False)
+        unit.drive_stepper_obj.do_enable.assert_called_with(False)
+
+    def test_adjusts_distance_when_dist_hub_over_400(self):
+        from extras.AFC_lane import MoveDirection
+        unit = _make_vivid()
+        lane = MagicMock()
+        lane.hub_obj = MagicMock()
+        lane.hub_obj.hub_clear_move_dis = 65
+        lane.dist_hub = 600.0  # > 400 → should subtract LANE_OVERSHOOT+100
+        unit.select_lane = MagicMock()
+        unit.unselect_lane = MagicMock()
+
+        unit.eject_lane(lane)
+
+        expected_dist = (600.0 - (AFC_vivid.LANE_OVERSHOOT + 100) - \
+                         lane.hub_obj.hub_clear_move_dis - lane.homing_overshoot) * MoveDirection.NEG
+        call_args = lane.move_to.call_args[0]
+        assert call_args[0] == expected_dist
+
+    def test_does_not_adjust_distance_when_dist_hub_at_or_below_400(self):
+        from extras.AFC_lane import MoveDirection
+        unit = _make_vivid()
+        lane = MagicMock()
+        lane.dist_hub = 300.0  # <= 400 → full dist used
+        unit.select_lane = MagicMock()
+        unit.unselect_lane = MagicMock()
+
+        unit.eject_lane(lane)
+
+        expected_dist = 300.0 * MoveDirection.NEG
+        call_args = lane.move_to.call_args[0]
+        assert call_args[0] == expected_dist


### PR DESCRIPTION
## Major Changes in this PR
Use Spoolman filament color for lane LEDs when available.

When a lane has a spool color defined in Spoolman, the lane LED will use that filament color instead of the default configured LED color.

If Spoolman is not configured or the spool has no color set, the existing LED configuration is used as a fallback.

Changes:

Added _get_lane_color() helper in extras/AFC_unit.py

Updated lane LED methods to prefer Spoolman filament color when available

Removed the commented TODO block in extras/AFC_functions.py

## Notes to Code Reviewers
Color selection is handled in _get_lane_color()

If lane.color exists, the Spoolman filament color is used.
If not, the method falls back to the existing LED configuration (led_ready, led_tool_loaded, etc.).

A new boolean option use_filament_color has been added that can be set globally in AFC.py, per unit in AFC_unit.py, or per lane in AFC_lane.py. Defaults to False to preserve existing behavior for users who don't set it.

## How the changes in this PR are tested
Tested with:

Spool assigned with color via SET_SPOOL_ID
*Lane LED reflects filament color

Lane without spool assigned

*Default LED color is used

Tool load / unload transitions
*LED updates correctly

Tool loaded idle state
*LED reflects filament color

No Spoolman configured
***Did not test***
## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [ x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.