### PR TITLE
(fix): Fixes weight calculation for spools when using multiple toolheads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Adds support for a new `AFC_SET_SPOOL_TEMP` in order to manually set extruder/bed temps for a lane when not using Spoolman.
 
+## [2026-03-25]
+### Fixed
+- Issue where spool weight calculation would be wrong in AFC when using multiple toolheads
+
 ## [2026-03-23]
 ### Added
 - Adds support for weight based spool runout to help support spools with hooked ends. See documentation for more details.

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -217,7 +217,6 @@ class AFCExtruder:
 
         self.toolhead_extruder: PrinterExtruder
         self.fullname                   = config.get_name()
-        # self.mutex                      = self.reactor.mutex()
 
         self.name: str                  = self.fullname.split(' ')[-1]
         self.tool_start                 = config.get('pin_tool_start', None)                                            # Pin for sensor before(pre) extruder gears

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -217,7 +217,7 @@ class AFCExtruder:
 
         self.toolhead_extruder: PrinterExtruder
         self.fullname                   = config.get_name()
-        self.mutex                      = self.reactor.mutex()
+        # self.mutex                      = self.reactor.mutex()
 
         self.name: str                  = self.fullname.split(' ')[-1]
         self.tool_start                 = config.get('pin_tool_start', None)                                            # Pin for sensor before(pre) extruder gears
@@ -471,26 +471,25 @@ class AFCExtruder:
         :param eventtime: Event time from the button press
         :param state: Boolean indicating sensor state (True = filament present, False = runout)
         """
-        with self.mutex:
-            if state != self.tool_start_state:
-                if self.tc_unit_name and self.no_lanes:
-                    self.tc_lane._load_state = state
-                    self.tc_lane.prep_state = state
+        if state != self.tool_start_state:
+            if self.tc_unit_name and self.no_lanes:
+                self.tc_lane._load_state = state
+                self.tc_lane.prep_state = state
 
-                    if (self.printer.state_message == READY and
-                        self.tc_lane._afc_prep_done):
-                        if state:
-                            if not self.load_active:
-                                self.load_unload_sequence(self.tool_stn)
-                        else:
-                            self.tc_lane.set_tool_unloaded()
-                            self.tc_lane.set_unloaded()
+                if (self.printer.state_message == READY and
+                    self.tc_lane._afc_prep_done):
+                    if state:
+                        if not self.load_active:
+                            self.load_unload_sequence(self.tool_stn)
+                    else:
+                        self.tc_lane.set_tool_unloaded()
+                        self.tc_lane.set_unloaded()
 
-                        self.afc.save_vars()
-            else:
-                self.logger.info("Not loading State matches tool_start_state")
+                    self.afc.save_vars()
+        else:
+            self.logger.info("Not loading State matches tool_start_state")
 
-            self.tool_start_state = state
+        self.tool_start_state = state
 
 
     def buffer_trailing_callback(self, eventtime, state):
@@ -787,8 +786,9 @@ class AFCExtruder:
             return True
 
         if hasattr(self.tool_obj, "detect_state"):
+            from extras.toolchanger import DETECT_PRESENT
             return (
-                self.tool_obj.detect_state == 1 or
+                self.tool_obj.detect_state == DETECT_PRESENT or
                 self.tool_obj.main_toolchanger.get_selected_tool() == self.tool_obj
             )
         else:

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -629,7 +629,7 @@ class afcFunction:
             self.logger.debug("Printer extruder not in absolute mode, setting to absolute mode")
             self.afc.gcode_move.absolute_extrude = True
 
-    def get_extruder_pos(self, eventtime=None, past_extruder_position=None):
+    def get_extruder_pos(self, eventtime=None, past_extruder_position=None, extruder=None):
         """
         This function find the last position of the filament and only returns a value if it greater than
         the previous passed in position.
@@ -641,7 +641,8 @@ class afcFunction:
         if eventtime is None:
             eventtime = self.afc.reactor.monotonic()
         print_time = self.mcu.estimated_print_time(eventtime)
