### PR TITLE
Add led_use_filament_color option for lane LEDs

### DIFF
--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -234,6 +234,7 @@ class afc:
         self.full_weight            = config.getfloat("full_weight",1000, minval=1) # full weight of filament spool (not counting spool itself)
         self.enable_sensors_in_gui  = config.getboolean("enable_sensors_in_gui", False) # Set to True to show all sensor switches as filament sensors in mainsail/fluidd gui
         self.ignore_spoolman_material_temps = config.getboolean("ignore_spoolman_material_temps", False)  # When True, AFC will ignore temperatures set in Spoolman and use default_material_temps instead.
+        self.led_use_filament_color = config.getboolean('led_use_filament_color', False)  # When True, uses filament color from color field for lane LEDs instead of configured LED colors
         self.restore_extruder_temp_on_load_or_unload = config.getboolean(
             "restore_extruder_temp_on_load_or_unload", False
         )  # Restore extruder target temp after tool load/unload when not printing

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -234,7 +234,7 @@ class afc:
         self.full_weight            = config.getfloat("full_weight",1000, minval=1) # full weight of filament spool (not counting spool itself)
         self.enable_sensors_in_gui  = config.getboolean("enable_sensors_in_gui", False) # Set to True to show all sensor switches as filament sensors in mainsail/fluidd gui
         self.ignore_spoolman_material_temps = config.getboolean("ignore_spoolman_material_temps", False)  # When True, AFC will ignore temperatures set in Spoolman and use default_material_temps instead.
-        self.led_use_filament_color = config.getboolean('led_use_filament_color', False)  # When True, uses filament color from color field for lane LEDs instead of configured LED colors
+        self.led_use_filament_color:bool = config.getboolean('led_use_filament_color', False)  # When True, uses filament color from color field for lane LEDs instead of configured LED colors
         self.restore_extruder_temp_on_load_or_unload = config.getboolean(
             "restore_extruder_temp_on_load_or_unload", False
         )  # Restore extruder target temp after tool load/unload when not printing

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -555,12 +555,7 @@ class afcFunction:
 
         # Switch spoolman ID
         self.afc.spool.set_active_spool(cur_lane_loaded.spool_id)
-        # Set lanes tool loaded led
-        # TODO: Add check to see if users want to change status led to spool color if set
-        # if cur_lane_loaded.color is not None and cur_lane_loaded.color:
-        #     led_color = self.HexToLedString(cur_lane_loaded.color.replace("#", ""))
-        #     self.afc_led( led_color, cur_lane_loaded.led_index )
-        # else:
+        # Set lanes tool loaded led (uses filament color when available via _get_lane_color)
         cur_lane_loaded.unit_obj.lane_tool_loaded( cur_lane_loaded )
         # Enable stepper
         cur_lane_loaded.do_enable(True)

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -167,7 +167,7 @@ class AFCLane:
         self.led_tool_unloaded    = config.get('led_tool_unloaded', None)               # LED color to set when lanes extruder is unloaded
         self.led_spool_index      = config.get('led_spool_index', None)                 # LED index to illuminate under spool
         self.led_spool_illum      = config.get('led_spool_illuminate', None)            # LED color to illuminate under spool
-        self.led_use_filament_color = config.getboolean('led_use_filament_color', None)  # When True, uses filament color from color field for lane LEDs instead of configured LED colors
+        self.led_use_filament_color: bool = config.getboolean('led_use_filament_color', None)  # When True, uses filament color from color field for lane LEDs instead of configured LED colors
 
         self.long_moves_speed: float   = config.getfloat("long_moves_speed", None)             # Speed in mm/s to move filament when doing long moves. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
         self.long_moves_accel: float   = config.getfloat("long_moves_accel", None)             # Acceleration in mm/s squared when doing long moves. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -167,6 +167,7 @@ class AFCLane:
         self.led_tool_unloaded    = config.get('led_tool_unloaded', None)               # LED color to set when lanes extruder is unloaded
         self.led_spool_index      = config.get('led_spool_index', None)                 # LED index to illuminate under spool
         self.led_spool_illum      = config.get('led_spool_illuminate', None)            # LED color to illuminate under spool
