### PR TITLE
Fix tool change not unloading stale lane on restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-03-21]
+### Fixed
+- Fixed initial load failure when an extruder is loaded with a different lane than the first in the print.
+
 ## [2026-03-20]
 ### Added
 - Adds support for specifying multiple LED objects/RGB ports in a single led_index string (e.g. `AFC_Indicator1:4,RGB1:1-4,RGB2:4-6`)

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1232,8 +1232,8 @@ class afc:
             return
 
         cur_lane = self.lanes[lane]
-        if cur_lane.extruder_obj.lane_loaded:
-            self.error.AFC_error("Cannot load {}, {} currently loaded".format(lane, cur_lane.extruder_obj.lane_loaded), pause=self.function.in_print())
+        if cur_lane.extruder_obj.lane_loaded == cur_lane.name:
+            self.error.AFC_error("Not loading {}, already loaded".format(lane), pause=self.function.in_print())
             return
 
         purge_length = gcmd.get('PURGE_LENGTH', None)
@@ -1277,11 +1277,26 @@ class afc:
         # Verify that printer is in absolute mode
         self.function.check_absolute_mode("TOOL_LOAD")
 
-        # TODO: add check to make sure current extruder is not loaded with a lane, mainly for scenarios with multuple toolheads
-
         # If the current extruder is not the one associated with the lane, switch to it.
         if self.function.get_current_extruder() != cur_lane.extruder_obj.name:
             cur_lane.tool_swap()
+
+        # After a tool swap the newly active extruder may already have a different lane
+        # loaded (e.g. after a restart). Unload it before attempting to load the new lane.
+        cur_extruder_obj = cur_lane.extruder_obj
+        if cur_extruder_obj.lane_loaded is not None and cur_extruder_obj.lane_loaded != cur_lane.name:
+            lane_name = cur_extruder_obj.lane_loaded
+            if lane_name not in self.lanes:
+                self.error.AFC_error(
+                    'Extruder "{}" has lane {} that is not in configured lanes.'.format(
+                        cur_extruder_obj.name, lane_name),
+                    pause=self.function.in_print())
+                return False
+            if not self.TOOL_UNLOAD(self.lanes[lane_name], set_start_time=False):
+                msg = ('Failed to unload currently loaded lane {} from extruder {} before loading new lane {}.'.format(
+                    lane_name, cur_extruder_obj.name, cur_lane.name))
+                self.error.fix(msg, self.lanes[lane_name])
+                return False
 
         if cur_lane.name != self.current:
             # Lookup extruder and hub objects associated with the lane.

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -10,6 +10,7 @@ Covers:
   - afc._cooldown_last_extruder: old-extruder temp-drop logic
   - afc._heat_next_extruder: explicit next_temp path
   - afc.CHANGE_TOOL: adjusting_temperature with new_extruder_temp