-        extruder = self.afc.toolhead.get_extruder()
+        if extruder is None:
+            extruder = self.afc.toolhead.get_extruder()
         last_extruder_position = extruder.find_past_position(print_time)
 
         if past_extruder_position is None or last_extruder_position > past_extruder_position:

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -1279,7 +1279,9 @@ class AFCLane:
         Helper function to enable weight callback timer, should be called once a lane is loaded
         to extruder or extruder is switched for multi-toolhead setups.
         """
-        self.past_extruder_position = self.afc.function.get_extruder_pos( None, self.past_extruder_position )
+        self.past_extruder_position = self.afc.function.get_extruder_pos(
+            None, self.past_extruder_position, self.extruder_obj.toolhead_extruder
+        )
         self.reactor.update_timer( self.cb_update_weight, self.reactor.monotonic() + self.UPDATE_WEIGHT_DELAY)
 
     def disable_weight_timer(self):
@@ -1301,7 +1303,9 @@ class AFCLane:
         :param eventtime: Current eventtime for timer callback
         :return int: Next time to call timer callback. Current time + UPDATE_WEIGHT_DELAY
         """
-        extruder_pos = self.afc.function.get_extruder_pos( eventtime, self.past_extruder_position )
+        extruder_pos = self.afc.function.get_extruder_pos(
+            eventtime, self.past_extruder_position, self.extruder_obj.toolhead_extruder
+        )
         delta_length = extruder_pos - self.past_extruder_position
 
         if -1 == self.past_extruder_position:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -386,6 +386,7 @@ class MockAFC:
         self.led_off = "0,0,0,0"
         # function mock helpers
         self.function.HexConvert = lambda x: x
+        self.toolhead = MagicMock()
 
 
 class MockPrinter:

--- a/tests/test_AFC_extruder.py
+++ b/tests/test_AFC_extruder.py
@@ -608,11 +608,28 @@ class TestGetStatus:
 
 # ── on_shuttle ────────────────────────────────────────────────────────────────
 # Sentinel value that mirrors the real DETECT_PRESENT constant
-_DETECT_PRESENT = "detect_present"
+_DETECT_PRESENT = "mounted"
+_DETECT_ABSENT  = "absent"
+_DETECT_UNAVAILABLE = "unavailable"
+
+_DETECT_PRESENT_OLD = 1
+_DETECT_ABSENT_OLD  = 0
+_DETECT_UNAVAILABLE_OLD = -1
+
 def _make_toolchanger_module():
     """Return a minimal fake extras.toolchanger module."""
     mod = types.ModuleType("extras.toolchanger")
     mod.DETECT_PRESENT = _DETECT_PRESENT
+    mod.DETECT_ABSENT = _DETECT_ABSENT
+    mod.DETECT_UNAVAILABLE = _DETECT_UNAVAILABLE
+    return mod
+
+def _make_toolchanger_module_old():
+    """Return a minimal fake extras.toolchanger module."""
+    mod = types.ModuleType("extras.toolchanger")
+    mod.DETECT_PRESENT = _DETECT_PRESENT_OLD
+    mod.DETECT_ABSENT = _DETECT_ABSENT_OLD
+    mod.DETECT_UNAVAILABLE = _DETECT_UNAVAILABLE_OLD
     return mod
 
 
@@ -677,31 +694,84 @@ class TestOnShuttle_WithDetectState:
     def test_returns_true_when_detect_state_is_present(self):
         ext = _make_afc_extruder()
         ext.tc_unit_name = "unit_0"
-        ext.tool_obj = _tool_with_detect_state(_DETECT_PRESENT, is_selected=False)
+        ext.tool_obj = _tool_with_detect_state("mounted", is_selected=False)
         assert ext.on_shuttle() is True
 
     def test_returns_true_when_tool_is_selected_but_not_present(self):
         ext = _make_afc_extruder()
         ext.tc_unit_name = "unit_0"
-        ext.tool_obj = _tool_with_detect_state("detect_absent", is_selected=True)
+        ext.tool_obj = _tool_with_detect_state("absent", is_selected=True)
         assert ext.on_shuttle() is True
 
     def test_returns_true_when_both_present_and_selected(self):
         ext = _make_afc_extruder()
         ext.tc_unit_name = "unit_0"
