### PR TITLE
[fix]: Fixed issue where zero was being passed into AFC_RESET during calibration, calibration errors show in popup window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed error where tool endstop was not being set correctly for homing when user had buffer set as pin_tool_start and an invalid buffer variable assigned in AFC_extruder config section. AFC now errors out if specified buffer config specified in AFC_extruder is not found.
 - Fixed an issue where `SET_LANE_LOADED` could incorrectly report bypass-enabled errors on physical bypass switches when no filament was present. `SET_LANE_LOADED` now correctly detects filament in bypass and only errors when appropriate.
+- Fixed calibration issue where 0 was being passed into `AFC_RESET` causing an error to display about invalid distance.
+### Added
+- Error message now pops up in calibration window when errors occur, no more searching console log to find applicable error.
+- Reset to hub button now only shows up when distance is not zero.
 
 ## [2026-05-16]
 ### Added

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -42,7 +42,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 try: from extras.AFC_stats import AFCStats
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
 
-AFC_VERSION="1.1.15"
+AFC_VERSION="1.1.16"
 
 # Class for holding different states so its clear what all valid states are
 class State:

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -420,7 +420,7 @@ class afcBoxTurtle(afcUnit):
 
         if not success:
             # fault if check is not successful
-            msg = f'Failed to calibrate dist_hub for {cur_lane.name} after moving {hub_fault_dis}mm. '
+            msg = f'Failed to calibrate dist_hub for {cur_lane.name} after moving {hub_pos}mm. '
             msg += 'If filament stopped short of the hub during calibration use the following command to increase dist_hub value.'
             msg += f' SET_HUB_DIST LANE={cur_lane.name} LENGTH=+(distance the filament was short from the hub)'
             return False, msg, hub_pos

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -223,14 +223,14 @@ class afcBoxTurtle(afcUnit):
                 # Check for error and return, if error state is set then AFC tried pausing
                 # during the homing
                 if warn == AFCMoveWarning.ERROR:
-                    return False, "Error occurred when trying to move lane", 0
+                    return False, "Error occurred when trying to move lane", fault_dis
                 bow_pos += distance
                 self.afc.reactor.pause(self.afc.reactor.monotonic() + 0.1)
                 if bow_pos >= fault_dis:
                     # fault if move to bowden length does not reach toolhead sensor return to calibration macro
-                    msg = 'while moving to toolhead. Failed after {}mm'.format(bow_pos)
-                    msg += '\n if filament stopped short of the toolhead sensor/ramming during calibration'
-                    msg += '\n use the following command to increase bowden length'
+                    msg = 'while moving to toolhead. Failed after {}mm, '.format(bow_pos)
+                    msg += 'if filament stopped short of the toolhead sensor/ramming during calibration'
+                    msg += 'use the following command to increase bowden length'
                     if not is_direct_dist:
                         msg += '\n SET_BOWDEN_LENGTH HUB={} LENGTH=+(distance the filament was short from the toolhead)'.format(cur_hub.name)
                     else:
@@ -256,7 +256,7 @@ class afcBoxTurtle(afcUnit):
                 success, _, _ = cur_lane.unit_obj.move_to_load(cur_lane, bow_pos, MoveDirection.NEG,
                                                                self.afc.homing_enabled)
             if not success:
-                return False, "Failed to home filament back to hub", 0
+                return False, "Failed to home filament back to hub", fault_dis
 
             if (not self.afc.homing_enabled
                 and not is_direct_dist):
@@ -420,8 +420,8 @@ class afcBoxTurtle(afcUnit):
 
         if not success:
             # fault if check is not successful
-            msg = f'Failed to calibrate dist_hub for {cur_lane.name} after moving {hub_fault_dis}mm'
-            msg += 'If filament stopped short of the hub during calibration use the following command to increase dist_hub value'
+            msg = f'Failed to calibrate dist_hub for {cur_lane.name} after moving {hub_fault_dis}mm. '
+            msg += 'If filament stopped short of the hub during calibration use the following command to increase dist_hub value.'
             msg += f' SET_HUB_DIST LANE={cur_lane.name} LENGTH=+(distance the filament was short from the hub)'
             return False, msg, hub_pos
 

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -901,7 +901,14 @@ class afcFunction:
                 checked, msg, pos = lane.unit_obj.calibrate_lane(lane, tol)
             if(not checked):
                 self.afc.error.AFC_error(msg, False)
-                self._afc_cali_fail(cali=lane, dis=pos, reset_lane=(pos!=0),fail_message=msg)
+
+                reset_lane = False
+                # Check to see if lane has hub object and thats its triggered, this will control
+                # if reset lane message is displayed when errors occur.
+                if hasattr(lane, "hub_obj") and hasattr(lane.hub_obj, "state"):
+                    reset_lane = lane.hub_obj.state
+
+                self._afc_cali_fail(cali=lane.name, dis=abs(pos), reset_lane=(pos!=0 and reset_lane),fail_message=msg)
                 return checked, [], []
             else:
                 if msg == "calibration_lane":
@@ -972,7 +979,10 @@ class afcFunction:
         text = f'{title} for {cali}. '
         if reset_lane:
             text += 'First: reset lane, Second: review messages and take necessary action and re-run calibration.'
-            buttons.append(("Reset lane", "AFC_LANE_RESET LANE={} DISTANCE={}".format(cali, dis), "primary"))
+            if dis is not None:
+                buttons.append(("Reset lane", "AFC_LANE_RESET LANE={} DISTANCE={}".format(cali, dis), "primary"))
+            else:
+                buttons.append(("Reset lane", "AFC_LANE_RESET LANE={}".format(cali), "primary"))
 
         if fail_message:
             text += f"\nFail message: {fail_message}"
@@ -1339,8 +1349,11 @@ class afcFunction:
 
             checked, msg, pos = cur_lane.unit_obj.calibrate_bowden(cur_lane, dis, tol)
             if not checked:
-                self.afc.error.AFC_error('{} failed to calibrate bowden length {}'.format(afc_bl, msg), pause=False)
-                self.afc.gcode.run_script_from_command('AFC_CALI_FAIL FAIL={} DISTANCE={}'.format(afc_bl, pos))
+                msg = '{} failed to calibrate bowden length {}'.format(afc_bl, msg)
+                self.afc.error.AFC_error(msg, pause=False)
+
+                self._afc_cali_fail(cali=cur_lane.name, dis=abs(pos), reset_lane=(pos!=0),
+                                    title="AFC Bowden Calibration Failed", fail_message=msg)
                 return
             else: calibrated.append('Bowden_length: {}'.format(afc_bl))
 


### PR DESCRIPTION
## Major Changes in this PR
- Fixed issue where zero was being passed into `AFC_RESET` during calibration, causing `AFC_RESET` macro to display an error because passed in distance was invalid.
- Error message now pops up in calibration window when errors occur, no more searching console log to find applicable error.
- Reset to hub button now only shows up when distance is not zero.
- Resolves #711 

## How the changes in this PR are tested
Locally on printer, made distance shorted so error would occur.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed calibration issue that caused invalid distance error messages.
  * Enhanced error messages displayed directly in the calibration window.
  * Improved reset button visibility to appear only when the configured distance is valid.

* **Chores**
  * Version bump to 1.1.16.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AFCProject/AFC-Klipper-Add-On/pull/718?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->