### PR TITLE
[feat]: Add extruder_index to lane_data moonraker endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-04-15]
+### Added
+- Added `extruder_index` field to the `lane_data` Moonraker database endpoint. This exposes the 0-based physical extruder index for each lane, enabling third-party tools such as OrcaSlicer's `physical_extruder_mapper` to correctly map filaments to physical extruders on multi-extruder machines.
+
 ## [2026-04-06]
 ### Fixed
 - Toolchanger: Issue where standalone toolheads would try to heat to 0.

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -406,6 +406,39 @@ class AFCLane:
                 self.filament_density = float(v[1])
                 break
 
+    @property
+    def lane_index(self) -> str:
+        """
+        Strip's T from lane map and return integer as string.
+
+        :returns str: Returns lane mapping index as string
+        """
+        if self.map is None:
+            return ""
+
+        return self.map.replace("T", "")
+
+    @property
+    def lane_extruder_index(self) -> int:
+        """
+        Finds lanes extruder integer number and returns as integer.
+
+        :return int: Returns lanes extruder index as integer.
+        """
+        extruder_index = 0
+        if not hasattr(self, "extruder_obj") or self.extruder_obj is None:
+            return extruder_index
+
+        extruder_name = self.extruder_obj.name
+
+        if extruder_name == "extruder":
+            return extruder_index
+
+        try:
+            return int(extruder_name.replace("extruder", ""))
+        except ValueError:
+            return extruder_index
+
     def _handle_mcu_identify(self):
         """
         Handles klippy:mcu_identify callback to register endstops for steppers
@@ -1569,9 +1602,6 @@ class AFCLane:
             scan_time = self.td1_data['scan_time'] if 'scan_time' in self.td1_data else ""
             td        = self.td1_data['td']        if 'td'        in self.td1_data else ""
 
-            lane_number = self.map.replace("T", "")
-            extruder_name = self.extruder_obj.name
-            extruder_index = 0 if extruder_name == "extruder" else int(extruder_name.replace("extruder", ""))
             lane_data = {
                 "namespace": "lane_data",
                 "key": self.name,
@@ -1582,8 +1612,8 @@ class AFCLane:
                     "nozzle_temp"    : self.extruder_temp,
                     "scan_time"      : scan_time,
                     "td"             : td,
-                    "lane"           : lane_number,
-                    "extruder_index" : extruder_index,
+                    "lane"           : self.lane_index,
+                    "extruder_index" : self.lane_extruder_index,
                     "spool_id"       : self.spool_id,
                     "weight"         : self.weight
                 }
@@ -1595,9 +1625,6 @@ class AFCLane:
         Clears lane data that is currently stored at moonrakers `machine/set_lane_data` endpoint
         """
         if self.map is not None and "T" in self.map:
-            lane_number = self.map.replace("T", "")
-            extruder_name = self.extruder_obj.name
-            extruder_index = 0 if extruder_name == "extruder" else int(extruder_name.replace("extruder", ""))
             lane_data = {
                 "namespace": "lane_data",
                 "key": self.name,
@@ -1608,8 +1635,8 @@ class AFCLane:
                     "nozzle_temp"    : "",
                     "scan_time"      : "",
                     "td"             : "",
-                    "lane"           : lane_number,
-                    "extruder_index" : extruder_index,
+                    "lane"           : self.lane_index,
+                    "extruder_index" : self.lane_extruder_index,
                     "spool_id"       : None
                 }
             }

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -1570,19 +1570,22 @@ class AFCLane:
             td        = self.td1_data['td']        if 'td'        in self.td1_data else ""
 
             lane_number = self.map.replace("T", "")
+            extruder_name = self.extruder_obj.name
+            extruder_index = 0 if extruder_name == "extruder" else int(extruder_name.replace("extruder", ""))
             lane_data = {
                 "namespace": "lane_data",
                 "key": self.name,
                 "value": {
-                    "color"         : self.color,
-                    "material"      : self.material,
-                    "bed_temp"      : self.bed_temp,
-                    "nozzle_temp"   : self.extruder_temp,
-                    "scan_time"     : scan_time,
-                    "td"            : td,
-                    "lane"          : lane_number,
-                    "spool_id"      : self.spool_id,
-                    "weight"        : self.weight
+                    "color"          : self.color,
+                    "material"       : self.material,
+                    "bed_temp"       : self.bed_temp,
+                    "nozzle_temp"    : self.extruder_temp,
+                    "scan_time"      : scan_time,
+                    "td"             : td,
+                    "lane"           : lane_number,
+                    "extruder_index" : extruder_index,
+                    "spool_id"       : self.spool_id,
+                    "weight"         : self.weight
                 }
             }
             self.afc.moonraker.send_lane_data(lane_data)