-        ext.tool_obj = _tool_with_detect_state(_DETECT_PRESENT, is_selected=True)
+        ext.tool_obj = _tool_with_detect_state("mounted", is_selected=True)
         assert ext.on_shuttle() is True
 
     def test_returns_false_when_not_present_and_not_selected(self):
         ext = _make_afc_extruder()
         ext.tc_unit_name = "unit_0"
-        ext.tool_obj = _tool_with_detect_state("detect_absent", is_selected=False)
+        ext.tool_obj = _tool_with_detect_state("absent", is_selected=False)
+        assert ext.on_shuttle() is False
+    
+    def test_returns_false_when_not_present_and_not_selected_unavailable(self):
+        ext = _make_afc_extruder()
+        ext.tc_unit_name = "unit_0"
+        ext.tool_obj = _tool_with_detect_state("unavailable", is_selected=False)
         assert ext.on_shuttle() is False
 
     def test_get_selected_tool_called_once_per_invocation(self):
         ext = _make_afc_extruder()
         ext.tc_unit_name = "unit_0"
-        ext.tool_obj = _tool_with_detect_state("detect_absent", is_selected=False)
+        ext.tool_obj = _tool_with_detect_state("absent", is_selected=False)
+        ext.on_shuttle()
+        ext.tool_obj.main_toolchanger.get_selected_tool.assert_called_once()
+
+class TestOnShuttle_WithDetectStateOld:
+    """tool_obj carries detect_state; result depends on sensor or tool selection."""
+
+    @pytest.fixture(autouse=True)
+    def patch_toolchanger_module(self):
+        """Inject a fake extras.toolchanger so the in-method import resolves."""
+        fake_mod = _make_toolchanger_module_old()
+        with patch.dict(sys.modules, {"extras.toolchanger": fake_mod}):
+            yield
+
+    def test_returns_true_when_detect_state_is_present(self):
+        ext = _make_afc_extruder()
+        ext.tc_unit_name = "unit_0"
+        ext.tool_obj = _tool_with_detect_state(1, is_selected=False)
+        assert ext.on_shuttle() is True
+
+    def test_returns_true_when_tool_is_selected_but_not_present(self):
+        ext = _make_afc_extruder()
+        ext.tc_unit_name = "unit_0"
+        ext.tool_obj = _tool_with_detect_state(0, is_selected=True)
+        assert ext.on_shuttle() is True
+
+    def test_returns_true_when_both_present_and_selected(self):
+        ext = _make_afc_extruder()
+        ext.tc_unit_name = "unit_0"
+        ext.tool_obj = _tool_with_detect_state(1, is_selected=True)
+        assert ext.on_shuttle() is True
+
+    def test_returns_false_when_not_present_and_not_selected(self):
+        ext = _make_afc_extruder()
+        ext.tc_unit_name = "unit_0"
+        ext.tool_obj = _tool_with_detect_state(0, is_selected=False)
+        assert ext.on_shuttle() is False
+    
+    def test_returns_false_when_not_present_and_not_selected_unavailable(self):
+        ext = _make_afc_extruder()
+        ext.tc_unit_name = "unit_0"
+        ext.tool_obj = _tool_with_detect_state(-1, is_selected=False)
+        assert ext.on_shuttle() is False
+
+    def test_get_selected_tool_called_once_per_invocation(self):
+        ext = _make_afc_extruder()
+        ext.tc_unit_name = "unit_0"
+        ext.tool_obj = _tool_with_detect_state(0, is_selected=False)
         ext.on_shuttle()
         ext.tool_obj.main_toolchanger.get_selected_tool.assert_called_once()
 

--- a/tests/test_AFC_extruder.py
+++ b/tests/test_AFC_extruder.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 import pytest
+import sys
+import types
 
 from extras.AFC_extruder import AFCExtruderStats, AFCExtruder
 
@@ -221,6 +223,10 @@ def _make_afc_extruder(name="extruder"):
     ext.reactor = reactor
     ext.fullname = f"AFC_extruder {name}"
     ext.name = name
