### PR TITLE
(feat): Implement safe copy function to prevent overwriting existing …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-03-30]
+### Fixed
+- Updated the `install-afc.sh` script to implement a `safe_copy` feature to prevent accidental overwriting of existing configuration files in 
+  certain circumstances.
+- Fixed an issue where using a custom unit name when installing would not properly update the unit name for buffer configurations.
+
 ## [2026-03-27]
 ### Added
 - Toolchanger: Restoring previous temperature when asynchronously loading standalone toolheads

--- a/include/buffer_configurations.sh
+++ b/include/buffer_configurations.sh
@@ -59,7 +59,7 @@ EOF
 
   # Add [include mcu/TurtleNeckv2.cfg] to AFC_Hardware.cfg if buffer_type is TurtleNeckV2 and not already present
   if [ "$buffer_type" == "TurtleNeckV2" ]; then
-    cp "${afc_path}/config/mcu/TurtleNeckv2.cfg" "$afc_config_dir/mcu/"
+    safe_copy "${afc_path}/config/mcu/TurtleNeckv2.cfg" "$afc_config_dir/mcu/"
     if ! grep -qF "[include mcu/TurtleNeckv2.cfg]" "$afc_config_dir/AFC_Hardware.cfg"; then
       echo -e "\n[include mcu/TurtleNeckv2.cfg]" >> "$afc_config_dir/AFC_Hardware.cfg"
     fi

--- a/include/buffer_configurations.sh
+++ b/include/buffer_configurations.sh
@@ -11,22 +11,23 @@ append_buffer_config() {
   local buffer_name=""
   tn_advance_pin=$2
   tn_trailing_pin=$3
+  local unit_name="${4:-Turtle_1}"
 
   case "$buffer_type" in
     "TurtleNeck")
       buffer_config=$(cat <<EOF
-[AFC_buffer Turtle_1]
+[AFC_buffer ${unit_name}]
 advance_pin: ${tn_advance_pin}    # set advance pin
 trailing_pin: ${tn_trailing_pin}  # set trailing pin
 multiplier_high: 1.05   # default 1.05, factor to feed more filament
 multiplier_low:  0.95   # default 0.95, factor to feed less filament
 EOF
 )
-      buffer_name="Turtle_1"
+      buffer_name="${unit_name}"
       ;;
     "TurtleNeckV2")
-      buffer_config=$(cat <<'EOF'
-[AFC_buffer Turtle_1]
+      buffer_config=$(cat <<EOF
+[AFC_buffer ${unit_name}]
 advance_pin: !turtleneck:ADVANCE
 trailing_pin: !turtleneck:TRAILING
 multiplier_high: 1.05   # default 1.05, factor to feed more filament
@@ -43,7 +44,7 @@ initial_BLUE: 0.0
 initial_WHITE: 0.0
 EOF
 )
-      buffer_name="Turtle_1"
+      buffer_name="${unit_name}"
       ;;
     *)
       echo "Invalid BUFFER_SYSTEM: $buffer_type"
