### PR TITLE
Add in weight based spool runout 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<<<<<<< issue-638
 ## [2026-03-23]
 ### Added
 - Adds support for weight based spool runout to help support spools with hooked ends. See documentation for more details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2026-03-21]
 ### Fixed
 - Fixed initial load failure when an extruder is loaded with a different lane than the first in the print.
->>>>>>> multi_extruder
 
 ## [2026-03-20]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2026-03-23]
 ### Added
 - Adds support for weight based spool runout to help support spools with hooked ends. See documentation for more details.
-=======
 ## [2026-03-21]
 ### Fixed
 - Fixed initial load failure when an extruder is loaded with a different lane than the first in the print.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-03-23]
+### Added
+- Adds support for weight based spool runout to help support spools with hooked ends. See documentation for more details.
+
 ## [2026-03-20]
 ### Added
 - Adds support for specifying multiple LED objects/RGB ports in a single led_index string (e.g. `AFC_Indicator1:4,RGB1:1-4,RGB2:4-6`)

--- a/config/AFC.cfg
+++ b/config/AFC.cfg
@@ -36,7 +36,6 @@ assisted_unload: True           # If True, the unload retract is assisted to pre
 
 #auto_spool_switch: False               # Trigger spool switch based on remaining filament weight from Spoolman
 #auto_spool_switch_threshold: 25        # Weight in grams at or below which to trigger auto switch
-#auto_spool_switch_infinite_only: True  # Only auto-switch when runout_lane is configured (infinite spool)
 
 #--=================================================================================-
 #------- TRSYNC Values --------------------------------------------------------------

--- a/config/AFC.cfg
+++ b/config/AFC.cfg
@@ -34,7 +34,7 @@ assisted_unload: True           # If True, the unload retract is assisted to pre
 #print_short_stats: True          # Set to true to print AFC_STATS in short form instead of wide form, printing short form is better for consoles that are small in width
 #debug: True                     # Setting to True turns on more debugging to show on console
 
-#auto_spool_switch: False               # Trigger spool switch based on remaining filament weight from Spoolman
+#auto_spool_switch: False               # Trigger spool switch based on remaining filament weight
 #auto_spool_switch_threshold: 25        # Weight in grams at or below which to trigger auto switch
 
 #--=================================================================================-

--- a/config/AFC.cfg
+++ b/config/AFC.cfg
@@ -34,6 +34,10 @@ assisted_unload: True           # If True, the unload retract is assisted to pre
 #print_short_stats: True          # Set to true to print AFC_STATS in short form instead of wide form, printing short form is better for consoles that are small in width
 #debug: True                     # Setting to True turns on more debugging to show on console
 
+#auto_spool_switch: False               # Trigger spool switch based on remaining filament weight from Spoolman
+#auto_spool_switch_threshold: 25        # Weight in grams at or below which to trigger auto switch
+#auto_spool_switch_infinite_only: True  # Only auto-switch when runout_lane is configured (infinite spool)
+
 #--=================================================================================-
 #------- TRSYNC Values --------------------------------------------------------------
 #--=================================================================================-

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -152,8 +152,9 @@ class afc:
         self.disable_ooze_check     = config.getboolean("disable_ooze_check", False) # Disable ooze check for lanes being on the same extruder in M104/M109 commands
 
         # Auto spool switch settings
-        self.auto_spool_switch              = config.getboolean("auto_spool_switch", False)              # Trigger spool switch based on remaining filament weight
-        self.auto_spool_switch_threshold    = config.getfloat("auto_spool_switch_threshold", 25.0, minval=0.)  # Weight threshold in grams
+        self.auto_spool_switch: bool              = config.getboolean("auto_spool_switch", False)                    # Trigger spool switch based on remaining filament weight
+        self.auto_spool_switch_threshold: float   = config.getfloat("auto_spool_switch_threshold", 25.0, minval=0.)  # Weight threshold in grams
+
         #LED SETTINGS
         # All variables use: (R,G,B,W) 0 = off, 1 = full brightness.
         self.ind_lights = None

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -150,6 +150,11 @@ class afc:
 
         self.disable_weight_check   = config.getboolean("disable_weight_check", False) # Set to True to disable weight check when loading filament into lane/toolhead
         self.disable_ooze_check     = config.getboolean("disable_ooze_check", False) # Disable ooze check for lanes being on the same extruder in M104/M109 commands
