### PR TITLE
(feat): Adding restoring temperature when asynchronously loading standalone toolheads, and fixed unload/load sequence for standalone toolheads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-03-27]
+## Added
+- Restoring previous temperature when asynchronously loading standalone toolheads
+## Fixed
+- Issue where standalone toolheads would cause a homing error when trying to load/unload filament
+- Fixing indention issue found in `prep_callback` method in AFC_lane.py
+
 ## [2026-03-26]
 ### Added
 - Adds support for a new `AFC_SET_SPOOL_TEMP` in order to manually set extruder/bed temps for a lane when not using Spoolman.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2026-03-27]
-## Added
+### Added
 - Restoring previous temperature when asynchronously loading standalone toolheads
-## Fixed
+### Fixed
 - Issue where standalone toolheads would cause a homing error when trying to load/unload filament
-- Fixing indention issue found in `prep_callback` method in AFC_lane.py
+- Fixing indentation issue found in `prep_callback` method in AFC_lane.py
 
 ## [2026-03-26]
 ### Added

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -637,19 +637,21 @@ class afc:
 
         return wait
 
-    def capture_toolhead_temp(self, extruder: AFCExtruder=None, async_capture: bool=False) -> Optional[dict]:
+    def capture_toolhead_temp(self, extruder: Optional[AFCExtruder]=None,
+                              async_capture: bool=False) -> Optional[dict]:
         """
         Helper function to capture current toolhead target temperature when not printing.
 
         :param extruder: Pass in extruder to capture current toolhead temperature for, if no extruder
             is passed in, defaults to current active extruder.
-        :param async_capture: Set to True to capure temp while printing, this is useful for capturing
+        :param async_capture: Set to True to capture temp while printing, this is useful for capturing
             other toolhead hotends on toolchangers.
 
         :return dict with extruder and target_temp, or None if printing or restore_extruder_temp_on_load_or_unload is False
         """
         if not self.restore_extruder_temp_on_load_or_unload:
             return None
+
         if (self.function.is_printing()
             and not async_capture):
             return None
@@ -659,7 +661,7 @@ class afc:
         heater = extruder.get_heater()
         return {"extruder": extruder, "target_temp": heater.target_temp}
 
-    def restore_toolhead_temp(self, temp_state:dict, async_restore: bool=False):
+    def restore_toolhead_temp(self, temp_state:dict, async_restore: bool=False) -> None:
         """
         Helper function to restore toolhead target temperature after load/unload when not printing AND restore_extruder_temp_on_load_or_unload is True
 
@@ -669,8 +671,7 @@ class afc:
         """
         if not self.restore_extruder_temp_on_load_or_unload:
             return
-        if not temp_state:
-            return
+
         if (self.function.is_printing()
             and not async_restore):
             return

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1189,7 +1189,7 @@ class afc:
 
         # TODO: add a check for multi-tools to verify lane is not loaded to toolhead before trying to unload
         if (cur_lane.name != cur_lane.extruder_obj.lane_loaded
-		    and not cur_lane.extruder_obj.no_lanes
+		    and not cur_lane.extruder_obj.is_standalone()
 			and not cur_lane.is_direct_hub()):
             # Setting status as ejecting so if filament is removed and de-activates the prep sensor while
             # extruder motors are still running it does not trigger infinite spool or pause logic
@@ -1211,7 +1211,7 @@ class afc:
             self.spool.set_spoolID(cur_lane, None)
             self.logger.info("LANE {} eject done".format(cur_lane.name))
             cur_lane.unit_obj.lane_not_ready(cur_lane)
-        elif cur_lane.extruder_obj.no_lanes and cur_lane.extruder_obj.lane_loaded:
+        elif cur_lane.extruder_obj.is_standalone() and cur_lane.extruder_obj.lane_loaded:
             cur_lane.status = AFCLaneState.EJECTING
             cur_lane.extruder_obj.load_unload_sequence(cur_lane.extruder_obj.tool_stn_unload*-1)
 
@@ -1893,7 +1893,7 @@ class afc:
                     self.function.log_toolhead_pos("Sensor move after ")
                     # For "standalone" toolheads, break out of the loop since sensor will always
                     # be triggered
-                    if cur_lane.extruder_obj.no_lanes:
+                    if cur_lane.extruder_obj.is_standalone():
                         break
 
             self.afcDeltaTime.log_with_time("Unloaded from toolhead")
@@ -2000,7 +2000,8 @@ class afc:
             cur_lane.unit_obj.lane_tool_unloaded(cur_lane)
             cur_lane.status = AFCLaneState.NONE
 
-            if cur_lane.is_direct_hub():
+            if (cur_lane.is_direct_hub()
+                and not cur_lane.extruder_obj.is_standalone()):
                 while cur_lane.raw_load_state:
                     cur_lane.move_advanced(cur_lane.short_move_dis * -1, SpeedMode.SHORT,
                                            assist_active=AssistActive.YES)

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1891,7 +1891,7 @@ class afc:
                         self.move_e_pos( cur_extruder.tool_stn_unload * -1, cur_extruder.tool_unload_speed, "Sensor move", wait_tool=True)
 
                     self.function.log_toolhead_pos("Sensor move after ")
-                    # For "standalone" toolheads, break out of the loop since sensor will always 
+                    # For "standalone" toolheads, break out of the loop since sensor will always
                     # be triggered
                     if cur_lane.extruder_obj.no_lanes:
                         break

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -637,7 +637,7 @@ class afc:
 
         return wait
 
-    def _capture_toolhead_temp(self):
+    def _capture_toolhead_temp(self, extruder: AFCExtruder=None, async_capture: bool=False) -> Optional[dict]:
         """
         Helper function to capture current toolhead target temperature when not printing.
 
@@ -645,13 +645,16 @@ class afc:
         """
         if not self.restore_extruder_temp_on_load_or_unload:
             return None
