### PR TITLE
(fix): Fixing issue where AFC was querying TD1 data 4 times a second

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2026-03-26]
 ### Added
 - Adds support for a new `AFC_SET_SPOOL_TEMP` in order to manually set extruder/bed temps for a lane when not using Spoolman.
+### Fixed
+- Fixed issue found where AFC was querying moonraker 4 times a second for TD1 data and could take up to 25% CPU usage from lower end SOCs
 
 ## [2026-03-23]
 ### Added

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -93,6 +93,7 @@ class afc:
         self.moonraker          = None
         self.td1_defined        = False
         self._td1_present       = False
+        self._last_td1_query:float    = 0
         self.lane_data_enabled  = False
         self.prep_done          = False         # Variable used to hold of save_vars function from saving too early and overriding save before prep can be ran
         self.in_print_timer     = None
@@ -509,8 +510,12 @@ class afc:
     @property
     def td1_present(self):
         present = self._td1_present
-        if self.printer.state_message == 'Printer is ready' and self.moonraker is not None:
+        current_time = self.reactor.monotonic()
+        if (self.printer.state_message == 'Printer is ready'
+            and self.moonraker is not None
+            and (current_time - self._last_td1_query) > 30 ):
             if not self.function.is_printing(check_movement=True):
+                self._last_td1_query = current_time
                 present = self.moonraker.check_for_td1()[1]
                 self._td1_present = present
 

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -42,7 +42,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 try: from extras.AFC_stats import AFCStats
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
 
-AFC_VERSION="1.1.010"
+AFC_VERSION="1.1.10"
 
 # Class for holding different states so its clear what all valid states are
 class State:

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -42,7 +42,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 try: from extras.AFC_stats import AFCStats
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
 
-AFC_VERSION="1.1.0"
+AFC_VERSION="1.1.010"
 
 # Class for holding different states so its clear what all valid states are
 class State:

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -169,6 +169,8 @@ class afcPrep:
                                 cur_lane.weight = int(cur_lane.weight)
                             else:
                                 cur_lane.weight = 0
+                        if 'bed_temp' in units[cur_lane.unit][cur_lane.name]: cur_lane.bed_temp = units[cur_lane.unit][cur_lane.name]['bed_temp']
+                        if 'extruder_temp' in units[cur_lane.unit][cur_lane.name]: cur_lane.extruder_temp = units[cur_lane.unit][cur_lane.name]['extruder_temp']
 
                     if 'runout_lane' in units[cur_lane.unit][cur_lane.name]: cur_lane.runout_lane = units[cur_lane.unit][cur_lane.name]['runout_lane']
                     if cur_lane.runout_lane == '' or cur_lane.runout_lane == 'NONE': cur_lane.runout_lane = None

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -163,14 +163,22 @@ class afcPrep:
                             cur_lane.filament_diameter= units[cur_lane.unit][cur_lane.name]["diameter"]
                         if 'empty_spool_weight' in units[cur_lane.unit][cur_lane.name]:
                             cur_lane.empty_spool_weight= units[cur_lane.unit][cur_lane.name]["empty_spool_weight"]
-
-                        if not isinstance(cur_lane.weight, int):
-                            if cur_lane.weight:
-                                cur_lane.weight = int(cur_lane.weight)
-                            else:
-                                cur_lane.weight = 0
                         if 'bed_temp' in units[cur_lane.unit][cur_lane.name]: cur_lane.bed_temp = units[cur_lane.unit][cur_lane.name]['bed_temp']
                         if 'extruder_temp' in units[cur_lane.unit][cur_lane.name]: cur_lane.extruder_temp = units[cur_lane.unit][cur_lane.name]['extruder_temp']
+
+                        for attr_name in ("bed_temp", "extruder_temp", "weight"):
+                            value = getattr(cur_lane, attr_name, None)
+                            if value == "" or value == "NONE":
+                                setattr(cur_lane, attr_name, None)
+                            else:
+                                try:
+                                    if not isinstance(value, float):
+                                        if value:
+                                            setattr(cur_lane, attr_name, float(value))
+                                        else:
+                                            setattr(cur_lane, attr_name, 0)
+                                except (ValueError, TypeError):
+                                    setattr(cur_lane, attr_name, 0)
 
                     if 'runout_lane' in units[cur_lane.unit][cur_lane.name]: cur_lane.runout_lane = units[cur_lane.unit][cur_lane.name]['runout_lane']
                     if cur_lane.runout_lane == '' or cur_lane.runout_lane == 'NONE': cur_lane.runout_lane = None

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -961,12 +961,12 @@ class TestTd1Present:
         assert obj.td1_present is True
     
     def test_returns_cached_when_query_interval_too_short_td1_false(self):