+    # Toolchanger fields – default mirrors single-toolhead state
+    ext.tool_obj     = None
+    ext.tc_unit_name = None
+    ext.tool         = None
     ext.lane_loaded = None
     ext.lanes = {}
     ext.tool_start = None
@@ -599,3 +605,305 @@ class TestGetStatus:
         ext.lanes = {"lane1": lane}
         result = ext.get_status()
         assert "lane1" in result["lanes"]
+
+# ── on_shuttle ────────────────────────────────────────────────────────────────
+# Sentinel value that mirrors the real DETECT_PRESENT constant
+_DETECT_PRESENT = "detect_present"
+def _make_toolchanger_module():
+    """Return a minimal fake extras.toolchanger module."""
+    mod = types.ModuleType("extras.toolchanger")
+    mod.DETECT_PRESENT = _DETECT_PRESENT
+    return mod
+
+
+def _tool_with_detect_state(detect_state_value, is_selected=False):
+    """Mock tool object that has detect_state."""
+    tool = MagicMock()
+    tool.detect_state = detect_state_value
+    selected = tool if is_selected else MagicMock()
+    tool.main_toolchanger.get_selected_tool.return_value = selected
+    return tool
+
+
+def _tool_without_detect_state():
+    """Mock tool object that does NOT have detect_state (spec=[] prevents any attr)."""
+    return MagicMock(spec=[])
+
+
+# ── Branch 1: single toolhead (both None) ────────────────────────────────────
+
+class TestOnShuttle_SingleToolhead:
+    """tool_obj=None AND tc_unit_name=None → always returns True."""
+
+    def test_returns_true_when_both_none(self):
+        ext = _make_afc_extruder()
+        assert ext.on_shuttle() is True
+
+    def test_still_true_after_repeated_calls(self):
+        ext = _make_afc_extruder()
+        assert ext.on_shuttle() is True
+        assert ext.on_shuttle() is True
+
+
+# ── Branch 2: toolchanger unit set, no tool object (custom macros) ────────────
+
+class TestOnShuttle_CustomMacros:
+    """tc_unit_name is set but tool_obj=None → returns True."""
+
+    def test_returns_true_with_unit_name_no_tool(self):
+        ext = _make_afc_extruder()
+        ext.tc_unit_name = "toolchanger_0"
+        assert ext.on_shuttle() is True
+
+    def test_returns_true_for_various_unit_names(self):
+        for name in ["unit_1", "my_toolchanger", "T0"]:
+            ext = _make_afc_extruder()
+            ext.tc_unit_name = name
+            assert ext.on_shuttle() is True, f"Expected True for tc_unit_name={name!r}"
+
+
+# ── Branch 3: tool_obj has detect_state ──────────────────────────────────────
+
+class TestOnShuttle_WithDetectState:
+    """tool_obj carries detect_state; result depends on sensor or tool selection."""
+
+    @pytest.fixture(autouse=True)
+    def patch_toolchanger_module(self):
+        """Inject a fake extras.toolchanger so the in-method import resolves."""
+        fake_mod = _make_toolchanger_module()
+        with patch.dict(sys.modules, {"extras.toolchanger": fake_mod}):
+            yield
+
+    def test_returns_true_when_detect_state_is_present(self):
+        ext = _make_afc_extruder()
+        ext.tc_unit_name = "unit_0"
+        ext.tool_obj = _tool_with_detect_state(_DETECT_PRESENT, is_selected=False)
+        assert ext.on_shuttle() is True
+
+    def test_returns_true_when_tool_is_selected_but_not_present(self):
+        ext = _make_afc_extruder()
+        ext.tc_unit_name = "unit_0"
+        ext.tool_obj = _tool_with_detect_state("detect_absent", is_selected=True)
+        assert ext.on_shuttle() is True
+
+    def test_returns_true_when_both_present_and_selected(self):
+        ext = _make_afc_extruder()
+        ext.tc_unit_name = "unit_0"
+        ext.tool_obj = _tool_with_detect_state(_DETECT_PRESENT, is_selected=True)
+        assert ext.on_shuttle() is True
+
+    def test_returns_false_when_not_present_and_not_selected(self):
+        ext = _make_afc_extruder()
+        ext.tc_unit_name = "unit_0"
+        ext.tool_obj = _tool_with_detect_state("detect_absent", is_selected=False)
+        assert ext.on_shuttle() is False
+
+    def test_get_selected_tool_called_once_per_invocation(self):
+        ext = _make_afc_extruder()
+        ext.tc_unit_name = "unit_0"
+        ext.tool_obj = _tool_with_detect_state("detect_absent", is_selected=False)
+        ext.on_shuttle()
+        ext.tool_obj.main_toolchanger.get_selected_tool.assert_called_once()
+
+
+# ── Branch 4: tool_obj exists but lacks detect_state ─────────────────────────
+
+class TestOnShuttle_WithoutDetectState:
+    """tool_obj present but no detect_state attr → returns False."""
+
+    def test_returns_false_when_no_detect_state(self):
+        ext = _make_afc_extruder()
+        ext.tc_unit_name = "unit_0"
+        ext.tool_obj = _tool_without_detect_state()
+        assert ext.on_shuttle() is False
+
+    def test_returns_false_with_no_tc_unit_name(self):
+        """tool_obj set but tc_unit_name=None still reaches detect_state check."""
+        ext = _make_afc_extruder()
+        ext.tc_unit_name = None
+        ext.tool_obj = _tool_without_detect_state()
+        assert ext.on_shuttle() is False
+
+# ── tool_start_callback helpers ───────────────────────────────────────────────
+
+def _make_ext_for_tool_start(name="extruder"):
+    """Extend _make_afc_extruder with the extra fields tool_start_callback touches."""
+    ext = _make_afc_extruder(name)
+    ext.no_lanes          = False
+    ext.load_active       = False
+    ext.load_unload_sequence = MagicMock()
+
+    # tc_lane mock with the attributes the method writes/reads
+    tc_lane               = MagicMock()
+    tc_lane._load_state   = False
+    tc_lane.prep_state    = False
+    tc_lane._afc_prep_done = False
+    ext.tc_lane           = tc_lane
+
+    return ext
+
+# ── tool_start_callback: state unchanged ──────────────────────────────────────
+
+class TestToolStartCallback_StateUnchanged:
+    """state == tool_start_state: logs, still updates tool_start_state."""
+
+    def test_logs_info_when_state_unchanged(self):
+        ext = _make_ext_for_tool_start()
+        ext.tool_start_state = False
+        ext.tool_start_callback(100.0, False)
+        info_msgs = [m for lvl, m in ext.logger.messages if lvl == "info"]
+        assert any("Not loading" in m for m in info_msgs)
+
+    def test_state_still_set_when_unchanged(self):
+        ext = _make_ext_for_tool_start()
+        ext.tool_start_state = True
+        ext.tool_start_callback(100.0, True)
+        assert ext.tool_start_state is True
+
+    def test_load_unload_sequence_not_called_when_state_unchanged(self):
+        ext = _make_ext_for_tool_start()
+        ext.tool_start_state = False
+        ext.tool_start_callback(100.0, False)
+        ext.load_unload_sequence.assert_not_called()
+
+
+# ── tool_start_callback: state changed, no toolchanger / no_lanes ─────────────
+
+class TestToolStartCallback_StateChanged_NoToolchanger:
+    """State changes but tc_unit_name=None or no_lanes=False: just updates state."""
+
+    def test_updates_state_to_true_no_tc_unit(self):
+        ext = _make_ext_for_tool_start()
+        ext.tc_unit_name     = None
+        ext.tool_start_state = False
+        ext.tool_start_callback(100.0, True)
+        assert ext.tool_start_state is True
+
+    def test_updates_state_to_false_no_tc_unit(self):
+        ext = _make_ext_for_tool_start()
+        ext.tc_unit_name     = None
+        ext.tool_start_state = True
+        ext.tool_start_callback(100.0, False)
+        assert ext.tool_start_state is False
+
+    def test_no_sequence_called_without_tc_unit(self):
+        ext = _make_ext_for_tool_start()
+        ext.tc_unit_name     = None
+        ext.tool_start_state = False
+        ext.tool_start_callback(100.0, True)
+        ext.load_unload_sequence.assert_not_called()
+
+    def test_no_sequence_called_when_no_lanes_false(self):
+        ext = _make_ext_for_tool_start()
+        ext.tc_unit_name     = "unit_0"
+        ext.no_lanes         = False          # toolchanger set but multi-lane
+        ext.tool_start_state = False
+        ext.tool_start_callback(100.0, True)
+        ext.load_unload_sequence.assert_not_called()
+
+    def test_tc_lane_not_updated_when_no_lanes_false(self):
+        ext = _make_ext_for_tool_start()
+        ext.tc_unit_name     = "unit_0"
+        ext.no_lanes         = False
+        ext.tool_start_state = False
+        ext.tool_start_callback(100.0, True)
+        assert ext.tc_lane._load_state is False  # untouched
+
+
+# ── tool_start_callback: state changed, toolchanger active ────────────────────
+
+class TestToolStartCallback_StateChanged_WithToolchanger:
+    """tc_unit_name set + no_lanes=True: tc_lane state is always updated."""
+
+    def _make_tc_ext(self, printer_ready=False, prep_done=False,
+                     state=True, load_active=False):
+        from klippy import message_ready as READY
+        ext                  = _make_ext_for_tool_start()
+        ext.tc_unit_name     = "unit_0"
+        ext.no_lanes         = True
+        ext.tool_start_state = not state      # ensure state != tool_start_state
+        ext.load_active      = load_active
+        ext.printer.state_message = READY if printer_ready else "startup"
+        ext.tc_lane._afc_prep_done = prep_done
+        return ext
+
+    def test_tc_lane_load_state_updated(self):
+        ext = self._make_tc_ext(state=True)
+        ext.tool_start_callback(100.0, True)
+        assert ext.tc_lane._load_state is True
+
+    def test_tc_lane_prep_state_updated(self):
+        ext = self._make_tc_ext(state=False)
+        ext.tool_start_callback(100.0, False)
+        assert ext.tc_lane.prep_state is False
+
+    def test_tool_start_state_updated(self):
+        ext = self._make_tc_ext(state=True)
+        ext.tool_start_callback(100.0, True)
+        assert ext.tool_start_state is True
+
+    # printer not ready ─────────────────────────────────────────────────────
+
+    def test_no_sequence_when_printer_not_ready(self):
+        ext = self._make_tc_ext(printer_ready=False, prep_done=True, state=True)
+        ext.tool_start_callback(100.0, True)
+        ext.load_unload_sequence.assert_not_called()
+
+    def test_save_vars_not_called_when_printer_not_ready(self):
+        ext = self._make_tc_ext(printer_ready=False, prep_done=True, state=True)
+        ext.tool_start_callback(100.0, True)
+        ext.afc.save_vars.assert_not_called()
+
+    # prep not done ─────────────────────────────────────────────────────────
+
+    def test_no_sequence_when_prep_not_done(self):
+        ext = self._make_tc_ext(printer_ready=True, prep_done=False, state=True)
+        ext.tool_start_callback(100.0, True)
+        ext.load_unload_sequence.assert_not_called()
+
+    def test_save_vars_not_called_when_prep_not_done(self):
+        ext = self._make_tc_ext(printer_ready=True, prep_done=False, state=True)
+        ext.tool_start_callback(100.0, True)
+        ext.afc.save_vars.assert_not_called()
+
+    # ready + prep done + filament present ──────────────────────────────────
+
+    def test_load_sequence_called_when_ready_and_filament_present(self):
+        ext = self._make_tc_ext(printer_ready=True, prep_done=True,
+                                state=True, load_active=False)
+        ext.tool_start_callback(100.0, True)
+        ext.load_unload_sequence.assert_called_once_with(ext.tool_stn)
+
+    def test_load_sequence_not_called_when_load_already_active(self):
+        ext = self._make_tc_ext(printer_ready=True, prep_done=True,
+                                state=True, load_active=True)
+        ext.tool_start_callback(100.0, True)
+        ext.load_unload_sequence.assert_not_called()
+
+    def test_save_vars_called_after_load_sequence(self):
+        ext = self._make_tc_ext(printer_ready=True, prep_done=True,
+                                state=True, load_active=False)
+        ext.tool_start_callback(100.0, True)
+        ext.afc.save_vars.assert_called_once()
+
+    # ready + prep done + filament absent (runout) ──────────────────────────
+
+    def test_set_tool_unloaded_called_on_runout(self):
+        ext = self._make_tc_ext(printer_ready=True, prep_done=True, state=False)
+        ext.tool_start_callback(100.0, False)
+        ext.tc_lane.set_tool_unloaded.assert_called_once()
+
+    def test_set_unloaded_called_on_runout(self):
+        ext = self._make_tc_ext(printer_ready=True, prep_done=True, state=False)
+        ext.tool_start_callback(100.0, False)
+        ext.tc_lane.set_unloaded.assert_called_once()
+
+    def test_save_vars_called_after_runout(self):
+        ext = self._make_tc_ext(printer_ready=True, prep_done=True, state=False)
+        ext.tool_start_callback(100.0, False)
+        ext.afc.save_vars.assert_called_once()
+
+    def test_load_sequence_not_called_on_runout(self):
+        ext = self._make_tc_ext(printer_ready=True, prep_done=True, state=False)
+        ext.tool_start_callback(100.0, False)
+        ext.load_unload_sequence.assert_not_called()