-        if self.function.is_printing():
+        if (self.function.is_printing()
+            and not async_capture):
             return None
-        extruder = self.toolhead.get_extruder()
+
+        if extruder is None:
+            extruder = self.toolhead.get_extruder()
         heater = extruder.get_heater()
         return {"extruder": extruder, "target_temp": heater.target_temp}
 
-    def _restore_toolhead_temp(self, temp_state):
+    def _restore_toolhead_temp(self, temp_state:dict, async_restore: bool=False):
         """
         Helper function to restore toolhead target temperature after load/unload when not printing AND restore_extruder_temp_on_load_or_unload is True
 
@@ -661,12 +664,14 @@ class afc:
             return
         if not temp_state:
             return
-        if self.function.is_printing():
+        if (self.function.is_printing()
+            and not async_restore):
             return
+
         try:
             pheaters = self.printer.lookup_object('heaters')
             pheaters.set_temperature(temp_state["extruder"].get_heater(), temp_state["target_temp"], wait=False)
-            self.logger.info("Restoring extruder temperature to {}".format(temp_state["target_temp"]))
+            self.logger.info(f"Restoring extruder temperature to {temp_state['target_temp']} for {temp_state['extruder'].name}")
         except Exception:
             self.logger.debug("Unable to restore extruder temperature", exc_info=True)
 

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1891,6 +1891,10 @@ class afc:
                         self.move_e_pos( cur_extruder.tool_stn_unload * -1, cur_extruder.tool_unload_speed, "Sensor move", wait_tool=True)
 
                     self.function.log_toolhead_pos("Sensor move after ")
+                    # For "standalone" toolheads, break out of the loop since sensor will always 
+                    # be triggered
+                    if cur_lane.extruder_obj.no_lanes:
+                        break
 
             self.afcDeltaTime.log_with_time("Unloaded from toolhead")
 

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -637,9 +637,14 @@ class afc:
 
         return wait
 
-    def _capture_toolhead_temp(self, extruder: AFCExtruder=None, async_capture: bool=False) -> Optional[dict]:
+    def capture_toolhead_temp(self, extruder: AFCExtruder=None, async_capture: bool=False) -> Optional[dict]:
         """
         Helper function to capture current toolhead target temperature when not printing.
+
+        :param extruder: Pass in extruder to capture current toolhead temperature for, if no extruder
+            is passed in, defaults to current active extruder.
+        :param async_capture: Set to True to capure temp while printing, this is useful for capturing
+            other toolhead hotends on toolchangers.
 
         :return dict with extruder and target_temp, or None if printing or restore_extruder_temp_on_load_or_unload is False
         """
@@ -654,11 +659,13 @@ class afc:
         heater = extruder.get_heater()
         return {"extruder": extruder, "target_temp": heater.target_temp}
 
-    def _restore_toolhead_temp(self, temp_state:dict, async_restore: bool=False):
+    def restore_toolhead_temp(self, temp_state:dict, async_restore: bool=False):
         """
         Helper function to restore toolhead target temperature after load/unload when not printing AND restore_extruder_temp_on_load_or_unload is True
 
         :param temp_state: Dictionary containing extruder object and target_temp, or None
+        :param async_restore: Set to True to restore while printing, this is useful for restoring
+            other toolhead hotends on toolchangers.
         """
         if not self.restore_extruder_temp_on_load_or_unload:
             return
@@ -1333,7 +1340,7 @@ class afc:
                 self.save_vars()
                 cur_lane.unit_obj.lane_loading( cur_lane )
 
-                temp_state = self._capture_toolhead_temp()
+                temp_state = self.capture_toolhead_temp()
                 try:
                     # Run the load sequence, which may include custom gcode commands.
                     success = self.load_sequence(cur_lane, cur_hub, cur_extruder)
@@ -1388,7 +1395,7 @@ class afc:
                         self.gcode.run_script_from_command(self.post_load_macro)
                         # TODO: Add afcDeltaTime log
                 finally:
-                    self._restore_toolhead_temp(temp_state)
+                    self.restore_toolhead_temp(temp_state)
 
             else:
                 # Handle errors if the hub is not clear or the lane is not ready for loading.
@@ -1731,14 +1738,14 @@ class afc:
             # Lookup current hub object using the lane's information.
             cur_hub = cur_lane.hub_obj
 
-            temp_state = self._capture_toolhead_temp()
+            temp_state = self.capture_toolhead_temp()
             try:
                 # Run the unload sequence, which may include custom gcode commands.
                 success = self.unload_sequence(cur_lane, cur_hub, cur_extruder)
                 if not success:
                     return success
             finally:
-                self._restore_toolhead_temp(temp_state)
+                self.restore_toolhead_temp(temp_state)
 
             unload_time = self.afcDeltaTime.log_major_delta("Lane {} unload done".format(cur_lane.name if cur_lane is not None else "None"))
             self.afc_stats.average_tool_unload_time.average_time(unload_time)

--- a/extras/AFC_Toolchanger.py
+++ b/extras/AFC_Toolchanger.py
@@ -88,8 +88,8 @@ class AfcToolchanger(afcUnit):
         return True, 0, AFCMoveWarning.NONE
 
     def move_to_load(self, lane: AFCLane, dist: float,
-                     dir: MoveDirection, use_homing=True,
-                     speed_mode:SpeedMode=SpeedMode.LONG
+                     dir: MoveDirection, use_homing: bool=True,
+                     speed_mode: SpeedMode=SpeedMode.LONG
                 ) -> tuple[bool, float|int, AFCMoveWarning]:
         """
         Overriding method from AFC_unit

