### PR TITLE
Support led_index spanning multiple MCUs/RGB ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-03-20]
+### Added
+- Adds support for specifying multiple LED objects/RGB ports in a single led_index string (e.g. `AFC_Indicator1:4,RGB1:1-4,RGB2:4-6`)
 
 ## [2026-03-15]
 ### Added

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -459,17 +459,42 @@ class afcFunction:
                 led_indexes += range(low, high+1)
         return led_indexes
 
+    def _parse_led_groups(self, idx):
+        """
+        Parse an LED index string into groups of (led_name, index_string).
+
+        Supports both single-LED format (``AFC_Indicator:1-4,9,10``) and
+        multi-LED format (``RGB1:1-4,RGB2:4-6,RGB3:5``).
+
+        When a comma-separated segment contains a colon it starts a new LED
+        group; otherwise it is appended to the current group's indexes.
+
+        :param idx: raw led_index config string
+        :return: list of (led_name, index_string) tuples
+        """
+        groups = []
+        for part in idx.split(","):
+            if ":" in part:
+                led_name, index_str = part.split(":", 1)
+                groups.append((led_name.strip(), index_str.strip()))
+            else:
+                # Continuation of the previous group's indexes
+                if groups:
+                    prev_name, prev_idx = groups[-1]
+                    groups[-1] = (prev_name, prev_idx + "," + part.strip())
+        return groups
+
     def afc_led (self, status, idx=None):
         if idx is None:
             return
 
-        error_string, led = self.verify_led_object(idx)
-        if led is not None:
-            led_indexes = idx.split(":")[1]
-            range_index = self._get_led_indexes(led_indexes)
-            led.led_change(range_index, status)
-        else:
-            self.logger.info( error_string )
+        for led_name, index_str in self._parse_led_groups(idx):
+            error_string, led = self.verify_led_object(led_name + ":")
+            if led is not None:
+                range_index = self._get_led_indexes(index_str)
+                led.led_change(range_index, status)
+            else:
+                self.logger.info( error_string )
 
     def get_filament_status(self, cur_lane):
         if cur_lane.prep_state:

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -427,7 +427,7 @@ class afcFunction:
         """
         Helper function to lookup AFC_led object.
 
-        :params led_name: name of AFC_led object to lookup
+        :params led_name: name of AFC_led object to lookup (e.g. "AFC_Indicator:1-4" or "AFC_Indicator")
 
         :return (string, object): error_string if AFC_led object is not found, led object if found
         """
@@ -437,7 +437,7 @@ class afcFunction:
         try:
             led = self.printer.lookup_object(afc_object)
         except:
-            error_string = "Error: Cannot find [{}] in config, make sure led_index in config is correct for AFC_stepper {}".format(afc_object, led_name.split(':')[-1])
+            error_string = "Error: Cannot find [{}] in config, make sure led_index in config is correct".format(afc_object)
         return error_string, led
 
     def _get_led_indexes(self, index_values):
@@ -478,10 +478,15 @@ class afcFunction:
                 led_name, index_str = part.split(":", 1)
                 groups.append((led_name.strip(), index_str.strip()))
             else:
-                # Continuation of the previous group's indexes
                 if groups:
+                    # Continuation of the previous group's indexes
                     prev_name, prev_idx = groups[-1]
                     groups[-1] = (prev_name, prev_idx + "," + part.strip())
+                else:
+                    self.logger.info(
+                        "Warning: led_index segment '{}' has no LED name "
+                        "and no prior group to attach to, skipping".format(part.strip())
+                    )
         return groups
 
     def afc_led (self, status, idx=None):
@@ -489,7 +494,7 @@ class afcFunction:
             return
 
         for led_name, index_str in self._parse_led_groups(idx):
-            error_string, led = self.verify_led_object(led_name + ":")
+            error_string, led = self.verify_led_object(led_name)
             if led is not None:
                 range_index = self._get_led_indexes(index_str)
                 led.led_change(range_index, status)

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -440,7 +440,7 @@ class afcFunction:
             error_string = "Error: Cannot find [{}] in config, make sure led_index in config is correct".format(afc_object)
         return error_string, led
 
-    def _get_led_indexes(self, index_values):
+    def _get_led_indexes(self, index_values: str) -> list[str]:
         """
         Helper function for creating a list for index values that have dashes and commas
         so the led's can be set correctly.
@@ -459,12 +459,13 @@ class afcFunction:
                 led_indexes += range(low, high+1)
         return led_indexes
 
-    def _parse_led_groups(self, idx):
+    def parse_led_groups(self, idx: str) -> list[str, str]:
         """
         Parse an LED index string into groups of (led_name, index_string).
 
         Supports both single-LED format (``AFC_Indicator:1-4,9,10``) and
