### PR TITLE
Reorder lanes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2026-06-19]
 ### Added
 - Added support for HTLF2-Claymore Unit type.
+### Fixed
+- Fixed lane and unit ordering so that units and lanes show correctly in Fluidd/Mainsail panels
 
 ## [2026-06-07]
 ### Added

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -44,7 +44,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 try: from extras.AFC_stats import AFCStats
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
 
-AFC_VERSION="1.1.19"
+AFC_VERSION="1.1.20"
 
 # Class for holding different states so its clear what all valid states are
 class State:
@@ -451,7 +451,7 @@ class afc:
         Sorts units base on lane numbering so that units/lanes show up in fluidd/mainsail panels
         in the correct order.
         """
-        def natural_lane_num(key, lane: AFCLane):
+        def natural_lane_num(key: int, lane: AFCLane):
             """
             Helper function for returning lane number, if lane name matches extruder name then this
             is a standalone toolhead and returns 9999 to force Tools to the bottom of this list
@@ -461,15 +461,12 @@ class afc:
             :return int: Lane integer if not standalone lane, 9999 if standalone lane
             """
             if lane.extruder_obj.name == lane.name:
-                self.logger.info("standalone")
                 return 9999
-            else:
-                self.logger.info("Not standalone")
 
             m = re.search(r'\d+', key)
             return int(m.group()) if m else 9999
 
-        def unit_min_lane(unit_dict):
+        def unit_min_lane(unit_dict: dict):
             """
             Helper function for getting minimum lane version found in unit
 

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -468,7 +468,7 @@ class afc:
 
         def unit_min_lane(unit_dict: dict):
             """
-            Helper function for getting minimum lane version found in unit
+            Helper function for getting minimum lane number found in unit
 
             :param unit_dict: Units lane dictionary to extract lane numbers from
             :return int: Minimum integer found in units lanes, if no list returns float("inf")

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -68,6 +68,7 @@ class afc:
         self.reactor = self.printer.get_reactor()
         self.webhooks = self.printer.load_object(config, 'webhooks')
         self.printer.register_event_handler("klippy:connect",self.handle_connect)
+        self.printer.register_event_handler("klippy:ready", self.handle_ready)
         self.logger  = AFC_logger(self.printer, self)
 
         self.spool: AFCSpool = self.printer.load_object(config, 'AFC_spool')
@@ -442,6 +443,56 @@ class afc:
         self._rename_macros()
 
         self.current_state = State.IDLE
+
+    def handle_ready(self):
+        """
+        Handle the ready event.
+
+        Sorts units base on lane numbering so that units/lanes show up in fluidd/mainsail panels
+        in the correct order.
+        """
+        def natural_lane_num(key, lane: AFCLane):
+            """
+            Helper function for returning lane number, if lane name matches extruder name then this
+            is a standalone toolhead and returns 9999 to force Tools to the bottom of this list
+
+            :param key: Key name to extract number from
+            :param lane: AFCLane to check if its extruder name matches its name
+            :return int: Lane integer if not standalone lane, 9999 if standalone lane
+            """
+            if lane.extruder_obj.name == lane.name:
+                self.logger.info("standalone")
+                return 9999
+            else:
+                self.logger.info("Not standalone")
+
+            m = re.search(r'\d+', key)
+            return int(m.group()) if m else 9999
+
+        def unit_min_lane(unit_dict):
+            """
+            Helper function for getting minimum lane version found in unit
+
+            :param unit_dict: Units lane dictionary to extract lane numbers from
+            :return int: Minimum integer found in units lanes, if no list returns float("inf")
+            """
+            nums = [
+                natural_lane_num(k, lanes) for k, lanes in unit_dict.lanes.items()
+            ]
+
+            minimum = float("inf")
+            if nums:
+                minimum = min(nums)
+            return minimum
+
+        sorted_units = dict(
+            sorted(
+                self.units.items(),
+                key=lambda x: unit_min_lane(x[1])
+            )
+        )
+
+        self.units = sorted_units
 
     def _rename_macros(self):
         self.function._rename(self.BASE_M104, self.RENAMED_M104, self.cmd_AFC_M104, self.cmd_AFC_M104_help)

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import traceback
+import re
 
 from configfile import error as config_error
 from datetime import datetime, timedelta
@@ -47,6 +48,7 @@ class afcUnit:
         self.printer        = config.get_printer()
         self.gcode          = self.printer.load_object(config, 'gcode')
         self.printer.register_event_handler("klippy:connect", self.handle_connect)
+        self.printer.register_event_handler("klippy:ready", self.handle_ready)
         self.printer.register_event_handler("afc:moonraker_connect", self.handle_moonraker_connect)
         self.afc: afc       = self.printer.load_object(config, 'AFC')
         self.reactor        = self.printer.get_reactor()
@@ -236,6 +238,17 @@ class afcUnit:
         self.gcode.register_mux_command('UNIT_CALIBRATION', "UNIT", self.name, self.cmd_UNIT_CALIBRATION, desc=self.cmd_UNIT_CALIBRATION_help)
         self.gcode.register_mux_command('UNIT_LANE_CALIBRATION', "UNIT", self.name, self.cmd_UNIT_LANE_CALIBRATION, desc=self.cmd_UNIT_LANE_CALIBRATION_help)
         self.gcode.register_mux_command('UNIT_BOW_CALIBRATION', "UNIT", self.name, self.cmd_UNIT_BOW_CALIBRATION, desc=self.cmd_UNIT_BOW_CALIBRATION_help)
+
+    def handle_ready(self):
+        """
+        Handles klippy:ready event, sorts lanes so they they will show up in the correct
+        natural order.
+        """
+        sorted_lanes = dict(sorted(
+            self.lanes.items(),
+            key=lambda x: int(re.search(r"\d+", x[0]).group())
+        ))
+        self.lanes = sorted_lanes
 
     def handle_moonraker_connect(self):
         """

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -246,7 +246,7 @@ class afcUnit:
         """
         sorted_lanes = dict(sorted(
             self.lanes.items(),
-            key=lambda x: int(re.search(r"\d+", x[0]).group())
+            key=lambda x: int(m.group()) if (m := re.search(r"\d+", x[0])) else 9999
         ))
         self.lanes = sorted_lanes
 

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -2525,3 +2525,87 @@ class TestCheckForSnapmakerSignature:
         obj.printer = Printer
         monkeypatch.setattr(Printer, "get_snapmaker_config_dir", True, raising=False)
         assert obj.snapmaker_printer
+
+class TestUnitOrdering:
+    def _make_unit(self, name, afc):
+        unit = MagicMock()
+        unit.name = name
+        unit.lanes = {}
+
+
+        afc.units.update({name: unit})
+        return unit
+        
+    def add_lane_to_unit(self, unit, lane_name, extruder_name="extruder"):
+        lane = MagicMock()
+        lane.name = lane_name
+        lane.extruder_obj.name = extruder_name
+        unit.lanes.update({lane_name: lane})
+        
+    def test_unit_lane_ordering(self):
+        obj = _make_afc()
+        claymore_unit = self._make_unit("HTLF_Claymore_1", obj)
+        self.add_lane_to_unit(claymore_unit, "lane11", "extruder")
+        self.add_lane_to_unit(claymore_unit, "lane12", "extruder")
+        self.add_lane_to_unit(claymore_unit, "lane13", "extruder")
+        self.add_lane_to_unit(claymore_unit, "lane14", "extruder")
+
+        emu_unit = self._make_unit("EMU_1", obj)
+        self.add_lane_to_unit(emu_unit, "lane9", "extruder3")
+        self.add_lane_to_unit(emu_unit, "lane10", "extruder3")
+        
+        tools_unit = self._make_unit("Tools", obj)
+        self.add_lane_to_unit(tools_unit, "extruder1", "extruder1")
+        self.add_lane_to_unit(tools_unit, "extruder2", "extruder2")
+
+        bt_unit = self._make_unit("Turtle_1", obj)
+        self.add_lane_to_unit(bt_unit, "lane4", "extruder")
+        self.add_lane_to_unit(bt_unit, "lane2", "extruder")
+        self.add_lane_to_unit(bt_unit, "lane1", "extruder")
+        self.add_lane_to_unit(bt_unit, "lane3", "extruder")
+
+        vivid_unit = self._make_unit("Vivid_1", obj)
+        self.add_lane_to_unit(vivid_unit, "lane8", "extruder3")
+        self.add_lane_to_unit(vivid_unit, "lane5", "extruder3")
+        self.add_lane_to_unit(vivid_unit, "lane7", "extruder3")
+        self.add_lane_to_unit(vivid_unit, "lane6", "extruder3")
+
+
+        obj.handle_ready()
+
+        key_order = list(obj.units.keys())
+
+        assert key_order == ["Turtle_1", "Vivid_1", "EMU_1", "HTLF_Claymore_1", "Tools"], key_order
+
+    def test_inf_unit_lane_ordering(self):
+        obj = _make_afc()
+        claymore_unit = self._make_unit("HTLF_Claymore_1", obj)
+        self.add_lane_to_unit(claymore_unit, "lane11", "extruder")
+        self.add_lane_to_unit(claymore_unit, "lane12", "extruder")
+        self.add_lane_to_unit(claymore_unit, "lane13", "extruder")
+        self.add_lane_to_unit(claymore_unit, "lane14", "extruder")
+
+        emu_unit = self._make_unit("EMU_1", obj)
+        
+        tools_unit = self._make_unit("Tools", obj)
+        self.add_lane_to_unit(tools_unit, "extruder1", "extruder1")
+        self.add_lane_to_unit(tools_unit, "extruder2", "extruder2")
+
+        bt_unit = self._make_unit("Turtle_1", obj)
+        self.add_lane_to_unit(bt_unit, "lane4", "extruder")
+        self.add_lane_to_unit(bt_unit, "lane2", "extruder")
+        self.add_lane_to_unit(bt_unit, "lane1", "extruder")
+        self.add_lane_to_unit(bt_unit, "lane3", "extruder")
+
+        vivid_unit = self._make_unit("Vivid_1", obj)
+        self.add_lane_to_unit(vivid_unit, "lane8", "extruder3")
+        self.add_lane_to_unit(vivid_unit, "lane5", "extruder3")
+        self.add_lane_to_unit(vivid_unit, "lane7", "extruder3")
+        self.add_lane_to_unit(vivid_unit, "lane6", "extruder3")
+
+        obj.handle_ready()
+
+        key_order = list(obj.units.keys())
+
+        assert key_order == ["Turtle_1", "Vivid_1", "HTLF_Claymore_1", "Tools", "EMU_1"], key_order
+        

--- a/tests/test_AFC_unit.py
+++ b/tests/test_AFC_unit.py
@@ -388,3 +388,15 @@ class TestBufferToolheadLoadCheck:
         call_args = lane.move.call_args[0]
         assert result is True
         assert call_args[0] == (SIDE_EFFECT_DIST * MoveDirection.NEG)
+
+
+class TestLaneOrdering:
+    def test_lane_in_correct_order(self):
+        # Tests to verify that lanes are in correct natural number order
+        unit = _make_unit()
+        lane = _make_lane()
+
+        unit.lanes = {"lane2": lane, "lane1": lane, "custom_name4":lane, "lane3": lane, "lane10": lane}
+        unit.handle_ready()
+
+        assert list(unit.lanes.keys()) == ["lane1", "lane2", "lane3", "custom_name4", "lane10"]


### PR DESCRIPTION
## Major Changes in this PR
- During klippy ready event added reordering lanes and units by minmum lane value so that lanes show in correct order in unit section and units show in correct order by lane in Fluidd/Mainsail UI's

Resolves #597

## Notes to Code Reviewers

## How the changes in this PR are tested
Tested on Snapmaker U1 since units were already out of order and forced ViVid lanes to be out of order

Before Fix:
<img width="893" height="1014" alt="image" src="https://github.com/user-attachments/assets/3012ec10-7733-4d46-8c9e-4c697c8648cc" />

After fix, all lanes and units show in correct order:
<img width="877" height="999" alt="image" src="https://github.com/user-attachments/assets/6734e0f4-89fb-4cce-b21b-765e15b47e69" />

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected lane and unit ordering so units and lanes display correctly in Fluidd/Mainsail panels.
  * Improved ordering behavior to sort lanes by natural numeric sequence and adjust unit ordering accordingly for consistent UI presentation.
* **Tests**
  * Added unit and lane ordering coverage to verify the new display order across multiple scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->