### PR TITLE
(feat): Adding setting color, material, etc into Snapmakers print_task_config object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2026-06-20]
 ### Fixed
 - Setting toolhead leds correctly during PREP for toolchangers
+### Added
+- Support for updating Snapmaker U1 print_task_config object with proper filament color, material, name, etc.
 
 ## [2026-06-19]
 ### Added

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -224,6 +224,8 @@ class afcFunction:
 
         :param cur_lane: Lane to assign auto generated T(n) macro
         """
+        
+        print_task_config_obj = self.printer.lookup_object('print_task_config', None)
         if cur_lane.map is None:
             for x in range(99):
                 cmd = 'T{}'.format(x)
@@ -239,6 +241,16 @@ class afcFunction:
                         cur_lane._map = cur_lane.map = cmd
                         break
         self.afc.tool_cmds[cur_lane.map]=cur_lane.name
+        # if print_task_config_obj is not None:
+        #     parsed_map = int(cur_lane.map.replace('T', ''))
+        #     self.logger.info(f"Extruder name {cur_lane.extruder_obj.name}")
+        #     if cur_lane.extruder_obj.name == "extruder":
+        #         extruder_num = 0
+        #     else:
+        #         extruder_num =int(cur_lane.extruder_obj.name.replace("extruder", ""))
+
+        #     print_task_config_obj.print_task_config['extruder_map_table'][parsed_map] = extruder_num
+        #     print_task_config_obj.print_task_config['reprint_info']['extruder_map_table'][parsed_map] = extruder_num
         try:
             if (cur_lane._map
                 or self.afc.force_assign_map):

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -224,8 +224,6 @@ class afcFunction:
 
         :param cur_lane: Lane to assign auto generated T(n) macro
         """
-        
-        print_task_config_obj = self.printer.lookup_object('print_task_config', None)
         if cur_lane.map is None:
             for x in range(99):
                 cmd = 'T{}'.format(x)
@@ -241,16 +239,6 @@ class afcFunction:
                         cur_lane._map = cur_lane.map = cmd
                         break
         self.afc.tool_cmds[cur_lane.map]=cur_lane.name
-        # if print_task_config_obj is not None:
-        #     parsed_map = int(cur_lane.map.replace('T', ''))
-        #     self.logger.info(f"Extruder name {cur_lane.extruder_obj.name}")
-        #     if cur_lane.extruder_obj.name == "extruder":
-        #         extruder_num = 0
-        #     else:
-        #         extruder_num =int(cur_lane.extruder_obj.name.replace("extruder", ""))
-
-        #     print_task_config_obj.print_task_config['extruder_map_table'][parsed_map] = extruder_num
-        #     print_task_config_obj.print_task_config['reprint_info']['extruder_map_table'][parsed_map] = extruder_num
         try:
             if (cur_lane._map
                 or self.afc.force_assign_map):

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -1459,6 +1459,7 @@ class AFCLane:
         if normal_toolchange:
             self.afc.current_loading = None
             self.afc.spool.set_active_spool(self.spool_id)
+        self.afc.spool.set_snapmaker_filament_params(self)
 
         self.unit_obj.lane_tool_loaded(self)
 

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -125,6 +125,7 @@ class AFCLane:
         self.spool_id           = None
         self.color: str         = ""
         self.multi_color: list  = []
+        self.spool_vendor       = ""
         self.weight: float      = 0.
         self.auto_switch_triggered = False
         self._material: str     = None

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -2128,6 +2128,9 @@ class AFCLane:
         response["remember_spool"]= bool(self.remember_spool)
         response["spool_id"]= int(self.spool_id) if self.spool_id else None
         response["color"]=self.color
+        if not save_to_file:
+            response["multi_color_hexes"] = self.multi_color
+
         response["weight"]=self.weight
         response["extruder_temp"] = self.extruder_temp
         response["bed_temp"] = self.bed_temp

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -123,10 +123,11 @@ class AFCLane:
         self.tool_loaded        = False
         self.loaded_to_hub      = False
         self.spool_id           = None
-        self.color              = None
-        self.weight             = 0
+        self.color: str         = ""
+        self.multi_color: list  = []
+        self.weight: float      = 0.
         self.auto_switch_triggered = False
-        self._material          = None
+        self._material: str     = None
         self.extruder_temp      = None
         self.bed_temp           = None
         self.td1_data           = {}

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -12,6 +12,10 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from extras.AFC import afc
+    from extras.AFC_lane import AFCLane
+
+if TYPE_CHECKING:
+    from extras.AFC import afc
 
 class afcPrep:
     def __init__(self, config):
@@ -268,6 +272,13 @@ class afcPrep:
                     self.logger.raw("<span class=warning--text>Warning: Both advance and trailing "
                                     "switches are triggered on Buffer {}. "
                                     "Please check your buffer switches or configuration.</span>".format(buffer_name))
+
+        if self.afc.snapmaker_printer:
+            for extruder in self.afc.tools.values():
+                lane: AFCLane = extruder.lanes.get(extruder.lane_loaded, None)
+                if (lane
+                    and lane.tool_loaded):
+                    self.afc.spool.set_snapmaker_filament_params(lane)
 
         # Verifying that user has macro positions set correctly for enabled park, cut, etc macros
         error_str = self.afc.verify_macro_positions()

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -3,9 +3,16 @@
 # Copyright (C) 2024-2026 Armored Turtle
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from extras.AFC import afc
+    from extras.AFC_lane import AFCLane
 
 class AFCSpool:
+    SNAPMAKER_SET_PRINT_FILAMENT_CONFIG = "SET_PRINT_FILAMENT_CONFIG"
     def __init__(self, config):
         self.printer = config.get_printer()
         self.printer.register_event_handler("klippy:connect", self.handle_connect)
@@ -20,11 +27,12 @@ class AFCSpool:
         This function is called when the printer connects. It looks up the AFC object
         and assigns it to the instance variable `self.AFC`.
         """
-        self.afc        = self.printer.lookup_object('AFC')
+        self.afc: afc   = self.printer.lookup_object('AFC')
         self.error      = self.afc.error
         self.reactor    = self.afc.reactor
         self.gcode      = self.afc.gcode
         self.logger     = self.afc.logger
+        self.print_task_config_obj = self.printer.lookup_object('print_task_config', None)
 
         self.disable_weight_check = self.afc.disable_weight_check
 
@@ -34,7 +42,7 @@ class AFCSpool:
         self.gcode.register_command("RESET_AFC_MAPPING", self.cmd_RESET_AFC_MAPPING, desc=self.cmd_RESET_AFC_MAPPING_help)
         self.gcode.register_command("SET_NEXT_SPOOL_ID", self.cmd_SET_NEXT_SPOOL_ID, desc=self.cmd_SET_NEXT_SPOOL_ID_help)
 
-    def register_lane_macros(self, lane_obj):
+    def register_lane_macros(self, lane_obj: AFCLane):
         """
         Callback function to register macros with proper lane names so that klipper errors out correctly when users supply lanes that
         are not valid
@@ -48,6 +56,22 @@ class AFCSpool:
         self.gcode.register_mux_command('SET_RUNOUT',           "LANE", lane_obj.name, self.cmd_SET_RUNOUT,             desc=self.cmd_SET_RUNOUT_help)
         self.gcode.register_mux_command('SET_MAP',              "LANE", lane_obj.name, self.cmd_SET_MAP,                desc=self.cmd_SET_MAP_help)
         self.gcode.register_mux_command('AFC_SET_SPOOL_TEMP',   "LANE", lane_obj.name, self.cmd_AFC_SET_SPOOL_TEMP,     desc=self.cmd_AFC_SET_SPOOL_TEMP_help)