@@ -73,7 +74,8 @@ add_buffer_to_extruder() {
   #   $2: buffer_name - The name of the buffer to be added.
   local file_path="$1"
   local buffer_name="$2"
-  local section="[AFC_BoxTurtle Turtle_1]"
+  local unit_name="${3:-Turtle_1}"
+  local section="[AFC_BoxTurtle $unit_name]"
   local buffer_line="buffer: $buffer_name"
 
   awk -v section="$section" -v buffer="$buffer_line" '
@@ -101,15 +103,16 @@ query_tn_pins() {
   # Arguments:
   #   $1: buffer_name - The name of the buffer to be added.
   local buffer_name="$1"
+  local unit_name="${2:-Turtle_1}"
   local input
-  tn_advance_pin="^Turtle_1:TN_ADV"
-  tn_trailing_pin="^Turtle_1:TN_TRL"
+  tn_advance_pin="^${unit_name}:TN_ADV"
+  tn_trailing_pin="^${unit_name}:TN_TRL"
 
   print_msg INFO "\nPlease enter the pin numbers for the TurtleNeck buffer '$buffer_name':"
   print_msg INFO "(Leave blank to use the default values)"
   print_msg INFO "Ensure you use a pull-up '^' if you are using a AFC end stop pin."
-  print_msg INFO "(Default: ^Turtle_1:TN_ADV)"
-  print_msg INFO "(Default: ^Turtle_1:TN_TRL)"
+  print_msg INFO "(Default: ^${unit_name}:TN_ADV)"
+  print_msg INFO "(Default: ^${unit_name}:TN_TRL)"
 
   read -p "  Enter the advance pin (default: $tn_advance_pin): " -r input
   if [ -n "$input" ]; then

--- a/include/install_functions.sh
+++ b/include/install_functions.sh
@@ -186,12 +186,12 @@ install_afc() {
       find "$afc_config_dir" -type f -exec sed -i "s/Turtle_1/$boxturtle_name/g" {} +
     fi
     if [ "$buffer_type" == "TurtleNeck" ]; then
-      query_tn_pins "TN"
-      append_buffer_config "TurtleNeck" "$tn_advance_pin" "$tn_trailing_pin"
-      add_buffer_to_extruder "${afc_config_dir}/AFC_${boxturtle_name}.cfg" "${boxturtle_name}"
+      query_tn_pins "TN" "$boxturtle_name"
+      append_buffer_config "TurtleNeck" "$tn_advance_pin" "$tn_trailing_pin" "$boxturtle_name"
+      add_buffer_to_extruder "${afc_config_dir}/AFC_${boxturtle_name}.cfg" "${boxturtle_name}" "${boxturtle_name}"
     elif [ "$buffer_type" == "TurtleNeckV2" ]; then
-      append_buffer_config "TurtleNeckV2"
-      add_buffer_to_extruder "${afc_config_dir}/AFC_${boxturtle_name}.cfg" "${boxturtle_name}"
+      append_buffer_config "TurtleNeckV2" "" "" "$boxturtle_name"
+      add_buffer_to_extruder "${afc_config_dir}/AFC_${boxturtle_name}.cfg" "${boxturtle_name}" "${boxturtle_name}"
     fi
   fi
   check_and_append_prep "${afc_config_dir}/AFC.cfg"

--- a/include/install_functions.sh
+++ b/include/install_functions.sh
@@ -70,69 +70,69 @@ template_unit_files() {
 copy_unit_files() {
   case "$installation_type" in
   "ViViD")
-    cp "${afc_path}/templates/AFC_Vivid_1.cfg" "${afc_config_dir}/AFC_Vivid_1.cfg"
-    cp "${afc_path}/templates/AFC_Hardware-AFC.cfg" "${afc_config_dir}/AFC_Hardware.cfg"
-    cp "${afc_path}/config/mcu/Vivid.cfg" "${afc_config_dir}/mcu/Vivid_1.cfg"
+    safe_copy "${afc_path}/templates/AFC_Vivid_1.cfg" "${afc_config_dir}/AFC_Vivid_1.cfg"
+    safe_copy "${afc_path}/templates/AFC_Hardware-AFC.cfg" "${afc_config_dir}/AFC_Hardware.cfg"
+    safe_copy "${afc_path}/config/mcu/Vivid.cfg" "${afc_config_dir}/mcu/Vivid_1.cfg"
     ;;
   "BoxTurtle (4-Lane)")
-    cp "${afc_path}/config/mcu/AFC_Lite.cfg" "${afc_config_dir}/mcu/AFC_Lite.cfg"
-    cp "${afc_path}/templates/AFC_Hardware-AFC.cfg" "${afc_config_dir}/AFC_Hardware.cfg"
-    cp "${afc_path}/templates/AFC_Turtle_1.cfg" "${afc_config_dir}/AFC_${boxturtle_name}.cfg"
+    safe_copy "${afc_path}/config/mcu/AFC_Lite.cfg" "${afc_config_dir}/mcu/AFC_Lite.cfg"
+    safe_copy "${afc_path}/templates/AFC_Hardware-AFC.cfg" "${afc_config_dir}/AFC_Hardware.cfg"
+    safe_copy "${afc_path}/templates/AFC_Turtle_1.cfg" "${afc_config_dir}/AFC_${boxturtle_name}.cfg"
     ;;
 
   "BoxTurtle (8-Lane)")
-    cp "${afc_path}/config/mcu/AFC_Pro.cfg" "${afc_config_dir}/mcu/AFC_Pro.cfg"
-    cp "${afc_path}/templates/AFC_Hardware-AFC.cfg" "${afc_config_dir}/AFC_Hardware.cfg"
-    cp "${afc_path}/templates/AFC_Pro_Turtle_1.cfg" "${afc_config_dir}/AFC_${boxturtle_name}.cfg"
+    safe_copy "${afc_path}/config/mcu/AFC_Pro.cfg" "${afc_config_dir}/mcu/AFC_Pro.cfg"
+    safe_copy "${afc_path}/templates/AFC_Hardware-AFC.cfg" "${afc_config_dir}/AFC_Hardware.cfg"
+    safe_copy "${afc_path}/templates/AFC_Pro_Turtle_1.cfg" "${afc_config_dir}/AFC_${boxturtle_name}.cfg"
     ;;
 
   "NightOwl")
-    cp "${afc_path}/config/mcu/ERB_2.0.cfg" "${afc_config_dir}/mcu/ERB_2.0.cfg"
-    cp "${afc_path}/templates/AFC_Hardware-NightOwl.cfg" "${afc_config_dir}/AFC_Hardware.cfg"
-    cp "${afc_path}/templates/AFC_NightOwl_1.cfg" "${afc_config_dir}/AFC_NightOwl_1.cfg"
+    safe_copy "${afc_path}/config/mcu/ERB_2.0.cfg" "${afc_config_dir}/mcu/ERB_2.0.cfg"
+    safe_copy "${afc_path}/templates/AFC_Hardware-NightOwl.cfg" "${afc_config_dir}/AFC_Hardware.cfg"
+    safe_copy "${afc_path}/templates/AFC_NightOwl_1.cfg" "${afc_config_dir}/AFC_NightOwl_1.cfg"
     ;;
 
   "HTLF")
     local board_type="$htlf_board_type"
-    cp "${afc_path}/config/mcu/HTLF_${board_type}.cfg" "${afc_config_dir}/mcu/"
+    safe_copy "${afc_path}/config/mcu/HTLF_${board_type}.cfg" "${afc_config_dir}/mcu/"
     [[ "$board_type" == "MMB_1.0" || "$board_type" == "MMB_1.1" ]] && board_type="MMB"
-    cp "${afc_path}/templates/AFC_HTLF_1-${board_type}.cfg" "${afc_config_dir}/AFC_${board_type}_${boxturtle_name}.cfg"
-    cp "${afc_path}/templates/AFC_Hardware-HTLF.cfg" "${afc_config_dir}/AFC_Hardware.cfg"
+    safe_copy "${afc_path}/templates/AFC_HTLF_1-${board_type}.cfg" "${afc_config_dir}/AFC_${board_type}_${boxturtle_name}.cfg"
+    safe_copy "${afc_path}/templates/AFC_Hardware-HTLF.cfg" "${afc_config_dir}/AFC_Hardware.cfg"
     ;;
 
   "QuattroBox")
-    cp "${afc_path}/templates/AFC_Hardware-QuattroBox.cfg" "${afc_config_dir}/AFC_Hardware.cfg"
-    cp "${afc_path}/templates/qb_macros/Eject_buttons.cfg" "${afc_config_dir}/macros/Eject_buttons.cfg"
+    safe_copy "${afc_path}/templates/AFC_Hardware-QuattroBox.cfg" "${afc_config_dir}/AFC_Hardware.cfg"
+    safe_copy "${afc_path}/templates/qb_macros/Eject_buttons.cfg" "${afc_config_dir}/macros/Eject_buttons.cfg"
     if [ "${qb_motor_type}" == "NEMA_14" ]; then
-      cp "${afc_path}/templates/AFC_QuattroBox_14.cfg" "${afc_config_dir}/AFC_QuattroBox_1.cfg"
+      safe_copy "${afc_path}/templates/AFC_QuattroBox_14.cfg" "${afc_config_dir}/AFC_QuattroBox_1.cfg"
       if [ "${qb_board_type}" == "MMB_1.0" ]; then
-        cp "${afc_path}/config/mcu/MMB_1.0_QB.cfg" "${afc_config_dir}/mcu/"
+        safe_copy "${afc_path}/config/mcu/MMB_1.0_QB.cfg" "${afc_config_dir}/mcu/"
         sed -i "s/include mcu\/MMB_QB.cfg/include mcu\/MMB_1.0_QB.cfg/g" "${afc_config_dir}/AFC_QuattroBox_1.cfg"
       elif [ "${qb_board_type}" == "MMB_1.1" ]; then
