### PR TITLE
feat: add NEW_EXTRUDER_TEMP to Tn and automatic temp drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [2026-03-15]
+### Added
+- Added `NEW_EXTRUDER_TEMP` parameter to Tn commands to set temperature before the tool change begins.
+- Added `toolchange_temp_drop` config option to automatically lower the old extruder's temperature during toolchange.
+
 ## [2026-03-07]
 ### Fix
 - Added error checking when homing during a Tool Load or Unload, if a homing error (like communication timeout or something similar) happens during these calls that AFC displays error and returns early.

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -10,7 +10,7 @@ import traceback
 import inspect
 from configfile import error
 
-from typing import Dict, TYPE_CHECKING, Union, Any
+from typing import Dict, TYPE_CHECKING, Union, Any, Optional, Tuple
 
 if TYPE_CHECKING:
     from configfile import ConfigWrapper
@@ -233,6 +233,9 @@ class afc:
             "restore_extruder_temp_on_load_or_unload", False
         )  # Restore extruder target temp after tool load/unload when not printing
         self.lower_extruder_temp_on_change = config.getboolean('lower_extruder_temp_on_change', True)  # When False, AFC will not lower extruder temp during filament change if already above target - 5
+        self.toolchange_temp_drop: float = config.getfloat(
+            "toolchange_temp_drop", 0
+        )  # Degrees to drop the old extruder's temperature (no wait) after a successful toolchange when the extruder changes.
         self.load_to_hub            = config.getboolean("load_to_hub", True)        # Fast loads filament to hub when inserted, set to False to disable. This is a global setting and can be overridden at AFC_stepper
         self.disable_homing_check   = config.getboolean("disable_homing_check", False)# Disables homing check when doing toolchanges. Only use this if you are using a toolchanger and don't need to home to unload toolheads
         self.assisted_unload        = config.getboolean("assisted_unload", True)    # If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool
@@ -1995,14 +1998,17 @@ class afc:
 
         Optionally setting PURGE_LENGTH parameter to pass a value into poop macro.
 
+        Optionally setting NEW_EXTRUDER_TEMP to set and wait for that temperature on the new extruder before
+        performing the tool change.
+
         Usage
         -----