+
+    def set_snapmaker_filament_params(self, lane: AFCLane):
+        if (self.afc.snapmaker_printer
+            and lane.tool_loaded
+            and lane.name == lane.extruder_obj.lane_loaded):
+            extruder_num = 0 if lane.extruder_obj.name == "extruder" else lane.extruder_obj.name[-1]
+            self.print_task_config_obj.print_task_config['filament_vendor'][extruder_num] = "Generic"
+            self.print_task_config_obj.print_task_config['filament_type'][extruder_num] = lane.material
+            self.print_task_config_obj.print_task_config['filament_color'][extruder_num] = lane.color.replace('#', '')
+            # msg = f"{self.SNAPMAKER_SET_PRINT_FILAMENT_CONFIG} CONFIG_EXTRUDER={extruder_num} VENDOR='Generic' "
+            # msg += f"FILAMENT_COLOR_RGBA={lane.color.replace('#', '')} FILAMENT_TYPE='{lane.material}' FILAMENT_SUBTYPE=''"
+            # self.logger.debug(msg)
+            # try:
+            #     self.gcode.run_script_from_command(msg)
+            # except:
+            #     pass
 
     cmd_AFC_SET_SPOOL_TEMP_help = "Set spool temperatures for a lane"
     def cmd_AFC_SET_SPOOL_TEMP(self, gcmd):
@@ -159,6 +183,7 @@ class AFCSpool:
             unit = cur_lane.unit_obj
             self.afc.function.afc_led(unit._get_lane_color(cur_lane, cur_lane.led_ready), cur_lane.led_index)
         self.afc.save_vars()
+        self.set_snapmaker_filament_params(cur_lane)
 
     cmd_SET_WEIGHT_help = "Sets filaments weight for a lane"
     def cmd_SET_WEIGHT(self, gcmd):
@@ -236,6 +261,7 @@ class AFCSpool:
 
         cur_lane.send_lane_data()
         self.afc.save_vars()
+        self.set_snapmaker_filament_params(cur_lane)
 
     def set_active_spool(self, ID):
         webhooks = self.printer.lookup_object('webhooks')
@@ -396,6 +422,9 @@ class AFCSpool:
             # Clears out values if users are not using spoolman and lane isn't set to remember spool, this is to cover this function being called from LANE UNLOAD and clearing out
             # Manually entered information
             self.clear_values(cur_lane)
+
+        self.set_snapmaker_filament_params(cur_lane)
+
         if save_vars: self.afc.save_vars()
 
     cmd_SET_RUNOUT_help = "Set runout lane"

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -454,8 +454,9 @@ class AFCSpool:
 
                     # Check to see if filament is defined as multi-color and take the first color for now
                     # Once support for multicolor is added this needs to be updated
-                    if "multi_color_hexes" in result['filament']:
-                        cur_lane.multi_color = self._get_filament_values(result['filament'], 'multi_color_hexes').split(",")
+                    multi_color_hex = self._get_filament_values(result['filament'], 'multi_color_hexes')
+                    if multi_color_hex:
+                        cur_lane.multi_color = multi_color_hex.split(",")
                         cur_lane.color = f"#{cur_lane.multi_color[0]}"
                     else:
                         cur_lane.color = '#{}'.format(self._get_filament_values(result['filament'], 'color_hex'))

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -84,9 +84,13 @@ class AFCSpool:
 
                 tmp_config = copy.deepcopy(self.print_task_config_obj.print_task_config)
 
-                tmp_config['filament_vendor'][extruder_num] = "Generic"
-                tmp_config['filament_type'][extruder_num] = lane.material
-                tmp_config['filament_sub_type'][extruder_num] = None
+                tmp_config['filament_vendor'][extruder_num] = (lane.spool_vendor or "Generic")
+                tmp_config['filament_type'][extruder_num] = (
+                    lane.material
+                    or getattr(self.afc, "default_material_type", None)
+                    or "NONE"
+                )
+                tmp_config['filament_sub_type'][extruder_num] = "NONE"
 
                 tmp_config['filament_color'][extruder_num] = int("FFFFFFFF", 16)
                 tmp_config['filament_color_rgba'][extruder_num] = "FFFFFFFF"
@@ -396,7 +400,7 @@ class AFCSpool:
             self.next_spool_id = None
             self.set_spoolID(cur_lane, spool_id)
 
-    def clear_values(self, cur_lane):
+    def clear_values(self, cur_lane: AFCLane):
         """
         Helper function for clearing out lane spool values
         """
@@ -409,8 +413,9 @@ class AFCSpool:
         cur_lane.extruder_temp = None
         cur_lane.bed_temp = None
         cur_lane.clear_lane_data()
+        cur_lane.spool_vendor = ""
 
-    def set_spoolID(self, cur_lane, SpoolID, save_vars=True):
+    def set_spoolID(self, cur_lane: AFCLane, SpoolID: str, save_vars=True):
         if self.afc.spoolman is not None:
             if SpoolID not in ('', None):
                 try:
@@ -427,6 +432,11 @@ class AFCSpool:
                     cur_lane.empty_spool_weight = self._get_filament_values(result, 'spool_weight', default=190)
                     cur_lane.weight             = self._get_filament_values(result, 'remaining_weight')
                     cur_lane.espooler.espooler_values.full_weight = self._get_filament_values(result, 'initial_weight', default=1000)
+
+                    vendor_result  = result["filament"].get("vendor", None)
+                    cur_lane.spool_vendor       = ""
+                    if vendor_result:
+                        cur_lane.spool_vendor   = self._get_filament_values(vendor_result, "name", None)
 
                     weight_check = self.disable_weight_check
 

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -220,6 +220,7 @@ class AFCSpool:
             return
         cur_lane = self.afc.lanes[lane]
         cur_lane.color = '#{}'.format(color.replace('#',''))
+        cur_lane.multi_color = []
         cur_lane.send_lane_data()
         # Refresh LED only if filament is loaded — empty lanes keep their state color
         if cur_lane.load_state and cur_lane.unit in self.afc.units:

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -6,13 +6,14 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+import copy
+import traceback
 
 if TYPE_CHECKING:
     from extras.AFC import afc
     from extras.AFC_lane import AFCLane
 
 class AFCSpool:
-    SNAPMAKER_SET_PRINT_FILAMENT_CONFIG = "SET_PRINT_FILAMENT_CONFIG"
     def __init__(self, config):
         self.printer = config.get_printer()
         self.printer.register_event_handler("klippy:connect", self.handle_connect)
@@ -61,17 +62,40 @@ class AFCSpool:
         if (self.afc.snapmaker_printer
             and lane.tool_loaded
             and lane.name == lane.extruder_obj.lane_loaded):