--- a/extras/AFC_Toolchanger.py
+++ b/extras/AFC_Toolchanger.py
@@ -19,10 +19,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from configfile import ConfigWrapper
     from gcode import GCodeCommand
-    from extras.AFC_lane import (
-        AFCLane, MoveDirection, SpeedMode, AssistActive,
-        AFCHomingPoints
-    )
+    from extras.AFC_lane import AFCLane, MoveDirection, AFCHomingPoints
     from extras.AFC_functions import afcFunction
     from extras.AFC_stepper import AFCExtruderStepper
 
@@ -35,7 +32,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_unit", trace=traceback.form
 try: from extras.AFC import State
 except: raise error(ERROR_STR.format(import_lib="AFC", trace=traceback.format_exc()))
 
-try: from extras.AFC_lane import AFCMoveWarning
+try: from extras.AFC_lane import AFCMoveWarning, SpeedMode, AssistActive
 except: raise error(ERROR_STR.format(import_lib="AFC_lane", trace=traceback.format_exc()))
 
 
@@ -79,9 +76,10 @@ class AfcToolchanger(afcUnit):
             current_extruder.estats.tool_unselected.increase_count()
 
     def move_to_hub(self, lane: AFCLane, dist: float,
-                dir:MoveDirection, use_homing=True,
-                speed_mode=SpeedMode.HUB,
-                assist_active=AssistActive.DYNAMIC) -> tuple[bool, float|int, AFCMoveWarning]:
+                    dir: MoveDirection, use_homing: bool=True,
+                    speed_mode: SpeedMode=SpeedMode.HUB,
+                    assist_active: AssistActive=AssistActive.DYNAMIC
+                ) -> tuple[bool, float|int, AFCMoveWarning]:
         """
         Overriding function from AFC_unit
 
@@ -91,7 +89,8 @@ class AfcToolchanger(afcUnit):
 
     def move_to_load(self, lane: AFCLane, dist: float,
                      dir: MoveDirection, use_homing=True,
-                     speed_mode:SpeedMode=SpeedMode.LONG) -> tuple[bool, float|int, AFCMoveWarning]:
+                     speed_mode:SpeedMode=SpeedMode.LONG
+                ) -> tuple[bool, float|int, AFCMoveWarning]:
         """
         Overriding function from AFC_unit
 
@@ -100,7 +99,8 @@ class AfcToolchanger(afcUnit):
         return True, 0, AFCMoveWarning.NONE
 
     def load_then_home(self, lane: AFCLane|AFCExtruderStepper, distance: float,
-                       assist_active: AssistActive, endstop: AFCHomingPoints) -> tuple[bool, float|int, AFCMoveWarning]:
+                       assist_active: AssistActive, endstop: AFCHomingPoints
+                    ) -> tuple[bool, float|int, AFCMoveWarning]:
         """
         Overriding function from AFC_unit
 

--- a/extras/AFC_Toolchanger.py
+++ b/extras/AFC_Toolchanger.py
@@ -81,7 +81,7 @@ class AfcToolchanger(afcUnit):
                     assist_active: AssistActive=AssistActive.DYNAMIC
                 ) -> tuple[bool, float|int, AFCMoveWarning]:
         """
-        Overriding function from AFC_unit
+        Overriding method from AFC_unit
 
         return: True, 0, AFCMoveWarning.NONE
         """
@@ -92,7 +92,7 @@ class AfcToolchanger(afcUnit):
                      speed_mode:SpeedMode=SpeedMode.LONG
                 ) -> tuple[bool, float|int, AFCMoveWarning]:
         """
-        Overriding function from AFC_unit
+        Overriding method from AFC_unit
 
         return: True, 0, AFCMoveWarning.NONE
         """
@@ -102,7 +102,7 @@ class AfcToolchanger(afcUnit):
                        assist_active: AssistActive, endstop: AFCHomingPoints
                     ) -> tuple[bool, float|int, AFCMoveWarning]:
         """
-        Overriding function from AFC_unit
+        Overriding method from AFC_unit
 
         return: True, 0, AFCMoveWarning.NONE
         """

--- a/extras/AFC_Toolchanger.py
+++ b/extras/AFC_Toolchanger.py
@@ -19,8 +19,12 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from configfile import ConfigWrapper
     from gcode import GCodeCommand
-    from extras.AFC_lane import AFCLane
+    from extras.AFC_lane import (
+        AFCLane, MoveDirection, SpeedMode, AssistActive,
+        AFCHomingPoints
+    )
     from extras.AFC_functions import afcFunction
+    from extras.AFC_stepper import AFCExtruderStepper
 
 try: from extras.AFC_utils import ERROR_STR
 except: raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".format(trace=traceback.format_exc()))
@@ -30,6 +34,10 @@ except: raise error(ERROR_STR.format(import_lib="AFC_unit", trace=traceback.form
 
 try: from extras.AFC import State
 except: raise error(ERROR_STR.format(import_lib="AFC", trace=traceback.format_exc()))
+
+try: from extras.AFC_lane import AFCMoveWarning
+except: raise error(ERROR_STR.format(import_lib="AFC_lane", trace=traceback.format_exc()))
+
 
 class AfcToolchanger(afcUnit):
     def __init__(self, config: ConfigWrapper) -> None:
@@ -69,6 +77,36 @@ class AfcToolchanger(afcUnit):
         current_extruder = self.afc.function.get_current_extruder_obj()
         if current_extruder:
             current_extruder.estats.tool_unselected.increase_count()
+
+    def move_to_hub(self, lane: AFCLane, dist: float,
+                dir:MoveDirection, use_homing=True,
+                speed_mode=SpeedMode.HUB,
+                assist_active=AssistActive.DYNAMIC) -> tuple[bool, float|int, AFCMoveWarning]:
+        """
+        Overriding function from AFC_unit
+
+        return: True, 0, AFCMoveWarning.NONE
+        """
+        return True, 0, AFCMoveWarning.NONE
+
+    def move_to_load(self, lane: AFCLane, dist: float,
+                     dir: MoveDirection, use_homing=True,
+                     speed_mode:SpeedMode=SpeedMode.LONG) -> tuple[bool, float|int, AFCMoveWarning]:
+        """
+        Overriding function from AFC_unit
+
+        return: True, 0, AFCMoveWarning.NONE
+        """
+        return True, 0, AFCMoveWarning.NONE
+
+    def load_then_home(self, lane: AFCLane|AFCExtruderStepper, distance: float,
+                       assist_active: AssistActive, endstop: AFCHomingPoints) -> tuple[bool, float|int, AFCMoveWarning]:
+        """
+        Overriding function from AFC_unit
+
+        return: True, 0, AFCMoveWarning.NONE
+        """
+        return True, 0, AFCMoveWarning.NONE
 
     cmd_AFC_SELECT_TOOL_help = "Select specified tool"
     cmd_AFC_SELECT_TOOL_options = {

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -368,7 +368,6 @@ class AFCExtruder:
                     f"buffer is not valid config for pin_tool_start when using {self.name} as a standalone extruder"
                 )
 
-
     def handle_connect(self):
         """
         Handle the connection event.