+  - afc.TOOL_LOAD: unload when destination extruder already has a different lane loaded
   - afc.cmd_CHANGE_TOOL: NEW_EXTRUDER_TEMP parameter parsing
 """
 
@@ -766,4 +767,204 @@ class TestCmdChangeTool_NewExtruderTempParsing:
         obj.CHANGE_TOOL.assert_not_called()
 
 
+# ── TOOL_LOAD: destination extruder already has a different lane loaded ───────
 
+def _make_afc_for_dest_extruder_loaded():
+    """
+    Build an afc instance simulating a post-restart state where:
+      - The active extruder is 'extruder1' (already current, no swap needed)
+      - 'extruder1' still has lane4 marked as loaded
+      - The print wants to load lane2 (also on extruder1)
+
+    afc.current is a property backed by get_current_lane(); stubbing
+    get_current_lane() to return 'lane2' makes self.current equal the
+    target so that after the pre-load unload check TOOL_LOAD
+    short-circuits without needing to mock the full load sequence.
+    """
+    from tests.test_AFC_lane import _make_afc_lane
+
+    obj = _make_afc()
+    obj.afcDeltaTime = MagicMock()
+    obj.afc_stats = MagicMock()
+    obj.testing = True
+    obj.TOOL_UNLOAD = MagicMock(return_value=True)
+    obj._check_bypass = MagicMock(return_value=False)
+    obj.error = MagicMock()
+    obj.verify_macro_positions = MagicMock(return_value="")
+
+    # Destination extruder — has lane4 already loaded
+    dest_extruder = MagicMock()
+    dest_extruder.name = "extruder1"
+    dest_extruder.lane_loaded = "lane4"
+    dest_extruder.estats = MagicMock()
+
+    # The lane that is already loaded on the extruder
+    loaded_lane = _make_afc_lane("AFC_stepper lane4")
+    loaded_lane.extruder_obj = dest_extruder
+    obj.lanes["lane4"] = loaded_lane
+
+    # The target lane on the same extruder
+    target_lane = _make_afc_lane("AFC_stepper lane2")
+    target_lane.extruder_obj = dest_extruder
+    obj.lanes["lane2"] = target_lane
+
+    # Current extruder is already extruder1 — no tool swap
+    obj.function.get_current_extruder.return_value = "extruder1"
+    # self.current == target lane so the full load body is skipped
+    obj.function.get_current_lane.return_value = "lane2"
+    obj.function.check_homed.return_value = True
+    obj.function.in_print.return_value = False
+    obj.function.is_paused.return_value = False
+    obj.function.log_toolhead_pos = MagicMock()
+
+    return obj, target_lane, loaded_lane, dest_extruder
+
+
+class TestToolLoad_DestExtruderAlreadyLoaded:
+    """
+    Tests for the pre-load unload check in TOOL_LOAD.
+
+    Reproduces the post-restart scenario where the destination extruder still
+    has a lane marked as loaded while a different lane is being requested.
+    """
+
+    def test_aborts_with_clear_error_when_stale_lane_not_in_lanes(self):
+        """If the stale loaded lane name is not in self.lanes, report an explicit error and abort."""
+        obj, target_lane, loaded_lane, dest_extruder = _make_afc_for_dest_extruder_loaded()
+        # Remove lane4 from lanes so it is unmapped
+        del obj.lanes["lane4"]
+        result = obj.TOOL_LOAD(target_lane)
+        assert result is False
+        obj.error.AFC_error.assert_called_once()
+        error_msg = obj.error.AFC_error.call_args.args[0]
+        assert "extruder1" in error_msg
+        assert "lane4" in error_msg
+        obj.TOOL_UNLOAD.assert_not_called()
+
+    def test_unloads_when_extruder_already_has_different_lane_loaded(self):
+        """TOOL_UNLOAD is called for the already-loaded lane before proceeding."""
+        obj, target_lane, loaded_lane, dest_extruder = _make_afc_for_dest_extruder_loaded()
+        obj.TOOL_LOAD(target_lane)
+        obj.TOOL_UNLOAD.assert_called_once_with(loaded_lane, set_start_time=False)
+
+    def test_aborts_if_unload_fails(self):
+        """If TOOL_UNLOAD returns False, TOOL_LOAD returns False immediately."""
+        obj, target_lane, loaded_lane, dest_extruder = _make_afc_for_dest_extruder_loaded()
+        obj.TOOL_UNLOAD.return_value = False
+        result = obj.TOOL_LOAD(target_lane)
+        assert result is False
+
+    def test_no_unload_when_extruder_already_has_target_lane_loaded(self):
+        """If the extruder already has the target lane loaded, no unload is triggered."""
+        obj, target_lane, loaded_lane, dest_extruder = _make_afc_for_dest_extruder_loaded()
+        dest_extruder.lane_loaded = "lane2"   # already the target
+        obj.TOOL_LOAD(target_lane)
+        obj.TOOL_UNLOAD.assert_not_called()
+
+    def test_no_unload_when_extruder_has_nothing_loaded(self):
+        """If the extruder has lane_loaded=None, no unload is triggered."""
+        obj, target_lane, loaded_lane, dest_extruder = _make_afc_for_dest_extruder_loaded()
+        dest_extruder.lane_loaded = None
+        obj.TOOL_LOAD(target_lane)
+        obj.TOOL_UNLOAD.assert_not_called()
+
+    def test_unloads_stale_lane_after_tool_swap(self):
+        """
+        The realistic restart scenario: active extruder is different from the
+        destination, so tool_swap() fires first, and only THEN the stale-lane
+        check runs.
+
+        Specifically:
+          - The printer restarts with extruder1 having lane4 still saved as loaded.
+          - The active toolhead comes up as 'extruder' (primary, nothing loaded).
+          - TOOL_LOAD is called for lane2 (on extruder1).
+          - get_current_extruder() != extruder1 → tool_swap() fires.
+          - extruder1.lane_loaded = 'lane4' != 'lane2' → stale unload triggers.
+
+        This path is distinct from the other stale-lane tests which start with
+        the active extruder already being extruder1 (no swap needed).
+        """
+        obj, target_lane, loaded_lane, dest_extruder = _make_afc_for_dest_extruder_loaded()
+
+        # Override: active extruder is 'extruder', not 'extruder1' — swap needed
+        obj.function.get_current_extruder.return_value = "extruder"
+        target_lane.tool_swap = MagicMock()
+
+        call_order = []
+        target_lane.tool_swap.side_effect = lambda: call_order.append("swap")
+        obj.TOOL_UNLOAD.side_effect = lambda *a, **kw: (call_order.append("unload"), True)[1]
+
+        obj.TOOL_LOAD(target_lane)
+
+        assert "swap" in call_order, "tool_swap was not called"
+        assert "unload" in call_order, "TOOL_UNLOAD was not called for the stale lane"
+        assert call_order.index("swap") < call_order.index("unload"), (
+            f"tool_swap must precede TOOL_UNLOAD; order was {call_order}"
+        )
+        obj.TOOL_UNLOAD.assert_called_once_with(loaded_lane, set_start_time=False)
+
+
+# ── cmd_TOOL_LOAD: lane_loaded guard ─────────────────────────────────────────
+
+class TestCmdToolLoad_LaneLoadedGuard:
+    """
+    Tests for the cmd_TOOL_LOAD GCode handler guard.
+
+    The guard should only block when the extruder already has the *target* lane
+    loaded (already done). If a *different* lane is loaded, cmd_TOOL_LOAD should
+    pass through to TOOL_LOAD which handles the auto-unload.
+    """
+
+    def _make_cmd_afc(self):
+        from tests.test_AFC_lane import _make_afc_lane
+        obj = _make_afc()
+        obj.TOOL_LOAD = MagicMock(return_value=True)
+        obj.error = MagicMock()
+        obj.function.in_print.return_value = False
+
+        extruder = MagicMock()
+        extruder.name = "extruder"
+
+        lane = _make_afc_lane("AFC_stepper lane1")
+        lane.extruder_obj = extruder
+        obj.lanes["lane1"] = lane
+        return obj, lane, extruder
+
+    def test_blocks_when_same_lane_already_loaded(self):
+        """If the target lane is already loaded, report an error and do not call TOOL_LOAD."""
+        obj, lane, extruder = self._make_cmd_afc()
+        extruder.lane_loaded = "lane1"  # same as target
+
+        gcmd = MagicMock()
+        gcmd.get = lambda key, default=None: {"LANE": "lane1", "PURGE_LENGTH": None}.get(key, default)
+
+        obj.cmd_TOOL_LOAD(gcmd)
+
+        obj.error.AFC_error.assert_called_once()
+        obj.TOOL_LOAD.assert_not_called()
+
+    def test_passes_through_when_different_lane_loaded(self):
+        """If a different lane is already loaded, cmd_TOOL_LOAD should call TOOL_LOAD (not error)."""
+        obj, lane, extruder = self._make_cmd_afc()
+        extruder.lane_loaded = "lane2"  # different lane — stale, let TOOL_LOAD handle it
+
+        gcmd = MagicMock()
+        gcmd.get = lambda key, default=None: {"LANE": "lane1", "PURGE_LENGTH": None}.get(key, default)
+
+        obj.cmd_TOOL_LOAD(gcmd)
+
+        obj.error.AFC_error.assert_not_called()
+        obj.TOOL_LOAD.assert_called_once_with(lane, None)
+
+    def test_passes_through_when_nothing_loaded(self):
+        """Normal case: nothing loaded, cmd_TOOL_LOAD proceeds."""
+        obj, lane, extruder = self._make_cmd_afc()
+        extruder.lane_loaded = None
+
+        gcmd = MagicMock()
+        gcmd.get = lambda key, default=None: {"LANE": "lane1", "PURGE_LENGTH": None}.get(key, default)
+
+        obj.cmd_TOOL_LOAD(gcmd)
+
+        obj.error.AFC_error.assert_not_called()
+        obj.TOOL_LOAD.assert_called_once_with(lane, None)


### PR DESCRIPTION
## Major Changes in this PR

At the start of a print, if the initial tool/extruder is not the
primary tool, and it already had filament loaded, self.current comes
back None. No unload would occur during CHANGE_TOOL, and old filament
would still be loaded to the toolhead. After this the initial
toolhead gets selected, and load fails if it's a different lane.
    
This change extends the load logic right to ensure that there is no
stale lane already loaded in the toolhead at the point before the
destination extruder is loaded, to protect againt this and other
occurrences in the future that might require an unload prior to load
before proceeding.

## How the changes in this PR are tested

Load a lane in a secondary toolhead, leave it loaded and restart klipper for good measure. Start a print with a different lane on that same toolhead. This should not result in a failure to load.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description
