### PR TITLE
Toolchanger: fix error initializing after restart with tool on the shuttle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [2026-03-16]
+### Fixed
+- Toolchanger: fixes an error initializing the toolchanger after klipper restart
+while a tool remained on the shuttle
+
 ## [2026-03-07]
 ### Fix
 - Added error checking when homing during a Tool Load or Unload, if a homing error (like communication timeout or something similar) happens during these calls that AFC displays error and returns early.

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -54,6 +54,17 @@ class afcPrep:
             if not self.dis_unload_macro:
                 self.afc.function._rename(self.afc.BASE_UNLOAD_FILAMENT, self.afc.RENAMED_UNLOAD_FILAMENT, self.afc.cmd_TOOL_UNLOAD, self.afc.cmd_TOOL_UNLOAD_help)
 
+    def _tc_restore(self) -> None:
+        """Re-query toolchanger detection pin states after a restart.
+
+        During PREP, we force a call note_detect_change() to re-query the
+        detection pins and update detected_tool. This way later calls to
+        INITIALIZE_TOOLCHANGER will set the correct tool as active.
+        """
+        tc = self.printer.lookup_object('toolchanger', default=None)
+        if tc is not None and tc.active_tool is None and tc.has_detection:
+            tc.note_detect_change(None)
+
     def _td1_prep(self, overrall_status):
         '''
         Helper function to perform TD-1 data capture during PREP
@@ -119,6 +130,9 @@ class afcPrep:
             error_string = 'Error: {}.unit file not found. Please check the path in the '.format(self.afc.VarFile)
             error_string += 'AFC.cfg file and make sure the file and path exists.'
             self.afc.error.AFC_error(error_string, False)
+
+        # run any toolchanger startup checks
+        self._tc_restore()
 
         # check if Lane is supposed to be loaded in tool head from saved file
         for extruder in self.afc.tools.keys():

--- a/tests/test_AFC_prep.py
+++ b/tests/test_AFC_prep.py
@@ -168,3 +168,43 @@ class TestTd1Prep:
         prep.afc.lanes = {"lane1": lane}
         prep._td1_prep(overrall_status=False)
         lane.get_td1_data.assert_not_called()
+
+
+# ── _tc_restore ───────────────────────────────────────────────────────────────
+
+class TestTcRestore:
+    def _make_tc(self, active_tool=None, has_detection=True):
+        tc = MagicMock()
+        tc.active_tool = active_tool
+        tc.has_detection = has_detection
+        return tc
+
+    def test_no_toolchanger_does_nothing(self):
+        """lookup_object returns None → method is a no-op and does not raise."""
+        prep = _make_prep()
+        # printer._objects has no 'toolchanger' entry → lookup_object returns None
+        prep._tc_restore()  # must not raise
+
+    def test_active_tool_already_set_skips_restore(self):
+        """If active_tool is already populated, note_detect_change must not be called."""
+        prep = _make_prep()
+        tc = self._make_tc(active_tool=MagicMock())
+        prep.printer._objects["toolchanger"] = tc
+        prep._tc_restore()
+        tc.note_detect_change.assert_not_called()
+
+    def test_no_detection_pins_skips_restore(self):
+        """If has_detection is False, note_detect_change must not be called."""
+        prep = _make_prep()
+        tc = self._make_tc(has_detection=False)
+        prep.printer._objects["toolchanger"] = tc
+        prep._tc_restore()
+        tc.note_detect_change.assert_not_called()
+
+    def test_detection_present_calls_note_detect_change(self):
+        """active_tool=None and has_detection=True → note_detect_change(None) called."""
+        prep = _make_prep()
+        tc = self._make_tc()  # active_tool=None, has_detection=True
+        prep.printer._objects["toolchanger"] = tc
+        prep._tc_restore()
+        tc.note_detect_change.assert_called_once_with(None)


### PR DESCRIPTION
## Major Changes in this PR

During PREP, force a call to note_detect_change() to re-query the detection pins and update detected_tool. This way later calls to INITIALIZE_TOOLCHANGER will set the correct tool as active.

Prior to this change, INITIALIZE_TOOLCHANGER would report 'active None' even if a tool was on the shuttle.

## How the changes in this PR are tested

Manual verification and unit tests

The sequence to reproduce the problem solved here:

1. Run the printer as per normal, AFC_SELECT_TOOL leaves a tool on the shuttle
2. Restart klipper
3. Home and initialize KTC
4. Run AFC_UNSELECT_TOOL

Observe that the tool is not removed from the shuttle, unless this fix is applied.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description