+
+        # Auto spool switch settings
+        self.auto_spool_switch              = config.getboolean("auto_spool_switch", False)              # Trigger spool switch based on remaining filament weight
+        self.auto_spool_switch_threshold    = config.getfloat("auto_spool_switch_threshold", 25.0, minval=0.)  # Weight threshold in grams
+        self.auto_spool_switch_infinite_only = config.getboolean("auto_spool_switch_infinite_only", True) # Only auto-switch when runout_lane is configured
         #LED SETTINGS
         # All variables use: (R,G,B,W) 0 = off, 1 = full brightness.
         self.ind_lights = None

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -154,7 +154,6 @@ class afc:
         # Auto spool switch settings
         self.auto_spool_switch              = config.getboolean("auto_spool_switch", False)              # Trigger spool switch based on remaining filament weight
         self.auto_spool_switch_threshold    = config.getfloat("auto_spool_switch_threshold", 25.0, minval=0.)  # Weight threshold in grams
-        self.auto_spool_switch_infinite_only = config.getboolean("auto_spool_switch_infinite_only", True) # Only auto-switch when runout_lane is configured
         #LED SETTINGS
         # All variables use: (R,G,B,W) 0 = off, 1 = full brightness.
         self.ind_lights = None

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -659,18 +659,11 @@ class AFCLane:
         Helper function to get steppers for lane and setup for proper homing
         """
         try:
-            # Debug: log all sections being considered
-            for s in config.fileconfig.sections():
-                match = (self.unit in s
-                         and s.startswith("AFC_")
-                         and not any(x in s for x in INVALID_UNIT_NAMES))
-                self.logger.info(f"Section: {s}, unit: {self.unit}, match: {match}")
             unit_cfg = next(
                 config.getsection(s) for s in config.fileconfig.sections()
                 if self.unit in s
                 and s.startswith("AFC_")
                 and not any(x in s for x in INVALID_UNIT_NAMES))
-            self.logger.info(f"Matched unit config: {unit_cfg.get_name()}")
             self.unit_obj: afcUnit = self.printer.load_object(config, unit_cfg.get_name())
 
             drive_stepper = self
@@ -956,12 +949,8 @@ class AFCLane:
 
         if self.runout_lane is not None:
             self._perform_infinite_runout()
-        elif not self.afc.auto_spool_switch_infinite_only:
-            self._perform_pause_runout()
         else:
-            self.logger.info(
-                "Auto spool switch: {} has no runout_lane set and "
-                "auto_spool_switch_infinite_only is True, skipping".format(self.name))
+            self._perform_pause_runout()
 
     def _perform_pause_runout(self):
         """

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -123,6 +123,7 @@ class AFCLane:
         self.spool_id           = None
         self.color              = None
         self.weight             = 0
+        self._auto_switch_triggered = False
         self._material          = None
         self.extruder_temp      = None
         self.bed_temp           = None
@@ -938,6 +939,23 @@ class AFCLane:
             # Set LED to not ready
             self.unit_obj.lane_not_ready(self)
 