+        self.led_use_filament_color = config.getboolean('led_use_filament_color', None)  # When True, uses filament color from color field for lane LEDs instead of configured LED colors
 
         self.long_moves_speed: float   = config.getfloat("long_moves_speed", None)             # Speed in mm/s to move filament when doing long moves. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
         self.long_moves_accel: float   = config.getfloat("long_moves_accel", None)             # Acceleration in mm/s squared when doing long moves. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
@@ -609,6 +610,7 @@ class AFCLane:
         if self.led_tool_loaded_idle is None: self.led_tool_loaded_idle = self.unit_obj.led_tool_loaded_idle
         if self.led_tool_unloaded    is None: self.led_tool_unloaded    = self.unit_obj.led_tool_unloaded
         if self.led_spool_illum      is None: self.led_spool_illum      = self.unit_obj.led_spool_illum
+        if self.led_use_filament_color is None: self.led_use_filament_color = self.unit_obj.led_use_filament_color
 
         if self.rev_long_moves_speed_factor is None: self.rev_long_moves_speed_factor  = self.unit_obj.rev_long_moves_speed_factor
         if self.long_moves_speed            is None: self.long_moves_speed  = self.unit_obj.long_moves_speed
@@ -1572,7 +1574,8 @@ class AFCLane:
                     "scan_time"     : scan_time,
                     "td"            : td,
                     "lane"          : lane_number,
-                    "spool_id"      : self.spool_id
+                    "spool_id"      : self.spool_id,
+                    "weight"        : self.weight
                 }
             }
             self.afc.moonraker.send_lane_data(lane_data)

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -127,7 +127,7 @@ class AFCSpool:
         cur_lane.send_lane_data()
         # Refresh LED only if filament is loaded — empty lanes keep their state color
         if cur_lane.load_state and cur_lane.unit in self.afc.units:
-            unit = self.afc.units[cur_lane.unit]
+            unit = cur_lane.unit_obj
             self.afc.function.afc_led(unit._get_lane_color(cur_lane, cur_lane.led_ready), cur_lane.led_index)
         self.afc.save_vars()
 
@@ -356,7 +356,7 @@ class AFCSpool:
                     cur_lane.send_lane_data()
                     # Refresh LED only if filament is loaded — empty lanes keep their state color
                     if cur_lane.load_state and cur_lane.unit in self.afc.units:
-                        unit = self.afc.units[cur_lane.unit]
+                        unit = cur_lane.unit_obj
                         self.afc.function.afc_led(unit._get_lane_color(cur_lane, cur_lane.led_ready), cur_lane.led_index)
 
                 except Exception as e:

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -125,6 +125,10 @@ class AFCSpool:
         cur_lane = self.afc.lanes[lane]
         cur_lane.color = '#{}'.format(color.replace('#',''))
         cur_lane.send_lane_data()
+        # Refresh LED only if filament is loaded — empty lanes keep their state color
+        if cur_lane.load_state and cur_lane.unit in self.afc.units:
+            unit = self.afc.units[cur_lane.unit]
+            self.afc.function.afc_led(unit._get_lane_color(cur_lane, cur_lane.led_ready), cur_lane.led_index)
         self.afc.save_vars()
 
     cmd_SET_WEIGHT_help = "Sets filaments weight for a lane"