-        cp "${afc_path}/config/mcu/MMB_1.1_QB.cfg" "${afc_config_dir}/mcu/"
+        safe_copy "${afc_path}/config/mcu/MMB_1.1_QB.cfg" "${afc_config_dir}/mcu/"
         sed -i "s/include mcu\/MMB_QB.cfg/include mcu\/MMB_1.1_QB.cfg/g" "${afc_config_dir}/AFC_QuattroBox_1.cfg"
       elif [ "${qb_board_type}" == "MMB_2.0" ]; then
-        cp "${afc_path}/config/mcu/MMB_2.0_QB.cfg" "${afc_config_dir}/mcu/"
+        safe_copy "${afc_path}/config/mcu/MMB_2.0_QB.cfg" "${afc_config_dir}/mcu/"
         sed -i "s/include mcu\/MMB_QB.cfg/include mcu\/MMB_2.0_QB.cfg/g" "${afc_config_dir}/AFC_QuattroBox_1.cfg"
       fi
     elif [ "${qb_motor_type}" == "NEMA_17" ]; then
-      cp "${afc_path}/templates/AFC_QuattroBox_17.cfg" "${afc_config_dir}/AFC_QuattroBox_1.cfg"
+      safe_copy "${afc_path}/templates/AFC_QuattroBox_17.cfg" "${afc_config_dir}/AFC_QuattroBox_1.cfg"
       if [ "${qb_board_type}" == "MMB_1.0" ]; then
-        cp "${afc_path}/config/mcu/MMB_1.0_QB.cfg" "${afc_config_dir}/mcu/"
+        safe_copy "${afc_path}/config/mcu/MMB_1.0_QB.cfg" "${afc_config_dir}/mcu/"
         sed -i "s/include mcu\/MMB_QB.cfg/include mcu\/MMB_1.0_QB.cfg/g" "${afc_config_dir}/AFC_QuattroBox_1.cfg"
       elif [ "${qb_board_type}" == "MMB_1.1" ]; then
-        cp "${afc_path}/config/mcu/MMB_1.1_QB.cfg" "${afc_config_dir}/mcu/"
+        safe_copy "${afc_path}/config/mcu/MMB_1.1_QB.cfg" "${afc_config_dir}/mcu/"
         sed -i "s/include mcu\/MMB_QB.cfg/include mcu\/MMB_1.1_QB.cfg/g" "${afc_config_dir}/AFC_QuattroBox_1.cfg"
       elif [ "${qb_board_type}" == "MMB_2.0" ]; then
-        cp "${afc_path}/config/mcu/MMB_2.0_QB.cfg" "${afc_config_dir}/mcu/"
+        safe_copy "${afc_path}/config/mcu/MMB_2.0_QB.cfg" "${afc_config_dir}/mcu/"
         sed -i "s/include mcu\/MMB_QB.cfg/include mcu\/MMB_2.0_QB.cfg/g" "${afc_config_dir}/AFC_QuattroBox_1.cfg"
       fi
     fi
     ;;
 
   "OpenAMS")
-    cp "${afc_path}/templates/AFC_Hardware-AFC.cfg" "${afc_config_dir}/AFC_Hardware.cfg"
-    cp "${afc_path}/templates/AFC_AMS_1.cfg" "${afc_config_dir}/AFC_AMS_1.cfg"
+    safe_copy "${afc_path}/templates/AFC_Hardware-AFC.cfg" "${afc_config_dir}/AFC_Hardware.cfg"
+    safe_copy "${afc_path}/templates/AFC_AMS_1.cfg" "${afc_config_dir}/AFC_AMS_1.cfg"
     ;;
 
 esac

--- a/include/menus/additional_system_menu.sh
+++ b/include/menus/additional_system_menu.sh
@@ -247,7 +247,7 @@ fi
     fi
     echo ""
     if [ "$files_updated_or_installed" == "False" ]; then
-      printf "I. Install system with current selections\n"
+      printf "${GREEN}I. Install system with current selections${NC}\n"
     fi
     printf "M. Return to Main Menu\n"
     printf "Q. Quit\n"

--- a/include/menus/install_menu.sh
+++ b/include/menus/install_menu.sh
@@ -255,7 +255,7 @@ fi
           printf "F. QuattroBox Motor Type : %s \n" "$qb_motor_type"
           ;;
       esac
-      printf "${BOLD_GREEN}I. Install system with current selections${RESET}\n"
+      printf "\n${BOLD_GREEN}I. Install system with current selections${RESET}\n"
     fi
 
     printf "M. Return to Main Menu\n"