-        `CHANGE_TOOL LANE=<lane> PURGE_LENGTH=<purge_length>(optional value)`
+        `CHANGE_TOOL LANE=<lane> PURGE_LENGTH=<purge_length>(optional) NEW_EXTRUDER_TEMP=<temp>(optional)`
 
         Example
         ------
         ```
-        CHANGE_TOOL LANE=lane1 PURGE_LENGTH=100
+        CHANGE_TOOL LANE=lane1 PURGE_LENGTH=100 NEW_EXTRUDER_TEMP=220
         ```
         """
         # Check if the bypass filament sensor detects filament; if so, abort the tool change.
@@ -2017,8 +2023,19 @@ class afc:
         # for some sort of backwards compatibility, so for example: T0 PURGE_LENGTH=200, the purge_length would be
         # equal to "=200". So run this check to remove it:
         if purge_length is not None:
-            if purge_length.startswith('='):
-                purge_length = purge_length[1:]
+            try:
+                purge_length = float(purge_length.lstrip('='))
+            except ValueError:
+                self.error.AFC_error("PURGE_LENGTH must be a numeric value", pause=False)
+                return
+
+        new_extruder_temp = gcmd.get('NEW_EXTRUDER_TEMP', None)
+        if new_extruder_temp is not None:
+            try:
+                new_extruder_temp = float(new_extruder_temp.lstrip('='))
+            except ValueError:
+                self.error.AFC_error("NEW_EXTRUDER_TEMP must be a numeric value", pause=False)
+                return
 
         command_line = gcmd.get_commandline()
         self.logger.debug("CHANGE_TOOL: cmd-{}".format(command_line))
@@ -2043,26 +2060,38 @@ class afc:
             self.error.AFC_error("I did not understand the change -- " + cmd, pause=self.function.in_print())
             return
 
-        self.CHANGE_TOOL(self.lanes[self.tool_cmds[Tcmd]], purge_length)
+        self.CHANGE_TOOL(self.lanes[self.tool_cmds[Tcmd]], purge_length, new_extruder_temp=new_extruder_temp)
 
-    def CHANGE_TOOL(self, cur_lane: AFCLane, purge_length=None, restore_pos=True):
+    def CHANGE_TOOL(self, cur_lane: AFCLane, purge_length: Optional[float]=None, restore_pos: bool=True, new_extruder_temp: Optional[float]=None) -> None:
         self.afcDeltaTime.set_start_time()
         # Check if the bypass filament sensor detects filament; if so, abort the tool change.
         if self._check_bypass(unload=False): return
-        infinite_runout = False
 
         self.next_lane_load = cur_lane.name
         next_extruder = cur_lane.extruder_obj.name
+        infinite_runout: bool = cur_lane.status == AFCLaneState.INFINITE_RUNOUT
+        adjusting_temperature: bool = new_extruder_temp is not None or \
+            (infinite_runout and self.function.get_current_extruder() != next_extruder)
 
-        if cur_lane.status == AFCLaneState.INFINITE_RUNOUT and self.function.get_current_extruder() != next_extruder:
-            infinite_runout = True
-            result = self._heat_next_extruder(wait=False)
+        if adjusting_temperature:
+            # Heat the next extruder FIRST so that _heat_next_extruder reads the
+            # current target temperature before it is changed by the cooldown below.
+            next_temp = None if infinite_runout else new_extruder_temp
+            result = self._heat_next_extruder(wait=False, next_temp=next_temp)
             if not result:
                 self.error.fix("Failed to select or heat next extruder", self.next_lane_load)
                 return
-            cur_lane.status = AFCLaneState.LOADED
-            next_heater = result[0]
+            if infinite_runout:
+                cur_lane.status = AFCLaneState.LOADED
+            next_extruder_obj = result[0]
             target_temp = result[1]
+
+            # Now cool down the old extruder (self.current changes during the toolchange,
+            # so capture the reference here after heating is already queued).
+            if self.current is not None:
+                _last_lane = self.lanes.get(self.current)
+                if _last_lane is not None and _last_lane.extruder_obj.name != next_extruder:
+                    self._cooldown_last_extruder(_last_lane.extruder_obj, infinite_runout)
 
         # If the requested lane is not the current lane, proceed with the tool change.
         if cur_lane.name != self.current:
@@ -2090,11 +2119,12 @@ class afc:
                         self.error.fix(msg, self.lanes[self.current])  #send to error handling
                         return
 
-            if infinite_runout:
-                infinite_extruder = cur_lane.extruder_obj
-                self.logger.info("Heating and waiting for {} for infinite runout".format(infinite_extruder.name))
-                self._wait_for_temp_within_tolerance(next_heater, target_temp, infinite_extruder.deadband)
-                self.logger.info("{} heated and ready to print".format(infinite_extruder.name))
+            if adjusting_temperature:
+                self.logger.info("Heating and waiting for {} for {}".format(next_extruder_obj.name,
+                    "infinite runout" if infinite_runout else "tool change"))
+                next_heater = next_extruder_obj.get_heater()
+                self._wait_for_temp_within_tolerance(next_heater, target_temp, next_extruder_obj.deadband)
+                self.logger.info("{} heated and ready to print".format(next_extruder_obj.name))
 
             # Load the new lane and restore the toolhead position if successful.
             if self.TOOL_LOAD(cur_lane, purge_length, set_start_time=False) and not self.error_state:
@@ -2290,12 +2320,17 @@ class afc:
         pheaters.set_temperature(heater, temp, should_wait)
         self.logger.debug("Done setting temp")
 
-    def _heat_next_extruder(self, wait=True):
+    def _heat_next_extruder(self, wait=True, next_temp: Optional[float]=None) -> Union[Tuple[AFCExtruder, float], bool]:
         """
         Heats the next extruder if it is not the current extruder.
         This function checks if the next lane to load is specified and if it is different from the current extruder.
