### PR TITLE
(fix): Correctly parse lower case multiplier names in SET_BUFFER_MULT…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-04-05]
+### Fixed
+- Fixed bug where `SET_BUFFER_MULTIPLIER` would not properly parse lower case multiplier names. 
+
 ## [2026-03-30]
 ### Fixed
 - Updated the `install-afc.sh` script to implement a `safe_copy` feature to prevent accidental overwriting of existing configuration files in 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2026-04-05]
 ### Fixed
-- Fixed bug where `SET_BUFFER_MULTIPLIER` would not properly parse lower case multiplier names. 
+- Fixed bug where `SET_BUFFER_MULTIPLIER` would not properly parse lowercase multiplier names.
 
 ## [2026-03-30]
 ### Fixed

--- a/extras/AFC_buffer.py
+++ b/extras/AFC_buffer.py
@@ -467,6 +467,7 @@ class AFCTrigger:
             if chg_multiplier is None:
                 self.logger.info("Multiplier must be provided, HIGH or LOW")
                 return
+            chg_multiplier = chg_multiplier.upper()
             chg_factor = gcmd.get_float('FACTOR')
             if chg_factor <= 0:
                 self.logger.info("FACTOR must be greater than 0")
@@ -623,6 +624,10 @@ class AFCTrigger:
         else:
             self.response['rotation_distance'] = None
             self.response['active_lane'] = None
+
+        # Add in multiplier information for automated testing
+        self.response['multiplier_high'] = self.multiplier_high
+        self.response['multiplier_low'] = self.multiplier_low
 
         # Add fault detection information
         self.response['fault_detection_enabled'] = self.error_sensitivity > 0

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -420,6 +420,7 @@ class AFCSpool:
             return
 
         runout = gcmd.get('RUNOUT', 'NONE')
+        is_none = runout.upper() == 'NONE'
         # Check to make sure runout does not equal lane
         if lane == runout:
             self.logger.error("Lane({}) and runout({}) cannot be the same".format(lane, runout))
@@ -429,12 +430,12 @@ class AFCSpool:
             self.logger.error('Unknown lane: {}'.format(lane))
             return
         # Check to make sure specified runout lane exists as long as runout is not set as 'NONE'
-        if runout != 'NONE' and runout not in self.afc.lanes:
+        if not is_none and runout not in self.afc.lanes:
             self.logger.error('Unknown runout lane: {}'.format(runout))
             return
 
         cur_lane = self.afc.lanes[lane]
-        cur_lane.runout_lane = None if runout == 'NONE' else runout
+        cur_lane.runout_lane = None if is_none else runout
         self.afc.save_vars()
 
     cmd_RESET_AFC_MAPPING_help = "Resets all lane mapping in AFC"

--- a/tests/klippy/afc_buffer_commands.test
+++ b/tests/klippy/afc_buffer_commands.test
@@ -17,8 +17,15 @@ CONFIG afc_with_buffer.cfg
 QUERY_BUFFER BUFFER=buf1
 
 # --- Enable / disable buffer ---
-# No active lane, so the internal set_multiplier call is a no-op.
 ENABLE_BUFFER BUFFER=buf1 LANE=lane1
+
+# --- Multiplier adjustment ---
+# Buffer is enabled with lane1 loaded, so multiplier comparisons are exercised.
+SET_BUFFER_MULTIPLIER BUFFER=buf1 MULTIPLIER=high FACTOR=1.15
+ASSERT TEST="{ printer['AFC_buffer buf1'].multiplier_high == 1.15 }"
+SET_BUFFER_MULTIPLIER BUFFER=buf1 MULTIPLIER=LOW FACTOR=0.85
+ASSERT TEST="{ printer['AFC_buffer buf1'].multiplier_low == 0.85 }"
+
 DISABLE_BUFFER BUFFER=buf1 LANE=lane1
 
 # --- Fault detection sensitivity transitions ---