-        multi-LED format (``RGB1:1-4,RGB2:4-6,RGB3:5``).
+        multi-LED format (``RGB1:1-4,RGB2:4-6,RGB3:5``) naming needs to be
+        AFC_led config name.
 
         When a comma-separated segment contains a colon it starts a new LED
         group; otherwise it is appended to the current group's indexes.
@@ -489,17 +490,17 @@ class afcFunction:
                     )
         return groups
 
-    def afc_led (self, status, idx=None):
+    def afc_led (self, status: list[str]|str, idx=None):
         if idx is None:
             return
 
-        for led_name, index_str in self._parse_led_groups(idx):
+        for led_name, index_str in self.parse_led_groups(idx):
             error_string, led = self.verify_led_object(led_name)
             if led is not None:
                 range_index = self._get_led_indexes(index_str)
                 led.led_change(range_index, status)
             else:
-                self.logger.info( error_string )
+                self.logger.error( error_string )
 
     def get_filament_status(self, cur_lane):
         if cur_lane.prep_state:

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -419,9 +419,10 @@ class AFCLane:
 
         if self.led_index is not None:
             # Verify that LED config is found
-            error_string, led = self.afc.function.verify_led_object(self.led_index)
-            if led is None:
-                raise error(error_string)
+            for led_name, index_str in self.afc.function.parse_led_groups(self.led_index):
+                error_string, led = self.afc.function.verify_led_object(led_name)
+                if led is None:
+                    raise error(error_string)
         self.espooler.handle_ready()
 
         # Setting debounce delay after ready so that callback does not get triggered when initially loading

--- a/tests/test_AFC_functions.py
+++ b/tests/test_AFC_functions.py
@@ -139,6 +139,37 @@ class TestGetLedIndexes:
         assert func._get_led_indexes("3-3") == [3]
 
 
+# ── _parse_led_groups ────────────────────────────────────────────────────────
+
+class TestParseLedGroups:
+    def test_single_led_single_index(self):
+        func = _make_func()
+        assert func._parse_led_groups("AFC_Indicator:1") == [("AFC_Indicator", "1")]
+
+    def test_single_led_range(self):
+        func = _make_func()
+        assert func._parse_led_groups("AFC_Indicator:1-4") == [("AFC_Indicator", "1-4")]
+
+    def test_single_led_range_and_singles(self):
+        func = _make_func()
+        assert func._parse_led_groups("AFC_Indicator:1-4,9,10") == [("AFC_Indicator", "1-4,9,10")]
+
+    def test_multi_led_groups(self):
+        func = _make_func()
+        result = func._parse_led_groups("RGB1:1-4,RGB2:4-6,RGB3:5")
+        assert result == [("RGB1", "1-4"), ("RGB2", "4-6"), ("RGB3", "5")]
+
+    def test_multi_led_with_mixed_indexes(self):
+        func = _make_func()
+        result = func._parse_led_groups("RGB1:1-4,9,RGB2:4-6")
+        assert result == [("RGB1", "1-4,9"), ("RGB2", "4-6")]
+
+    def test_whitespace_handling(self):
+        func = _make_func()
+        result = func._parse_led_groups("RGB1: 1-4, RGB2: 5")
+        assert result == [("RGB1", "1-4"), ("RGB2", "5")]
+
+
 # ── _calc_length ──────────────────────────────────────────────────────────────
 
 class TestCalcLength:

--- a/tests/test_AFC_functions.py
+++ b/tests/test_AFC_functions.py
@@ -139,39 +139,39 @@ class TestGetLedIndexes:
         assert func._get_led_indexes("3-3") == [3]
 
 
-# ── _parse_led_groups ────────────────────────────────────────────────────────
+# ── parse_led_groups ────────────────────────────────────────────────────────
 
 class TestParseLedGroups:
     def test_single_led_single_index(self):
         func = _make_func()
-        assert func._parse_led_groups("AFC_Indicator:1") == [("AFC_Indicator", "1")]
+        assert func.parse_led_groups("AFC_Indicator:1") == [("AFC_Indicator", "1")]
 
     def test_single_led_range(self):
         func = _make_func()
-        assert func._parse_led_groups("AFC_Indicator:1-4") == [("AFC_Indicator", "1-4")]
+        assert func.parse_led_groups("AFC_Indicator:1-4") == [("AFC_Indicator", "1-4")]
 
     def test_single_led_range_and_singles(self):
         func = _make_func()