+    def _handle_auto_spool_switch(self):
+        """
+        Handle automatic spool switch triggered by weight threshold.
+        Called via reactor.register_callback from update_weight_callback.
+        """
+        if self.afc.error_state or not self.afc.function.is_printing():
+            return
+
+        if self.runout_lane is not None:
+            self._perform_infinite_runout()
+        elif not self.afc.auto_spool_switch_infinite_only:
+            self._perform_pause_runout()
+        else:
+            self.logger.info(
+                "Auto spool switch: {} has no runout_lane set and "
+                "auto_spool_switch_infinite_only is True, skipping".format(self.name))
+
     def _perform_pause_runout(self):
         """
         Common function to pause print when runout occurs, fully unloads and ejects spool if specified by user
@@ -1293,6 +1311,22 @@ class AFCLane:
         if extruder_pos > self.past_extruder_position:
             self.update_remaining_weight(delta_length)
             self.past_extruder_position = extruder_pos
+
+            # Check if weight-based auto spool switch should trigger
+            if (self.afc.auto_spool_switch
+                and not self._auto_switch_triggered
+                and self.weight > 0
+                and self.weight <= self.afc.auto_spool_switch_threshold
+                and self.name == self.afc.current
+                and self.afc.function.is_printing()
+                and not self.afc.error_state):
+                self._auto_switch_triggered = True
+                self.logger.info(
+                    "Auto spool switch: {} weight ({:.1f}g) at or below "
+                    "threshold ({:.1f}g), triggering switch".format(
+                        self.name, self.weight, self.afc.auto_spool_switch_threshold))
+                self.reactor.register_callback(
+                    lambda et: self._handle_auto_spool_switch())
 
             # self.logger.debug(f"{self.name} Weight Timer Callback: New weight {self.weight}")
 

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -967,8 +967,12 @@ class AFCLane:
                 self.afc.LANE_UNLOAD(self)
         # Pause print
         self.status = AFCLaneState.NONE
-        msg = "Runout triggered for lane {} and runout lane is not setup to switch to another lane".format(self.name)
-        msg += "\nPlease manually load next spool into toolhead and then hit resume to continue"
+        if self.auto_switch_triggered:
+            runout_method = "Minimum weight threshold reached"
+        else:
+            runout_method = "Runout triggered"
+        msg = "{} for lane {} and runout lane is not setup to switch to another lane.".format(runout_method, self.name)
+        msg += "\nPlease manually load next spool into toolhead and then hit resume to continue."
         self.unit_obj.lane_not_ready(self)
         self.afc.error.AFC_error(msg)
 

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -123,7 +123,7 @@ class AFCLane:
         self.spool_id           = None
         self.color              = None
         self.weight             = 0
-        self._auto_switch_triggered = False
+        self.auto_switch_triggered = False
         self._material          = None
         self.extruder_temp      = None
         self.bed_temp           = None
@@ -1310,13 +1310,13 @@ class AFCLane:
 
             # Check if weight-based auto spool switch should trigger
             if (self.afc.auto_spool_switch
-                and not self._auto_switch_triggered
+                and not self.auto_switch_triggered
                 and self.weight > 0
                 and self.weight <= self.afc.auto_spool_switch_threshold
                 and self.name == self.afc.current
                 and self.afc.function.is_printing()
                 and not self.afc.error_state):
-                self._auto_switch_triggered = True
+                self.auto_switch_triggered = True
                 self.logger.info(
                     "Auto spool switch: {} weight ({:.1f}g) at or below "
                     "threshold ({:.1f}g), triggering switch".format(

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -41,7 +41,7 @@ EXCLUDE_TYPES = ["HTLF", "ViViD"]
 # Names to exclude from search when trying to find unit name in config file
 # These are more for name that could be in config files
 INVALID_UNIT_NAMES = ["AFC_buffer", "AFC_button", "AFC_extruder",
-                      "AFC_hub", "AFC_lane", "AFC_led", "AFC_prep" "AFC_stepper"]
+                      "AFC_hub", "AFC_lane", "AFC_led", "AFC_prep", "AFC_stepper"]
 
 class AssistActive(Enum):
     YES = 1
@@ -659,11 +659,18 @@ class AFCLane:
         Helper function to get steppers for lane and setup for proper homing
         """
         try:
+            # Debug: log all sections being considered
+            for s in config.fileconfig.sections():
+                match = (self.unit in s
+                         and s.startswith("AFC_")
+                         and not any(x in s for x in INVALID_UNIT_NAMES))
+                self.logger.info(f"Section: {s}, unit: {self.unit}, match: {match}")
             unit_cfg = next(
                 config.getsection(s) for s in config.fileconfig.sections()
                 if self.unit in s
-                and "AFC" in s
+                and s.startswith("AFC_")
                 and not any(x in s for x in INVALID_UNIT_NAMES))
+            self.logger.info(f"Matched unit config: {unit_cfg.get_name()}")
             self.unit_obj: afcUnit = self.printer.load_object(config, unit_cfg.get_name())
 
             drive_stepper = self

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -287,6 +287,7 @@ class AFCSpool:
         if not cur_lane.remember_spool:
             cur_lane.material = self.afc.default_material_type
             cur_lane.weight = 1000 # Defaulting weight to 1000 upon load
+            cur_lane._auto_switch_triggered = False
 
         if self.afc.spoolman is not None and self.next_spool_id is not None:
             spool_id = self.next_spool_id
@@ -301,6 +302,7 @@ class AFCSpool:
         cur_lane.material = ''
         cur_lane.color = ''
         cur_lane.weight = 0
+        cur_lane._auto_switch_triggered = False
         cur_lane.extruder_temp = None
         cur_lane.bed_temp = None
         cur_lane.clear_lane_data()
@@ -311,6 +313,7 @@ class AFCSpool:
                 try:
                     result = self.afc.moonraker.get_spool(SpoolID)
                     cur_lane.spool_id = SpoolID