-            extruder_num = 0 if lane.extruder_obj.name == "extruder" else lane.extruder_obj.name[-1]
-            self.print_task_config_obj.print_task_config['filament_vendor'][extruder_num] = "Generic"
-            self.print_task_config_obj.print_task_config['filament_type'][extruder_num] = lane.material
-            self.print_task_config_obj.print_task_config['filament_color'][extruder_num] = lane.color.replace('#', '')
-            # msg = f"{self.SNAPMAKER_SET_PRINT_FILAMENT_CONFIG} CONFIG_EXTRUDER={extruder_num} VENDOR='Generic' "
-            # msg += f"FILAMENT_COLOR_RGBA={lane.color.replace('#', '')} FILAMENT_TYPE='{lane.material}' FILAMENT_SUBTYPE=''"
-            # self.logger.debug(msg)
-            # try:
-            #     self.gcode.run_script_from_command(msg)
-            # except:
-            #     pass
+            try:
+                # Below could also be done with the following macro for multi color spools
+                # SET_PRINT_FILAMENT_CONFIG CONFIG_EXTRUDER=3 COLORS=123456,654321 COLOR_NUMS=2 MULTI_MODE=1
+                from extras.print_task_config import DEFAULT_PRINT_TASK_CONFIG
+                extruder_num = "0" if lane.extruder_obj.name == "extruder" else lane.extruder_obj.name[-1]
+                extruder_num = 0 if not extruder_num.isdigit() else int(extruder_num)
+
+                tmp_print_task_config = copy.deepcopy(self.print_task_config_obj.print_task_config)
+
+                tmp_print_task_config['filament_vendor'][extruder_num] = "Generic"
+                tmp_print_task_config['filament_type'][extruder_num] = lane.material
+                tmp_print_task_config['filament_sub_type'][extruder_num] = None
+
+                tmp_print_task_config['filament_color'][extruder_num] = "FFFFFFFF"
+                tmp_print_task_config['filament_color_rgba'][extruder_num] = "FFFFFFFF"
+                if lane.color:
+                  tmp_print_task_config['filament_color'][extruder_num] = int(lane.color.replace('#', ''), 16) | 0xFF000000
+                  tmp_print_task_config['filament_color_rgba'][extruder_num] = lane.color.replace('#', '') + "FF"
+
+                if lane.multi_color:
+                    tmp_print_task_config['filament_color_multi'][extruder_num]["nums"] = len(lane.multi_color)
+                    tmp_print_task_config['filament_color_multi'][extruder_num]["colors"] = lane.multi_color
+                    tmp_print_task_config['filament_color_multi'][extruder_num]["mode"] = 1
+                else:
+                    tmp_print_task_config['filament_color_multi'][extruder_num]["colors"] = [f"{lane.color.replace('#', '')}"]
+                    tmp_print_task_config['filament_color_multi'][extruder_num]["mode"] = 0
+                    tmp_print_task_config['filament_color_multi'][extruder_num]["nums"] = 1
+                self.print_task_config_obj.print_task_config = tmp_print_task_config
+                self.printer.update_snapmaker_config_file(self.print_task_config_obj.config_path,
+                                                          self.print_task_config_obj.print_task_config,
+                                                          DEFAULT_PRINT_TASK_CONFIG)
+            except Exception as e:
+                self.logger.error("Error when trying to update colors for snapmaker print_task_config")
+                self.logger.debug(traceback.format_exc())
 
     cmd_AFC_SET_SPOOL_TEMP_help = "Set spool temperatures for a lane"
     def cmd_AFC_SET_SPOOL_TEMP(self, gcmd):
@@ -364,6 +388,7 @@ class AFCSpool:
         cur_lane.spool_id = None
         cur_lane.material = ''
         cur_lane.color = ''
+        cur_lane.multi_color = []
         cur_lane.weight = 0
         cur_lane.auto_switch_triggered = False
         cur_lane.extruder_temp = None
@@ -405,8 +430,10 @@ class AFCSpool:
                     # Once support for multicolor is added this needs to be updated
                     if "multi_color_hexes" in result['filament']:
                         cur_lane.color = '#{}'.format(self._get_filament_values(result['filament'], 'multi_color_hexes').split(",")[0])
+                        cur_lane.multi_color = self._get_filament_values(result['filament'], 'multi_color_hexes').split(",")
                     else:
                         cur_lane.color = '#{}'.format(self._get_filament_values(result['filament'], 'color_hex'))
+                        cur_lane.multi_color = []
 
                     cur_lane.send_lane_data()
                     # Refresh LED only if filament is loaded — empty lanes keep their state color

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -18,6 +18,7 @@ class AFCSpool:
         self.printer = config.get_printer()
         self.printer.register_event_handler("klippy:connect", self.handle_connect)
         self.SPOOLMAN_REMOTE_METHOD = 'spoolman_set_active_spool'
+        self.print_task_config_obj = None
 
         # Temporary status variables
         self.next_spool_id      = None
@@ -59,41 +60,55 @@ class AFCSpool:
         self.gcode.register_mux_command('AFC_SET_SPOOL_TEMP',   "LANE", lane_obj.name, self.cmd_AFC_SET_SPOOL_TEMP,     desc=self.cmd_AFC_SET_SPOOL_TEMP_help)
 
     def set_snapmaker_filament_params(self, lane: AFCLane):
+        """
+        This method is only for snapmaker printers, this method updates filament color, material,
+        vendor into snapmakers print_task_config object. This is needed so that the proper filament
+        reflects correctly per toolhead on the screen UI and its needed to be able to properly resume
+        a print. Without updating these values into print_task_config object snapmakers internal
+        python logic will not resume once paused.
+
+        Logic is based off this file in u1-klipper repo:
+            https://github.com/Snapmaker/u1-klipper/blob/main/klippy/extras/print_task_config.py
+
+        :param lane: AFC lane to update correct toolhead with color, material, vendor, etc information.
+        """
         if (self.afc.snapmaker_printer
+            and self.print_task_config_obj is not None
             and lane.tool_loaded
             and lane.name == lane.extruder_obj.lane_loaded):
             try:
                 # Below could also be done with the following macro for multi color spools
                 # SET_PRINT_FILAMENT_CONFIG CONFIG_EXTRUDER=3 COLORS=123456,654321 COLOR_NUMS=2 MULTI_MODE=1
                 from extras.print_task_config import DEFAULT_PRINT_TASK_CONFIG
-                extruder_num = "0" if lane.extruder_obj.name == "extruder" else lane.extruder_obj.name[-1]
-                extruder_num = 0 if not extruder_num.isdigit() else int(extruder_num)
+                extruder_num = lane.lane_extruder_index
 
-                tmp_print_task_config = copy.deepcopy(self.print_task_config_obj.print_task_config)
+                tmp_config = copy.deepcopy(self.print_task_config_obj.print_task_config)
 
-                tmp_print_task_config['filament_vendor'][extruder_num] = "Generic"
-                tmp_print_task_config['filament_type'][extruder_num] = lane.material
-                tmp_print_task_config['filament_sub_type'][extruder_num] = None
+                tmp_config['filament_vendor'][extruder_num] = "Generic"
+                tmp_config['filament_type'][extruder_num] = lane.material
+                tmp_config['filament_sub_type'][extruder_num] = None
 
-                tmp_print_task_config['filament_color'][extruder_num] = "FFFFFFFF"
-                tmp_print_task_config['filament_color_rgba'][extruder_num] = "FFFFFFFF"
+                tmp_config['filament_color'][extruder_num] = int("FFFFFFFF", 16)
+                tmp_config['filament_color_rgba'][extruder_num] = "FFFFFFFF"
+                tmp_config['filament_color_multi'][extruder_num]["colors"] = ["FFFFFF"]
+                tmp_config['filament_color_multi'][extruder_num]["mode"] = 0
+                tmp_config['filament_color_multi'][extruder_num]["nums"] = 1
+
                 if lane.color:
-                  tmp_print_task_config['filament_color'][extruder_num] = int(lane.color.replace('#', ''), 16) | 0xFF000000
-                  tmp_print_task_config['filament_color_rgba'][extruder_num] = lane.color.replace('#', '') + "FF"
+                    tmp_config['filament_color'][extruder_num] = int(lane.color.replace('#', ''), 16) | 0xFF000000
+                    tmp_config['filament_color_rgba'][extruder_num] = lane.color.replace('#', '') + "FF"
+                    tmp_config['filament_color_multi'][extruder_num]["colors"] = [f"{lane.color.replace('#', '')}"]
 
                 if lane.multi_color:
-                    tmp_print_task_config['filament_color_multi'][extruder_num]["nums"] = len(lane.multi_color)
-                    tmp_print_task_config['filament_color_multi'][extruder_num]["colors"] = lane.multi_color
-                    tmp_print_task_config['filament_color_multi'][extruder_num]["mode"] = 1
-                else:
-                    tmp_print_task_config['filament_color_multi'][extruder_num]["colors"] = [f"{lane.color.replace('#', '')}"]
-                    tmp_print_task_config['filament_color_multi'][extruder_num]["mode"] = 0
-                    tmp_print_task_config['filament_color_multi'][extruder_num]["nums"] = 1
-                self.print_task_config_obj.print_task_config = tmp_print_task_config
+                    tmp_config['filament_color_multi'][extruder_num]["nums"] = len(lane.multi_color)
+                    tmp_config['filament_color_multi'][extruder_num]["colors"] = lane.multi_color
+                    tmp_config['filament_color_multi'][extruder_num]["mode"] = 1
+
+                self.print_task_config_obj.print_task_config = tmp_config
                 self.printer.update_snapmaker_config_file(self.print_task_config_obj.config_path,
                                                           self.print_task_config_obj.print_task_config,
                                                           DEFAULT_PRINT_TASK_CONFIG)
-            except Exception as e:
+            except Exception:
                 self.logger.error("Error when trying to update colors for snapmaker print_task_config")
                 self.logger.debug(traceback.format_exc())
 
@@ -429,8 +444,8 @@ class AFCSpool:
                     # Check to see if filament is defined as multi-color and take the first color for now
                     # Once support for multicolor is added this needs to be updated
                     if "multi_color_hexes" in result['filament']:
-                        cur_lane.color = '#{}'.format(self._get_filament_values(result['filament'], 'multi_color_hexes').split(",")[0])
                         cur_lane.multi_color = self._get_filament_values(result['filament'], 'multi_color_hexes').split(",")
+                        cur_lane.color = f"#{cur_lane.multi_color[0]}"
                     else:
                         cur_lane.color = '#{}'.format(self._get_filament_values(result['filament'], 'color_hex'))
                         cur_lane.multi_color = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,6 +198,25 @@ def _make_klippy_ready_mock():
     mod.Printer = Printer
     return mod
 
+def _make_print_task_config():
+    config = {
+        "filament_vendor": ["NONE"] * 4,
+        "filament_type": ["NONE"] * 4,
+        "filament_sub_type": ["NONE"] * 4,
+        "filament_color": [0xFFFFFFFF] * 4,
+        "filament_color_rgba": ['FFFFFFFF'] * 4,
+        "filament_color_multi": [
+            {"nums": 1, "alpha": 0xFF, "mode": 0, "colors": ["FFFFFF"]}
+            for _ in range(4)
+        ],
+    }
+    mod = types.ModuleType("print_task_config")
+    mod.DEFAULT_PRINT_TASK_CONFIG = config
+    mod.print_task_config = config
+    mod.config_path = MagicMock()
+
+    return mod
+
 
 # Install mocks before any extras imports happen
 sys.modules.setdefault("configfile", _make_configfile_mock())
@@ -395,6 +414,8 @@ class MockAFC:
         self.save_pos = MagicMock()
         self.CHANGE_TOOL = MagicMock()
         self.restore_pos = MagicMock()
+
+        self.snapmaker_printer = False
 
 
 class MockPrinter:

--- a/tests/test_AFC_spool.py
+++ b/tests/test_AFC_spool.py
@@ -34,6 +34,7 @@ def _make_spool():
     afc.spoolman = None
     afc.tool_cmds = {}
     afc.lanes = {}
+    afc.units = {}
 
     spool.printer = printer
     spool.afc = afc
@@ -48,7 +49,7 @@ def _make_spool():
     return spool
 
 
-def _make_lane(name="lane1"):
+def _make_lane(name="lane1", extruder_name="extruder", extruder_index=0):
     lane = MagicMock()
     lane.name = name
     lane.map = None
@@ -60,6 +61,8 @@ def _make_lane(name="lane1"):
     lane.unit_obj = MagicMock()
     lane.hub_obj = MagicMock()
     lane.extruder_obj = MagicMock()
+    lane.extruder_obj.name = extruder_name
+    lane.lane_extruder_index = extruder_index
     return lane
 
 
@@ -137,9 +140,47 @@ class TestSetColor:
         spool = _make_spool()
         lane = _make_lane("lane1")
         spool.afc.lanes = {"lane1": lane}
+        spool.set_snapmaker_filament_params = MagicMock()
         gcmd = _make_gcmd(LANE="lane1", COLOR="#FF0000")
         spool.cmd_SET_COLOR(gcmd)
         assert lane.color == "#FF0000"
+        spool.set_snapmaker_filament_params.assert_called_once()
+    
+    def test_set_led(self):
+        spool = _make_spool()
+        spool.set_snapmaker_filament_params = MagicMock()
+        lane = _make_lane("lane1")
+        lane.unit = "test"
+        spool.afc.units[lane.unit] = lane.unit_obj
+        lane.load_state = True
+        spool.afc.lanes = {"lane1": lane}
+        gcmd = _make_gcmd(LANE="lane1", COLOR="#FF0000")
+        spool.cmd_SET_COLOR(gcmd)
+        spool.afc.function.afc_led.assert_called()
+        
+
+    def test_not_set_led_lane_loaded_not_lane_in_unit(self):
+        spool = _make_spool()
+        spool.set_snapmaker_filament_params = MagicMock()
+        lane = _make_lane("lane1")
+        spool.afc.lanes = {"lane1": lane}
+        lane.unit = "test"
+        lane.load_state = True
+        gcmd = _make_gcmd(LANE="lane1", COLOR="#FF0000")
+        spool.cmd_SET_COLOR(gcmd)
+        spool.afc.function.afc_led.assert_not_called()
+
+    def test_not_set_led_not_lane_loaded_lane_in_unit(self):
+        spool = _make_spool()
+        spool.set_snapmaker_filament_params = MagicMock()
+        lane = _make_lane("lane1")
+        spool.afc.lanes = {"lane1": lane}
+        lane.unit = "test"
+        spool.afc.units[lane.unit] = lane.unit_obj
+        lane.load_state = False
+        gcmd = _make_gcmd(LANE="lane1", COLOR="#FF0000")
+        spool.cmd_SET_COLOR(gcmd)
+        spool.afc.function.afc_led.assert_not_called()
 
     def test_set_color_saves_vars(self):
         spool = _make_spool()
@@ -175,9 +216,11 @@ class TestSetMaterial:
         spool = _make_spool()
         lane = _make_lane("lane1")
         spool.afc.lanes = {"lane1": lane}
+        spool.set_snapmaker_filament_params = MagicMock()
         gcmd = _make_gcmd(LANE="lane1", MATERIAL="PLA")
         spool.cmd_SET_MATERIAL(gcmd)
         assert lane.material == "PLA"
+        spool.set_snapmaker_filament_params.assert_called_once()
 
     def test_set_material_saves_vars(self):
         spool = _make_spool()
@@ -587,6 +630,14 @@ class TestSetActiveSpool:
             spool.SPOOLMAN_REMOTE_METHOD, spool_id=None
         )
 
