### PR TITLE
[fix]: Updates so that Snapmaker U1 pause/resume and power loss resume works correctly with AFC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-02]
+### Added
+- Added support for AFC correctly working with Snapmaker U1 pause/resume and power loss resume functionality.
+
 ## [2026-05-28]
 ### Added
 - Added support for AFC working on Snapmaker U1

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -8,7 +8,9 @@ import json
 import re
 import traceback
 import inspect
+from functools import cached_property
 from configfile import error
+from klippy import Printer
 
 from typing import Dict, TYPE_CHECKING, Union, Any, Optional, Tuple
 
@@ -312,10 +314,6 @@ class afc:
         self.function.register_commands(self.show_macros, 'AFC_RESET_STATS', self.cmd_AFC_RESET_STATS,
                                         self.cmd_AFC_RESET_STATS_help, self.cmd_AFC_RESET_STATS_options)
 
-        # Snapmaker Related Checks
-        self.snapmaker_printer = False
-        self._check_for_snapmaker_signature()
-
     @property
     def current(self):
         return self.function.get_current_lane()
@@ -346,14 +344,14 @@ class afc:
             except Exception as e:
                 self.logger.info("Unable to update TRSYNC_TIMEOUT: {}".format(e))
 
-    def _check_for_snapmaker_signature(self):
+    @cached_property
+    def snapmaker_printer(self):
         """
-        Method to check for Snapmaker U1 signature. If get_snapmaker_config_dir method exists in
-        klippy Printer Class, then print is running u1-klipper version. Sets `snapmaker_printer` to
-        True when this method exists.
+        Property to check get_snapmaker_config_dir method exists in klippy Printer Class.
+
+        :return bool: Returns True of get_snapmaker_config_dir method is found in Printer class
         """
-        from klippy import Printer
-        self.snapmaker_printer = hasattr(Printer, "get_snapmaker_config_dir")
+        return hasattr(Printer, "get_snapmaker_config_dir")
 
     def register_config_callback(self, option):
         # Function needed for virtual pins, does nothing

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -60,7 +60,6 @@ def load_config(config):
     return afc(config)
 
 class afc:
-    SNAPMAKER_TRAPQ_APPEND_LEN = 15
     def __init__(self, config: ConfigWrapper):
         self.config  = config
         self.printer = config.get_printer()
@@ -313,6 +312,10 @@ class afc:
         self.function.register_commands(self.show_macros, 'AFC_RESET_STATS', self.cmd_AFC_RESET_STATS,
                                         self.cmd_AFC_RESET_STATS_help, self.cmd_AFC_RESET_STATS_options)
 
+        # Snapmaker Related Checks
+        self.snapmaker_printer = False
+        self._check_for_snapmaker_signature()
+
     @property
     def current(self):
         return self.function.get_current_lane()
@@ -342,6 +345,15 @@ class afc:
                 else : self.logger.info("TRSYNC_SINGLE_MCU_TIMEOUT does not exist in mcu file, not updating")
             except Exception as e:
                 self.logger.info("Unable to update TRSYNC_TIMEOUT: {}".format(e))
+
+    def _check_for_snapmaker_signature(self):
+        """
+        Method to check for Snapmaker U1 signature. If get_snapmaker_config_dir method exists in
+        klippy Printer Class, then print is running u1-klipper version. Sets `snapmaker_printer` to
+        True when this method exists.
+        """
+        from klippy import Printer
+        self.snapmaker_printer = hasattr(Printer, "get_snapmaker_config_dir")
 
     def register_config_callback(self, option):
         # Function needed for virtual pins, does nothing