-        If so, it retrieves the extruder object and its heater, then waits for the extruder to reach the desired temperature.
-        Also sets the temperature of the current extruder to 0 to ensure it is not heated while empty.
+        If so, it retrieves the next extruder object and its heater, sets a target temperature for it, and can wait for the
+        extruder to reach that temperature before proceeding with the tool change.
+
+        :param wait: Whether to wait for the next extruder to reach the target temperature before proceeding with the tool change
+        :param next_temp: The temperature to set for the next extruder. If None, uses the current toolhead extruder heater's
+            target temperature as the setpoint for the next extruder.
+        :return: A tuple of the next extruder object and the target temperature if successful, or False if there was an error
         """
         # Check if the current extruder is loaded with the lane to be unloaded.
         if self.next_lane_load is not None:
@@ -2308,22 +2343,39 @@ class afc:
 
         # get the current extruder from the toolhead and it's current temperature
         pheaters = self.printer.lookup_object('heaters')
-        extruder = self.toolhead.get_extruder()
-        current_heater = extruder.get_heater()
-        current_temp = current_heater.get_temp(self.reactor.monotonic())
+        if next_temp is None:
+            extruder = self.toolhead.get_extruder()
+            current_heater = extruder.get_heater()
+            current_temp = current_heater.get_temp(self.reactor.monotonic())
+            set_temp = current_temp[1]
+        else:
+            set_temp = next_temp
         next_heater = next_extruder.get_heater()
-        set_temp = current_temp[1]
         pheaters.set_temperature(next_heater, set_temp, False)
         self.logger.info("Heating next extruder: {} to {}".format(next_extruder.name, set_temp))
-        pheaters.set_temperature(current_heater, 0, False)  # Always set temp of the extruder than ran out to 0
-        self.logger.info("Setting current extruder {} temperature to 0".format(extruder.name))
 
         # If the next extruder is specified and it is not the current extruder, heat the next extruder.
-        if wait and (next_extruder is not None and self.function.get_current_extruder() != next_extruder):
+        if wait and (next_extruder is not None and self.function.get_current_extruder() != next_extruder.name):
             deadband = next_extruder.deadband
             self._wait_for_temp_within_tolerance(next_heater, set_temp, deadband)
 
-        return next_heater, set_temp
+        return next_extruder, set_temp
+
+    def _cooldown_last_extruder(self, last_extruder: AFCExtruder, is_infinite_runout: bool) -> None:
+        """
+        Cools down the last extruder by setting its temperature to the specified value.
+        This function retrieves the heater of the last extruder and sets its temperature to the specified value.
+
+        :param last_extruder: The last/previously used extruder object to be cooled down
+        :param is_infinite_runout: True if this is considered an infinite runout state and should be cooled to 0, or False for toolchange temperature drop
+        :return: None
+        """
+        pheaters = self.printer.lookup_object('heaters')
+        last_heater = last_extruder.get_heater()
+        temperature = 0 if is_infinite_runout \
+            else max(0, last_heater.target_temp - last_extruder.toolchange_temp_drop)
+        self.logger.info("Cooling down last extruder: {} to {}".format(last_extruder.name, temperature))
+        pheaters.set_temperature(last_heater, temperature, False)
 
     def _wait_for_temp_within_tolerance(self, heater, target_temp, tolerance=20):
         """

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -232,6 +232,7 @@ class AFCExtruder:
         self.enable_runout              = config.getboolean("enable_tool_runout",       self.afc.enable_tool_runout)
         self.debounce_delay             = config.getfloat("debounce_delay",             self.afc.debounce_delay)
         self.deadband                   = config.getfloat("deadband", 2)                                                # Deadband for extruder heater, default is 2 degrees Celsius
+        self.toolchange_temp_drop: float = config.getfloat("toolchange_temp_drop",    self.afc.toolchange_temp_drop)  # Degrees to drop this extruder's temperature after it is the old extruder in a toolchange. Overrides global toolchange_temp_drop in AFC.cfg
 
         self.toolhead_leds              = config.get('led_name', None)
         self.toolhead_status_index      = config.get('status_led_idx', None)

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -7,6 +7,10 @@ Covers:
   - afc._remove_after_last: string helper
   - afc._get_message: message queue peek and pop
   - afc.get_status: returns required keys