@@ -472,7 +471,7 @@ class AFCExtruder:
         :param state: Boolean indicating sensor state (True = filament present, False = runout)
         """
         if state != self.tool_start_state:
-            if self.tc_unit_name and self.no_lanes:
+            if self.tc_unit_name and self.is_standalone():
                 self.tc_lane._load_state = state
                 self.tc_lane.prep_state = state
 
@@ -798,6 +797,9 @@ class AFCExtruder:
             )
         else:
             return False
+
+    def is_standalone(self):
+        return self.no_lanes
 
     cmd_UPDATE_TOOLHEAD_SENSORS_help = "Gives ability to update tool_stn, tool_stn_unload, tool_sensor_after_extruder values without restarting klipper"
     cmd_UPDATE_TOOLHEAD_SENSORS_options = {

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -556,7 +556,7 @@ class AFCExtruder:
         else:
             self.tc_lane.status = AFCLaneState.TOOL_UNLOADING
 
-        self._captured_toolhead_temp = self.afc._capture_toolhead_temp( extruder=self, async_capture=True)
+        self._captured_toolhead_temp = self.afc.capture_toolhead_temp( extruder=self, async_capture=True)
         self.afc._check_extruder_temp(self.tc_lane, no_wait=True)
         self.reactor.update_timer(self.temp_check_timer,
                                 self.reactor.monotonic() +1 )
@@ -624,7 +624,7 @@ class AFCExtruder:
         self.function.do_enable(False, self.name)
         self.load_active = False
 
-        self.afc._restore_toolhead_temp(temp_state=self._captured_toolhead_temp, async_restore=True)
+        self.afc.restore_toolhead_temp(temp_state=self._captured_toolhead_temp, async_restore=True)
         self._captured_toolhead_temp = None
 
         info_str = "loading" if self.current_move_distance > 0 else "unloading"
@@ -799,6 +799,12 @@ class AFCExtruder:
             return False
 
     def is_standalone(self):
+        """
+        Method for returning if extruder is a standalone lane (no unit system attached to it)
+
+        :return bool: Returns True if no unit system is attached to extruder, False if units/lanes
+            are attached.
+        """
         return self.no_lanes
 
     cmd_UPDATE_TOOLHEAD_SENSORS_help = "Gives ability to update tool_stn, tool_stn_unload, tool_sensor_after_extruder values without restarting klipper"

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -240,6 +240,7 @@ class AFCExtruder:
         self.set_status_color_fn        = None
         self.check_transmit_status_fn   = None
         self.status_led_count:int       = 0
+        self._captured_toolhead_temp: dict|None = None
 
         if self.toolhead_status_index:
             self.toolhead_status_index  = self.afc.function._get_led_indexes(self.toolhead_status_index)
@@ -556,6 +557,7 @@ class AFCExtruder:
         else:
             self.tc_lane.status = AFCLaneState.TOOL_UNLOADING
 
+        self._captured_toolhead_temp = self.afc._capture_toolhead_temp( extruder=self, async_capture=True)
         self.afc._check_extruder_temp(self.tc_lane, no_wait=True)
         self.reactor.update_timer(self.temp_check_timer,
                                 self.reactor.monotonic() +1 )
@@ -622,6 +624,10 @@ class AFCExtruder:
 
         self.function.do_enable(False, self.name)
         self.load_active = False
+
+        self.afc._restore_toolhead_temp(temp_state=self._captured_toolhead_temp, async_restore=True)
+        self._captured_toolhead_temp = None
+
         info_str = "loading" if self.current_move_distance > 0 else "unloading"
         self.logger.info(f"{self.name} {info_str} done")
         self.tc_lane.status = AFCLaneState.NONE

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -240,7 +240,7 @@ class AFCExtruder:
         self.set_status_color_fn        = None
         self.check_transmit_status_fn   = None
         self.status_led_count:int       = 0
-        self._captured_toolhead_temp: dict|None = None
+        self._captured_toolhead_temp: Optional[dict] = None
 
         if self.toolhead_status_index:
             self.toolhead_status_index  = self.afc.function._get_led_indexes(self.toolhead_status_index)

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -888,7 +888,7 @@ class afcFunction:
 
         calibration_info = {}
         for lane in calibrate_lanes:
-            if lane.extruder_obj.no_lanes:
+            if lane.extruder_obj.is_standalone():
                 self.logger.info(f"{lane.name} is a standalone lane, skipping calibration")
                 continue
             if not lane.load_state or not lane.prep_state:
@@ -1189,7 +1189,7 @@ class afcFunction:
                 continue
 
             # Filtering out units that only have standalone lanes (toolchanger extruders without assist)
-            if all( lane.extruder_obj.no_lanes for lane in self.afc.units.get(key).lanes.values() ):
+            if all( lane.extruder_obj.is_standalone() for lane in self.afc.units.get(key).lanes.values() ):
                 continue
 
             # Create a button for each unit
@@ -1298,7 +1298,7 @@ class afcFunction:
 
         if (lanes is not None
             and lanes != 'all'
-            and self.afc.lanes.get(lanes).extruder_obj.no_lanes):
+            and self.afc.lanes.get(lanes).extruder_obj.is_standalone()):
             self.afc.error.AFC_error(f"{lanes} is a standalone lane, cannot calibrate", pause=False)
             return
 

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -868,7 +868,7 @@ class AFCLane:
                 self.move_advanced(distance, speed_mode, assist_active )
                 return True, 0, warn
         else:
-            if self.extruder_obj.no_lanes:
+            if self.extruder_obj.is_standalone():
                 return True, 0, AFCMoveWarning.NONE
             else:
                 return False, 0, AFCMoveWarning.ERROR

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -868,7 +868,10 @@ class AFCLane:
                 self.move_advanced(distance, speed_mode, assist_active )
                 return True, 0, warn
         else:
-            return False, 0, AFCMoveWarning.ERROR
+            if self.extruder_obj.no_lanes:
+                return True, 0, AFCMoveWarning.NONE
+            else:
+                return False, 0, AFCMoveWarning.ERROR
 
 
     def move_advanced(self, distance, speed_mode: SpeedMode, assist_active: AssistActive = AssistActive.NO):

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -1108,38 +1108,38 @@ class AFCLane:
                         self.status = AFCLaneState.NONE
                         self.logger.debug(f"Prep: Load Done-{self.name}")
 
-                    # Verify that load state is still true as this would still trigger if prep sensor was triggered and then filament was removed
-                    #   This is only really a issue when using direct_load and still using load sensor
-                    if self.hub == 'direct_load' and self.prep_state:
-                        self.logger.debug(f"Prep: direct load logic-{self.name}-{self.hub}")
-                        self.afc.TOOL_LOAD(self)
-                        self.afc.spool._set_values(self)
-                        self.logger.debug(f"Prep: direct load logic done-{self.name}-{self.hub}")
-                        break
+                        # Verify that load state is still true as this would still trigger if prep sensor was triggered and then filament was removed
+                        #   This is only really a issue when using direct_load and still using load sensor
+                        if self.hub == 'direct_load' and self.prep_state:
+                            self.logger.debug(f"Prep: direct load logic-{self.name}-{self.hub}")
+                            self.afc.TOOL_LOAD(self)
+                            self.afc.spool._set_values(self)
+                            self.logger.debug(f"Prep: direct load logic done-{self.name}-{self.hub}")
+                            break
 
-                    self.unit_obj.prep_post_load(self)
+                        self.unit_obj.prep_post_load(self)
 
-                    self.do_enable(False)
-                    if (self.load_state
-                        and self.prep_state):
-                        self.set_loaded()
-                        self._post_prep_user_macro()
-                        # Check if user wants to get TD-1 data when loading
-                        # TODO: When implementing multi-extruder this could still happen if a lane is loaded for a
-                        # different extruder/hub
-                        if self.td1_device_id:
-                            self._prep_capture_td1()
+                        self.do_enable(False)
+                        if (self.load_state
+                            and self.prep_state):
+                            self.set_loaded()
+                            self._post_prep_user_macro()
+                            # Check if user wants to get TD-1 data when loading
+                            # TODO: When implementing multi-extruder this could still happen if a lane is loaded for a
+                            # different extruder/hub
+                            if self.td1_device_id:
+                                self._prep_capture_td1()
 
-                elif (self.prep_state == True
-                      and self.raw_load_state == True
-                      and not self.afc.function.is_printing()):
-                    message = 'Cannot load {} load sensor is triggered.'.format(self.name)
-                    message += '\n    Make sure filament is not stuck in load sensor or check to make sure load sensor is not stuck triggered.'
-                    if self.unit_obj.type == "ViViD":
-                        message += f'\n    If filament is not stuck in sensor run AFC_RECOVER_LANE LANE={self.name}'
-                        message += " to reset internal AFC state."
-                    message += '\n    Once cleared try loading again'
-                    self.afc.error.AFC_error(message, pause=False)
+                    elif (self.prep_state == True
+                        and self.raw_load_state == True
+                        and not self.afc.function.is_printing()):
+                        message = 'Cannot load {} load sensor is triggered.'.format(self.name)
+                        message += '\n    Make sure filament is not stuck in load sensor or check to make sure load sensor is not stuck triggered.'
+                        if self.unit_obj.type == "ViViD":
+                            message += f'\n    If filament is not stuck in sensor run AFC_RECOVER_LANE LANE={self.name}'
+                            message += " to reset internal AFC state."
+                        message += '\n    Once cleared try loading again'
+                        self.afc.error.AFC_error(message, pause=False)
         self.prep_active = False
         self.afc.save_vars()
 

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -753,9 +753,10 @@ class afcUnit:
         self._print_function_not_defined(self.eject_lane.__name__)
 
     def move_to_hub(self, lane: AFCLane, dist: float,
-                    dir:MoveDirection, use_homing=True,
-                    speed_mode=SpeedMode.HUB,
-                    assist_active=AssistActive.DYNAMIC) -> tuple[bool, float|int, AFCMoveWarning]:
+                    dir: MoveDirection, use_homing: bool=True,
+                    speed_mode: SpeedMode=SpeedMode.HUB,
+                    assist_active: AssistActive=AssistActive.DYNAMIC
+                ) -> tuple[bool, float|int, AFCMoveWarning]:
         """
         Helper method to move filament to hub sensor, calls lanes move_to method with HUB as trigger
         point when homing is enabled.