--- a/include/unit_functions.sh
+++ b/include/unit_functions.sh
@@ -165,70 +165,70 @@ verify_name_not_in_use() {
 
 install_additional_unit() {
   if [ "$installation_type" == "BoxTurtle (4-Lane)" ]; then
-    cp "${afc_path}/templates/AFC_Turtle_1.cfg" "${afc_config_dir}/AFC_${boxturtle_name}.cfg"
+    safe_copy "${afc_path}/templates/AFC_Turtle_1.cfg" "${afc_config_dir}/AFC_${boxturtle_name}.cfg"
     find "$afc_config_dir/AFC_${boxturtle_name}.cfg" -type f -exec sed -i "s/Turtle_1/$boxturtle_name/g" {} +
-    cp "${afc_path}"/config/mcu/AFC_Lite.cfg "${afc_config_dir}"/mcu/AFC_"${boxturtle_name}"_mcu.cfg
+    safe_copy "${afc_path}/config/mcu/AFC_Lite.cfg" "${afc_config_dir}/mcu/AFC_${boxturtle_name}_mcu.cfg"
     sed -i "s/include mcu\/AFC_Lite.cfg/include mcu\/AFC_${boxturtle_name}_mcu.cfg/g" "${afc_config_dir}"/AFC_"${boxturtle_name}".cfg
     # If we are installing a NightOwl, then copy these files over.
   elif [ "$installation_type" == "NightOwl" ]; then
-    cp "${afc_path}/templates/AFC_NightOwl_1.cfg" "${afc_config_dir}/AFC_${boxturtle_name}.cfg"
-    cp "${afc_path}/config/mcu/ERB_2.0.cfg" "${afc_config_dir}/mcu/"
+    safe_copy "${afc_path}/templates/AFC_NightOwl_1.cfg" "${afc_config_dir}/AFC_${boxturtle_name}.cfg"
+    safe_copy "${afc_path}/config/mcu/ERB_2.0.cfg" "${afc_config_dir}/mcu/"
     find "$afc_config_dir/AFC_${boxturtle_name}.cfg" -type f -exec sed -i "s/NightOwl/$boxturtle_name/g" {} +
   elif [ "$installation_type" == "ViViD" ]; then
-    cp "${afc_path}/templates/AFC_Vivid_1.cfg" "${afc_config_dir}/AFC_${boxturtle_name}.cfg"
-    cp "${afc_path}/config/mcu/Vivid.cfg" "${afc_config_dir}/mcu/${boxturtle_name}.cfg"
+    safe_copy "${afc_path}/templates/AFC_Vivid_1.cfg" "${afc_config_dir}/AFC_${boxturtle_name}.cfg"
+    safe_copy "${afc_path}/config/mcu/Vivid.cfg" "${afc_config_dir}/mcu/${boxturtle_name}.cfg"
     find "$afc_config_dir/AFC_${boxturtle_name}.cfg" -type f -exec sed -i "s/Vivid_1/$boxturtle_name/g" {} +
     sed -i "s/include mcu\/Vivid_1.cfg/include mcu\/${boxturtle_name}.cfg/g" "${afc_config_dir}/AFC_${boxturtle_name}.cfg"
     sed -i "s/Vivid_1/$boxturtle_name/g" "${afc_config_dir}/mcu/${boxturtle_name}.cfg"
   elif [ "$installation_type" == "HTLF" ]; then
     local board_type="$htlf_board_type"
     mkdir -p "${afc_config_dir}/mcu"
-    cp "${afc_path}/config/mcu/HTLF_${board_type}.cfg" "${afc_config_dir}/mcu/"
+    safe_copy "${afc_path}/config/mcu/HTLF_${board_type}.cfg" "${afc_config_dir}/mcu/"
     if [ "$board_type" == "MMB_1.0" ] || [ "$board_type" == "MMB_1.1" ]; then
       board_type="MMB"
     fi
-    cp "${afc_path}/templates/AFC_HTLF_1-${board_type}.cfg" "${afc_config_dir}/AFC_${board_type}_${boxturtle_name}.cfg"
+    safe_copy "${afc_path}/templates/AFC_HTLF_1-${board_type}.cfg" "${afc_config_dir}/AFC_${board_type}_${boxturtle_name}.cfg"
     sed -i "s/HTLF_1/$boxturtle_name/g" "${afc_config_dir}/AFC_${board_type}_${boxturtle_name}.cfg"
   elif [ "$installation_type" == "QuattroBox" ]; then
     mkdir -p "${afc_config_dir}/macros"
     mkdir -p "${afc_config_dir}/mcu"
-    cp "${afc_path}/templates/qb_macros/Eject_buttons.cfg" "${afc_config_dir}/macros/Eject_buttons.cfg"
+    safe_copy "${afc_path}/templates/qb_macros/Eject_buttons.cfg" "${afc_config_dir}/macros/Eject_buttons.cfg"
     sed -i "s/QuattroBox_1/${boxturtle_name}/g" "${afc_config_dir}/macros/Eject_buttons.cfg"
     if [ "${qb_motor_type}" == "NEMA_14" ]; then
-      cp "${afc_path}/templates/AFC_QuattroBox_14.cfg" "${afc_config_dir}/AFC_${boxturtle_name}.cfg"
+      safe_copy "${afc_path}/templates/AFC_QuattroBox_14.cfg" "${afc_config_dir}/AFC_${boxturtle_name}.cfg"
       if [ "${qb_board_type}" == "MMB_1.0" ]; then
         sed -i "s/include mcu\/MMB_QB.cfg/include mcu\/MMB_1.0_QB_${boxturtle_name}.cfg/g" "${afc_config_dir}/AFC_${boxturtle_name}.cfg"
-        cp "${afc_path}/config/mcu/MMB_1.0_QB.cfg" "${afc_config_dir}/mcu/MMB_1.0_QB_${boxturtle_name}.cfg"
+        safe_copy "${afc_path}/config/mcu/MMB_1.0_QB.cfg" "${afc_config_dir}/mcu/MMB_1.0_QB_${boxturtle_name}.cfg"
         sed -i "s/mcu: QuattroBox_1/mcu: ${boxturtle_name}/g" "${afc_config_dir}/mcu/MMB_1.0_QB_${boxturtle_name}.cfg"
       elif [ "${qb_board_type}" == "MMB_1.1" ]; then
         sed -i "s/include mcu\/MMB_QB.cfg/include mcu\/MMB_1.1_QB_${boxturtle_name}.cfg/g" "${afc_config_dir}/AFC_${boxturtle_name}.cfg"
-        cp "${afc_path}/config/mcu/MMB_1.1_QB.cfg" "${afc_config_dir}/mcu/MMB_1.1_QB_${boxturtle_name}.cfg"
+        safe_copy "${afc_path}/config/mcu/MMB_1.1_QB.cfg" "${afc_config_dir}/mcu/MMB_1.1_QB_${boxturtle_name}.cfg"
         sed -i "s/mcu: QuattroBox_1/mcu: ${boxturtle_name}/g" "${afc_config_dir}/mcu/MMB_1.1_QB_${boxturtle_name}.cfg"
       elif [ "${qb_board_type}" == "MMB_2.0" ]; then
         sed -i "s/include mcu\/MMB_QB.cfg/include mcu\/MMB_2.0_QB_${boxturtle_name}.cfg/g" "${afc_config_dir}/AFC_${boxturtle_name}.cfg"
-        cp "${afc_path}/config/mcu/MMB_2.0_QB.cfg" "${afc_config_dir}/mcu/MMB_2.0_QB_${boxturtle_name}.cfg"
+        safe_copy "${afc_path}/config/mcu/MMB_2.0_QB.cfg" "${afc_config_dir}/mcu/MMB_2.0_QB_${boxturtle_name}.cfg"
         sed -i "s/mcu: QuattroBox_1/mcu: ${boxturtle_name}/g" "${afc_config_dir}/mcu/MMB_2.0_QB_${boxturtle_name}.cfg"
       fi
     elif [ "${qb_motor_type}" == "NEMA_17" ]; then
-      cp "${afc_path}/templates/AFC_QuattroBox_17.cfg" "${afc_config_dir}/AFC_${boxturtle_name}.cfg"
+      safe_copy "${afc_path}/templates/AFC_QuattroBox_17.cfg" "${afc_config_dir}/AFC_${boxturtle_name}.cfg"
       if [ "${qb_board_type}" == "MMB_1.0" ]; then
         sed -i "s/include mcu\/MMB_QB.cfg/include mcu\/MMB_1.0_QB_${boxturtle_name}.cfg/g" "${afc_config_dir}/AFC_${boxturtle_name}.cfg"
-        cp "${afc_path}/config/mcu/MMB_1.0_QB.cfg" "${afc_config_dir}/mcu/MMB_1.0_QB_${boxturtle_name}.cfg"
+        safe_copy "${afc_path}/config/mcu/MMB_1.0_QB.cfg" "${afc_config_dir}/mcu/MMB_1.0_QB_${boxturtle_name}.cfg"
         sed -i "s/mcu: QuattroBox_1/mcu: ${boxturtle_name}/g" "${afc_config_dir}/mcu/MMB_1.0_QB_${boxturtle_name}.cfg"
       elif [ "${qb_board_type}" == "MMB_1.1" ]; then
         sed -i "s/include mcu\/MMB_QB.cfg/include mcu\/MMB_1.1_QB_${boxturtle_name}.cfg/g" "${afc_config_dir}/AFC_${boxturtle_name}.cfg"
-        cp "${afc_path}/config/mcu/MMB_1.1_QB.cfg" "${afc_config_dir}/mcu/MMB_1.1_QB_${boxturtle_name}.cfg"
+        safe_copy "${afc_path}/config/mcu/MMB_1.1_QB.cfg" "${afc_config_dir}/mcu/MMB_1.1_QB_${boxturtle_name}.cfg"
         sed -i "s/mcu: QuattroBox_1/mcu: ${boxturtle_name}/g" "${afc_config_dir}/mcu/MMB_1.1_QB_${boxturtle_name}.cfg"
       elif [ "${qb_board_type}" == "MMB_2.0" ]; then
         sed -i "s/include mcu\/MMB_QB.cfg/include mcu\/MMB_2.0_QB_${boxturtle_name}.cfg/g" "${afc_config_dir}/AFC_${boxturtle_name}.cfg"
-        cp "${afc_path}/config/mcu/MMB_2.0_QB.cfg" "${afc_config_dir}/mcu/MMB_2.0_QB_${boxturtle_name}.cfg"
+        safe_copy "${afc_path}/config/mcu/MMB_2.0_QB.cfg" "${afc_config_dir}/mcu/MMB_2.0_QB_${boxturtle_name}.cfg"
         sed -i "s/mcu: QuattroBox_1/mcu: ${boxturtle_name}/g" "${afc_config_dir}/mcu/MMB_2.0_QB_${boxturtle_name}.cfg"
       fi
     fi
     find "$afc_config_dir/AFC_${boxturtle_name}.cfg" -type f -exec sed -i "s/QuattroBox_1/$boxturtle_name/g" {} +
   elif [ "$installation_type" == "OpenAMS" ]; then
     mkdir -p "${afc_config_dir}/macros"
-    cp "${afc_path}/templates/AFC_AMS_1.cfg" "${afc_config_dir}/AFC_${boxturtle_name}.cfg"
+    safe_copy "${afc_path}/templates/AFC_AMS_1.cfg" "${afc_config_dir}/AFC_${boxturtle_name}.cfg"
     sed -i "s/AMS_1/${boxturtle_name}/g" "${afc_config_dir}/AFC_${boxturtle_name}.cfg"
   fi
 }

--- a/include/update_functions.sh
+++ b/include/update_functions.sh
@@ -18,7 +18,11 @@ update_afc() {
       for macro in "Brush" "Cut" "Kick" "Park" "Poop" "AFC_macros"; do
         rm -rf "${afc_config_dir}/macros/${macro}.cfg"
       done
-      if cp "${afc_path}/config/macros/"*.cfg "${afc_config_dir}/macros/"; then
+      local _macro_ok=true
+      for cfg in "${afc_path}/config/macros/"*.cfg; do
+        safe_copy "$cfg" "${afc_config_dir}/macros/" || _macro_ok=false
+      done
+      if [ "$_macro_ok" = true ]; then
         update_message+="""
 AFC Macros updated successfully.
         """

--- a/include/update_functions.sh
+++ b/include/update_functions.sh
@@ -18,18 +18,31 @@ update_afc() {
       for macro in "Brush" "Cut" "Kick" "Park" "Poop" "AFC_macros"; do
         rm -rf "${afc_config_dir}/macros/${macro}.cfg"
       done
-      local _macro_ok=true
-      for cfg in "${afc_path}/config/macros/"*.cfg; do
-        safe_copy "$cfg" "${afc_config_dir}/macros/" || _macro_ok=false
-      done
-      if [ "$_macro_ok" = true ]; then
+      local _macro_copied=0
+      local _macro_skipped=0
+      local _cfg_files=("${afc_path}/config/macros/"*.cfg)
+      if [ ! -e "${_cfg_files[0]}" ]; then
         update_message+="""
-AFC Macros updated successfully.
+No macro files found to update.
         """
       else
-        update_message+="""
-AFC Macros update failed.
-        """
+        for cfg in "${_cfg_files[@]}"; do
+          safe_copy "$cfg" "${afc_config_dir}/macros/"
+          if [ "$safe_copy_result" = "copied" ]; then
+            _macro_copied=$(( _macro_copied + 1 ))
+          else
+            _macro_skipped=$(( _macro_skipped + 1 ))
+          fi
+        done
+        if [ "$_macro_copied" -gt 0 ]; then
+          update_message+="""
+AFC Macros updated successfully (${_macro_copied} copied, ${_macro_skipped} skipped).
+          """
+        else
+          update_message+="""
+AFC Macros update skipped (all ${_macro_skipped} files kept as-is).
+          """
+        fi
       fi
     fi
   fi

--- a/include/update_functions.sh
+++ b/include/update_functions.sh
@@ -15,9 +15,6 @@ update_afc() {
     read -p "Please confirm you want to update these macros: (y/n): " confirm_update_macros
     confirm_update_macros="${confirm_update_macros,,}"
     if [[ "$confirm_update_macros" == "y" ]]; then
-      for macro in "Brush" "Cut" "Kick" "Park" "Poop" "AFC_macros"; do
-        rm -rf "${afc_config_dir}/macros/${macro}.cfg"
-      done
       local _macro_copied=0
       local _macro_skipped=0
       local _cfg_files=("${afc_path}/config/macros/"*.cfg)

--- a/include/utils.sh
+++ b/include/utils.sh
@@ -35,18 +35,25 @@ safe_copy() {
   # Safe copy that prompts the user before overwriting existing files/directories.
   # Usage: safe_copy <source> <destination>
   # Drop-in replacement for cp / cp -R.
+  # Returns: 0 on success (including skip), 1 on error.
+  # Sets safe_copy_result: "copied" | "skipped" after each call.
   local src="$1"
   local dst="$2"
   local effective_dst="$dst"
   local is_dir_copy="false"
+  safe_copy_result="copied"
 
   # Determine if source is a directory
   if [ -d "$src" ]; then
     is_dir_copy="true"
   fi
 
-  # Resolve effective destination path (e.g., cp file dir/ -> dir/file)
-  if [ "$is_dir_copy" = "false" ] && [ -d "$dst" ]; then
+  # Resolve effective destination path
+  # cp behaves the same for files and directories: when the destination is an
+  # existing directory, the source is placed *inside* it.
+  #   cp file dir/       -> dir/file
+  #   cp -R src_dir dir/ -> dir/src_dir
+  if [ -d "$dst" ]; then
     effective_dst="${dst%/}/$(basename "$src")"
   fi
 
@@ -68,6 +75,9 @@ safe_copy() {
     choice="${choice,,}"
     case "$choice" in
       o)
+        # Remove existing destination first so directory copies don't
+        # merge into stale content.
+        rm -rf "$effective_dst"
         if [ "$is_dir_copy" = "true" ]; then
           cp -R "$src" "$dst"
         else
@@ -78,6 +88,7 @@ safe_copy() {
         ;;
       s)
         print_msg INFO "Skipped: ${effective_dst}"
+        safe_copy_result="skipped"
         return 0
         ;;
       b)

--- a/include/utils.sh
+++ b/include/utils.sh
@@ -31,20 +31,86 @@ function show_help() {
   echo " $0 [-a <moonraker address>] [-k <klipper_path>] [-s <klipper_service_name>] [-m <moonraker_config_path>] [-n <moonraker_port>] [-p <printer_config_dir>] [-p <printer_config_dir>] [-b <branch>] [-y <klipper venv dir>] [-h] "
 }
 
+safe_copy() {
+  # Safe copy that prompts the user before overwriting existing files/directories.
+  # Usage: safe_copy <source> <destination>
+  # Drop-in replacement for cp / cp -R.
+  local src="$1"
+  local dst="$2"
+  local effective_dst="$dst"
+  local is_dir_copy="false"
+
+  # Determine if source is a directory
+  if [ -d "$src" ]; then
+    is_dir_copy="true"
+  fi
+
+  # Resolve effective destination path (e.g., cp file dir/ -> dir/file)
+  if [ "$is_dir_copy" = "false" ] && [ -d "$dst" ]; then
+    effective_dst="${dst%/}/$(basename "$src")"
+  fi
+
+  # If destination doesn't exist, just copy
+  if [ ! -e "$effective_dst" ]; then
+    if [ "$is_dir_copy" = "true" ]; then
+      cp -R "$src" "$dst"
+    else
+      cp "$src" "$dst"
+    fi
+    return 0
+  fi
+
+  # Destination exists — prompt the user
+  local choice
+  print_msg WARNING "Destination already exists: ${effective_dst}"
+  while true; do
+    read -p "  (o)verwrite / (s)kip / (b)ackup and copy? [o/s/b]: " choice
+    choice="${choice,,}"
+    case "$choice" in
+      o)
+        if [ "$is_dir_copy" = "true" ]; then
+          cp -R "$src" "$dst"
+        else
+          cp "$src" "$dst"
+        fi
+        print_msg INFO "Overwritten: ${effective_dst}"
+        return 0
+        ;;
+      s)
+        print_msg INFO "Skipped: ${effective_dst}"
+        return 0
+        ;;
+      b)
+        mv "$effective_dst" "${effective_dst}.bak.${backup_date}"
+        print_msg INFO "Backed up to: ${effective_dst}.bak.${backup_date}"
+        if [ "$is_dir_copy" = "true" ]; then
+          cp -R "$src" "$dst"
+        else
+          cp "$src" "$dst"
+        fi
+        return 0
+        ;;
+      *)
+        echo "  Invalid choice. Please enter o, s, or b."
+        ;;
+    esac
+  done
+}
+
 function copy_config() {
   mkdir -p "${afc_config_dir}"
-  cp "${afc_path}/config/AFC.cfg" "${afc_config_dir}/"
-  cp "${afc_path}/config/AFC_Macro_Vars.cfg" "${afc_config_dir}/"
+  safe_copy "${afc_path}/config/AFC.cfg" "${afc_config_dir}/"
+  safe_copy "${afc_path}/config/AFC_Macro_Vars.cfg" "${afc_config_dir}/"
   mkdir -p "${afc_config_dir}/mcu"
-  cp -R "${afc_path}/config/macros" "${afc_config_dir}/"
+  safe_copy "${afc_path}/config/macros" "${afc_config_dir}/"
 }
 
 function copy_openams_config() {
   mkdir -p "${afc_config_dir}"
-  cp ${afc_path}/config/AFC.cfg "${afc_config_dir}/"
-  cp ${afc_path}/config/AFC_Macro_Vars.cfg "${afc_config_dir}/"
+  safe_copy "${afc_path}/config/AFC.cfg" "${afc_config_dir}/"
+  safe_copy "${afc_path}/config/AFC_Macro_Vars.cfg" "${afc_config_dir}/"
   mkdir -p "${afc_config_dir}/mcu"
-  cp -R ${afc_path}/config/macros "${afc_config_dir}/"
+  safe_copy "${afc_path}/config/macros" "${afc_config_dir}/"
 }
 
 get_git_version() {

--- a/troubleshooting/afc-debug.sh
+++ b/troubleshooting/afc-debug.sh
@@ -27,6 +27,21 @@ NO_NC=false
 
 ALL_CAN_IDS=()
 
+check_prereqs() {
+    if ! command -v jq > /dev/null 2>&1; then
+        echo "jq is required but not found. Please install it and rerun the script."
+        exit 1
+    fi
+    if ! command -v curl > /dev/null 2>&1; then
+        echo "curl is required but not found. Please install it and rerun the script."
+        exit 1
+    fi
+    if ! command -v column > /dev/null 2>&1; then
+        echo "column is required but not found. Please install it and rerun the script."
+        exit 1
+    fi
+}
+
 log_can_interfaces() {
     local interfaces
     interfaces=$(ip -br link show | awk '{print $1}' ) # Let's get all the network interfaces in case someone named a CAN interface something weird
@@ -143,16 +158,20 @@ temp_dir_creation() {
 }
 
 clean_up_temp_dir() {
-	trap 'rm -rf -- "$temp_dir"' EXIT
+	rm -rf -- "$temp_dir"
 }
 
 extract_klipper_logs() {
 	echo "Extracting Klipper logs..."
 	temp_dir_creation
 	cp "$printer_log_dir"/klippy.log "$temp_dir"
-	cp "$printer_log_dir"/AFC.log* "$temp_dir"
-	cd "$temp_dir" || exit
-	"$klipper_venv"/python "$klipper_dir"/scripts/logextract.py ./klippy.log
+	# Use nullglob to avoid errors if no AFC.log files exist
+	local afc_logs
+	afc_logs=("$printer_log_dir"/AFC.log*)
+	if [[ -e "${afc_logs[0]}" ]]; then
+		cp "${afc_logs[@]}" "$temp_dir"
+	fi
+	(cd "$temp_dir" && "$klipper_venv"/python "$klipper_dir"/scripts/logextract.py ./klippy.log)
 }
 
 create_temp_log() {
@@ -169,28 +188,29 @@ clean_up_temp_log() {
 trap clean_up_temp_log EXIT
 
 get_afc_version() {
-	cd "$afc_path"
-	git_hash=$(git -C . rev-parse --short HEAD)
-	git_commit_num=$(git -C . rev-list HEAD --count)
+	local git_hash
+	local git_commit_num
+	git_hash=$(git -C "$afc_path" rev-parse --short HEAD)
+	git_commit_num=$(git -C "$afc_path" rev-list HEAD --count)
 	afc_version="${git_commit_num}-${git_hash}"
-	cd - > /dev/null
 }
 
 get_klipper_version() {
-	cd "$klipper_dir"
-	klipper_version=$(git describe --tags)
-	cd - > /dev/null
+	klipper_version=$(git -C "$klipper_dir" describe --tags)
 }
 
 # Upload a file to termbin, return a plain text string (no colors)
 upload_file_to_termbin() {
 	local file="$1"
-	local file_name=$(basename "$file")
+	local file_name
+  file_name=$(basename "$file")
 
 	# Upload only (no colors or print_msg in this function)
-	local tmp_url_file=$(mktemp)
+	local tmp_url_file
+  local url
+  tmp_url_file=$(mktemp)
 	tr -d '\0' < "$file" | nc termbin.com 9999 > "$tmp_url_file"
-	local url=$(tr -d '\0' < "$tmp_url_file")
+  url=$(tr -d '\0' < "$tmp_url_file")
 	rm -f "$tmp_url_file"
 
 	if [[ -n "$url" ]]; then
@@ -233,7 +253,7 @@ extract_klipper_logs
 
 echo "Gathering system information..."
 
-DISTRO=$(strings /etc/*-release 2>/dev/null || echo "Unknown")
+DISTRO=$(cat /etc/*-release 2>/dev/null || echo "Unknown")
 KERNEL=$(uname -a)
 UPTIME=$(uptime)
 LSUSB=$(lsusb | tr -d '\0')
@@ -260,11 +280,11 @@ log_can_interfaces
 	echo "$SERIAL_IDS"
 
 	prepout "CAN Bus IDs"
-  if [ ${#ALL_CAN_IDS[@]} -eq 0 ]; then
-      echo "No CAN devices found."
-  else
-      printf "%s\n" "${ALL_CAN_IDS[@]}"
-  fi
+	if [ ${#ALL_CAN_IDS[@]} -eq 0 ]; then
+		echo "No CAN devices found."
+	else
+		printf "%s\n" "${ALL_CAN_IDS[@]}"
+	fi
 } >> "$temp_log"
 
 echo "Gathering AFC statistics "
@@ -277,10 +297,10 @@ echo "Gathering AFC statistics "
 } >> "$temp_log"
 
 # Let's get all the AFC config files
-find "$afc_config_dir" -type f | while read -r file; do
+while read -r file; do
     file_name=$(basename "$file")
     append_file_to_log "$file_name" "$file"
-done
+done < <(find "$afc_config_dir" -type f)
 
 # Add the moonraker config if it exists
 if [ -f "$moonraker_config" ]; then
@@ -321,8 +341,10 @@ else
 
   if nc -z -w 3 termbin.com 9999; then
     echo "Uploading logs to termbin.com..."
-    tr -d '\0' < "$temp_log" | nc termbin.com 9999 > /tmp/afc_upload_url
-    OUTPUTURL=$(tr -d '\0' < /tmp/afc_upload_url)
+    tmp_url_main=$(mktemp)
+    tr -d '\0' < "$temp_log" | nc termbin.com 9999 > "$tmp_url_main"
+    OUTPUTURL=$(tr -d '\0' < "$tmp_url_main")
+    rm -f "$tmp_url_main"
     echo "Logs are available at ${OUTPUTURL}"
     echo "Please share this URL with the Armored Turtle support team."
   else
@@ -333,4 +355,3 @@ fi
 start_klipper
 clean_up_temp_dir
 clean_up_temp_log
-rm -rf /tmp/afc_upload_url

--- a/troubleshooting/afc-debug.sh
+++ b/troubleshooting/afc-debug.sh
@@ -321,6 +321,11 @@ fi
 uploaded_files=()
 
 if [ "$NO_NC" = true ]; then
+    if ! command -v zip > /dev/null 2>&1; then
+        echo "zip is required but not found. Please install it and rerun the script."
+        exit 1
+    fi
+
     echo "NetCat is unavailable. Creating a zip archive of logs instead."
     zipfile="$HOME/afc_debug_logs_$(date +%Y%m%d_%H%M%S).zip"
     zip -j "$zipfile" "$temp_log" "$temp_dir"/* > /dev/null

--- a/troubleshooting/afc-debug.sh
+++ b/troubleshooting/afc-debug.sh
@@ -158,7 +158,9 @@ temp_dir_creation() {
 }
 
 clean_up_temp_dir() {
-	rm -rf -- "$temp_dir"
+	if [ -n "${temp_dir:-}" ]; then
+		rm -rf -- "$temp_dir"
+	fi
 }
 
 extract_klipper_logs() {
@@ -185,7 +187,12 @@ clean_up_temp_log() {
 	fi
 }
 
-trap clean_up_temp_log EXIT
+clean_up_all() {
+	clean_up_temp_dir
+	clean_up_temp_log
+}
+
+trap clean_up_all EXIT
 
 get_afc_version() {
 	local git_hash
@@ -238,6 +245,8 @@ echo "This script will collect diagnostic information and upload it to Armored T
 echo "Please review the script if you have concerns about its contents."
 echo "Klipper will be stopped during this process — do not run this while printing."
 echo ""
+
+check_prereqs
 
 read -p "Do you wish to continue? [y/n]: " yn < /dev/tty
 case $yn in
@@ -353,5 +362,3 @@ else
 fi
 
 start_klipper
-clean_up_temp_dir
-clean_up_temp_log

--- a/troubleshooting/afc-debug.sh
+++ b/troubleshooting/afc-debug.sh
@@ -40,6 +40,10 @@ check_prereqs() {
         echo "column is required but not found. Please install it and rerun the script."
         exit 1
     fi
+    if ! command -v zip > /dev/null 2>&1; then
+        echo "zip is required but not found. Please install it and rerun the script."
+        exit 1
+    fi
 }
 
 log_can_interfaces() {

--- a/troubleshooting/afc-debug.sh
+++ b/troubleshooting/afc-debug.sh
@@ -40,10 +40,6 @@ check_prereqs() {
         echo "column is required but not found. Please install it and rerun the script."
         exit 1
     fi
-    if ! command -v zip > /dev/null 2>&1; then
-        echo "zip is required but not found. Please install it and rerun the script."
-        exit 1
-    fi
 }
 
 log_can_interfaces() {


### PR DESCRIPTION
## Major Changes in this PR

This pull request introduces a new `safe_copy` utility function to standardize and improve file and directory copying throughout the codebase. The function prompts the user before overwriting existing files, offering options to overwrite, skip, or backup, thereby reducing the risk of accidental data loss during installations and updates. All major installation, update, and configuration scripts have been updated to use this new function in place of direct `cp` commands. Additionally, several improvements and bug fixes were made in the troubleshooting script to enhance reliability and error handling.

**Key changes:**

File copy safety and user prompts:
- Added the `safe_copy` function to `include/utils.sh`, which wraps `cp` and prompts the user before overwriting files or directories, with options to overwrite, skip, or backup existing files. All relevant scripts now use `safe_copy` instead of `cp` for configuration file operations. [[1]](diffhunk://#diff-9e64712e624ee22bf3a68f5ecd584c7f805f610eb1fb10ce184a3d3beb0b8352R34-R113) [[2]](diffhunk://#diff-282cd2c171b111ef2455bf6299137610dcedcf6c31ac01b646f8e612d5d4f078L62-R62) [[3]](diffhunk://#diff-cf22d03e9fcc2eda523c8a6f6005097e735a940a77248d9251bdd84219106e77L73-R135) [[4]](diffhunk://#diff-f6131696193a4ab24c6a1876731beb2a794500eb159de2cce549c2ee339f55f4L168-R231) [[5]](diffhunk://#diff-e640ec65703f5a9486beb53f428b150d6d1f3b3f7956b24766b783061f5d5ddeL21-R25)

Troubleshooting script improvements:
- Added a `check_prereqs` function to `troubleshooting/afc-debug.sh` to ensure required tools (`jq`, `curl`, `column`) are installed before running the script, and improved log extraction to handle missing files gracefully. [[1]](diffhunk://#diff-f90bf2ef443900b47139a1df1cf4fed2ee7afaea3274ba701e86d8905f704d54R30-R44) [[2]](diffhunk://#diff-f90bf2ef443900b47139a1df1cf4fed2ee7afaea3274ba701e86d8905f704d54L146-R174)
- Refactored version retrieval and log upload functions in `afc-debug.sh` for better reliability and code clarity, using `git -C` and improved temporary file handling. [[1]](diffhunk://#diff-f90bf2ef443900b47139a1df1cf4fed2ee7afaea3274ba701e86d8905f704d54L172-R213) [[2]](diffhunk://#diff-f90bf2ef443900b47139a1df1cf4fed2ee7afaea3274ba701e86d8905f704d54L324-R347)
- Fixed a bug in how AFC config files are added to logs, ensuring all files are included even if filenames contain spaces.
- Improved system info gathering in `afc-debug.sh` by using `cat` instead of `strings` for `/etc/*-release` to avoid errors and get complete information.

User interface enhancements:
- Improved color formatting for install menu prompts in `include/menus/additional_system_menu.sh` and `include/menus/install_menu.sh` for better readability. [[1]](diffhunk://#diff-26da24e70bfd199617eb2822c925f082c4a375eb11cf6b3aaecc1c93645685f1L250-R250) [[2]](diffhunk://#diff-7d3ccff3338bda5c44e5e12b5a5fdd0fd923457b75f99e5a1d9d8a26e0164a49L258-R258)

## Notes to Code Reviewers

```
T. Installation Type: BoxTurtle (4-Lane)
1. Add AFC includes? : True
2. Enable tip-forming? : False
3. Enable toolhead cutter? : True
4. Enable hub cutter? : False
5. Enable kick macro? : True
6. Enable park macro? : True
7. Enable poop macro? : True
8. Enable wipe macro? : True
9. Use a toolhead sensor or ramming with a TurtleNeck buffer? : Sensor
A. Toolhead sensor pin : Unknown
B. Buffer type : TurtleNeck
C. BoxTurtle Name : Turtle_1
I. Install system with current selections
M. Return to Main Menu
Q. Quit

Enter your choice: i
Destination already exists: /home/eric/printer_data/config/AFC/AFC.cfg
  (o)verwrite / (s)kip / (b)ackup and copy? [o/s/b]: s
Skipped: /home/eric/printer_data/config/AFC/AFC.cfg
Destination already exists: /home/eric/printer_data/config/AFC/AFC_Macro_Vars.cfg
  (o)verwrite / (s)kip / (b)ackup and copy? [o/s/b]: s
Skipped: /home/eric/printer_data/config/AFC/AFC_Macro_Vars.cfg
Destination already exists: /home/eric/printer_data/config/AFC/
  (o)verwrite / (s)kip / (b)ackup and copy? [o/s/b]: s
Skipped: /home/eric/printer_data/config/AFC/
Destination already exists: /home/eric/printer_data/config/AFC/mcu/AFC_Lite.cfg
  (o)verwrite / (s)kip / (b)ackup and copy? [o/s/b]: o
Overwritten: /home/eric/printer_data/config/AFC/mcu/AFC_Lite.cfg
Destination already exists: /home/eric/printer_data/config/AFC/AFC_Hardware.cfg
  (o)verwrite / (s)kip / (b)ackup and copy? [o/s/b]: b
Backed up to: /home/eric/printer_data/config/AFC/AFC_Hardware.cfg.bak.20260329150546
Destination already exists: /home/eric/printer_data/config/AFC/AFC_Turtle_1.cfg
  (o)verwrite / (s)kip / (b)ackup and copy? [o/s/b]: o
Overwritten: /home/eric/printer_data/config/AFC/AFC_Turtle_1.cfg
```
## How the changes in this PR are tested

Running different combinations. Some double checking would be good.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.