+  - afc._cooldown_last_extruder: old-extruder temp-drop logic
+  - afc._heat_next_extruder: explicit next_temp path
+  - afc.CHANGE_TOOL: adjusting_temperature with new_extruder_temp
+  - afc.cmd_CHANGE_TOOL: NEW_EXTRUDER_TEMP parameter parsing
 """
 
 from __future__ import annotations
@@ -15,6 +19,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from extras.AFC import afc, State, AFC_VERSION
+from extras.AFC_lane import AFCLaneState
 
 
 # ── State constants ───────────────────────────────────────────────────────────
@@ -375,3 +380,390 @@ class TestCheckExtruderTemp:
         obj._wait_for_temp_within_tolerance.assert_not_called()
         assert result is None
     # TODO: add passing in a no_wait variable
+
+
+# ── _cooldown_last_extruder ───────────────────────────────────────────────────
+
+def _make_afc_for_cooldown(target_temp=220.0, toolchange_temp_drop=0.0, is_infinite_runout=False):
+    """Build an afc instance wired up for _cooldown_last_extruder tests."""
+    obj = _make_afc()
+
+    last_heater = MagicMock()
+    last_heater.target_temp = target_temp
+
+    last_extruder = MagicMock()
+    last_extruder.name = "extruder"
+    last_extruder.get_heater.return_value = last_heater
+    last_extruder.toolchange_temp_drop = toolchange_temp_drop
+
+    pheaters = MagicMock()
+    obj.printer._objects["heaters"] = pheaters
+
+    return obj, last_extruder, last_heater, pheaters
+
+
+class TestCooldownLastExtruder:
+    """Tests for afc._cooldown_last_extruder()."""
+
+    def test_infinite_runout_always_sets_zero(self):
+        """When is_infinite_runout=True, target is always 0 regardless of drop setting."""
+        obj, ext, heater, pheaters = _make_afc_for_cooldown(
+            target_temp=220.0, toolchange_temp_drop=30.0, is_infinite_runout=True
+        )
+        obj._cooldown_last_extruder(ext, is_infinite_runout=True)
+        pheaters.set_temperature.assert_called_once_with(heater, 0, False)
+
+    def test_no_drop_configured_keeps_current_target(self):
+        """When toolchange_temp_drop=0, temperature is unchanged (drop of 0)."""
+        obj, ext, heater, pheaters = _make_afc_for_cooldown(
+            target_temp=220.0, toolchange_temp_drop=0.0
+        )
+        obj._cooldown_last_extruder(ext, is_infinite_runout=False)
+        pheaters.set_temperature.assert_called_once_with(heater, 220.0, False)
+
+    def test_drop_reduces_temperature_by_configured_amount(self):
+        """Normal drop: target_temp - toolchange_temp_drop."""
+        obj, ext, heater, pheaters = _make_afc_for_cooldown(
+            target_temp=220.0, toolchange_temp_drop=40.0
+        )
+        obj._cooldown_last_extruder(ext, is_infinite_runout=False)
+        pheaters.set_temperature.assert_called_once_with(heater, 180.0, False)
+
+    def test_drop_larger_than_target_clamps_to_zero(self):
+        """Drop larger than current target is clamped to 0 (no negative temps)."""
+        obj, ext, heater, pheaters = _make_afc_for_cooldown(
+            target_temp=30.0, toolchange_temp_drop=50.0
+        )
+        obj._cooldown_last_extruder(ext, is_infinite_runout=False)
+        pheaters.set_temperature.assert_called_once_with(heater, 0, False)
+
+    def test_drop_equal_to_target_sets_zero(self):
+        """Drop exactly equal to target → 0."""
+        obj, ext, heater, pheaters = _make_afc_for_cooldown(
+            target_temp=50.0, toolchange_temp_drop=50.0
+        )
+        obj._cooldown_last_extruder(ext, is_infinite_runout=False)
+        pheaters.set_temperature.assert_called_once_with(heater, 0, False)
+
+    def test_logs_cooldown_message(self):
+        """A log message is emitted describing the cooldown action."""
+        obj, ext, heater, pheaters = _make_afc_for_cooldown(
+            target_temp=220.0, toolchange_temp_drop=20.0
+        )
+        obj._cooldown_last_extruder(ext, is_infinite_runout=False)
+        logged = [msg for level, msg in obj.logger.messages if "Cooling down" in msg]
+        assert len(logged) == 1
+        assert "extruder" in logged[0]
+
+
+# ── _heat_next_extruder with explicit next_temp ───────────────────────────────
+
+def _make_afc_for_heat_next(current_target=220.0, next_extruder_name="extruder1"):
+    """Build an afc instance wired up for _heat_next_extruder tests."""
+    from tests.test_AFC_lane import _make_afc_lane
+
+    obj = _make_afc()
+
+    # Current toolhead extruder (the one that ran out)
+    current_heater = MagicMock()
+    current_heater.target_temp = current_target
+    current_heater.get_temp = MagicMock(return_value=(current_target - 2, current_target))
+    current_extruder_mock = MagicMock()
+    current_extruder_mock.get_heater.return_value = current_heater
+    obj.toolhead = MagicMock()
+    obj.toolhead.get_extruder.return_value = current_extruder_mock
+
+    # Next extruder
+    next_heater = MagicMock()
+    next_extruder_obj = MagicMock()
+    next_extruder_obj.name = next_extruder_name
+    next_extruder_obj.get_heater.return_value = next_heater
+    next_extruder_obj.deadband = 3.0
+
+    # Lane pointing at next extruder
+    lane = _make_afc_lane("AFC_stepper lane2")
+    lane.extruder_obj = next_extruder_obj
+
+    obj.next_lane_load = "lane2"
+    obj.lanes["lane2"] = lane
+
+    pheaters = MagicMock()
+    obj.printer._objects["heaters"] = pheaters
+
+    # get_current_extruder returns a different name to trigger heating path
+    obj.function.get_current_extruder.return_value = "extruder0"
+
+    obj._wait_for_temp_within_tolerance = MagicMock()
+
+    return obj, next_extruder_obj, next_heater, current_heater, pheaters
+
+
+class TestHeatNextExtruderWithExplicitTemp:
+    """Tests for the new next_temp parameter of _heat_next_extruder."""
+
+    def test_explicit_temp_used_instead_of_current_heater(self):
+        """When next_temp is given, the next heater is set to that value, not the current target."""
+        obj, next_ext, next_heater, current_heater, pheaters = _make_afc_for_heat_next(
+            current_target=220.0
+        )
+        result = obj._heat_next_extruder(wait=False, next_temp=190.0)
+        pheaters.set_temperature.assert_called_once_with(next_heater, 190.0, False)
+
+    def test_explicit_temp_returns_extruder_and_temp(self):
+        """Return value is (AFCExtruder object, set_temp) — not the heater."""
+        obj, next_ext, next_heater, current_heater, pheaters = _make_afc_for_heat_next()
+        result = obj._heat_next_extruder(wait=False, next_temp=200.0)
+        assert result[0] is next_ext
+        assert result[1] == 200.0
+
+    def test_none_next_temp_reads_current_heater_target(self):
+        """When next_temp=None (infinite runout path), target is read from current heater."""
+        obj, next_ext, next_heater, current_heater, pheaters = _make_afc_for_heat_next(
+            current_target=215.0
+        )
+        result = obj._heat_next_extruder(wait=False, next_temp=None)
+        pheaters.set_temperature.assert_called_once_with(next_heater, 215.0, False)
+        assert result[1] == 215.0
+
+    def test_current_heater_not_touched_when_next_temp_given(self):
+        """Providing next_temp must NOT set or reset the current heater temperature."""
+        obj, next_ext, next_heater, current_heater, pheaters = _make_afc_for_heat_next(
+            current_target=220.0
+        )
+        obj._heat_next_extruder(wait=False, next_temp=200.0)
+        # set_temperature must only be called for the next heater, never the current one
+        for call in pheaters.set_temperature.call_args_list:
+            assert call.args[0] is next_heater, "set_temperature was called on unexpected heater"
+
+    def test_wait_skipped_when_next_extruder_is_already_current(self):
+        """
+        When the next extruder is the same as the current one, wait should be skipped.
+        """
+        obj, next_ext, next_heater, current_heater, pheaters = _make_afc_for_heat_next(
+            next_extruder_name="extruder0",  # same as current (get_current_extruder returns "extruder0")
+        )
+        obj._heat_next_extruder(wait=True, next_temp=200.0)
+        obj._wait_for_temp_within_tolerance.assert_not_called()
+
+    def test_wait_triggered_when_next_extruder_differs_from_current(self):
+        """
+        When the next extruder differs from the current one, _wait_for_temp_within_tolerance
+        must be called with the next heater and the target temp.
+        """
+        obj, next_ext, next_heater, current_heater, pheaters = _make_afc_for_heat_next(
+            next_extruder_name="extruder1",  # different from current ("extruder0")
+        )
+        obj._heat_next_extruder(wait=True, next_temp=200.0)
+        obj._wait_for_temp_within_tolerance.assert_called_once_with(next_heater, 200.0, 3.0)
+
+
+# ── CHANGE_TOOL: new_extruder_temp integration ────────────────────────────────
+
+def _make_afc_for_change_tool(lane_name="lane2", next_extruder_name="extruder1",
+                               current_lane_name="lane1", current_extruder_name="extruder0"):
+    """Build a minimal afc suitable for driving CHANGE_TOOL with new_extruder_temp."""
+    from tests.test_AFC_lane import _make_afc_lane
+
+    obj = _make_afc()
+    obj.afcDeltaTime = MagicMock()
+    obj.afc_stats = MagicMock()
+    obj.afc_stats.average_toolchange_time = MagicMock()
+    obj.testing = True
+    obj.save_pos = MagicMock()
+    obj.restore_pos = MagicMock()
+    obj.TOOL_LOAD = MagicMock(return_value=True)
+    obj.TOOL_UNLOAD = MagicMock(return_value=True)
+    obj._check_bypass = MagicMock(return_value=False)
+    obj._heat_next_extruder = MagicMock()
+    obj._cooldown_last_extruder = MagicMock()
+    obj._wait_for_temp_within_tolerance = MagicMock()
+    obj.error = MagicMock()
+
+    # Current (old) lane/extruder
+    current_extruder = MagicMock()
+    current_extruder.name = current_extruder_name
+    current_extruder.get_heater = MagicMock(return_value=MagicMock())
+    current_extruder.deadband = 2.0
+    current_extruder.estats = MagicMock()
+    current_lane = _make_afc_lane(f"AFC_stepper {current_lane_name}")
+    current_lane.extruder_obj = current_extruder
+    current_lane._afc_prep_done = True
+    obj.lanes[current_lane_name] = current_lane
+    obj.function.get_current_lane.return_value = current_lane_name
+
+    # Next (new) lane/extruder
+    next_extruder = MagicMock()
+    next_extruder.name = next_extruder_name
+    next_extruder.get_heater = MagicMock(return_value=MagicMock())
+    next_extruder.deadband = 2.0
+    next_extruder.estats = MagicMock()
+    cur_lane = _make_afc_lane(f"AFC_stepper {lane_name}")
+    cur_lane.extruder_obj = next_extruder
+    cur_lane._afc_prep_done = True
+    cur_lane.status = AFCLaneState.LOADED
+    obj.lanes[lane_name] = cur_lane
+
+    obj.function.get_current_extruder.return_value = current_extruder_name
+    obj.function.in_print.return_value = False
+    obj.function.is_paused.return_value = False
+    obj.function.log_toolhead_pos = MagicMock()
+    obj.function._handle_activate_extruder = MagicMock()
+
+    # _heat_next_extruder stub: return (next_extruder_obj, set_temp)
+    obj._heat_next_extruder.return_value = (next_extruder, 200.0)
+
+    return obj, cur_lane, current_lane
+
+
+class TestChangeTool_NewExtruderTemp:
+    """Tests for CHANGE_TOOL with new_extruder_temp (non-infinite-runout path)."""
+
+    def test_heat_next_called_with_explicit_temp(self):
+        """Providing new_extruder_temp causes _heat_next_extruder to receive that value."""
+        obj, cur_lane, current_lane = _make_afc_for_change_tool()
+        obj.CHANGE_TOOL(cur_lane, new_extruder_temp=200.0)
+        obj._heat_next_extruder.assert_called_once_with(wait=False, next_temp=200.0)
+
+    def test_cooldown_called_for_old_extruder(self):
+        """Old extruder is cooled down when new_extruder_temp is provided."""
+        obj, cur_lane, current_lane = _make_afc_for_change_tool()
+        obj.CHANGE_TOOL(cur_lane, new_extruder_temp=200.0)
+        obj._cooldown_last_extruder.assert_called_once()
+        called_extruder = obj._cooldown_last_extruder.call_args.args[0]
+        assert called_extruder is current_lane.extruder_obj
+
+    def test_heat_called_before_cooldown(self):
+        """
+        _heat_next_extruder must be called before _cooldown_last_extruder.
+
+        Note that if this ordering behavior changes in the future, ensure that the infinite runout
+        case is properly setting the new extruder temperature, because currently this order is
+        required to read the current target temp before adjustment.
+        """
+        call_order = []
+        obj, cur_lane, current_lane = _make_afc_for_change_tool()
+        obj._heat_next_extruder.side_effect = lambda **kw: (
+            call_order.append("heat"),
+            obj._heat_next_extruder.return_value
+        )[1]
+        obj._cooldown_last_extruder.side_effect = lambda *a, **kw: call_order.append("cool")
+        obj.CHANGE_TOOL(cur_lane, new_extruder_temp=200.0)
+        assert call_order == ["heat", "cool"], f"Wrong call order: {call_order}"
+
+    def test_wait_for_temp_called_after_unload(self):
+        """_wait_for_temp_within_tolerance is called (after unload) when adjusting temps."""
+        obj, cur_lane, current_lane = _make_afc_for_change_tool()
+        obj.CHANGE_TOOL(cur_lane, new_extruder_temp=200.0)
+        obj._wait_for_temp_within_tolerance.assert_called_once()
+
+    def test_no_adjusting_temperature_without_param(self):
+        """Without new_extruder_temp, _heat_next_extruder and _cooldown are not called."""
+        obj, cur_lane, current_lane = _make_afc_for_change_tool()
+        obj.CHANGE_TOOL(cur_lane)  # no new_extruder_temp
+        obj._heat_next_extruder.assert_not_called()
+        obj._cooldown_last_extruder.assert_not_called()
+
+    def test_lane_status_not_set_to_loaded_for_normal_toolchange(self):
+        """For a normal toolchange (not infinite runout), cur_lane.status is NOT forced to LOADED."""
+        obj, cur_lane, current_lane = _make_afc_for_change_tool()
+        cur_lane.status = AFCLaneState.LOADED  # already loaded
+        obj.CHANGE_TOOL(cur_lane, new_extruder_temp=200.0)
+        # status should not have been touched by the infinite_runout branch
+        assert cur_lane.status == AFCLaneState.LOADED
+
+    def test_no_cooldown_when_same_extruder(self):
+        """If cur_lane uses the same extruder as current, cooldown is not called."""
+        obj, cur_lane, current_lane = _make_afc_for_change_tool(
+            next_extruder_name="extruder0",   # same as current
+            current_extruder_name="extruder0",
+        )
+        obj.CHANGE_TOOL(cur_lane, new_extruder_temp=200.0)
+        obj._cooldown_last_extruder.assert_not_called()
+
+
+# ── cmd_CHANGE_TOOL: NEW_EXTRUDER_TEMP parameter parsing ─────────────────────
+
+class TestCmdChangeTool_NewExtruderTempParsing:
+    """Tests for NEW_EXTRUDER_TEMP parameter parsing in cmd_CHANGE_TOOL."""
+
+    def _make_gcmd(self, new_extruder_temp_str, lane="lane1", purge_length=None):
+        gcmd = MagicMock()
+        # Use a T0 command line so cmd_CHANGE_TOOL takes the simple else-branch
+        # (no "CHANGE" in command) and Tcmd = "T0" directly.
+        gcmd.get_commandline.return_value = "T0"
+        gcmd.get.side_effect = lambda key, default=None: {
+            "PURGE_LENGTH": purge_length,
+            "NEW_EXTRUDER_TEMP": new_extruder_temp_str,
+        }.get(key, default)
+        return gcmd
+
+    def _make_afc_for_cmd(self):
+        obj = _make_afc()
+        obj.CHANGE_TOOL = MagicMock()
+        obj.error = MagicMock()
+        obj.function.check_homed.return_value = True
+        obj._check_bypass = MagicMock(return_value=False)
+        lane = MagicMock()
+        obj.lanes["lane1"] = lane
+        obj.tool_cmds["T0"] = "lane1"
+        return obj
+
+    def test_plain_numeric_string_parsed_to_float(self):
+        """'220' → 220.0"""
+        obj = self._make_afc_for_cmd()
+        gcmd = self._make_gcmd("220")
+        obj.cmd_CHANGE_TOOL(gcmd)
+        _, kwargs = obj.CHANGE_TOOL.call_args
+        assert kwargs["new_extruder_temp"] == 220.0
+
+    def test_equals_prefixed_string_stripped_and_parsed(self):
+        """'=220' → 220.0 (Klipper T0 macro compat)"""
+        obj = self._make_afc_for_cmd()
+        gcmd = self._make_gcmd("=220")
+        obj.cmd_CHANGE_TOOL(gcmd)
+        _, kwargs = obj.CHANGE_TOOL.call_args
+        assert kwargs["new_extruder_temp"] == 220.0
+
+    def test_none_new_extruder_temp_passes_none(self):
+        """When the parameter is absent (None), None is forwarded to CHANGE_TOOL."""
+        obj = self._make_afc_for_cmd()
+        gcmd = self._make_gcmd(None)
+        obj.cmd_CHANGE_TOOL(gcmd)
+        _, kwargs = obj.CHANGE_TOOL.call_args
+        assert kwargs["new_extruder_temp"] is None
+
+    def test_float_string_parsed_correctly(self):
+        """'215.5' parses to 215.5"""
+        obj = self._make_afc_for_cmd()
+        gcmd = self._make_gcmd("215.5")
+        obj.cmd_CHANGE_TOOL(gcmd)
+        _, kwargs = obj.CHANGE_TOOL.call_args
+        assert kwargs["new_extruder_temp"] == 215.5
+
+    def test_invalid_new_extruder_temp_reports_error_and_does_not_call_change_tool(self):
+        """A non-numeric NEW_EXTRUDER_TEMP triggers AFC_error and aborts without calling CHANGE_TOOL."""
+        obj = self._make_afc_for_cmd()
+        gcmd = self._make_gcmd("notanumber")
+        obj.cmd_CHANGE_TOOL(gcmd)
+        obj.error.AFC_error.assert_called_once()
+        error_msg = obj.error.AFC_error.call_args.args[0]
+        assert "NEW_EXTRUDER_TEMP" in error_msg
+        obj.CHANGE_TOOL.assert_not_called()
+
+    def test_invalid_purge_length_reports_error_and_does_not_call_change_tool(self):
+        """A non-numeric PURGE_LENGTH triggers AFC_error and aborts without calling CHANGE_TOOL."""
+        obj = self._make_afc_for_cmd()
+        gcmd = MagicMock()
+        gcmd.get_commandline.return_value = "T0"
+        gcmd.get.side_effect = lambda key, default=None: {
+            "PURGE_LENGTH": "notanumber",
+            "NEW_EXTRUDER_TEMP": None,
+        }.get(key, default)
+        obj.cmd_CHANGE_TOOL(gcmd)
+        obj.error.AFC_error.assert_called_once()
+        error_msg = obj.error.AFC_error.call_args.args[0]
+        assert "PURGE_LENGTH" in error_msg
+        obj.CHANGE_TOOL.assert_not_called()
+
+
+


### PR DESCRIPTION
## Major Changes in this PR

Add NEW_EXTRUDER_TEMP to Tn and automatic temp drop

To better support toolchangers, we want to be able to pass the next extruder temperature to AFC so that it can set the temperature for the next tool to be loaded before the load happens. We also take the opportunity to adjust the temperature of the old extruder if it is not the same one being used.

This is particularly important when doing print-by-object, because Orca does not emit temperatures for other extruders not involved in printing the first object in a way they can be looked up in print start.

## Notes to Code Reviewers

In order to use this, change filament gcode should now the following. Note that if not changed, operations remain the same as they were:

```
T[next_extruder] PURGE_LENGTH={flush_length} NEW_EXTRUDER_TEMP={new_filament_temp} 
```

The start macro pattern to load the initial tool and ensure it is up to temperature is now:

```
T{INITIAL_TOOL} NEW_EXTRUDER_TEMP={EXTRUDER_TEMP} # Load Initial Tool
M109 S{EXTRUDER_TEMP} # wait for extruder temp, in case the tool was already loaded
```

## How the changes in this PR are tested

Unit tests added for new functionality. This setup is meant to be used with a toolchanger and slicer configured for single-extruder multi-material.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description