@@ -1593,18 +1596,21 @@ class AFCLane:
         """
         if self.map is not None and "T" in self.map:
             lane_number = self.map.replace("T", "")
+            extruder_name = self.extruder_obj.name
+            extruder_index = 0 if extruder_name == "extruder" else int(extruder_name.replace("extruder", ""))
             lane_data = {
                 "namespace": "lane_data",
                 "key": self.name,
                 "value": {
-                    "color"         :  "",
-                    "material"      : "",
-                    "bed_temp"      : "",
-                    "nozzle_temp"   : "",
-                    "scan_time"     : "",
-                    "td"            : "",
-                    "lane"          : lane_number,
-                    "spool_id"      : None
+                    "color"          : "",
+                    "material"       : "",
+                    "bed_temp"       : "",
+                    "nozzle_temp"    : "",
+                    "scan_time"      : "",
+                    "td"             : "",
+                    "lane"           : lane_number,
+                    "extruder_index" : extruder_index,
+                    "spool_id"       : None
                 }
             }
             self.afc.moonraker.send_lane_data(lane_data)

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -352,6 +352,47 @@ class TestAFCLaneLoadEs:
 
         assert lane_a.load_es != lane_b.load_es
 
+class TestAFCLaneIndexProperty:
+    def test_lane_index_property_map_none(self):
+        lane = _make_afc_lane()
+        lane.map = None
+        assert lane.lane_index == ""
+    
+    def test_lane_index_property_map_set(self):
+        lane = _make_afc_lane()
+        lane.map = "T5"
+        assert lane.lane_index == "5"
+    
+    def test_lane_index_property_is_str(self):
+        lane = _make_afc_lane()
+        lane.map = "T5"
+        assert isinstance(lane.lane_index, str)
+
+class TestAFCLaneExtruderIndexProperty:
+    def test_lane_extruder_index_property_is_int(self):
+        lane = _make_afc_lane()
+        lane.extruder_obj.name = "extruder1"
+        assert isinstance(lane.lane_extruder_index, int)
+
+    def test_lane_extruder_index_property_is_none(self):
+        lane = _make_afc_lane()
+        lane.extruder_obj = None
+        assert isinstance(lane.lane_extruder_index, int)
+    
+    def test_lane_extruder_index_property_extruder(self):
+        lane = _make_afc_lane()
+        lane.extruder_obj.name = "extruder"
+        assert lane.lane_extruder_index == 0
+    
+    def test_lane_extruder_index_property_extruder1(self):
+        lane = _make_afc_lane()
+        lane.extruder_obj.name = "extruder1"
+        assert lane.lane_extruder_index == 1
+    
+    def test_lane_extruder_index_property_value_error(self):
+        lane = _make_afc_lane()
+        lane.extruder_obj.name = "extruderT"
+        assert lane.lane_extruder_index == 0    
 
 # ── get_color ─────────────────────────────────────────────────────────────────
 

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -594,6 +594,119 @@ class TestIsNormalPrintingState:
         lane = self._make_lane(AFCLaneState.NONE)
         assert lane._is_normal_printing_state() is False
 
+
+# ── send_lane_data / clear_lane_data ──────────────────────────────────────────
+
+def _make_lane_for_moonraker(extruder_name="extruder", map_value="T0"):
+    """Build a minimal AFCLane wired up for send/clear lane data tests."""
+    lane = _make_afc_lane("AFC_stepper lane1")
+    lane.map = map_value
+    lane.extruder_obj = MagicMock()
+    lane.extruder_obj.name = extruder_name
+    lane.color = "#FF0000"
+    lane._material = "PLA"
+    lane.bed_temp = 60
+    lane.extruder_temp = 210
+    lane.td1_data = {"scan_time": "1.23", "td": "0.95"}
+    lane.spool_id = "abc123"
+    lane.weight = 750.0
+    return lane
+
+
+def _get_sent_payload(lane):
+    """Call send_lane_data and return the payload passed to moonraker."""
+    lane.send_lane_data()
+    lane.afc.moonraker.send_lane_data.assert_called_once()
+    return lane.afc.moonraker.send_lane_data.call_args[0][0]
+
+
+def _get_cleared_payload(lane):
+    """Call clear_lane_data and return the payload passed to moonraker."""
+    lane.clear_lane_data()
+    lane.afc.moonraker.send_lane_data.assert_called_once()
+    return lane.afc.moonraker.send_lane_data.call_args[0][0]
+
+
+class TestSendLaneDataExtruderIndex:
+    @pytest.mark.parametrize("extruder_name,expected_index", [
+        ("extruder",  0),
+        ("extruder1", 1),
+        ("extruder2", 2),
+        ("extruder3", 3),
+    ])
+    def test_extruder_index_derivation(self, extruder_name, expected_index):
+        lane = _make_lane_for_moonraker(extruder_name=extruder_name, map_value=f"T{expected_index}")
+        payload = _get_sent_payload(lane)
+        assert payload["value"]["extruder_index"] == expected_index
+
+    def test_extruder_index_is_int(self):
+        lane = _make_lane_for_moonraker(extruder_name="extruder1", map_value="T1")
+        payload = _get_sent_payload(lane)
+        assert isinstance(payload["value"]["extruder_index"], int)
+
+    def test_multiple_lanes_same_extruder_same_index(self):
+        lane_a = _make_lane_for_moonraker(extruder_name="extruder", map_value="T0")
+        lane_b = _make_lane_for_moonraker(extruder_name="extruder", map_value="T1")
+        payload_a = _get_sent_payload(lane_a)
+        payload_b = _get_sent_payload(lane_b)
+        assert payload_a["value"]["extruder_index"] == payload_b["value"]["extruder_index"]
+
+    def test_payload_namespace_is_lane_data(self):
+        lane = _make_lane_for_moonraker()
+        payload = _get_sent_payload(lane)
+        assert payload["namespace"] == "lane_data"
+
+    def test_no_send_when_map_is_none(self):
+        lane = _make_lane_for_moonraker()
+        lane.map = None
+        lane.send_lane_data()
+        lane.afc.moonraker.send_lane_data.assert_not_called()
+
+    def test_no_send_when_map_has_no_T(self):
+        lane = _make_lane_for_moonraker()
+        lane.map = "0"
+        lane.send_lane_data()
+        lane.afc.moonraker.send_lane_data.assert_not_called()
+
+
+class TestClearLaneDataExtruderIndex:
+    @pytest.mark.parametrize("extruder_name,expected_index", [
+        ("extruder",  0),
+        ("extruder1", 1),
+        ("extruder2", 2),
+        ("extruder3", 3),
+    ])
+    def test_extruder_index_derivation(self, extruder_name, expected_index):
+        lane = _make_lane_for_moonraker(extruder_name=extruder_name, map_value=f"T{expected_index}")
+        payload = _get_cleared_payload(lane)
+        assert payload["value"]["extruder_index"] == expected_index
+
+    def test_extruder_index_is_int(self):
+        lane = _make_lane_for_moonraker(extruder_name="extruder1", map_value="T1")
+        payload = _get_cleared_payload(lane)
+        assert isinstance(payload["value"]["extruder_index"], int)
+
+    def test_color_is_cleared(self):
+        lane = _make_lane_for_moonraker()
+        payload = _get_cleared_payload(lane)
+        assert payload["value"]["color"] == ""
+
+    def test_no_clear_when_map_is_none(self):
+        lane = _make_lane_for_moonraker()
+        lane.map = None
+        lane.clear_lane_data()
+        lane.afc.moonraker.send_lane_data.assert_not_called()
+
+
+# ── _is_normal_printing_state (continued) ─────────────────────────────────────
+
+class TestIsNormalPrintingStateContinued:
+    def _make_lane(self, status, in_toolchange=False):
+        lane = _make_lane_with_afc()
+        lane.status = status
+        lane.afc.in_toolchange = in_toolchange
+        return lane
+
     def test_in_toolchange_returns_false_even_if_tooled(self):
         from extras.AFC_lane import AFCLaneState
         lane = self._make_lane(AFCLaneState.TOOLED, in_toolchange=True)


### PR DESCRIPTION
## Major Changes in this PR
Adds `extruder_index` field to the lane_data namespace so consumers
like OrcaSlicer's physical_extruder_mapper can identify which physical
extruder each lane is associated with.

## Notes to Code Reviewers

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [X] I have performed a self-review of my code
- [X] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The lane data endpoint now includes an extruder index field (0-based physical extruder identifier) to support proper physical-to-filament mapping in multi-extruder printer setups.

* **Tests**
  * Added comprehensive test coverage for lane indexing properties and Moonraker payload generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AFCProject/AFC-Klipper-Add-On/pull/701?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->