+                    cur_lane._auto_switch_triggered = False
 
                     cur_lane.material           = self._get_filament_values(result['filament'], 'material')
                     if not self.afc.ignore_spoolman_material_temps:

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -283,11 +283,12 @@ class AFCSpool:
         """
         Helper function for setting lane spool values
         """
+        # Always reset debounce on spool change
+        cur_lane.auto_switch_triggered = False
         # set defaults if there's no spool id, or the spoolman lookup fails
         if not cur_lane.remember_spool:
             cur_lane.material = self.afc.default_material_type
             cur_lane.weight = 1000 # Defaulting weight to 1000 upon load
-            cur_lane._auto_switch_triggered = False
 
         if self.afc.spoolman is not None and self.next_spool_id is not None:
             spool_id = self.next_spool_id
@@ -302,7 +303,7 @@ class AFCSpool:
         cur_lane.material = ''
         cur_lane.color = ''
         cur_lane.weight = 0
-        cur_lane._auto_switch_triggered = False
+        cur_lane.auto_switch_triggered = False
         cur_lane.extruder_temp = None
         cur_lane.bed_temp = None
         cur_lane.clear_lane_data()
@@ -313,7 +314,7 @@ class AFCSpool:
                 try:
                     result = self.afc.moonraker.get_spool(SpoolID)
                     cur_lane.spool_id = SpoolID
-                    cur_lane._auto_switch_triggered = False
+                    cur_lane.auto_switch_triggered = False
 
                     cur_lane.material           = self._get_filament_values(result['filament'], 'material')
                     if not self.afc.ignore_spoolman_material_temps:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -370,7 +370,6 @@ class MockAFC:
         self.ignore_spoolman_material_temps = False
         self.auto_spool_switch = False
         self.auto_spool_switch_threshold = 25.0
-        self.auto_spool_switch_infinite_only = True
         self.default_material_type = "PLA"
         self.bypass = MagicMock()
         self.save_vars = MagicMock()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -368,6 +368,9 @@ class MockAFC:
         self.spoolman = None
         self.disable_weight_check = False
         self.ignore_spoolman_material_temps = False
+        self.auto_spool_switch = False
+        self.auto_spool_switch_threshold = 25.0
+        self.auto_spool_switch_infinite_only = True
         self.default_material_type = "PLA"
         self.bypass = MagicMock()
         self.save_vars = MagicMock()

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -825,3 +825,130 @@ class TestMoveTo:
         assert call_args[3] == lane.short_moves_accel
         assert call_args[4] == HOMING
         assert kwargs["assist_active"] == False