@@ -2087,6 +2099,22 @@ class afc:
         CHANGE_TOOL LANE=lane1 PURGE_LENGTH=100 NEW_EXTRUDER_TEMP=220
         ```
         """
+        # Following code originally by J0eB0l
+        # U1 power resume and temperature commands pass A=0 to activate the
+        # extruder without a full tool change.  Rebuild in extended-param
+        # format (A=<val>) because the renamed handler (_T0) is registered
+        # as a non-traditional command and expects key=value syntax.
+        a_param: str = gcmd.get('A', None)
+        if (a_param is not None
+            and self.snapmaker_printer):
+            cmd: str = gcmd.get_commandline().split()[0].upper()
+            renamed = f"_{cmd}"
+            if renamed in self.gcode.ready_gcode_handlers:
+                sm_command = f"{renamed} A={a_param}"
+                self.logger.info(f"Calling snapmakers T(n) command: {sm_command}")
+                self.gcode.run_script_from_command(sm_command)
+                return
+
         # Check if the bypass filament sensor detects filament; if so, abort the tool change.
         if self._check_bypass(unload=False): return
 
@@ -2394,16 +2422,32 @@ class afc:
         """
 
         # TODO: this currently does not work correctly when lanes are remapped and KTC calls M109
-        toolnum  = gcmd.get_int('T', None, minval=0)
-        temp     = gcmd.get_float('S', 0.0)
-        deadband = gcmd.get_float('D', None)
+        toolnum: int = gcmd.get_int('T', None, minval=0)
+        temp: float  = gcmd.get_float('S', 0.0)
+        deadband: float = gcmd.get_float('D', None)
+        snapmaker_param_a: int = gcmd.get_int('A', None)
 
         curr_extruder = self.function.get_current_extruder_obj()
 
         if toolnum is not None:
             map = "T{}".format(toolnum)
             lane = self.function.get_lane_by_map(map)
-            if lane is not None:
+            # If A(n) is in commandline and AFC is running on a snapmaker printer lookup extruder
+            # by T param. For snapmaker printers M109/M104 normally passes in `A0` when resuming, or
+            # resuming from power loss.
+            #
+            # Example command: M104 S220 T0 A0
+            # Result, AFC will heat hotend for extruder instead of the TO lane that could be mapped
+            # to a different toolhead.
+            if (snapmaker_param_a is not None
+                and self.snapmaker_printer):
+                extruder_name = "extruder"
+                if toolnum > 0:
+                    extruder_name = f"extruder{toolnum}"
+                self.logger.debug(f"Snapmaker Temp extruder name {extruder_name}")
+
+                extruder = self.tools.get(extruder_name, self.toolhead.get_extruder())
+            elif lane is not None:
                 extruder = lane.extruder_obj
 
                 # Checking if slicer is trying to set temperature(ooze prevention) for another lane

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -96,7 +96,6 @@ class afcPrep:
             self.afc.reactor.pause(self.afc.reactor.monotonic() + 1)
 
         self._rename_macros()
-        self.afc.print_version(console_only=True)
 
         # Try and connect to moonraker
         self.afc.handle_moonraker_connect()
@@ -137,6 +136,9 @@ class afcPrep:
                   units["system"]["extruders"][extruder_obj.name]['lane_loaded']:
                     extruder_obj.lane_loaded = units["system"]["extruders"][extruder_obj.name]['lane_loaded']
 
+        self.afc.print_version(console_only=True)
+        if self.afc.snapmaker_printer:
+            self.logger.info("Snapmaker Printer Detected")
 
         for lane in self.afc.lanes.keys():
             cur_lane = self.afc.lanes[lane]

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -719,8 +719,9 @@ class AFCExtruderStepper(AFCLane):
                 steps_moved = abs(trig_mcu_pos - start_mcu_pos)
                 dist_mm = steps_moved * step_dist
             except Exception as e:
+                steps_moved = 0
+                dist_mm = 0.0
                 self.logger.debug(f"Exception {e}")
-                pass
             self.logger.debug(f"Homed lane {self.name} to ENDSTOP={endstop_spec} trigger after "\
                               f"{dist_mm:.3f}mm (steps={steps_moved} dt={(end_ts-start_ts):.3f}s)")
 

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -721,8 +721,8 @@ class AFCExtruderStepper(AFCLane):
             except Exception as e:
                 self.logger.debug(f"Exception {e}")
                 pass
-            self.logger.debug(f"Homed lane {self.name}'to ENDSTOP={endstop_spec} trigger after "\
-                              f"{dist_mm:.3f}mm (steps={steps_moved} dt={(end_ts-start_ts):.3f}s")
+            self.logger.debug(f"Homed lane {self.name} to ENDSTOP={endstop_spec} trigger after "\
+                              f"{dist_mm:.3f}mm (steps={steps_moved} dt={(end_ts-start_ts):.3f}s)")
 
             return True, dist_mm
         except Exception as e:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -192,6 +192,7 @@ def _make_force_move_mock():
 def _make_klippy_ready_mock():
     mod = types.ModuleType("klippy")
     mod.message_ready = "Printer is ready"
+    mod.Printer = MagicMock()
     return mod
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -192,7 +192,10 @@ def _make_force_move_mock():
 def _make_klippy_ready_mock():
     mod = types.ModuleType("klippy")
     mod.message_ready = "Printer is ready"
-    mod.Printer = MagicMock()
+    
+    class Printer:
+        pass
+    mod.Printer = Printer
     return mod
 
 

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -1366,9 +1366,9 @@ class TestCmdChangeTool_SnapmakerPath:
     def get_snapmaker_config_dir():
             pass
 
-    def test_setting_A_param(self):
+    def test_setting_A_param(self, monkeypatch):
         obj, _, _ = _make_afc_for_change_tool()
-        setattr(Printer, "get_snapmaker_config_dir", self.get_snapmaker_config_dir)
+        monkeypatch.setattr(Printer, "get_snapmaker_config_dir", True, raising=False)
         gcmd = self._make_gcmd()
         obj.gcode = MagicMock()
         obj.gcode.ready_gcode_handlers = {"_T0": MagicMock()}
@@ -1378,8 +1378,6 @@ class TestCmdChangeTool_SnapmakerPath:
     def test_setting_A_param_snapmaker_false(self):
         obj, _, _ = _make_afc_for_change_tool()
         obj.function.check_homed.return_value = False
-        if hasattr(Printer, "get_snapmaker_config_dir"):
-            delattr(Printer, "get_snapmaker_config_dir")
         gcmd = self._make_gcmd()
         obj.gcode = MagicMock()
         obj.gcode.ready_gcode_handlers = {"_T0": MagicMock()}
@@ -1387,10 +1385,10 @@ class TestCmdChangeTool_SnapmakerPath:
         obj.gcode.run_script_from_command.assert_not_called()
         assert not ret
 
-    def test_setting_A_param_not_in_ready_gcode_handlers(self):
+    def test_setting_A_param_not_in_ready_gcode_handlers(self, monkeypatch):
         obj, _, _ = _make_afc_for_change_tool()
         obj.function.check_homed.return_value = False
-        setattr(Printer, "get_snapmaker_config_dir", self.get_snapmaker_config_dir)
+        monkeypatch.setattr(Printer, "get_snapmaker_config_dir", True, raising=False)
         obj.function.check_homed.return_value = False
         gcmd = self._make_gcmd("T5")
         obj.gcode = MagicMock()
@@ -2396,12 +2394,10 @@ class TestCheckForSnapmakerSignature:
     def test_check_snapmaker_printer_property_false(self):
         obj = _make_afc()
         obj.printer = Printer
-        if hasattr(Printer, "get_snapmaker_config_dir"):
-            delattr(Printer, "get_snapmaker_config_dir")
         assert not obj.snapmaker_printer
     
-    def test_check_snapmaker_printer_property_true(self):
+    def test_check_snapmaker_printer_property_true(self, monkeypatch):
         obj = _make_afc()
         obj.printer = Printer
-        setattr(Printer, "get_snapmaker_config_dir", True)
+        monkeypatch.setattr(Printer, "get_snapmaker_config_dir", True, raising=False)
         assert obj.snapmaker_printer

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -28,6 +28,7 @@ import pytest
 
 from extras.AFC import afc, State, AFC_VERSION
 from extras.AFC_lane import AFCLaneState
+from klippy import Printer
 
 
 # ── State constants ───────────────────────────────────────────────────────────
@@ -120,7 +121,6 @@ def _make_afc():
     obj.number_of_toolchanges = 0
     obj.temp_wait_tolerance = 5
     obj.in_toolchange = False
-    obj.snapmaker_printer = False
     obj.get_bypass_state = MagicMock(return_value=False)
     obj._get_quiet_mode = MagicMock(return_value=False)
     return obj
@@ -589,6 +589,7 @@ def _make_afc_for_change_tool(lane_name="lane2", next_extruder_name="extruder1",
     obj._cooldown_last_extruder = MagicMock()
     obj._wait_for_temp_within_tolerance = MagicMock()
     obj.error = MagicMock()
+    obj.printer = Printer
 
     # Current (old) lane/extruder
     current_extruder = MagicMock()
@@ -1362,10 +1363,12 @@ class TestCmdChangeTool_SnapmakerPath:
             "A": "0"
         }.get(key, default)
         return gcmd
+    def get_snapmaker_config_dir():
+            pass
 
     def test_setting_A_param(self):
         obj, _, _ = _make_afc_for_change_tool()
-        obj.snapmaker_printer = True
+        setattr(Printer, "get_snapmaker_config_dir", self.get_snapmaker_config_dir)
         gcmd = self._make_gcmd()
         obj.gcode = MagicMock()
         obj.gcode.ready_gcode_handlers = {"_T0": MagicMock()}
@@ -1374,8 +1377,9 @@ class TestCmdChangeTool_SnapmakerPath:
     
     def test_setting_A_param_snapmaker_false(self):
         obj, _, _ = _make_afc_for_change_tool()
-        obj.snapmaker_printer = False
         obj.function.check_homed.return_value = False
+        if hasattr(Printer, "get_snapmaker_config_dir"):
+            delattr(Printer, "get_snapmaker_config_dir")
         gcmd = self._make_gcmd()
         obj.gcode = MagicMock()
         obj.gcode.ready_gcode_handlers = {"_T0": MagicMock()}
@@ -1385,7 +1389,8 @@ class TestCmdChangeTool_SnapmakerPath:
 
     def test_setting_A_param_not_in_ready_gcode_handlers(self):
         obj, _, _ = _make_afc_for_change_tool()
-        obj.snapmaker_printer = True
+        obj.function.check_homed.return_value = False
+        setattr(Printer, "get_snapmaker_config_dir", self.get_snapmaker_config_dir)
         obj.function.check_homed.return_value = False
         gcmd = self._make_gcmd("T5")
         obj.gcode = MagicMock()
@@ -2388,17 +2393,15 @@ class TestCmdLaneMove:
         assert args[1] == SpeedMode.LONG
 
 class TestCheckForSnapmakerSignature:
-    def test_check_for_snapmaker_signature_false(self):
-        from klippy import Printer
+    def test_check_snapmaker_printer_property_false(self):
         obj = _make_afc()
+        obj.printer = Printer
         if hasattr(Printer, "get_snapmaker_config_dir"):
             delattr(Printer, "get_snapmaker_config_dir")
-        obj._check_for_snapmaker_signature()
         assert not obj.snapmaker_printer
     
-    def test_check_for_snapmaker_signature_false(self):
-        from klippy import Printer
+    def test_check_snapmaker_printer_property_true(self):
         obj = _make_afc()
-        Printer.get_snapmaker_config_dir = MagicMock()
-        obj._check_for_snapmaker_signature()
+        obj.printer = Printer
+        setattr(Printer, "get_snapmaker_config_dir", True)
         assert obj.snapmaker_printer

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -120,6 +120,7 @@ def _make_afc():
     obj.number_of_toolchanges = 0
     obj.temp_wait_tolerance = 5
     obj.in_toolchange = False
+    obj.snapmaker_printer = False
     obj.get_bypass_state = MagicMock(return_value=False)
     obj._get_quiet_mode = MagicMock(return_value=False)
     return obj
@@ -1327,6 +1328,71 @@ class TestCmdChangeTool_NewExtruderTempParsing:
         assert "PURGE_LENGTH" in error_msg
         obj.CHANGE_TOOL.assert_not_called()
 
+class TestCmdChange_ToolCheckBypass_CheckHomed():
+    def _make_gcmd(self):
+        gcmd = MagicMock()
+        # Use a T0 command line so cmd_CHANGE_TOOL takes the simple else-branch
+        # (no "CHANGE" in command) and Tcmd = "T0" directly.
+        gcmd.get_commandline.return_value = "T0"
+        return gcmd
+
+    def test_check_bypass_True(self):
+        obj, _, _ = _make_afc_for_change_tool()
+        gcmd = self._make_gcmd()
+        obj._check_bypass.return_value = True
+
+        ret = obj.cmd_CHANGE_TOOL(gcmd)
+        assert not ret
+
+    def test_check_homed_False(self):
+        obj, _, _ = _make_afc_for_change_tool()
+        gcmd = self._make_gcmd()
+        obj.function.check_homed.return_value = False
+
+        ret = obj.cmd_CHANGE_TOOL(gcmd)
+        assert not ret
+
+class TestCmdChangeTool_SnapmakerPath:
+    def _make_gcmd(self, tcmd="T0"):
+        gcmd = MagicMock()
+        # Use a T0 command line so cmd_CHANGE_TOOL takes the simple else-branch
+        # (no "CHANGE" in command) and Tcmd = "T0" directly.
+        gcmd.get_commandline.return_value = f"{tcmd} A0"
+        gcmd.get.side_effect = lambda key, default=None: {
+            "A": "0"
+        }.get(key, default)
+        return gcmd
+
+    def test_setting_A_param(self):
+        obj, _, _ = _make_afc_for_change_tool()
+        obj.snapmaker_printer = True
+        gcmd = self._make_gcmd()
+        obj.gcode = MagicMock()
+        obj.gcode.ready_gcode_handlers = {"_T0": MagicMock()}
+        ret = obj.cmd_CHANGE_TOOL(gcmd)
+        obj.gcode.run_script_from_command.assert_called_once()
+    
+    def test_setting_A_param_snapmaker_false(self):
+        obj, _, _ = _make_afc_for_change_tool()
+        obj.snapmaker_printer = False
+        obj.function.check_homed.return_value = False
+        gcmd = self._make_gcmd()
+        obj.gcode = MagicMock()
+        obj.gcode.ready_gcode_handlers = {"_T0": MagicMock()}
+        ret = obj.cmd_CHANGE_TOOL(gcmd)
+        obj.gcode.run_script_from_command.assert_not_called()
+        assert not ret
+
+    def test_setting_A_param_not_in_ready_gcode_handlers(self):
+        obj, _, _ = _make_afc_for_change_tool()
+        obj.snapmaker_printer = True
+        obj.function.check_homed.return_value = False
+        gcmd = self._make_gcmd("T5")
+        obj.gcode = MagicMock()
+        obj.gcode.ready_gcode_handlers = {"_T0": MagicMock()}
+        ret = obj.cmd_CHANGE_TOOL(gcmd)
+        obj.gcode.run_script_from_command.assert_not_called()
+        assert not ret
 
 # ── TOOL_LOAD: destination extruder already has a different lane loaded ───────
 
@@ -2320,3 +2386,19 @@ class TestCmdLaneMove:
         obj.cmd_LANE_MOVE(gcmd)
         args = lane.move_advanced.call_args.args
         assert args[1] == SpeedMode.LONG
+
+class TestCheckForSnapmakerSignature:
+    def test_check_for_snapmaker_signature_false(self):
+        from klippy import Printer
+        obj = _make_afc()
+        if hasattr(Printer, "get_snapmaker_config_dir"):
+            delattr(Printer, "get_snapmaker_config_dir")
+        obj._check_for_snapmaker_signature()
+        assert not obj.snapmaker_printer
+    
+    def test_check_for_snapmaker_signature_false(self):
+        from klippy import Printer
+        obj = _make_afc()
+        Printer.get_snapmaker_config_dir = MagicMock()
+        obj._check_for_snapmaker_signature()
+        assert obj.snapmaker_printer


### PR DESCRIPTION
## Major Changes in this PR
Before these changes U1 printer would select the wrong toolhead when resuming from pause or heat the wrong toolhead when resuming from power loss. These fixes allow pause/resume and power loss resume to work correctly when having more that 4 T(n) macros defined by AFC.
- Updated CHANGE_TOOL method to call original T(n) if A(n) param is passed in.
- Updated M104/M109 macro to heat hot end based off T(n) index if A(n) param was passed in.

## How the changes in this PR are tested
Tested on my U1 printer.
- Reordered T(n) so T0 was not extruder, T1 was not extruder1 etc and pause print. Once resumed correct toolhead was heated and resume worked correctly.
- Caused klipper to crash by unplugging an attached boxturtle, verified that printer was successfully able to resume print with correct toolhead after crash happened.

2.4 Printer, Snapmaker Detected not printing out in console during PREP:
<img width="1462" height="421" alt="image" src="https://github.com/user-attachments/assets/5775c2d4-7e87-40d3-8ff4-040133d3f278" />

Snapmaker U1, Snapmaker Printer Decteted printing out in console during PREP:
<img width="676" height="334" alt="image" src="https://github.com/user-attachments/assets/aacb38a7-27e8-41ae-8214-2c0b2c7e8f72" />

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detect and specially handle Snapmaker U1-style printers to improve tool-change and temperature handling.

* **Bug Fixes**
  * Fixed stepper homing debug logging and improved exception reporting during homing.

* **Behaviour / UX**
  * Prep flow now logs when a Snapmaker printer is detected.

* **Tests**
  * Expanded tests for Snapmaker-specific paths and tool-change scenarios.

* **Documentation**
  * Changelog updated with Snapmaker support entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->