+    def test_calls_webhook_catch_exception(self):
+        spool = _make_spool()
+        spool.afc.spoolman = MagicMock()
+        spool.printer.lookup_object = MagicMock(return_value=None)
+        spool.set_active_spool(7)
+        error_msgs = [m for lvl, m in spool.logger.messages if lvl == "error"]
+        assert any("Error trying to set active spool" in m for m in error_msgs)
+
 
 # ── _get_filament_values ──────────────────────────────────────────────────────
 
@@ -654,6 +705,46 @@ class TestSetValues:
         spool.set_spoolID.assert_called_once_with(lane, 42)
         assert spool.next_spool_id is None  # consumed after use
 
+    def test_set_value_material_not_set_remember_spool(self):
+        spool = _make_spool()
+        lane = _make_lane()
+        lane.remember_spool = True
+        lane.spool_id = 42
+        lane.color = "123456"
+        spool.afc.default_material_type = "PLA"
+        spool.afc.spoolman = MagicMock()
+        spool.next_spool_id = 42
+        spool.set_spoolID = MagicMock()
+        spool._set_values(lane)
+        assert lane.material == ""
+        assert lane.weight == 0
+
+    def test_set_value_material_not_set_no_spool_id(self):
+        spool = _make_spool()
+        lane = _make_lane()
+        lane.remember_spool = False
+        lane.color = "123456"
+        spool.afc.default_material_type = "PLA"
+        spool.afc.spoolman = MagicMock()
+        spool.set_spoolID = MagicMock()
+        spool._set_values(lane)
+        assert lane.material == ""
+        assert lane.weight == 0
+    
+    def test_set_value_material_not_set_no_color(self):
+        spool = _make_spool()
+        lane = _make_lane()
+        lane.remember_spool = False
+        lane.spool_id = 42
+        lane.color = ""
+        spool.afc.default_material_type = "PLA"
+        spool.afc.spoolman = MagicMock()
+        spool.next_spool_id = 42
+        spool.set_spoolID = MagicMock()
+        spool._set_values(lane)
+        assert lane.material == ""
+        assert lane.weight == 0
+
 
 # ── set_spoolID ───────────────────────────────────────────────────────────────
 
@@ -686,9 +777,18 @@ class TestSetSpoolID:
         spool.clear_values = MagicMock()
         spool.set_spoolID(lane, "")
         spool.clear_values.assert_called_once_with(lane)
+    
+    def test_no_spool_remember_spool_clear_spoolid(self):
+        spool = _make_spool()
+        lane = _make_lane()
+        lane.remember_spool = True
+        spool.clear_values = MagicMock()
+        spool.set_spoolID(lane, "")
+        spool.clear_values.assert_not_called()
 
     def test_valid_spool_id_sets_lane_attributes(self):
         spool = self._make_spool_with_spoolman()
+        spool.set_snapmaker_filament_params = MagicMock()
         lane = _make_lane()
         lane.remember_spool = False
         lane.espooler = MagicMock()
@@ -698,6 +798,46 @@ class TestSetSpoolID:
         assert lane.spool_id == 42
         assert lane.material == "PLA"
         assert lane.color == "#FF0000"
+        spool.set_snapmaker_filament_params.assert_called_once()
+        spool.afc.function.afc_led.assert_not_called()
+    
+    def test_valid_spool_id_lane_not_loaded_lane_in_unit(self):
+        spool = self._make_spool_with_spoolman()
+        lane = _make_lane()
+        lane.remember_spool = False
+        lane.espooler = MagicMock()
+        lane.load_state = False
+        lane.unit = "test"
+        spool.afc.units[lane.unit] = lane.unit_obj
+        result = _make_spool_result()
+        spool.afc.moonraker.get_spool = MagicMock(return_value=result)
+        spool.set_spoolID(lane, 42)
+        spool.afc.function.afc_led.assert_not_called()
+
+    def test_valid_spool_id_lane_loaded_lane_in_unit(self):
+        spool = self._make_spool_with_spoolman()
+        lane = _make_lane()
+        lane.load_state = True
+        lane.unit = "test"
+        spool.afc.units[lane.unit] = lane.unit_obj
+        lane.remember_spool = False
+        lane.espooler = MagicMock()
+        result = _make_spool_result()
+        spool.afc.moonraker.get_spool = MagicMock(return_value=result)
+        spool.set_spoolID(lane, 42)
+        spool.afc.function.afc_led.assert_called()
+    
+    def test_valid_spool_id_lane_loaded_lane_not_in_unit(self):
+        spool = self._make_spool_with_spoolman()
+        lane = _make_lane()
+        lane.load_state = True
+        lane.unit = "test"
+        lane.remember_spool = False
+        lane.espooler = MagicMock()
+        result = _make_spool_result()
+        spool.afc.moonraker.get_spool = MagicMock(return_value=result)
+        spool.set_spoolID(lane, 42)
+        spool.afc.function.afc_led.assert_not_called()
 
     def test_zero_weight_triggers_error_when_check_enabled(self):
         spool = self._make_spool_with_spoolman()
@@ -733,6 +873,7 @@ class TestSetSpoolID:
         spool.afc.moonraker.get_spool = MagicMock(return_value=result)
         spool.set_spoolID(lane, 42)
         assert lane.color == "#AABBCC"
+        assert lane.multi_color == result["filament"]["multi_color_hexes"].split(",")
 
     def test_ignore_spoolman_material_temps_skips_extruder_temp(self):
         spool = self._make_spool_with_spoolman()
@@ -766,11 +907,28 @@ class TestSetSpoolID:
         spool.clear_values = MagicMock()
         spool.set_spoolID(lane, "")
         spool.clear_values.assert_called_once_with(lane)
-
+    
+    def test_remember_spool_clear_spoolid(self):
+        spool = self._make_spool_with_spoolman()
+        lane = _make_lane()
+        lane.remember_spool = True
+        spool.clear_values = MagicMock()
+        spool.set_spoolID(lane, "")
+        spool.clear_values.assert_not_called()
 
 # ── cmd_SET_SPOOL_ID ──────────────────────────────────────────────────────────
 
 class TestCmdSetSpoolID:
+    def test_no_op_when_spoolman_is_none(self):
+        spool = _make_spool()
+        spool.afc.spoolman = None
+        lane = _make_lane("lane1")
+        spool.afc.lanes = {"lane1": lane}
+        gcmd = _make_gcmd(LANE="lane1", SPOOL_ID="42")
+        spool.set_spoolID = MagicMock()
+        spool.cmd_SET_SPOOL_ID(gcmd)
+        spool.set_spoolID.assert_not_called()
+    
     def test_no_op_when_spoolman_is_none(self):
         spool = _make_spool()
         spool.afc.spoolman = None
@@ -819,6 +977,18 @@ class TestCmdSetSpoolID:
         spool.set_spoolID = MagicMock()
         spool.cmd_SET_SPOOL_ID(gcmd)
         spool.set_spoolID.assert_called_once_with(lane1, 5)
+
+    def test_no_spoolid_provided_set_spool_id(self):
+        spool = _make_spool()
+        spool.afc.spoolman = MagicMock()
+        lane1 = _make_lane("lane1")
+        lane1.spool_id = None
+        spool.afc.lanes = {"lane1": lane1}
+        spool.afc.current = None
+        gcmd = _make_gcmd(LANE="lane1")
+        spool.set_spoolID = MagicMock()
+        spool.cmd_SET_SPOOL_ID(gcmd)
+        spool.set_spoolID.assert_called_once_with(lane1, '')
 
     def test_no_lane_param_logs_info(self):
         """Covers lines 239-241: spoolman not None + lane=None → log info + return."""