-        """Does not refresh when printer is ready and interval has passed but a print is active."""
+        """Does not refresh when printer is ready and interval has not passed."""
         obj = _make_afc_for_td1(
             td1_present=False,
             current_time=100.0,
             last_td1_query=90.0,
-            is_printing=True,
+            is_printing=False,
             moonraker_td1_result=True,
         )
         assert obj.td1_present is False

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -904,6 +904,169 @@ class TestToolLoad_DestExtruderAlreadyLoaded:
         obj.TOOL_UNLOAD.assert_called_once_with(loaded_lane, set_start_time=False)
 
 
+# ── td1_present property ─────────────────────────────────────────────────────
+
+def _make_afc_for_td1(*, td1_present=False, last_td1_query=0.0,
+                       current_time=100.0, printer_ready=True,
+                       moonraker=True, is_printing=False,
+                       moonraker_td1_result=True):
+    """
+    Build an afc instance pre-configured for td1_present property tests.
+
+    Parameters
+    ----------
+    td1_present        : initial value of _td1_present
+    last_td1_query     : initial value of _last_td1_query (seconds, monotonic)
+    current_time       : value reactor.monotonic() will return
+    printer_ready      : if True, printer.state_message == 'Printer is ready'
+    moonraker          : if True, attach a MagicMock moonraker; if False leave None
+    is_printing        : return value of function.is_printing(check_movement=True)
+    moonraker_td1_result : value moonraker.check_for_td1() returns as [1] index
+    """
+    obj = _make_afc()
+    obj._td1_present = td1_present
+    obj._last_td1_query = last_td1_query
+    obj.reactor.monotonic = MagicMock(return_value=current_time)
+    obj.printer.state_message = 'Printer is ready' if printer_ready else 'Startup'
+    obj.function.is_printing = MagicMock(return_value=is_printing)
+
+    if moonraker:
+        obj.moonraker = MagicMock()
+        obj.moonraker.check_for_td1.return_value = (None, moonraker_td1_result)
+    else:
+        obj.moonraker = None
+
+    return obj
+
+
+class TestTd1Present:
+    """Tests for the afc.td1_present property."""
+
+    # ── cached-value paths (no moonraker call) ────────────────────────────────
+
+    def test_returns_cached_when_printer_not_ready(self):
+        """Returns _td1_present without querying moonraker when printer is not ready."""
+        obj = _make_afc_for_td1(td1_present=True, printer_ready=False)
+        assert obj.td1_present is True
+
+    def test_returns_cached_when_moonraker_is_none(self):
+        """Returns _td1_present without error when moonraker is None."""
+        obj = _make_afc_for_td1(td1_present=False, moonraker=False)
+        assert obj.td1_present is False
+
+    def test_returns_cached_when_query_interval_too_short(self):
+        """Returns _td1_present when less than 30 s have elapsed since last query."""
+        # current_time - last_td1_query == 10 s (< 30 s threshold)
+        obj = _make_afc_for_td1(td1_present=True, current_time=100.0, last_td1_query=90.0)
+        assert obj.td1_present is True
+    
+    def test_returns_cached_when_query_interval_too_short_td1_false(self):
+        """Does not refresh when printer is ready and interval has passed but a print is active."""
+        obj = _make_afc_for_td1(
+            td1_present=False,
+            current_time=100.0,
+            last_td1_query=90.0,
+            is_printing=True,
+            moonraker_td1_result=True,
+        )
+        assert obj.td1_present is False
+
+    def test_returns_cached_when_exactly_30s_elapsed(self):
+        """Interval must be *greater than* 30 s; exactly 30 s still returns cached value."""
+        obj = _make_afc_for_td1(td1_present=True, current_time=100.0, last_td1_query=70.0)
+        assert obj.td1_present is True
+
+    def test_returns_cached_when_is_printing(self):
+        """Does not refresh when printer is ready and interval has passed but a print is active."""
+        obj = _make_afc_for_td1(
+            td1_present=False,
+            current_time=100.0,
+            last_td1_query=0.0,
+            is_printing=True,
+            moonraker_td1_result=True,
+        )
+        assert obj.td1_present is False
+
+    # ── moonraker not called paths ────────────────────────────────────────────
+
+    def test_moonraker_not_called_when_printer_not_ready(self):
+        """moonraker.check_for_td1 is never invoked when the printer is not ready."""
+        obj = _make_afc_for_td1(printer_ready=False)
+        _ = obj.td1_present
+        obj.moonraker.check_for_td1.assert_not_called()
+
+    def test_moonraker_not_called_when_interval_too_short(self):
+        """moonraker.check_for_td1 is never invoked when the cooldown has not expired."""
+        obj = _make_afc_for_td1(current_time=100.0, last_td1_query=90.0)
+        _ = obj.td1_present
+        obj.moonraker.check_for_td1.assert_not_called()
+
+    def test_moonraker_not_called_when_is_printing(self):
+        """moonraker.check_for_td1 is never invoked during an active print."""
+        obj = _make_afc_for_td1(current_time=100.0, last_td1_query=0.0, is_printing=True)
+        _ = obj.td1_present
+        obj.moonraker.check_for_td1.assert_not_called()
+
+    # ── refresh paths ─────────────────────────────────────────────────────────
+
+    def test_returns_moonraker_value_when_all_conditions_met(self):
+        """Returns the fresh value from moonraker when printer is ready, interval > 30 s, not printing."""
+        obj = _make_afc_for_td1(
+            td1_present=False,
+            current_time=100.0,
+            last_td1_query=0.0,
+            is_printing=False,
+            moonraker_td1_result=True,
+        )
+        assert obj.td1_present is True
+
+    def test_updates_internal_td1_present_after_refresh(self):
+        """_td1_present is updated to the moonraker result after a successful refresh."""
+        obj = _make_afc_for_td1(
+            td1_present=False,
+            current_time=100.0,
+            last_td1_query=0.0,
+            moonraker_td1_result=True,
+        )
+        _ = obj.td1_present
+        assert obj._td1_present is True
+
+    def test_updates_last_query_time_after_refresh(self):
+        """_last_td1_query is updated to current_time after a successful refresh."""
+        obj = _make_afc_for_td1(current_time=100.0, last_td1_query=0.0)
+        _ = obj.td1_present
+        assert obj._last_td1_query == 100.0
+
+    def test_last_query_time_unchanged_when_not_refreshed(self):
+        """_last_td1_query is not modified when the refresh is skipped (interval too short)."""
+        obj = _make_afc_for_td1(current_time=100.0, last_td1_query=90.0)
+        _ = obj.td1_present
+        assert obj._last_td1_query == 90.0
+
+    def test_moonraker_called_once_per_refresh(self):
+        """moonraker.check_for_td1 is called exactly once when a refresh is due."""
+        obj = _make_afc_for_td1(current_time=100.0, last_td1_query=0.0)
+        _ = obj.td1_present
+        obj.moonraker.check_for_td1.assert_called_once()
+
+    def test_is_printing_called_with_check_movement(self):
+        """is_printing is invoked with check_movement=True when the refresh gate is reached."""
+        obj = _make_afc_for_td1(current_time=100.0, last_td1_query=0.0)
+        _ = obj.td1_present
+        obj.function.is_printing.assert_called_once_with(check_movement=True)
+
+    def test_refresh_stores_false_from_moonraker(self):
+        """A False result from moonraker is correctly stored and returned."""
+        obj = _make_afc_for_td1(
+            td1_present=True,
+            current_time=100.0,
+            last_td1_query=0.0,
+            moonraker_td1_result=False,
+        )
+        assert obj.td1_present is False
+        assert obj._td1_present is False
+
+
 # ── cmd_TOOL_LOAD: lane_loaded guard ─────────────────────────────────────────
 
 class TestCmdToolLoad_LaneLoadedGuard:


### PR DESCRIPTION
## Major Changes in this PR
- Fixes #672 
- Added restoring bed/extruder temps from vars file

## How the changes in this PR are tested
Queries before fix(note time delta):
<img width="1745" height="481" alt="issue_672_before" src="https://github.com/user-attachments/assets/9b66bc4a-e96b-4cac-b51b-d16a36b9f8ac" />

Queries after fix:
<img width="981" height="571" alt="image" src="https://github.com/user-attachments/assets/c7f2106e-58e7-4402-ba03-0ffcf427483f" />

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.