@@ -285,8 +289,11 @@ class AFCSpool:
         """
         # Always reset debounce on spool change
         cur_lane.auto_switch_triggered = False
-        # set defaults if there's no spool id, or the spoolman lookup fails
-        if not cur_lane.remember_spool:
+        # Only apply defaults (material type, 1000g weight) when no spool data has been
+        # assigned to this lane. If SET_SPOOL_ID or SET_COLOR was called before loading
+        # (e.g. from an NFC tag scan), the spool_id and/or color will already be set with
+        # real values — don't overwrite them with defaults during the load sequence.
+        if not cur_lane.remember_spool and cur_lane.spool_id is None and not cur_lane.color:
             cur_lane.material = self.afc.default_material_type
             cur_lane.weight = 1000 # Defaulting weight to 1000 upon load
 
@@ -347,6 +354,10 @@ class AFCSpool:
                         cur_lane.color = '#{}'.format(self._get_filament_values(result['filament'], 'color_hex'))
 
                     cur_lane.send_lane_data()
+                    # Refresh LED only if filament is loaded — empty lanes keep their state color
+                    if cur_lane.load_state and cur_lane.unit in self.afc.units:
+                        unit = self.afc.units[cur_lane.unit]
+                        self.afc.function.afc_led(unit._get_lane_color(cur_lane, cur_lane.led_ready), cur_lane.led_index)
 
                 except Exception as e:
                     self.afc.error.AFC_error("Error when trying to get Spoolman data for ID:{}, Error: {}".format(SpoolID, e), False)

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -89,7 +89,7 @@ class afcUnit:
         self.led_logo_color              = self.afc.function.HexConvert(config.get('led_logo_color', '0,0,0,0'))# Default logo color when nothing is loaded
         self.led_logo_loading            = self.afc.function.HexConvert(config.get('led_logo_loading', self.led_loading ))
 
-        self.led_use_filament_color      = config.getboolean('led_use_filament_color', self.afc.led_use_filament_color)  # When True, uses filament color from color field for lane LEDs instead of configured LED colors
+        self.led_use_filament_color:bool  = config.getboolean('led_use_filament_color', self.afc.led_use_filament_color)  # When True, uses filament color from color field for lane LEDs instead of configured LED colors
 
         self.long_moves_speed            = config.getfloat("long_moves_speed", self.afc.long_moves_speed)   # Speed in mm/s to move filament when doing long moves. Setting value here overrides values set in AFC.cfg file
         self.long_moves_accel            = config.getfloat("long_moves_accel", self.afc.long_moves_accel)   # Acceleration in mm/s squared when doing long moves. Setting value here overrides values set in AFC.cfg file
@@ -492,7 +492,7 @@ class afcUnit:
         """
         self.afc.function.afc_led(lane.led_not_ready, lane.led_index)
 
-    def _get_lane_color(self, lane, fallback):
+    def _get_lane_color(self, lane: AFCLane, fallback: str) -> str:
         """
         Use filament color if available, otherwise use the default LED color.
         When a spool has a color set (via SET_COLOR or SET_SPOOL_ID) and

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -89,6 +89,8 @@ class afcUnit:
         self.led_logo_color              = self.afc.function.HexConvert(config.get('led_logo_color', '0,0,0,0'))# Default logo color when nothing is loaded
         self.led_logo_loading            = self.afc.function.HexConvert(config.get('led_logo_loading', self.led_loading ))
 
+        self.led_use_filament_color      = config.getboolean('led_use_filament_color', self.afc.led_use_filament_color)  # When True, uses filament color from color field for lane LEDs instead of configured LED colors
+
         self.long_moves_speed            = config.getfloat("long_moves_speed", self.afc.long_moves_speed)   # Speed in mm/s to move filament when doing long moves. Setting value here overrides values set in AFC.cfg file
         self.long_moves_accel            = config.getfloat("long_moves_accel", self.afc.long_moves_accel)   # Acceleration in mm/s squared when doing long moves. Setting value here overrides values set in AFC.cfg file
         self.short_moves_speed           = config.getfloat("short_moves_speed", self.afc.short_moves_speed) # Speed in mm/s to move filament when doing short moves. Setting value here overrides values set in AFC.cfg file
@@ -490,13 +492,31 @@ class afcUnit:
         """
         self.afc.function.afc_led(lane.led_not_ready, lane.led_index)
 
+    def _get_lane_color(self, lane, fallback):
+        """
+        Use filament color if available, otherwise use the default LED color.
+        When a spool has a color set (via SET_COLOR or SET_SPOOL_ID) and
+        use_filament_color is enabled, that color is used for the lane LED.
+        Otherwise falls back to the configured state color (led_ready,
+        led_tool_loaded, etc.).
+
+        :param lane: Lane object to get color for
+        :param fallback: Default LED color to use if no filament color is set
+        :return: LED color value (list of floats or config color string)
+        """
+        if lane.led_use_filament_color and lane.color:
+            hex_str = lane.color.replace("#", "").strip().upper()
+            if len(hex_str) in (6, 8) and all(c in "0123456789ABCDEF" for c in hex_str):
+                return self.afc.function.HexToLedString(hex_str)
+        return fallback
+
     def lane_loaded(self, lane: AFCLane):
         """
         Common function for setting a lanes led when lane is loaded
 
         :param lane: Lane object to set led
         """