--- a/tests/test_AFC_functions.py
+++ b/tests/test_AFC_functions.py
@@ -29,6 +29,7 @@ def _make_func():
     from tests.conftest import MockAFC, MockLogger
 
     afc = MockAFC()
+    afc.reactor = MagicMock()
     func.afc = afc
     func.logger = MockLogger()
     func.printer = MagicMock()
@@ -404,3 +405,152 @@ class TestRename:
         func._rename("RESUME", "_AFC_RENAMED_RESUME_", MagicMock(), "help")
         debug_msgs = [m for lvl, m in func.logger.messages if lvl == "debug"]
         assert any("RESUME" in m for m in debug_msgs)
+
+# ── get_extruder_pos ──────────────────────────────────────────────────────────
+
+def _wire_extruder(func, last_position):
+    """
+    Return a mock extruder whose find_past_position returns last_position,
+    and wire it up as the toolhead's active extruder.
+    """
+    extruder = MagicMock()
+    extruder.find_past_position.return_value = last_position
+    func.afc.toolhead.get_extruder.return_value = extruder
+    return extruder
+
+
+# ── eventtime resolution ──────────────────────────────────────────────────────
+
+class TestGetExtruderPos_EventTime:
+    def test_uses_reactor_monotonic_when_eventtime_is_none(self):
+        func = _make_func()
+        func.afc.reactor.monotonic.return_value = 42.0
+        func.mcu.estimated_print_time.return_value = 10.0
+        _wire_extruder(func, last_position=5.0)
+
+        func.get_extruder_pos(eventtime=None)
+
+        func.afc.reactor.monotonic.assert_called_once()
+
+    def test_passes_reactor_monotonic_to_mcu(self):
+        func = _make_func()
+        func.afc.reactor.monotonic.return_value = 42.0
+        func.mcu.estimated_print_time.return_value = 10.0
+        _wire_extruder(func, last_position=5.0)
+
+        func.get_extruder_pos(eventtime=None)
+
+        func.mcu.estimated_print_time.assert_called_once_with(42.0)
+
+    def test_uses_provided_eventtime_directly(self):
+        func = _make_func()
+        func.mcu.estimated_print_time.return_value = 10.0
+        _wire_extruder(func, last_position=5.0)
+
+        func.get_extruder_pos(eventtime=99.0)
+
+        func.mcu.estimated_print_time.assert_called_once_with(99.0)
+
+    def test_reactor_not_called_when_eventtime_provided(self):
+        func = _make_func()
+        func.mcu.estimated_print_time.return_value = 10.0
+        _wire_extruder(func, last_position=5.0)
+
+        func.get_extruder_pos(eventtime=99.0)
+
+        func.afc.reactor.monotonic.assert_not_called()
+
+
+# ── extruder resolution ───────────────────────────────────────────────────────
+
+class TestGetExtruderPos_ExtruderParam:
+    def test_falls_back_to_toolhead_get_extruder_when_none(self):
+        func = _make_func()
+        func.mcu.estimated_print_time.return_value = 10.0
+        _wire_extruder(func, last_position=5.0)
+
+        func.get_extruder_pos(eventtime=1.0, extruder=None)
+
+        func.afc.toolhead.get_extruder.assert_called_once()
+
+    def test_uses_provided_extruder_directly(self):
+        func = _make_func()
+        func.mcu.estimated_print_time.return_value = 10.0
+
+        custom_extruder = MagicMock()
+        custom_extruder.find_past_position.return_value = 7.0
+
+        func.get_extruder_pos(eventtime=1.0, extruder=custom_extruder)
+
+        custom_extruder.find_past_position.assert_called_once()
+        func.afc.toolhead.get_extruder.assert_not_called()
+
+    def test_find_past_position_receives_print_time(self):
+        func = _make_func()
+        func.mcu.estimated_print_time.return_value = 55.5
+
+        custom_extruder = MagicMock()
+        custom_extruder.find_past_position.return_value = 3.0
+
+        func.get_extruder_pos(eventtime=1.0, extruder=custom_extruder)
+
+        custom_extruder.find_past_position.assert_called_once_with(55.5)
+
+
+# ── return value logic ────────────────────────────────────────────────────────
+
+class TestGetExtruderPos_ReturnValue:
+    def test_returns_last_position_when_past_is_none(self):
+        func = _make_func()
+        func.mcu.estimated_print_time.return_value = 10.0
+        _wire_extruder(func, last_position=8.0)
+
+        result = func.get_extruder_pos(eventtime=1.0, past_extruder_position=None)
+
+        assert result == pytest.approx(8.0)
+
+    def test_returns_last_position_when_greater_than_past(self):
+        func = _make_func()
+        func.mcu.estimated_print_time.return_value = 10.0
+        _wire_extruder(func, last_position=15.0)
+
+        result = func.get_extruder_pos(eventtime=1.0, past_extruder_position=10.0)
+
+        assert result == pytest.approx(15.0)
+
+    def test_returns_past_position_when_last_equals_past(self):
+        func = _make_func()
+        func.mcu.estimated_print_time.return_value = 10.0
+        _wire_extruder(func, last_position=10.0)
+
+        result = func.get_extruder_pos(eventtime=1.0, past_extruder_position=10.0)
+
+        assert result == pytest.approx(10.0)
+
+    def test_returns_past_position_when_last_less_than_past(self):
+        func = _make_func()
+        func.mcu.estimated_print_time.return_value = 10.0
+        _wire_extruder(func, last_position=3.0)
+
+        result = func.get_extruder_pos(eventtime=1.0, past_extruder_position=9.0)
+
+        assert result == pytest.approx(9.0)
+
+    def test_returns_zero_when_last_is_zero_and_past_is_none(self):
+        func = _make_func()
+        func.mcu.estimated_print_time.return_value = 10.0
+        _wire_extruder(func, last_position=0.0)
+
+        result = func.get_extruder_pos(eventtime=1.0, past_extruder_position=None)
+
+        assert result == pytest.approx(0.0)
+
+    def test_returns_float(self):
+        func = _make_func()
+        func.mcu.estimated_print_time.return_value = 10.0
+        _wire_extruder(func, last_position=4.5)
+
+        result = func.get_extruder_pos(eventtime=1.0)
+
+        assert isinstance(result, float)
+# ── end get_extruder_pos ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Major Changes in this PR
- Noticed that weight was updating incorrectly since AFC could use the previous toolhead filament distance when switching toolheads. This PR fixes that calculation by looking up lanes specific toolhead before calculating weight based off filament distance consumed.
- Removed mutex in extruder tool_start_callback as sometime it would cause lane load failures
- Updated on_shuttle method to use detect constants from Klipper-toolchanger, this is need so that AFC can work with recent KTC updates.
- Claude assisted in adding unit tests

## Notes to Code Reviewers

## How the changes in this PR are tested
- Noticed and testing on U1 toolchanger and also been testing on my 2.4 toolchanger

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.