@@ -896,3 +1066,230 @@ class TestAutoSwitchFlagReset:
         lane.espooler.espooler_values = MagicMock()
         spool.set_spoolID(lane, "123")
         assert lane.auto_switch_triggered is False
+
+class TestSetSnapmakerFilamentParams:
+    def create_print_task_config(self):
+        config = {
+            "filament_vendor": ["NONE"]*4,
+            "filament_type": ["NONE"]*4,
+            "filament_sub_type": ["NONE"]*4,
+            "filament_color": ["NONE"]*4,
+            "filament_color_rgba": ["NONE"]*4,
+            "filament_color_multi": ["NONE"]*4,
+        }
+        return config
+
+    def test_no_snapmaker_printer(self):
+        spool = _make_spool()
+        spool.afc.snapmaker_printer = False  # explicit: default is False
+        lane = _make_lane("lane1")
+        spool.printer = MagicMock()
+        spool.set_snapmaker_filament_params(lane)
+        spool.printer.update_snapmaker_config_file.assert_not_called()
+    
+    def test_snapmaker_printer_print_task_none(self):
+        spool = _make_spool()
+        spool.afc.snapmaker_printer = True
+        lane = _make_lane("lane1")
+        spool.printer = MagicMock()
+        spool.print_task_config_obj = None
+        spool.set_snapmaker_filament_params(lane)
+        spool.printer.update_snapmaker_config_file.assert_not_called()
+    
+    def test_snapmaker_printer_tool_not_loaded(self):
+        from tests.conftest import _make_print_task_config
+        import sys
+        sys.modules.setdefault("print_task_config", _make_print_task_config())
+        spool = _make_spool()
+        spool.afc.snapmaker_printer = True
+        spool.print_task_config_obj = MagicMock()
+        lane = _make_lane("lane1")
+        lane.tool_loaded = False
+        lane.extruder_obj.lane_loaded = lane.name
+        spool.printer = MagicMock()
+        spool.set_snapmaker_filament_params(lane)
+        spool.printer.update_snapmaker_config_file.assert_not_called()
+
+    def test_snapmaker_printer_lane_name_not_match(self):
+        from tests.conftest import _make_print_task_config
+        import sys
+        sys.modules.setdefault("print_task_config", _make_print_task_config())
+        spool = _make_spool()
+        spool.afc.snapmaker_printer = True
+        spool.print_task_config_obj = MagicMock()
+        lane = _make_lane("lane1")
+        lane.tool_loaded = True
+        lane.extruder_obj.lane_loaded = "lane2"
+        spool.printer = MagicMock()
+        spool.set_snapmaker_filament_params(lane)
+        spool.printer.update_snapmaker_config_file.assert_not_called()
+    
+    def test_snapmaker_printer_exception(self):
+        from tests.conftest import _make_print_task_config
+        import sys
+        sys.modules.setdefault("print_task_config", _make_print_task_config())
+        spool = _make_spool()
+        spool.afc.snapmaker_printer = True
+        spool.print_task_config_obj = MagicMock()
+        lane = _make_lane("lane1")
+        lane.color = "#123456"
+        lane.material = "PLA"
+        lane.tool_loaded = True
+        lane.extruder_obj.lane_loaded = lane.name
+        spool.printer = MagicMock()
+        spool.set_snapmaker_filament_params(lane)
+        error_msgs = [m for lvl, m in spool.logger.messages if lvl == "error"]
+        assert any("Error when trying to update colors for snapmaker print_task_config" in m for m in error_msgs)
+    
+    def test_snapmaker_printer_extruder_update_called(self):
+        from tests.conftest import _make_print_task_config
+        import sys
+        sys.modules.setdefault("extras.print_task_config", _make_print_task_config())
+        from extras.print_task_config import DEFAULT_PRINT_TASK_CONFIG, config_path
+        spool = _make_spool()
+        spool.afc.snapmaker_printer = True
+        spool.print_task_config_obj = MagicMock()
+        spool.print_task_config_obj.print_task_config = DEFAULT_PRINT_TASK_CONFIG
+        spool.print_task_config_obj.config_path = config_path
+        lane = _make_lane("lane1")
+        lane.color = "#123456"
+        lane.material = "PLA"
+        lane.tool_loaded = True
+        lane.extruder_obj.lane_loaded = lane.name
+        spool.printer = MagicMock()
+        spool.set_snapmaker_filament_params(lane)
+        spool.printer.update_snapmaker_config_file.assert_called_with(
+            config_path,
+            spool.print_task_config_obj.print_task_config,
+            DEFAULT_PRINT_TASK_CONFIG
+        )
+
+    def test_snapmaker_printer_extruder_check_material(self):
+        from tests.conftest import _make_print_task_config
+        import sys
+        sys.modules.setdefault("extras.print_task_config", _make_print_task_config())
+        from extras.print_task_config import DEFAULT_PRINT_TASK_CONFIG
+        spool = _make_spool()
+        spool.afc.snapmaker_printer = True
+        spool.print_task_config_obj = MagicMock()
+        spool.print_task_config_obj.print_task_config = DEFAULT_PRINT_TASK_CONFIG
+        lane = _make_lane("lane1")
+        lane.color = "#123456"
+        lane.material = "PLA"
+        lane.tool_loaded = True
+        lane.extruder_obj.lane_loaded = lane.name
+        lane.multi_color = []
+        spool.printer = MagicMock()
+        spool.set_snapmaker_filament_params(lane)
+
+        print_task_config = spool.print_task_config_obj.print_task_config
+
+        assert print_task_config["filament_vendor"][0] == "Generic"
+        assert print_task_config["filament_type"][0] == lane.material
+        assert print_task_config["filament_sub_type"][0] == None
+
+    def test_snapmaker_printer_extruder_check_single_color(self):
+        from tests.conftest import _make_print_task_config
+        import sys
+        sys.modules.setdefault("extras.print_task_config", _make_print_task_config())
+        from extras.print_task_config import DEFAULT_PRINT_TASK_CONFIG
+        spool = _make_spool()
+        spool.afc.snapmaker_printer = True
+        spool.print_task_config_obj = MagicMock()
+        spool.print_task_config_obj.print_task_config = DEFAULT_PRINT_TASK_CONFIG
+        lane = _make_lane("lane1")
+        lane.color = "#123456"
+        lane.material = "PLA"
+        lane.tool_loaded = True
+        lane.extruder_obj.lane_loaded = lane.name
+        lane.multi_color = []
+        spool.printer = MagicMock()
+        spool.set_snapmaker_filament_params(lane)
+
+        print_task_config = spool.print_task_config_obj.print_task_config
+
+        assert print_task_config["filament_color"][0] == int("FF123456", 16) 
+        assert print_task_config["filament_color_rgba"][0] == "123456FF"
+        assert print_task_config["filament_color_multi"][0]["mode"] == 0
+        assert print_task_config["filament_color_multi"][0]["nums"] == 1
+        assert print_task_config["filament_color_multi"][0]["colors"] == ["123456"]
+    
+    def test_snapmaker_printer_extruder_check_no_color(self):
+        from tests.conftest import _make_print_task_config
+        import sys
+        sys.modules.setdefault("extras.print_task_config", _make_print_task_config())
+        from extras.print_task_config import DEFAULT_PRINT_TASK_CONFIG
+        spool = _make_spool()
+        spool.afc.snapmaker_printer = True
+        spool.print_task_config_obj = MagicMock()
+        spool.print_task_config_obj.print_task_config = DEFAULT_PRINT_TASK_CONFIG
+        lane = _make_lane("lane1")
+        lane.color = ""
+        lane.material = "PLA"
+        lane.tool_loaded = True
+        lane.extruder_obj.lane_loaded = lane.name
+        lane.multi_color = []
+        spool.printer = MagicMock()
+        spool.set_snapmaker_filament_params(lane)
+
+        print_task_config = spool.print_task_config_obj.print_task_config
+
+        assert print_task_config["filament_color"][0] == int("FFFFFFFF", 16) 
+        assert print_task_config["filament_color_rgba"][0] == "FFFFFFFF"
+        assert print_task_config["filament_color_multi"][0]["mode"] == 0
+        assert print_task_config["filament_color_multi"][0]["nums"] == 1
+        assert print_task_config["filament_color_multi"][0]["colors"] == ["FFFFFF"]
+
+    def test_snapmaker_printer_extruder_check_multi_color(self):
+        from tests.conftest import _make_print_task_config
+        import sys
+        sys.modules.setdefault("extras.print_task_config", _make_print_task_config())
+        from extras.print_task_config import DEFAULT_PRINT_TASK_CONFIG
+        spool = _make_spool()
+        spool.afc.snapmaker_printer = True
+        spool.print_task_config_obj = MagicMock()
+        spool.print_task_config_obj.print_task_config = DEFAULT_PRINT_TASK_CONFIG
+        lane = _make_lane("lane1")
+        lane.multi_color = ["123456", "589465", "725893"]
+        lane.color = "#123456"
+        lane.material = "PLA"
+        lane.tool_loaded = True
+        lane.extruder_obj.lane_loaded = lane.name
+        spool.printer = MagicMock()
+        spool.set_snapmaker_filament_params(lane)
+
+        print_task_config = spool.print_task_config_obj.print_task_config
+        
+        assert print_task_config["filament_color"][0] == int("FF123456", 16) 
+        assert print_task_config["filament_color_rgba"][0] == "123456FF"
+        assert print_task_config["filament_color_multi"][0]["mode"] == 1
+        assert print_task_config["filament_color_multi"][0]["nums"] == 3
+        assert print_task_config["filament_color_multi"][0]["colors"] == ["123456", "589465", "725893"]
+
+    def test_snapmaker_printer_extruder3_check_multi_color(self):
+        from tests.conftest import _make_print_task_config
+        import sys
+        sys.modules.setdefault("extras.print_task_config", _make_print_task_config())
+        from extras.print_task_config import DEFAULT_PRINT_TASK_CONFIG
+        spool = _make_spool()
+        spool.afc.snapmaker_printer = True
+        spool.print_task_config_obj = MagicMock()
+        spool.print_task_config_obj.print_task_config = DEFAULT_PRINT_TASK_CONFIG
+        extruder_num = 3
+        lane = _make_lane("lane1", f"extruder{extruder_num}", extruder_num)
+        lane.multi_color = ["123456", "589465", "725893"]
+        lane.color = "#123456"
+        lane.material = "PLA"
+        lane.tool_loaded = True
+        lane.extruder_obj.lane_loaded = lane.name
+        spool.printer = MagicMock()
+        spool.set_snapmaker_filament_params(lane)
+
+        print_task_config = spool.print_task_config_obj.print_task_config
+        
+        assert print_task_config["filament_color"][extruder_num] == int("FF123456", 16), print_task_config 
+        assert print_task_config["filament_color_rgba"][extruder_num] == "123456FF"
+        assert print_task_config["filament_color_multi"][extruder_num]["mode"] == 1
+        assert print_task_config["filament_color_multi"][extruder_num]["nums"] == 3
+        assert print_task_config["filament_color_multi"][extruder_num]["colors"] == ["123456", "589465", "725893"]
+    