@@ -28,8 +35,3 @@ AFC_SET_ERROR_SENSITIVITY BUFFER=buf1 SENSITIVITY=5.0
 AFC_SET_ERROR_SENSITIVITY BUFFER=buf1 SENSITIVITY=7.0
 # 7 → 0: stops the fault detection timer.
 AFC_SET_ERROR_SENSITIVITY BUFFER=buf1 SENSITIVITY=0
-
-# --- Multiplier adjustment ---
-# Buffer is disabled and no lane is loaded, so these are logged no-ops.
-SET_BUFFER_MULTIPLIER BUFFER=buf1 MULTIPLIER=HIGH FACTOR=1.15
-SET_BUFFER_MULTIPLIER BUFFER=buf1 MULTIPLIER=LOW FACTOR=0.85

--- a/tests/klippy_testing_plugin.py
+++ b/tests/klippy_testing_plugin.py
@@ -1,5 +1,6 @@
 import ast
 import logging
+import re
 
 from extras import gcode_macro
 
@@ -34,19 +35,24 @@ class KlippyTestingPlugin:
             f"Unknown command during test execution: {cmd}"
         )
 
+    # Match a leading TEST= token (case-insensitive key), capturing a quoted
+    # or unquoted value while stopping before subsequent KEY= parameters.
+    _test_re = re.compile(
+        r'(?:^|\s)TEST='            # word boundary + key
+        r'(?:"((?:[^"\\]|\\.)*)"|'  # quoted value  -> group 1
+        r'(\S+))',                   # unquoted value -> group 2
+        re.IGNORECASE,
+    )
+
     def cmd_ASSERT(self, gcmd):
         "Evaluate an expression, raising an error if the return value is False"
         # Use raw command line to preserve case for Jinja expressions
         # (the normal params dict is uppercased by Klipper's gcode parser).
         raw = gcmd.get_raw_command_parameters()
-        # Extract value after TEST=
-        idx = raw.upper().find("TEST=")
-        if idx < 0:
+        m = self._test_re.search(raw)
+        if not m:
             raise gcmd.error("ASSERT: missing TEST parameter")