@@ -783,8 +784,9 @@ class afcUnit:
                             endstop=lane.hub_endstop_name, use_homing=use_homing)
 
     def move_to_load(self, lane: AFCLane, dist: float,
-                     dir: MoveDirection, use_homing=True,
-                     speed_mode:SpeedMode=SpeedMode.LONG) -> tuple[bool, float|int, AFCMoveWarning]:
+                     dir: MoveDirection, use_homing: bool=True,
+                     speed_mode: SpeedMode=SpeedMode.LONG
+                ) -> tuple[bool, float|int, AFCMoveWarning]:
         """
         Helper method to move filament to load sensor, calls lane's move_to method with the load
         sensor endpoint (lane.load_es) as trigger point when homing is enabled.
@@ -813,7 +815,8 @@ class afcUnit:
                             assist_active=AssistActive.DYNAMIC, use_homing=use_homing)
 
     def load_then_home(self, lane: AFCLane|AFCExtruderStepper, distance: float,
-                       assist_active: AssistActive, endstop: AFCHomingPoints) -> tuple[bool, float|int, AFCMoveWarning]:
+                       assist_active: AssistActive, endstop: AFCHomingPoints
+                    ) -> tuple[bool, float|int, AFCMoveWarning]:
         """
         Helper method to move filament to toolhead. If load_then_home boolean is set, AFC will do
         a normal move without homing enabled for a distance of: distance - load_undershoot.