+
+
+# ── Auto Spool Switch ────────────────────────────────────────────────────────
+
+def _make_lane_for_auto_switch(weight=20.0, threshold=25.0, enabled=True,
+                                infinite_only=True, current=True,
+                                printing=True, error_state=False,
+                                runout_lane="lane2"):
+    """Build an AFCLane configured for auto spool switch testing."""
+    from tests.conftest import MockAFC, MockLogger, MockReactor
+    lane = _make_afc_lane("AFC_stepper lane1")
+    lane.afc = MockAFC()
+    lane.afc.auto_spool_switch = enabled
+    lane.afc.auto_spool_switch_threshold = threshold
+    lane.afc.auto_spool_switch_infinite_only = infinite_only
+    lane.afc.current = "lane1" if current else "other_lane"
+    lane.afc.error_state = error_state
+    lane.afc.function.is_printing.return_value = printing
+    lane.afc.function.get_extruder_pos.return_value = 100.0
+    lane.reactor = MockReactor()
+    lane.reactor.register_callback = MagicMock()
+    lane.logger = MockLogger()
+    lane.weight = weight
+    lane._auto_switch_triggered = False
+    lane.filament_diameter = 1.75
+    lane.filament_density = 1.24
+    lane.past_extruder_position = 50.0
+    lane.save_counter = 0
+    lane.UPDATE_WEIGHT_DELAY = 10.0
+    lane.runout_lane = runout_lane
+    lane._perform_infinite_runout = MagicMock()
+    lane._perform_pause_runout = MagicMock()
+    return lane
+
+
+class TestAutoSpoolSwitchWeightCheck:
+    """Tests for the weight threshold check in update_weight_callback."""
+
+    def test_auto_switch_not_triggered_when_disabled(self):
+        lane = _make_lane_for_auto_switch(weight=20.0, enabled=False)
+        lane.update_weight_callback(None)
+        lane.reactor.register_callback.assert_not_called()
+        assert lane._auto_switch_triggered is False
+
+    def test_auto_switch_triggered_at_threshold(self):
+        lane = _make_lane_for_auto_switch(weight=25.5, threshold=25.0)
+        lane.afc.function.get_extruder_pos.return_value = 100.0
+        lane.past_extruder_position = -400.0  # 500mm delta to push weight below threshold
+        lane.update_weight_callback(None)
+        assert lane._auto_switch_triggered is True
+        lane.reactor.register_callback.assert_called_once()
+
+    def test_auto_switch_not_triggered_above_threshold(self):
+        lane = _make_lane_for_auto_switch(weight=500.0, threshold=25.0)
+        lane.update_weight_callback(None)
+        lane.reactor.register_callback.assert_not_called()
+        assert lane._auto_switch_triggered is False
+
+    def test_auto_switch_debounce_prevents_second_trigger(self):
+        lane = _make_lane_for_auto_switch(weight=10.0, threshold=25.0)
+        lane._auto_switch_triggered = True
+        lane.update_weight_callback(None)
+        lane.reactor.register_callback.assert_not_called()
+
+    def test_auto_switch_not_triggered_when_not_current(self):
+        lane = _make_lane_for_auto_switch(weight=10.0, current=False)
+        lane.update_weight_callback(None)
+        lane.reactor.register_callback.assert_not_called()
+
+    def test_auto_switch_not_triggered_when_not_printing(self):
+        lane = _make_lane_for_auto_switch(weight=10.0, printing=False)
+        lane.update_weight_callback(None)
+        lane.reactor.register_callback.assert_not_called()
+
+    def test_auto_switch_not_triggered_when_error_state(self):
+        lane = _make_lane_for_auto_switch(weight=10.0, error_state=True)
+        lane.update_weight_callback(None)
+        lane.reactor.register_callback.assert_not_called()
+
+    def test_auto_switch_not_triggered_when_weight_zero(self):
+        lane = _make_lane_for_auto_switch(weight=0.0, threshold=25.0)
+        lane.update_weight_callback(None)
+        lane.reactor.register_callback.assert_not_called()
+
+    def test_auto_switch_logs_message(self):
+        lane = _make_lane_for_auto_switch(weight=10.0, threshold=25.0)
+        lane.afc.function.get_extruder_pos.return_value = 51.0
+        lane.update_weight_callback(None)
+        assert lane._auto_switch_triggered is True
+        log_messages = [msg for level, msg in lane.logger.messages if level == "info"]
+        assert any("Auto spool switch" in msg and "threshold" in msg for msg in log_messages)
+
+
+class TestHandleAutoSpoolSwitch:
+    """Tests for _handle_auto_spool_switch method."""
+
+    def test_calls_infinite_runout_when_runout_lane_set(self):
+        lane = _make_lane_for_auto_switch(runout_lane="lane2")
+        lane._handle_auto_spool_switch()
+        lane._perform_infinite_runout.assert_called_once()
+        lane._perform_pause_runout.assert_not_called()
+
+    def test_calls_pause_runout_when_not_infinite_only(self):
+        lane = _make_lane_for_auto_switch(runout_lane=None, infinite_only=False)
+        lane._handle_auto_spool_switch()
+        lane._perform_pause_runout.assert_called_once()
+        lane._perform_infinite_runout.assert_not_called()
+
+    def test_skips_when_infinite_only_and_no_runout_lane(self):
+        lane = _make_lane_for_auto_switch(runout_lane=None, infinite_only=True)
+        lane._handle_auto_spool_switch()
+        lane._perform_infinite_runout.assert_not_called()
+        lane._perform_pause_runout.assert_not_called()
+        log_messages = [msg for level, msg in lane.logger.messages if level == "info"]
+        assert any("no runout_lane set" in msg for msg in log_messages)
+
+    def test_skips_when_error_state(self):
+        lane = _make_lane_for_auto_switch(error_state=True, runout_lane="lane2")
+        lane._handle_auto_spool_switch()
+        lane._perform_infinite_runout.assert_not_called()
+        lane._perform_pause_runout.assert_not_called()
+
+    def test_skips_when_not_printing(self):
+        lane = _make_lane_for_auto_switch(printing=False, runout_lane="lane2")
+        lane._handle_auto_spool_switch()
+        lane._perform_infinite_runout.assert_not_called()
+        lane._perform_pause_runout.assert_not_called()

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -942,3 +942,35 @@ class TestHandleAutoSpoolSwitch:
         lane._handle_auto_spool_switch()
         lane._perform_infinite_runout.assert_not_called()
         lane._perform_pause_runout.assert_not_called()