--- a/tests/test_AFC_spool.py
+++ b/tests/test_AFC_spool.py
@@ -948,16 +948,6 @@ class TestCmdSetSpoolID:
         spool.set_spoolID = MagicMock()
         spool.cmd_SET_SPOOL_ID(gcmd)
         spool.set_spoolID.assert_not_called()
-    
-    def test_no_op_when_spoolman_is_none(self):
-        spool = _make_spool()
-        spool.afc.spoolman = None
-        lane = _make_lane("lane1")
-        spool.afc.lanes = {"lane1": lane}
-        gcmd = _make_gcmd(LANE="lane1", SPOOL_ID="42")
-        spool.set_spoolID = MagicMock()
-        spool.cmd_SET_SPOOL_ID(gcmd)
-        spool.set_spoolID.assert_not_called()
 
     def test_invalid_spool_id_string_logs_error(self):
         spool = _make_spool()

--- a/tests/test_AFC_spool.py
+++ b/tests/test_AFC_spool.py
@@ -895,6 +895,18 @@ class TestSetSpoolID:
         assert lane.color == "#AABBCC"
         assert lane.multi_color == result["filament"]["multi_color_hexes"].split(",")
 
+    def test_multi_color_is_none(self):
+        spool = self._make_spool_with_spoolman()
+        lane = _make_lane()
+        lane.remember_spool = False
+        lane.espooler = MagicMock()
+        result = _make_spool_result(color_hex="AABBCC")
+        result["filament"]["multi_color_hexes"] = None
+        spool.afc.moonraker.get_spool = MagicMock(return_value=result)
+        spool.set_spoolID(lane, 42)
+        assert lane.color == "#AABBCC"
+        assert lane.multi_color == []
+
     def test_ignore_spoolman_material_temps_skips_extruder_temp(self):
         spool = self._make_spool_with_spoolman()
         spool.afc.ignore_spoolman_material_temps = True

--- a/tests/test_AFC_spool.py
+++ b/tests/test_AFC_spool.py
@@ -58,6 +58,7 @@ def _make_lane(name="lane1", extruder_name="extruder", extruder_index=0):
     lane.weight = 0
     lane.spool_id = None
     lane.runout_lane = None
+    lane.spool_vendor = ""
     lane.unit_obj = MagicMock()
     lane.hub_obj = MagicMock()
     lane.extruder_obj = MagicMock()
@@ -798,6 +799,25 @@ class TestSetSpoolID:
         assert lane.spool_id == 42
         assert lane.material == "PLA"
         assert lane.color == "#FF0000"
+        assert lane.spool_vendor == ""
+        spool.set_snapmaker_filament_params.assert_called_once()
+        spool.afc.function.afc_led.assert_not_called()
+
+    def test_valid_spool_id_sets_vendor(self):
+        spool = self._make_spool_with_spoolman()
+        spool.set_snapmaker_filament_params = MagicMock()
+        lane = _make_lane()
+        lane.remember_spool = False
+        lane.espooler = MagicMock()
+        result = _make_spool_result()
+        result["filament"]["vendor"] = {}
+        result["filament"]["vendor"]["name"] = "Polymaker"
+        spool.afc.moonraker.get_spool = MagicMock(return_value=result)
+        spool.set_spoolID(lane, 42)
+        assert lane.spool_id == 42
+        assert lane.material == "PLA"
+        assert lane.color == "#FF0000"
+        assert lane.spool_vendor == "Polymaker"
         spool.set_snapmaker_filament_params.assert_called_once()
         spool.afc.function.afc_led.assert_not_called()
     
@@ -1099,7 +1119,7 @@ class TestSetSnapmakerFilamentParams:
     def test_snapmaker_printer_tool_not_loaded(self):
         from tests.conftest import _make_print_task_config
         import sys