-        self.afc.function.afc_led(lane.led_ready, lane.led_index)
+        self.afc.function.afc_led(self._get_lane_color(lane, lane.led_ready), lane.led_index)
 
     def lane_unloading(self, lane):
         """
@@ -539,7 +559,7 @@ class afcUnit:
 
         :param lane: Lane object to set led
         """
-        self.afc.function.afc_led(lane.led_ready, lane.led_index)
+        self.afc.function.afc_led(self._get_lane_color(lane, lane.led_ready), lane.led_index)
         lane.extruder_obj.set_status_led(lane.led_tool_unloaded)
 
     def lane_tool_loaded_idle(self, lane):
@@ -550,8 +570,12 @@ class afcUnit:
 
         :param lane: Lane object to set led
         """
-        self.afc.function.afc_led(lane.led_tool_loaded_idle, lane.led_index)
-        lane.extruder_obj.set_status_led(lane.led_tool_loaded_idle)
+        color = self._get_lane_color(lane, lane.led_tool_loaded_idle)
+        self.afc.function.afc_led(color, lane.led_index)
+        # Extruder LED also shows filament color when tool is parked/idle —
+        # gives a visual indicator of what's loaded. Reverts to config color
+        # when tool becomes active (lane_tool_loaded) or unloads (lane_tool_unloaded).
+        lane.extruder_obj.set_status_led(color)
 
     def lane_illuminate_spool(self, lane):
         """

--- a/tests/test_AFC_QuattroBox.py
+++ b/tests/test_AFC_QuattroBox.py
@@ -68,6 +68,7 @@ def _make_lane(name="lane1", color="#FF0000"):
     lane.led_tool_loaded = "0,1,0.5,0"
     lane.led_index = "1"
     lane.led_spool_index = "2"
+    lane.led_use_filament_color = False
     return lane
 
 

--- a/tests/test_AFC_unit.py
+++ b/tests/test_AFC_unit.py
@@ -68,6 +68,7 @@ def _make_lane(name="lane1", hub="hub1", extruder="ext1", buffer_name="buf1"):
     lane.led_tool_unloaded = "0,1,0,0"
     lane.led_index = "1"
     lane.led_spool_illum = "1,1,1,0"
+    lane.led_use_filament_color = False
     lane._load_state = True
     lane.short_moves_speed = 50
     lane.short_moves_accel = 50
@@ -254,6 +255,58 @@ class TestLaneStatusLeds:
         unit.lane_tool_unloaded(lane)
         unit.afc.function.afc_led.assert_called_once_with(lane.led_ready, lane.led_index)
         lane.extruder_obj.set_status_led.assert_called_once_with(lane.led_tool_unloaded)
