### PR TITLE
Improve hub:direct unload behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2026-05-24]
 ### Fixed
 - Toolchanger: unload support for hub:direct lanes
+- Toolchanger: tool unload with eject for hub:direct_load lanes
 
 ## [2026-05-23]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-05-24]
+### Fixed
+- Toolchanger: unload support for hub:direct lanes
+
 ## [2026-05-23]
 ### Fixed
 - Fixed error where tool endstop was not being set correctly for homing when user had buffer set as pin_tool_start and an invalid buffer variable assigned in AFC_extruder config section. AFC now errors out if specified buffer config specified in AFC_extruder is not found.

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1204,8 +1204,7 @@ class afc:
 
         # TODO: add a check for multi-tools to verify lane is not loaded to toolhead before trying to unload
         if (cur_lane.name != cur_lane.extruder_obj.lane_loaded
-		    and not cur_lane.extruder_obj.is_standalone()
-			and not cur_lane.is_direct_hub()):
+		    and not cur_lane.extruder_obj.is_standalone()):
             # Setting status as ejecting so if filament is removed and de-activates the prep sensor while
             # extruder motors are still running it does not trigger infinite spool or pause logic
             # once user removes filament lanes status will go to None
@@ -1232,9 +1231,6 @@ class afc:
 
         elif cur_lane.name == cur_lane.extruder_obj.lane_loaded:
             self.logger.info("LANE {} is loaded in toolhead, can't unload.".format(cur_lane.name))
-
-        elif cur_lane.is_direct_hub():
-            self.logger.info("LANE {} is a direct lane must be tool unloaded.".format(cur_lane.name))
 
         self.current_state = State.IDLE
 
@@ -2029,10 +2025,12 @@ class afc:
 
             if (cur_lane.is_direct_hub()
                 and not cur_lane.extruder_obj.is_standalone()):
-                while cur_lane.raw_load_state:
-                    cur_lane.move_advanced(cur_lane.short_move_dis * -1, SpeedMode.SHORT,
-                                           assist_active=AssistActive.YES)
-                cur_lane.move_advanced(cur_lane.short_move_dis * -5, SpeedMode.SHORT)
+                park_tries = 0
+                while not cur_lane.raw_load_state and cur_lane.prep_state:
+                    park_tries += 1
+                    cur_lane.move_advanced(cur_lane.short_move_dis, SpeedMode.SHORT)
+                    if park_tries >= 5:
+                        break
 
             if self.post_unload_macro is not None:
                 self.gcode.run_script_from_command(self.post_unload_macro)

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1759,6 +1759,8 @@ class afc:
 
             unload_time = self.afcDeltaTime.log_major_delta("Lane {} unload done".format(cur_lane.name if cur_lane is not None else "None"))
             self.afc_stats.average_tool_unload_time.average_time(unload_time)
+            if cur_lane is not None and cur_lane.hub == 'direct_load':
+                self.LANE_UNLOAD(cur_lane)
         self.current_state = State.IDLE
         return True
 


### PR DESCRIPTION
## Major Changes in this PR

In hub:direct mode (toolchanger, single lane driving toolhead) unsetting load_to_hub will keep newly loaded spools from winding all the way out to the toolhead, leaving more of the filament inside the enclosure. What doesn't work in this case is the unload. Since there is no hub to home back to, filament homes back to the load switch, which means that the lane loaded state is lost since that switch is no longer triggered.

This change updates the unload behavior so that hub:direct lanes can be unloaded. It does this by doing the same homing move, but then scootching the filament forward until the load switch is triggered again.

This change also addresses an inconsistency where hub:direct lanes can't be ejected. The sequencing of this now works normally with the working unload routine.

Fixes #719

## Notes to Code Reviewers

One inconsistency is that when load_to_hub:False is omitted from the config, the unload routine does not bring the filament back to its load position near the toolhead, it is still unloaded to the position near the load switch. Subsequent loads still work fine though.

## How the changes in this PR are tested

Toolchanger setup with hub:direct lanes in both load_to_hub:False and default configurations.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Toolchanger unload support for direct-hub lanes to use the shared eject path and avoid redundant branch behavior.
  * Added explicit “tool unload with eject” handling for direct-load lanes so they perform an eject pass during unload.
  * Refined unload finalization to use a bounded retry step, reducing unexpected motions and improving reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AFCProject/AFC-Klipper-Add-On/pull/720?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->