-        expression = raw[idx + 5:].strip()
-        # Strip surrounding quotes if present
-        if len(expression) >= 2 and expression[0] == '"' and expression[-1] == '"':
-            expression = expression[1:-1]
+        expression = (m.group(1) if m.group(1) is not None else m.group(2)).strip()
 
         try:
             template = _TemplateClass(

--- a/tests/klippy_testing_plugin.py
+++ b/tests/klippy_testing_plugin.py
@@ -3,6 +3,9 @@ import logging
 
 from extras import gcode_macro
 
+# Klipper uses TemplateWrapper, Kalico uses Template
+_TemplateClass = getattr(gcode_macro, 'TemplateWrapper', None) or gcode_macro.Template
+
 
 class KlippyTestingPlugin:
     def __init__(self, config):
@@ -33,10 +36,20 @@ class KlippyTestingPlugin:
 
     def cmd_ASSERT(self, gcmd):
         "Evaluate an expression, raising an error if the return value is False"
-        expression = gcmd.get("TEST")
+        # Use raw command line to preserve case for Jinja expressions
+        # (the normal params dict is uppercased by Klipper's gcode parser).
+        raw = gcmd.get_raw_command_parameters()
+        # Extract value after TEST=
+        idx = raw.upper().find("TEST=")
+        if idx < 0:
+            raise gcmd.error("ASSERT: missing TEST parameter")
+        expression = raw[idx + 5:].strip()
+        # Strip surrounding quotes if present
+        if len(expression) >= 2 and expression[0] == '"' and expression[-1] == '"':
+            expression = expression[1:-1]
 
         try:
-            template = gcode_macro.Template(
+            template = _TemplateClass(
                 self.printer,
                 self.gcode_macro.env,
                 "ASSERT:runtime_expression",

--- a/tests/test_AFC_spool.py
+++ b/tests/test_AFC_spool.py
@@ -349,6 +349,36 @@ class TestSetRunout:
         error_msgs = [m for lvl, m in spool.logger.messages if lvl == "error"]
         assert any("ghost" in m for m in error_msgs)
 
+    def test_set_runout_none_clears_runout_lane(self):
+        """RUNOUT='NONE' (uppercase) → runout_lane set to None."""
+        spool = _make_spool()
+        lane1 = _make_lane("lane1")
+        lane1.runout_lane = "lane2"
+        spool.afc.lanes = {"lane1": lane1}
+        gcmd = _make_gcmd(LANE="lane1", RUNOUT="NONE")
+        spool.cmd_SET_RUNOUT(gcmd)
+        assert lane1.runout_lane is None
+
+    def test_set_runout_lowercase_none_clears_runout_lane(self):
+        """RUNOUT='none' (lowercase) → runout_lane set to None."""
+        spool = _make_spool()
+        lane1 = _make_lane("lane1")
+        lane1.runout_lane = "lane2"
+        spool.afc.lanes = {"lane1": lane1}
+        gcmd = _make_gcmd(LANE="lane1", RUNOUT="none")
+        spool.cmd_SET_RUNOUT(gcmd)
+        assert lane1.runout_lane is None
+
+    def test_set_runout_mixedcase_none_clears_runout_lane(self):
+        """RUNOUT='None' (mixed case) → runout_lane set to None."""
+        spool = _make_spool()
+        lane1 = _make_lane("lane1")
+        lane1.runout_lane = "lane2"
+        spool.afc.lanes = {"lane1": lane1}
+        gcmd = _make_gcmd(LANE="lane1", RUNOUT="None")
+        spool.cmd_SET_RUNOUT(gcmd)
+        assert lane1.runout_lane is None
+
     def test_runout_not_in_lanes_logs_error(self):
         """Covers lines 387-389: runout != 'NONE' but not in lanes → log error + return."""
         spool = _make_spool()


### PR DESCRIPTION
…IPLIER command

Closes #696 

## Major Changes in this PR

This pull request fixes a bug with the `SET_BUFFER_MULTIPLIER` command not properly handling lowercase multiplier names, enhances automated testing, and improves test infrastructure compatibility. The most important changes are:

### Bug Fixes & Command Handling

* Updated `cmd_SET_BUFFER_MULTIPLIER` in `AFC_buffer.py` to normalize the `MULTIPLIER` argument to uppercase, ensuring both lower and upper case names are accepted.
* Added a changelog entry documenting the fix for `SET_BUFFER_MULTIPLIER` parsing lower case multiplier names.

### Automated Testing Improvements

* Added status fields for `multiplier_high` and `multiplier_low` in the `get_status` method of `AFC_buffer.py`, supporting more thorough automated tests.
* Expanded test coverage in `afc_buffer_commands.test` to verify correct handling of both lower and upper case multiplier names and correct value assignment. [[1]](diffhunk://#diff-e587ab4410da4114d566bd1b56f550f1c566c5fac163a0edb20a8c19f85ccc0cL20-R28) [[2]](diffhunk://#diff-e587ab4410da4114d566bd1b56f550f1c566c5fac163a0edb20a8c19f85ccc0cL31-L35)

### Test Infrastructure Compatibility

* Improved `klippy_testing_plugin.py` to support both `TemplateWrapper` and `Template` classes for better compatibility between Klipper and Kalico.
* Enhanced the `ASSERT` command in `klippy_testing_plugin.py` to preserve case in Jinja expressions, ensuring accurate test assertions.

## Notes to Code Reviewers

Added multiplier values to get_status so we could use it for testing.

## How the changes in this PR are tested

<img width="832" height="94" alt="image" src="https://github.com/user-attachments/assets/7f05d18c-0bdf-40ca-87d3-a629e642afea" />

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.