--- a/extras/AFC_vivid.py
+++ b/extras/AFC_vivid.py
@@ -290,9 +290,11 @@ class AFC_vivid(afcBoxTurtle):
         self.selector_stepper_obj.do_enable(False)
         self.drive_stepper_obj.do_enable(False)
 
-    def move_to_hub(self, lane: AFCLane, dist: float, dir:MoveDirection, use_homing=True,
-                    speed_mode=SpeedMode.HUB, assist_active=AssistActive.DYNAMIC
-                    ) -> tuple[bool, float|int, AFCMoveWarning]:
+    def move_to_hub(self, lane: AFCLane, dist: float,
+                    dir: MoveDirection, use_homing: bool=True,
+                    speed_mode: SpeedMode=SpeedMode.HUB,
+                    assist_active: AssistActive=AssistActive.DYNAMIC
+                ) -> tuple[bool, float|int, AFCMoveWarning]:
         """
         Helper method for calling lanes move_to method and passing in lanes load endstop as trigger
         point when homing is enabled.

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -1132,3 +1132,246 @@ class TestCmdToolLoad_LaneLoadedGuard:
 
         obj.error.AFC_error.assert_not_called()
         obj.TOOL_LOAD.assert_called_once_with(lane, None)
+
+
+# ── capture_toolhead_temp ─────────────────────────────────────────────────────
+
+def _make_afc_for_capture_restore(
+    *,
+    restore_enabled: bool = True,
+    is_printing: bool = False,
+    target_temp: float = 200.0,
+):
+    """
+    Build an afc instance pre-configured for capture_toolhead_temp /
+    restore_toolhead_temp tests.
+
+    Parameters
+    ----------
+    restore_enabled : value of restore_extruder_temp_on_load_or_unload
+    is_printing     : return value of function.is_printing()
+    target_temp     : heater.target_temp on the mock extruder
+    """
+    obj = _make_afc()
+    obj.restore_extruder_temp_on_load_or_unload = restore_enabled
+    obj.function.is_printing = MagicMock(return_value=is_printing)
+    obj.logger = MagicMock()
+
+    # Build a mock extruder with a heater whose target_temp is controllable
+    mock_heater = MagicMock()
+    mock_heater.target_temp = target_temp
+
+    mock_extruder = MagicMock()
+    mock_extruder.name = "extruder"
+    mock_extruder.get_heater.return_value = mock_heater
+
+    # toolhead.get_extruder() returns the same mock extruder by default
+    mock_toolhead = MagicMock()
+    mock_toolhead.get_extruder.return_value = mock_extruder
+    obj.toolhead = mock_toolhead
+
+    # printer.lookup_object('heaters') returns a mock pheaters
+    mock_pheaters = MagicMock()
+    obj.printer.lookup_object = MagicMock(return_value=mock_pheaters)
+
+    return obj, mock_extruder, mock_heater, mock_pheaters
+
+
+class TestCaptureToolheadTemp:
+    """Tests for afc.capture_toolhead_temp."""
+
+    # ── early-return paths ────────────────────────────────────────────────────
+
+    def test_returns_none_when_restore_disabled(self):
+        """Returns None immediately when restore_extruder_temp_on_load_or_unload is False."""
+        obj, extruder, heater, _ = _make_afc_for_capture_restore(restore_enabled=False)
+        assert obj.capture_toolhead_temp() is None
+
+    def test_returns_none_when_printing_and_not_async(self):
+        """Returns None when is_printing() is True and async_capture is False (default)."""
+        obj, extruder, heater, _ = _make_afc_for_capture_restore(is_printing=True)
+        assert obj.capture_toolhead_temp() is None
+
+    def test_returns_none_when_printing_explicit_async_false(self):
+        """Returns None when printing and async_capture is explicitly False."""
+        obj, extruder, heater, _ = _make_afc_for_capture_restore(is_printing=True)
+        assert obj.capture_toolhead_temp(async_capture=False) is None
+
+    # ── successful capture paths ──────────────────────────────────────────────
+
+    def test_returns_dict_when_not_printing(self):
+        """Returns a dict (not None) when the printer is idle."""
+        obj, extruder, heater, _ = _make_afc_for_capture_restore(is_printing=False)
+        result = obj.capture_toolhead_temp()
+        assert result is not None
+
+    def test_returns_dict_when_printing_and_async_capture(self):
+        """Returns a dict when printing but async_capture=True bypasses the guard."""
+        obj, extruder, heater, _ = _make_afc_for_capture_restore(is_printing=True)
+        result = obj.capture_toolhead_temp(async_capture=True)
+        assert result is not None
+
+    def test_returned_dict_has_extruder_key(self):
+        """The returned dict contains the 'extruder' key."""
+        obj, extruder, heater, _ = _make_afc_for_capture_restore()
+        result = obj.capture_toolhead_temp()
+        assert "extruder" in result
+
+    def test_returned_dict_has_target_temp_key(self):
+        """The returned dict contains the 'target_temp' key."""
+        obj, extruder, heater, _ = _make_afc_for_capture_restore()
+        result = obj.capture_toolhead_temp()
+        assert "target_temp" in result
+
+    def test_target_temp_matches_heater(self):
+        """target_temp in the returned dict equals heater.target_temp."""
+        obj, extruder, heater, _ = _make_afc_for_capture_restore(target_temp=215.0)
+        result = obj.capture_toolhead_temp()
+        assert result["target_temp"] == 215.0
+
+    def test_uses_toolhead_extruder_when_none_passed(self):
+        """When no extruder is passed, uses toolhead.get_extruder()."""
+        obj, extruder, heater, _ = _make_afc_for_capture_restore()
+        result = obj.capture_toolhead_temp()
+        obj.toolhead.get_extruder.assert_called_once()
+        assert result["extruder"] is extruder
+
+    def test_uses_passed_extruder_over_toolhead(self):
+        """When an extruder is passed explicitly, it is used instead of toolhead.get_extruder()."""
+        obj, _, _, _ = _make_afc_for_capture_restore()
+
+        custom_heater = MagicMock()
+        custom_heater.target_temp = 240.0
+        custom_extruder = MagicMock()
+        custom_extruder.get_heater.return_value = custom_heater
+
+        result = obj.capture_toolhead_temp(extruder=custom_extruder)
+
+        obj.toolhead.get_extruder.assert_not_called()
+        assert result["extruder"] is custom_extruder
+        assert result["target_temp"] == 240.0
+
+    def test_restore_disabled_skips_is_printing_check(self):
+        """When restore is disabled, is_printing is never consulted."""
+        obj, _, _, _ = _make_afc_for_capture_restore(restore_enabled=False)
+        obj.capture_toolhead_temp()
+        obj.function.is_printing.assert_not_called()
+
+
+# ── restore_toolhead_temp ─────────────────────────────────────────────────────
+
+class TestRestoreToolheadTemp:
+    """Tests for afc.restore_toolhead_temp."""
+
+    def _make_valid_temp_state(self, target_temp: float = 200.0):
+        """Return a minimal temp_state dict with a mock extruder."""
+        mock_heater = MagicMock()
+        mock_extruder = MagicMock()
+        mock_extruder.name = "extruder"
+        mock_extruder.get_heater.return_value = mock_heater
+        return {"extruder": mock_extruder, "target_temp": target_temp}
+
+    # ── early-return paths ────────────────────────────────────────────────────
+
+    def test_returns_early_when_restore_disabled(self):
+        """Does nothing when restore_extruder_temp_on_load_or_unload is False."""
+        obj, _, _, pheaters = _make_afc_for_capture_restore(restore_enabled=False)
+        temp_state = self._make_valid_temp_state()
+        obj.restore_toolhead_temp(temp_state)
+        pheaters.set_temperature.assert_not_called()
+
+    def test_returns_early_when_temp_state_is_none(self):
+        """Does nothing when temp_state is None."""
+        obj, _, _, pheaters = _make_afc_for_capture_restore()
+        obj.restore_toolhead_temp(None)
+        pheaters.set_temperature.assert_not_called()
+
+    def test_returns_early_when_temp_state_is_empty_dict(self):
+        """Does nothing when temp_state is an empty dict (falsy)."""
+        obj, _, _, pheaters = _make_afc_for_capture_restore()
+        obj.restore_toolhead_temp({})
+        pheaters.set_temperature.assert_not_called()
+
+    def test_returns_early_when_printing_and_not_async(self):
+        """Does nothing when is_printing() is True and async_restore is False (default)."""
+        obj, _, _, pheaters = _make_afc_for_capture_restore(is_printing=True)
+        temp_state = self._make_valid_temp_state()
+        obj.restore_toolhead_temp(temp_state)
+        pheaters.set_temperature.assert_not_called()
+
+    def test_returns_early_when_printing_explicit_async_false(self):
+        """Does nothing when printing and async_restore is explicitly False."""
+        obj, _, _, pheaters = _make_afc_for_capture_restore(is_printing=True)
+        temp_state = self._make_valid_temp_state()
+        obj.restore_toolhead_temp(temp_state, async_restore=False)
+        pheaters.set_temperature.assert_not_called()
+
+    # ── successful restore paths ──────────────────────────────────────────────
+
+    def test_calls_set_temperature_when_not_printing(self):
+        """Calls pheaters.set_temperature when all conditions allow a restore."""
+        obj, _, _, pheaters = _make_afc_for_capture_restore(is_printing=False)
+        temp_state = self._make_valid_temp_state(target_temp=210.0)
+        obj.restore_toolhead_temp(temp_state)
+        pheaters.set_temperature.assert_called_once()
+
+    def test_restores_correct_temperature(self):
+        """set_temperature is called with the target_temp from temp_state."""
+        obj, _, _, pheaters = _make_afc_for_capture_restore()
+        temp_state = self._make_valid_temp_state(target_temp=225.0)
+        obj.restore_toolhead_temp(temp_state)
+        _, call_kwargs = pheaters.set_temperature.call_args
+        assert call_kwargs.get("wait") is False
+        positional = pheaters.set_temperature.call_args.args
+        assert positional[1] == 225.0
+
+    def test_restores_using_extruder_heater(self):
+        """set_temperature receives the heater obtained from temp_state['extruder']."""
+        obj, _, _, pheaters = _make_afc_for_capture_restore()
+        temp_state = self._make_valid_temp_state()
+        mock_heater = temp_state["extruder"].get_heater()
+        obj.restore_toolhead_temp(temp_state)
+        positional = pheaters.set_temperature.call_args.args
+        assert positional[0] is mock_heater
+
+    def test_restores_when_printing_and_async_restore(self):
+        """Restores temperature when printing but async_restore=True bypasses the guard."""
+        obj, _, _, pheaters = _make_afc_for_capture_restore(is_printing=True)
+        temp_state = self._make_valid_temp_state()
+        obj.restore_toolhead_temp(temp_state, async_restore=True)
+        pheaters.set_temperature.assert_called_once()
+
+    def test_logs_info_after_restore(self):
+        """logger.info is called with extruder name and target temp after a successful restore."""
+        obj, _, _, _ = _make_afc_for_capture_restore()
+        temp_state = self._make_valid_temp_state(target_temp=200.0)
+        obj.restore_toolhead_temp(temp_state)
+        obj.logger.info.assert_called_once()
+        log_msg = obj.logger.info.call_args.args[0]
+        assert "extruder" in log_msg
+        assert "200" in log_msg
+
+    def test_restore_disabled_skips_is_printing_check(self):
+        """When restore is disabled, is_printing is never consulted."""
+        obj, _, _, _ = _make_afc_for_capture_restore(restore_enabled=False)
+        temp_state = self._make_valid_temp_state()
+        obj.restore_toolhead_temp(temp_state)
+        obj.function.is_printing.assert_not_called()
+
+    # ── exception handling ────────────────────────────────────────────────────
+
+    def test_logs_debug_on_exception(self):
+        """If set_temperature raises, logger.debug is called and no exception propagates."""
+        obj, _, _, pheaters = _make_afc_for_capture_restore()
+        pheaters.set_temperature.side_effect = RuntimeError("heater fault")
+        temp_state = self._make_valid_temp_state()
+        obj.restore_toolhead_temp(temp_state)   # must not raise
+        obj.logger.debug.assert_called_once()
+
+    def test_no_exception_propagated_on_lookup_failure(self):
+        """If printer.lookup_object raises, the exception is swallowed."""
+        obj, _, _, _ = _make_afc_for_capture_restore()
+        obj.printer.lookup_object.side_effect = KeyError("heaters")
+        temp_state = self._make_valid_temp_state()
+        obj.restore_toolhead_temp(temp_state)   # must not raise
+        obj.logger.debug.assert_called_once()

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -100,6 +100,7 @@ def _make_afc():
     obj.position_saved = False
     obj.spoolman = None
     obj._td1_present = False
+    obj._last_td1_query = 0.0
     obj.lane_data_enabled = False
     obj.units = {}
     obj.lanes = {}

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -668,11 +668,23 @@ class TestMoveTo:
         lane = _make_afc_lane()
         lane.drive_stepper = None
         lane.extruder_stepper = None
+        lane.extruder_obj.is_standalone.return_value=False
         homed, dist, warn = lane.move_to(100, SpeedMode.SHORT, AFCHomingPoints.BUFFER,
                                           False, False)
         assert homed == False
         assert dist == 0
         assert warn == AFCMoveWarning.ERROR
+    
+    def test_no_drive_stepper_no_extruder_stepper_standalone_extruder(self):
+        lane = _make_afc_lane()
+        lane.drive_stepper = None
+        lane.extruder_stepper = None
+        lane.extruder_obj.is_standalone.return_value=True
+        homed, dist, warn = lane.move_to(100, SpeedMode.SHORT, AFCHomingPoints.BUFFER,
+                                          False, False)
+        assert homed == True
+        assert dist == 0
+        assert warn == AFCMoveWarning.NONE
     
     def test_drive_stepper_no_extruder_stepper_no_homing(self):
         lane = _make_afc_lane()


### PR DESCRIPTION
## Major Changes in this PR
- Added restoring previous temperature when asynchronously loading standalone toolheads
- Fixed issue where standalone toolheads would cause a homing error when trying to load/unload filament
- Fixing indention issue found in `prep_callback` method in AFC_lane.py

## How the changes in this PR are tested
Tested in 2.4 toolchanger, output from setting temperature back:
<img width="773" height="125" alt="image" src="https://github.com/user-attachments/assets/24a5f7b5-e533-418f-a7d0-eda3c82bf733" />

Successfully loading and unloading extruder3 which is a standalone toolhead:
<img width="850" height="465" alt="image" src="https://github.com/user-attachments/assets/efd1dafb-262b-43e3-a82a-598db1adf2ce" />

<img width="1002" height="225" alt="image" src="https://github.com/user-attachments/assets/ed6ab8cf-54f3-480c-ade3-3b83a160b7a6" />

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.