-        sys.modules.setdefault("print_task_config", _make_print_task_config())
+        sys.modules.setdefault("extras.print_task_config", _make_print_task_config())
         spool = _make_spool()
         spool.afc.snapmaker_printer = True
         spool.print_task_config_obj = MagicMock()
@@ -1113,7 +1133,7 @@ class TestSetSnapmakerFilamentParams:
     def test_snapmaker_printer_lane_name_not_match(self):
         from tests.conftest import _make_print_task_config
         import sys
-        sys.modules.setdefault("print_task_config", _make_print_task_config())
+        sys.modules.setdefault("extras.print_task_config", _make_print_task_config())
         spool = _make_spool()
         spool.afc.snapmaker_printer = True
         spool.print_task_config_obj = MagicMock()
@@ -1127,16 +1147,20 @@ class TestSetSnapmakerFilamentParams:
     def test_snapmaker_printer_exception(self):
         from tests.conftest import _make_print_task_config
         import sys
-        sys.modules.setdefault("print_task_config", _make_print_task_config())
+        sys.modules.setdefault("extras.print_task_config", _make_print_task_config())
+        from extras.print_task_config import DEFAULT_PRINT_TASK_CONFIG, config_path
         spool = _make_spool()
         spool.afc.snapmaker_printer = True
         spool.print_task_config_obj = MagicMock()
+        spool.print_task_config_obj.print_task_config = DEFAULT_PRINT_TASK_CONFIG
+        spool.print_task_config_obj.config_path = config_path
         lane = _make_lane("lane1")
         lane.color = "#123456"
         lane.material = "PLA"
         lane.tool_loaded = True
         lane.extruder_obj.lane_loaded = lane.name
         spool.printer = MagicMock()
+        spool.printer.update_snapmaker_config_file.side_effect = RuntimeError("Creating error")
         spool.set_snapmaker_filament_params(lane)
         error_msgs = [m for lvl, m in spool.logger.messages if lvl == "error"]
         assert any("Error when trying to update colors for snapmaker print_task_config" in m for m in error_msgs)
@@ -1186,7 +1210,83 @@ class TestSetSnapmakerFilamentParams:
 
         assert print_task_config["filament_vendor"][0] == "Generic"
         assert print_task_config["filament_type"][0] == lane.material
-        assert print_task_config["filament_sub_type"][0] == None
+        assert print_task_config["filament_sub_type"][0] == "NONE"
+    
+    def test_snapmaker_printer_extruder_check_vendor(self):
+        from tests.conftest import _make_print_task_config
+        import sys
+        sys.modules.setdefault("extras.print_task_config", _make_print_task_config())
+        from extras.print_task_config import DEFAULT_PRINT_TASK_CONFIG
+        spool = _make_spool()
+        spool.afc.snapmaker_printer = True
+        spool.print_task_config_obj = MagicMock()
+        spool.print_task_config_obj.print_task_config = DEFAULT_PRINT_TASK_CONFIG
+        lane = _make_lane("lane1")
+        lane.color = "#123456"
+        lane.material = "PLA"
+        lane.tool_loaded = True
+        lane.spool_vendor = "Polymaker"
+        lane.extruder_obj.lane_loaded = lane.name
+        lane.multi_color = []
+        spool.printer = MagicMock()
+        spool.set_snapmaker_filament_params(lane)
+
+        print_task_config = spool.print_task_config_obj.print_task_config
+
+        assert print_task_config["filament_vendor"][0] == lane.spool_vendor
+        assert print_task_config["filament_type"][0] == lane.material
+        assert print_task_config["filament_sub_type"][0] == "NONE"
+
+    def test_snapmaker_printer_extruder_check_material_NONE(self):
+        from tests.conftest import _make_print_task_config
+        import sys
+        sys.modules.setdefault("extras.print_task_config", _make_print_task_config())
+        from extras.print_task_config import DEFAULT_PRINT_TASK_CONFIG
+        spool = _make_spool()
+        spool.afc.snapmaker_printer = True
+        spool.afc.default_material_type = None
+        spool.print_task_config_obj = MagicMock()
+        spool.print_task_config_obj.print_task_config = DEFAULT_PRINT_TASK_CONFIG
+        lane = _make_lane("lane1")
+        lane.color = "#123456"
+        lane.material = ""
+        lane.tool_loaded = True
+        lane.extruder_obj.lane_loaded = lane.name
+        lane.multi_color = []
+        spool.printer = MagicMock()
+        spool.set_snapmaker_filament_params(lane)
+
+        print_task_config = spool.print_task_config_obj.print_task_config
+
+        assert print_task_config["filament_vendor"][0] == "Generic"
+        assert print_task_config["filament_type"][0] == "NONE"
+        assert print_task_config["filament_sub_type"][0] == "NONE"
+
+    def test_snapmaker_printer_extruder_check_material_default(self):
+        from tests.conftest import _make_print_task_config
+        import sys
+        sys.modules.setdefault("extras.print_task_config", _make_print_task_config())
+        from extras.print_task_config import DEFAULT_PRINT_TASK_CONFIG
+        spool = _make_spool()
+        spool.afc.snapmaker_printer = True
+        spool.afc.default_material_type = "ABS"
+        spool.print_task_config_obj = MagicMock()
+        spool.print_task_config_obj.print_task_config = DEFAULT_PRINT_TASK_CONFIG
+
+        lane = _make_lane("lane1")
+        lane.color = "#123456"
+        lane.material = ""
+        lane.tool_loaded = True
+        lane.extruder_obj.lane_loaded = lane.name
+        lane.multi_color = []
+        spool.printer = MagicMock()
+        spool.set_snapmaker_filament_params(lane)
+
+        print_task_config = spool.print_task_config_obj.print_task_config
+
+        assert print_task_config["filament_vendor"][0] == "Generic"
+        assert print_task_config["filament_type"][0] == "ABS"
+        assert print_task_config["filament_sub_type"][0] == "NONE"
 
     def test_snapmaker_printer_extruder_check_single_color(self):
         from tests.conftest import _make_print_task_config


### PR DESCRIPTION
## Major Changes in this PR
- Added setting color, material, vendor into snapmakers print_task_config object so that proper color shows up when loading in screen interface. This is also needed to properly resume from pause, if these are not set then Snapmakers internal logic will not resume from pause.
- Added exposing multi_hex colors to lanes `get_status`
- Added unit tests

## How the changes in this PR are tested
Tested in my Snapmaker U1

Color and material properly being set when unloading then loading another lane:

https://github.com/user-attachments/assets/1bdaed63-458b-46bc-b6fd-3384ba75558a

Multi-hex colors being displayed properly:

https://github.com/user-attachments/assets/7045db9a-0d1d-4483-9216-05ce75ca29a9

## PR Checklist: (Checked-off items are either done or do not apply to this PR)

Vendor updating correctly:
<img width="412" height="159" alt="image" src="https://github.com/user-attachments/assets/17c9b15e-4339-4a89-bc3a-72ea89f427ad" />

 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enhanced Snapmaker printer integration to keep filament color/material and lane-based settings synchronized during preparation, normal tool changes, and spool/color/material updates.
  * Added support for updating Snapmaker U1 `print_task_config` using lane filament details (single- and multi-color), including per-extruder application.

* **Improvements**
  * Refined lane defaults and status reporting, including multi-color hex details when not saving to a file.

* **Tests**
  * Expanded coverage for Snapmaker filament parameter generation, multi-color parsing, LED gating, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->