### PR TITLE
Update git remote address

### DIFF
--- a/.github/ISSUE_TEMPLATE/all_others.yml
+++ b/.github/ISSUE_TEMPLATE/all_others.yml
@@ -2,7 +2,7 @@ name: All others
 description: Anything else!
 title: "[Other]: "
 labels: ["Other", "triage"]
-projects: ["ArmoredTurtle/AFC-Klipper-Add-On"]
+projects: ["AFCProject/AFC-Klipper-Add-On"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,7 +2,7 @@ name: Bug Report
 description: File a bug report.
 title: "[Bug]: "
 labels: ["bug", "triage"]
-projects: ["ArmoredTurtle/AFC-Klipper-Add-On"]
+projects: ["AFCProject/AFC-Klipper-Add-On"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,7 +2,7 @@ name: Feature Request
 description: Request a new feature.
 title: "[Enhancement]: "
 labels: ["enhancement", "triage"]
-projects: ["ArmoredTurtle/AFC-Klipper-Add-On"]
+projects: ["AFCProject/AFC-Klipper-Add-On"]
 body:
   - type: markdown
     attributes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thanks for your interest in contributing! Whether it's a bug report, new feature
 
 1. **Fork the repository** and create your branch from `main` or the default branch.
 2. Make your changes, following the guidelines below.
-3. Submit a [pull request](https://github.com/ArmoredTurtle/AFC-Klipper-Add-On/pulls).
+3. Submit a [pull request](https://github.com/AFCProject/AFC-Klipper-Add-On/pulls).
 
 **NOTE** All pull requests should be up to date with the latest changes from the `DEV` branch and PRs should be opened against the `DEV` branch.
 
@@ -39,7 +39,7 @@ Thanks for your interest in contributing! Whether it's a bug report, new feature
 
 ## Bug Reports & Feature Requests
 
-- Use GitHub [Issues](https://github.com/ArmoredTurtle/AFC-Klipper-Add-On/issues) to report bugs or request features.
+- Use GitHub [Issues](https://github.com/AFCProject/AFC-Klipper-Add-On/issues) to report bugs or request features.
 - When reporting a bug, please include:
   - A description of the issue
   - Steps to reproduce

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To install this plugin, you can use the following commands from the users home d
 
 ```bash
 cd ~
-git clone https://github.com/ArmoredTurtle/AFC-Klipper-Add-On.git
+git clone https://github.com/AFCProject/AFC-Klipper-Add-On.git
 cd AFC-Klipper-Add-On
 ./install-afc.sh
 ```

--- a/include/constants.sh
+++ b/include/constants.sh
@@ -23,7 +23,7 @@ moonraker="${moonraker_address}:${moonraker_port}"
 
 
 # Git related constants
-gitrepo="https://github.com/ArmoredTurtle/AFC-Klipper-Add-On.git"
+gitrepo="https://github.com/AFCProject/AFC-Klipper-Add-On.git"
 branch="main"
 git_install="True"
 


### PR DESCRIPTION
## Major Changes in this PR

This pull request updates all references to the project's GitHub repository, changing them from the old `ArmoredTurtle/AFC-Klipper-Add-On` organization to the new `AFCProject/AFC-Klipper-Add-On` repository. This ensures consistency across documentation, issue templates, and scripts, and prevents confusion or errors when users or contributors interact with the project.

Repository reference updates:

* Updated the repository URL in the installation instructions in `README.md` to use the new `AFCProject` organization.
* Changed the `gitrepo` variable in `include/constants.sh` to point to the new repository URL.

Documentation and contribution guidelines:

* Updated all repository links in `CONTRIBUTING.md`, including pull request and issue links, to reference the new organization and repository. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L10-R10) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L42-R42)

GitHub issue templates:

* Changed the `projects` field in `.github/ISSUE_TEMPLATE/bug_report.yml`, `.github/ISSUE_TEMPLATE/feature_request.yml`, and `.github/ISSUE_TEMPLATE/all_others.yml` to use the new project path. [[1]](diffhunk://#diff-637f7b97bba458badb691a1557c3d4648686292e948dbe3e8360564378b653efL5-R5) [[2]](diffhunk://#diff-c6b098646bf32c644234bec14c2675ea2a3d9c2dc2df450a25aa0e7ff02323cdL5-R5) [[3]](diffhunk://#diff-793e7f6b49bfff3e00dcbb99b62a22883b0a404f3ad99a56e5292b34a57c1900L5-R5)

## Notes to Code Reviewers

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.