+
+
+# ── Pause Runout ─────────────────────────────────────────────────────────────
+
+def _make_lane_for_pause_runout(auto_switch_triggered=False, unload_on_runout=False):
+    lane = _make_afc_lane("AFC_stepper lane1")
+    lane.afc = MagicMock()
+    lane.afc.error_state = False
+    lane.unit_obj = MagicMock()
+    lane.unit_obj.unload_on_runout = unload_on_runout
+    lane.auto_switch_triggered = auto_switch_triggered
+    return lane
+
+
+class TestPerformPauseRunout:
+
+    def test_msg_shows_weight_based_when_auto_switch_triggered(self):
+        lane = _make_lane_for_pause_runout(auto_switch_triggered=True)
+        lane._perform_pause_runout()
+        msg = lane.afc.error.AFC_error.call_args[0][0]
+        print(msg)
+        assert "Minimum weight" in msg
+        assert lane.name in msg
+
+    def test_msg_shows_runout_when_not_auto_switch_triggered(self):
+        lane = _make_lane_for_pause_runout(auto_switch_triggered=False)
+        lane._perform_pause_runout()
+        msg = lane.afc.error.AFC_error.call_args[0][0]
+        print(msg)
+        assert "Runout" in msg
+        assert "Minimum weight" not in msg
+        assert lane.name in msg

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -830,16 +830,14 @@ class TestMoveTo:
 # ── Auto Spool Switch ────────────────────────────────────────────────────────
 
 def _make_lane_for_auto_switch(weight=20.0, threshold=25.0, enabled=True,
-                                infinite_only=True, current=True,
-                                printing=True, error_state=False,
-                                runout_lane="lane2"):
+                                current=True, printing=True,
+                                error_state=False, runout_lane="lane2"):
     """Build an AFCLane configured for auto spool switch testing."""
     from tests.conftest import MockAFC, MockLogger, MockReactor
     lane = _make_afc_lane("AFC_stepper lane1")
     lane.afc = MockAFC()
     lane.afc.auto_spool_switch = enabled
     lane.afc.auto_spool_switch_threshold = threshold
-    lane.afc.auto_spool_switch_infinite_only = infinite_only
     lane.afc.current = "lane1" if current else "other_lane"
     lane.afc.error_state = error_state
     lane.afc.function.is_printing.return_value = printing
@@ -927,19 +925,11 @@ class TestHandleAutoSpoolSwitch:
         lane._perform_infinite_runout.assert_called_once()
         lane._perform_pause_runout.assert_not_called()
 
-    def test_calls_pause_runout_when_not_infinite_only(self):
-        lane = _make_lane_for_auto_switch(runout_lane=None, infinite_only=False)
+    def test_calls_pause_runout_when_no_runout_lane(self):
+        lane = _make_lane_for_auto_switch(runout_lane=None)
         lane._handle_auto_spool_switch()
         lane._perform_pause_runout.assert_called_once()
         lane._perform_infinite_runout.assert_not_called()