-        assert func._parse_led_groups("AFC_Indicator:1-4,9,10") == [("AFC_Indicator", "1-4,9,10")]
+        assert func.parse_led_groups("AFC_Indicator:1-4,9,10") == [("AFC_Indicator", "1-4,9,10")]
 
     def test_multi_led_groups(self):
         func = _make_func()
-        result = func._parse_led_groups("RGB1:1-4,RGB2:4-6,RGB3:5")
+        result = func.parse_led_groups("RGB1:1-4,RGB2:4-6,RGB3:5")
         assert result == [("RGB1", "1-4"), ("RGB2", "4-6"), ("RGB3", "5")]
 
     def test_multi_led_with_mixed_indexes(self):
         func = _make_func()
-        result = func._parse_led_groups("RGB1:1-4,9,RGB2:4-6")
+        result = func.parse_led_groups("RGB1:1-4,9,RGB2:4-6")
         assert result == [("RGB1", "1-4,9"), ("RGB2", "4-6")]
 
     def test_whitespace_handling(self):
         func = _make_func()
-        result = func._parse_led_groups("RGB1: 1-4, RGB2: 5")
+        result = func.parse_led_groups("RGB1: 1-4, RGB2: 5")
         assert result == [("RGB1", "1-4"), ("RGB2", "5")]
 
     def test_orphan_segment_logs_warning(self):
         func = _make_func()
-        result = func._parse_led_groups("42,RGB1:1")
+        result = func.parse_led_groups("42,RGB1:1")
         # Orphan "42" is skipped, only the valid group is returned
         assert result == [("RGB1", "1")]
         assert any("42" in msg for _, msg in func.logger.messages)

--- a/tests/test_AFC_functions.py
+++ b/tests/test_AFC_functions.py
@@ -169,6 +169,52 @@ class TestParseLedGroups:
         result = func._parse_led_groups("RGB1: 1-4, RGB2: 5")
         assert result == [("RGB1", "1-4"), ("RGB2", "5")]
 
+    def test_orphan_segment_logs_warning(self):
+        func = _make_func()
+        result = func._parse_led_groups("42,RGB1:1")
+        # Orphan "42" is skipped, only the valid group is returned
+        assert result == [("RGB1", "1")]
+        assert any("42" in msg for _, msg in func.logger.messages)
+
+
+# ── afc_led (integration) ───────────────────────────────────────────────────
+
+class TestAfcLed:
+    def test_none_idx_is_noop(self):
+        func = _make_func()
+        # Should not raise
+        func.afc_led("1,0,0,0", idx=None)
+
+    def test_single_led_group(self):
+        led_mock = MagicMock()
+        func = _make_func()
+        func.printer.lookup_object.return_value = led_mock
+        func.afc_led("1,0,0,0", idx="AFC_Indicator:1-4")
+        func.printer.lookup_object.assert_called_once_with("AFC_led AFC_Indicator")
+        led_mock.led_change.assert_called_once_with([1, 2, 3, 4], "1,0,0,0")
+
+    def test_multi_led_groups(self):
+        led1 = MagicMock()
+        led2 = MagicMock()
+        led3 = MagicMock()
+        lookup_map = {
+            "AFC_led RGB1": led1,
+            "AFC_led RGB2": led2,
+            "AFC_led RGB3": led3,
+        }
+        func = _make_func()
+        func.printer.lookup_object.side_effect = lambda name: lookup_map[name]
+        func.afc_led("0,1,0,0", idx="RGB1:1-4,RGB2:4-6,RGB3:5")
+        led1.led_change.assert_called_once_with([1, 2, 3, 4], "0,1,0,0")
+        led2.led_change.assert_called_once_with([4, 5, 6], "0,1,0,0")
+        led3.led_change.assert_called_once_with([5], "0,1,0,0")
+
+    def test_missing_led_logs_error(self):
+        func = _make_func()
+        func.printer.lookup_object.side_effect = Exception("not found")
+        func.afc_led("1,0,0,0", idx="BadLed:1")
+        assert any("BadLed" in msg for _, msg in func.logger.messages)
+
 
 # ── _calc_length ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Major Changes in this PR
Allow led_index config to reference multiple AFC_led objects in a single value, e.g. "RGB1:1-4,RGB2:4-6,RGB3:5". A new _parse_led_groups() method splits the string into per-LED groups while remaining backwards compatible with the existing single-LED format ("AFC_Indicator:1-4,9,10").

## Notes to Code Reviewers
Code was generated by Claude Opus 4.6, but reviewed manually by me - seems to do what we need.

## How the changes in this PR are tested
New tests were added to test suite.  For physical testing, set led_index to have two different RGB ports in use for the same indicator (e.g., for using a BT LED strip range on skirts and a regular neopixel on spooler logo)

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.