+
+
+# ── led_use_filament_color ─────────────────────────────────────────────────────
+
+class TestLedUseFilamentColor:
+    def test_filament_color_used_when_enabled_and_color_set(self):
+        """When led_use_filament_color=True and lane has a color, LED uses the filament color."""
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.led_use_filament_color = True
+        lane.color = "#FF0000"
+        unit.afc.function.HexToLedString.return_value = "1,0,0,0"
+        unit.lane_loaded(lane)
+        unit.afc.function.HexToLedString.assert_called_once_with("FF0000")
+        unit.afc.function.afc_led.assert_called_once_with("1,0,0,0", lane.led_index)
+
+    def test_fallback_to_state_color_when_enabled_but_no_color(self):
+        """When led_use_filament_color=True but lane has no color, falls back to state color."""
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.led_use_filament_color = True
+        lane.color = ""
+        unit.lane_loaded(lane)
+        unit.afc.function.afc_led.assert_called_once_with(lane.led_ready, lane.led_index)
+
+    def test_state_color_used_when_disabled(self):
+        """When led_use_filament_color=False, LED uses the configured state color."""
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.led_use_filament_color = False
+        lane.color = "#FF0000"
+        unit.lane_loaded(lane)
+        unit.afc.function.afc_led.assert_called_once_with(lane.led_ready, lane.led_index)
+
+    def test_filament_color_with_hash_prefix(self):
+        """Color with # prefix is handled correctly."""
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.led_use_filament_color = True
+        lane.color = "#00FF00"
+        unit.afc.function.HexToLedString.return_value = "0,1,0,0"
+        unit.lane_loaded(lane)
+        unit.afc.function.HexToLedString.assert_called_once_with("00FF00")
+
+    def test_filament_color_invalid_hex_falls_back(self):
+        """Invalid hex color falls back to state color."""
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.led_use_filament_color = True
+        lane.color = "not-a-color"
+        unit.lane_loaded(lane)
+        unit.afc.function.afc_led.assert_called_once_with(lane.led_ready, lane.led_index)
 
 
 # ── set_logo_color ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Major Changes in this PR
When led_use_filament_color: True is set, lane LEDs show the actual filament color (set via SET_COLOR, SET_SPOOL_ID, or any other method) instead of the default configured state colors. The option can be set globally, per unit, or per lane. Defaults to False to preserve existing behavior.
Config Cascade

### Global 
[AFC]
led_use_filament_color: True

### Per unit 
[AFC_unit Turtle_1]
led_use_filament_color: True

### Per lane 
[AFC_lane lane1]
led_use_filament_color: False

## Changes
extras/AFC.py — Added led_use_filament_color global config option (default: False)

extras/AFC_unit.py — Added per-unit config (inherits from global), added _get_lane_color(lane, fallback) helper. Updated lane_loaded(), lane_tool_loaded_idle(), lane_tool_unloaded() to use filament color when enabled. lane_tool_loaded() intentionally unchanged 

extras/AFC_lane.py — Added per-lane config (inherits from unit). Added weight to send_lane_data() payload.

extras/AFC_spool.py — LED refresh in cmd_SET_COLOR() and set_spoolID() when filament is loaded. Fixed _set_values() overwriting spool data with defaults.

extras/AFC_functions.py — Removed commented TODO block for spool color LED.

## Bug Fixes
Weight reset to 1000g — _set_values() was overwriting Spoolman/SET_COLOR weight with 1000g default during load sequence. Fixed by checking if spool_id or color is already set before applying defaults.

Missing weight in Mainsail — send_lane_data() wasn't including weight in the payload sent to Moonraker.

## Future Enhancements
lane_tool_loaded filament color — currently stays config color during active printing. Could be a separate configurable option.

Breathing LED animation — breathe the filament color during active printing instead of solid.

Single toolhead idle state — lane_tool_loaded_idle only fires for toolchangers. An equivalent for single toolhead setups would let the extruder LED show filament color between prints.

## Notes to Code Reviewers
All changes are behind led_use_filament_color which defaults to False — zero behavior change for existing users.

_get_lane_color() is the single entry point for the filament-vs-config color decision. All LED call sites go through it.

lane_tool_loaded intentionally left unchanged — keeping the config color during active printing avoids confusion about which lane is actively extruding.

The _set_values() and send_lane_data() fixes are independent bug fixes bundled here because they were discovered during testing this feature. Happy to split them into a separate PR if preferred.

## How the changes in this PR are tested
Scan tag on empty lane → LED stays default state color (data stored, LED waits for load)
Load filament after scan → LED changes to filament color
SET_SPOOL_ID with Spoolman → LED changes on load
SET_COLOR without Spoolman → LED changes on load
SET_COLOR + SET_MATERIAL + SET_WEIGHT without Spoolman → all values survive load cycle
Klipper restart with color stored → LED shows stored color
No color set → falls back to config LED colors
Weight displayed correctly in Mainsail after scan + load
led_use_filament_color: False → all LEDs use config colors (existing behavior)

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x ] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.