-
-    def test_skips_when_infinite_only_and_no_runout_lane(self):
-        lane = _make_lane_for_auto_switch(runout_lane=None, infinite_only=True)
-        lane._handle_auto_spool_switch()
-        lane._perform_infinite_runout.assert_not_called()
-        lane._perform_pause_runout.assert_not_called()
-        log_messages = [msg for level, msg in lane.logger.messages if level == "info"]
-        assert any("no runout_lane set" in msg for msg in log_messages)
 
     def test_skips_when_error_state(self):
         lane = _make_lane_for_auto_switch(error_state=True, runout_lane="lane2")

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -846,7 +846,7 @@ def _make_lane_for_auto_switch(weight=20.0, threshold=25.0, enabled=True,
     lane.reactor.register_callback = MagicMock()
     lane.logger = MockLogger()
     lane.weight = weight
-    lane._auto_switch_triggered = False
+    lane.auto_switch_triggered = False
     lane.filament_diameter = 1.75
     lane.filament_density = 1.24
     lane.past_extruder_position = 50.0
@@ -865,25 +865,25 @@ class TestAutoSpoolSwitchWeightCheck:
         lane = _make_lane_for_auto_switch(weight=20.0, enabled=False)
         lane.update_weight_callback(None)
         lane.reactor.register_callback.assert_not_called()
-        assert lane._auto_switch_triggered is False
+        assert lane.auto_switch_triggered is False
 
-    def test_auto_switch_triggered_at_threshold(self):
+    def testauto_switch_triggered_at_threshold(self):
         lane = _make_lane_for_auto_switch(weight=25.5, threshold=25.0)
         lane.afc.function.get_extruder_pos.return_value = 100.0
         lane.past_extruder_position = -400.0  # 500mm delta to push weight below threshold
         lane.update_weight_callback(None)
-        assert lane._auto_switch_triggered is True
+        assert lane.auto_switch_triggered is True
         lane.reactor.register_callback.assert_called_once()
 
     def test_auto_switch_not_triggered_above_threshold(self):
         lane = _make_lane_for_auto_switch(weight=500.0, threshold=25.0)
         lane.update_weight_callback(None)
         lane.reactor.register_callback.assert_not_called()
-        assert lane._auto_switch_triggered is False
+        assert lane.auto_switch_triggered is False
 
     def test_auto_switch_debounce_prevents_second_trigger(self):
         lane = _make_lane_for_auto_switch(weight=10.0, threshold=25.0)
-        lane._auto_switch_triggered = True
+        lane.auto_switch_triggered = True
         lane.update_weight_callback(None)
         lane.reactor.register_callback.assert_not_called()
 
@@ -911,7 +911,7 @@ class TestAutoSpoolSwitchWeightCheck:
         lane = _make_lane_for_auto_switch(weight=10.0, threshold=25.0)
         lane.afc.function.get_extruder_pos.return_value = 51.0
         lane.update_weight_callback(None)
-        assert lane._auto_switch_triggered is True
+        assert lane.auto_switch_triggered is True
         log_messages = [msg for level, msg in lane.logger.messages if level == "info"]
         assert any("Auto spool switch" in msg and "threshold" in msg for msg in log_messages)
 

--- a/tests/test_AFC_spool.py
+++ b/tests/test_AFC_spool.py
@@ -762,3 +762,47 @@ class TestCmdSetSpoolID:
         spool.set_active_spool = MagicMock()
         spool.cmd_SET_SPOOL_ID(gcmd)
         spool.set_active_spool.assert_called_once_with(lane1.spool_id)
+
+
+# ── Auto switch debounce flag reset ──────────────────────────────────────────
+
+class TestAutoSwitchFlagReset:
+    def test_set_values_resets_auto_switch_flag(self):
+        spool = _make_spool()
+        lane = _make_lane("lane1")
+        lane._auto_switch_triggered = True
+        lane.remember_spool = False
+        spool._set_values(lane)
+        assert lane._auto_switch_triggered is False
+
+    def test_clear_values_resets_auto_switch_flag(self):
+        spool = _make_spool()
+        lane = _make_lane("lane1")
+        lane._auto_switch_triggered = True
+        lane.clear_lane_data = MagicMock()
+        spool.clear_values(lane)
+        assert lane._auto_switch_triggered is False
+
+    def test_set_spoolID_resets_auto_switch_flag(self):
+        spool = _make_spool()
+        spool.afc.spoolman = "http://spoolman:7912"
+        spool.afc.moonraker = MagicMock()
+        spool.afc.moonraker.get_spool.return_value = {
+            'filament': {
+                'material': 'PLA',
+                'settings_extruder_temp': 210,
+                'settings_bed_temp': 60,
+                'density': 1.24,
+                'diameter': 1.75,
+                'color_hex': 'FF0000',
+            },
+            'remaining_weight': 800,
+            'spool_weight': 190,
+            'initial_weight': 1000,
+        }
+        lane = _make_lane("lane1")
+        lane._auto_switch_triggered = True
+        lane.espooler = MagicMock()
+        lane.espooler.espooler_values = MagicMock()
+        spool.set_spoolID(lane, "123")
+        assert lane._auto_switch_triggered is False

--- a/tests/test_AFC_spool.py
+++ b/tests/test_AFC_spool.py
@@ -770,18 +770,18 @@ class TestAutoSwitchFlagReset:
     def test_set_values_resets_auto_switch_flag(self):
         spool = _make_spool()
         lane = _make_lane("lane1")
-        lane._auto_switch_triggered = True
+        lane.auto_switch_triggered = True
         lane.remember_spool = False
         spool._set_values(lane)
-        assert lane._auto_switch_triggered is False
+        assert lane.auto_switch_triggered is False
 
     def test_clear_values_resets_auto_switch_flag(self):
         spool = _make_spool()
         lane = _make_lane("lane1")
-        lane._auto_switch_triggered = True
+        lane.auto_switch_triggered = True
         lane.clear_lane_data = MagicMock()
         spool.clear_values(lane)
-        assert lane._auto_switch_triggered is False
+        assert lane.auto_switch_triggered is False
 
     def test_set_spoolID_resets_auto_switch_flag(self):
         spool = _make_spool()
@@ -801,8 +801,8 @@ class TestAutoSwitchFlagReset:
             'initial_weight': 1000,
         }
         lane = _make_lane("lane1")
-        lane._auto_switch_triggered = True
+        lane.auto_switch_triggered = True
         lane.espooler = MagicMock()
         lane.espooler.espooler_values = MagicMock()
         spool.set_spoolID(lane, "123")
-        assert lane._auto_switch_triggered is False
+        assert lane.auto_switch_triggered is False


### PR DESCRIPTION
## Major Changes in this PR

This pull request introduces an automatic spool switch feature based on filament weight, along with supporting configuration options, logic, and tests. The main goal is to enable the system to automatically trigger a spool change when the remaining filament weight drops below a configurable threshold, improving print reliability and reducing manual intervention. The implementation includes configuration changes, logic updates in the main codebase, and comprehensive tests to ensure correct behavior and edge case handling.

**Auto Spool Switch Feature:**

* Added `auto_spool_switch` and `auto_spool_switch_threshold` options to `AFC.cfg` and integrated them into the configuration parsing and AFC initialization logic, allowing users to enable auto spool switching and set the weight threshold. [[1]](diffhunk://#diff-4d52fbf62af0688fc800a885ce481e17100e1723916a4bdbd0f8ac41ce10f0d8R37-R39) [[2]](diffhunk://#diff-749740ba904c224003143ed84a943eb5885a486b4ec55cd658a5beeea1cd1ff4R153-R156) [[3]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R371-R372)
* Implemented weight-based auto spool switch logic in `AFC_lane.py`, including a debounce flag (`_auto_switch_triggered`) to prevent repeated triggers, and methods to handle the switch event by pausing or performing an infinite runout as appropriate. [[1]](diffhunk://#diff-120880cf9386cf18b6cdd101a1352383e1aa13474d51b2d99255ff11f286a279R126) [[2]](diffhunk://#diff-120880cf9386cf18b6cdd101a1352383e1aa13474d51b2d99255ff11f286a279R942-R954) [[3]](diffhunk://#diff-120880cf9386cf18b6cdd101a1352383e1aa13474d51b2d99255ff11f286a279R1311-R1326)
* Ensured the auto switch trigger flag is reset whenever spool values are set, cleared, or a new spool ID is assigned, preventing stale state across spool changes. [[1]](diffhunk://#diff-13e9a07c4eadfbd5a3e17927b682551beac5c0ce7d2ccf5315cff8bdb139985fR290) [[2]](diffhunk://#diff-13e9a07c4eadfbd5a3e17927b682551beac5c0ce7d2ccf5315cff8bdb139985fR305) [[3]](diffhunk://#diff-13e9a07c4eadfbd5a3e17927b682551beac5c0ce7d2ccf5315cff8bdb139985fR316)
* Fixed a typo in the `INVALID_UNIT_NAMES` list and improved section matching logic for unit configuration discovery. [[1]](diffhunk://#diff-120880cf9386cf18b6cdd101a1352383e1aa13474d51b2d99255ff11f286a279L44-R44) [[2]](diffhunk://#diff-120880cf9386cf18b6cdd101a1352383e1aa13474d51b2d99255ff11f286a279L664-R665)

**Testing:**

* Added comprehensive tests for the auto spool switch feature, covering correct triggering, debounce logic, logging, and edge cases such as error states and non-printing conditions. Also included tests to verify that the auto switch flag is properly reset during spool operations. [[1]](diffhunk://#diff-550044c902c6dceb6e3b5a8f92eb6c172507b14326249c4a61597dccff232fcaR828-R944) [[2]](diffhunk://#diff-38f66a43af34f26bc5348b36c9d78620e9fb1cefed03fc2b602285413be57e67R765-R808)

## Notes to Code Reviewers

Closes #638 


## How the changes in this PR are tested

Set infinite runout and appropriate options, and start print.

```
18:48:03   4194.312 [AFC_lane.py:update_weight_callback():1293]         - INFO: Auto spool switch: lane8 weight (649.9g) at or below threshold (650.0g), triggering switch
```
Verify it switches.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.