### PR TITLE
(fix) Fixes #734, correctly sets toolhead leds during PREP for toolchangers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-20]
+### Fixed
+- Setting toolhead leds correctly during PREP for toolchangers
+
 ## [2026-06-19]
 ### Added
 - Added support for HTLF2-Claymore Unit type.

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -44,7 +44,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 try: from extras.AFC_stats import AFCStats
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
 
-AFC_VERSION="1.1.20"
+AFC_VERSION="1.1.22"
 
 # Class for holding different states so its clear what all valid states are
 class State:

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -117,11 +117,8 @@ class afcBoxTurtle(afcUnit):
                         or cur_lane.extruder_obj.tool_end_state):
                         if cur_lane.extruder_obj.lane_loaded == cur_lane.name:
                             cur_lane.sync_to_extruder()
-                            on_shuttle = ""
-                            if (cur_lane.extruder_obj.tool_obj
-                                and cur_lane.extruder_obj.tc_unit_name):
-                                on_shuttle = " and toolhead on shuttle" if cur_lane.extruder_obj.on_shuttle() else ""
-                            msg += f"<span class=primary--text> in ToolHead{on_shuttle}</span>"
+
+                            msg += cur_lane.extruder_obj.prep_on_shuttle_check(cur_lane)
 
                             if (cur_lane.extruder_obj.tool_start == "buffer"
                                 and (not self.afc.homing_enabled

--- a/extras/AFC_OpenAMS.py
+++ b/extras/AFC_OpenAMS.py
@@ -858,11 +858,9 @@ class afcAMS(afcUnit):
                     )
                     if tool_ready and cur_lane.extruder_obj.lane_loaded == cur_lane.name:
                         cur_lane.sync_to_extruder()
-                        on_shuttle = ""
-                        if (cur_lane.extruder_obj.tool_obj
-                            and cur_lane.extruder_obj.tc_unit_name):
-                            on_shuttle = " and toolhead on shuttle" if cur_lane.extruder_obj.on_shuttle() else ""
-                        msg += f"<span class=primary--text> in ToolHead{on_shuttle}</span>"
+
+                        msg += cur_lane.extruder_obj.prep_on_shuttle_check(cur_lane)
+
                         if cur_lane.extruder_obj.tool_start == "buffer":
                             msg += (
                                 '<span class=warning--text>'

--- a/extras/AFC_Toolchanger.py
+++ b/extras/AFC_Toolchanger.py
@@ -61,8 +61,12 @@ class AfcToolchanger(afcUnit):
         # Now that a T command is assigned, send lane data to moonraker
         cur_lane.send_lane_data()
         msg = ""
-        if( cur_lane.prep_state and cur_lane.load_state ):
-            msg = "<span class=success--text>LOADED</span> <span class=primary--text>in ToolHead</span>"
+        if( cur_lane.prep_state
+            and cur_lane.load_state
+            and cur_lane.extruder_obj.lane_loaded == cur_lane.name):
+            msg = "<span class=success--text>LOADED</span>"
+            msg += cur_lane.extruder_obj.prep_on_shuttle_check(cur_lane)
+
         self.logger.raw( '{lane_name} tool cmd: {tcmd:3} {msg}'.format(lane_name=cur_lane.name, tcmd=cur_lane.map, msg=msg))
         cur_lane.set_afc_prep_done()
         return True

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from extras.AFC_Toolchanger import AfcToolchanger
     from extras.AFC_functions import afcFunction
     from extras.AFC_utils import AFC_moonraker
+    from extras.AFC_lane import AFCLane
 
 try: from extras.AFC_utils import ERROR_STR
 except: raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".format(trace=traceback.format_exc()))
@@ -868,6 +869,28 @@ class AFCExtruder:
             return status.get('state') == 'ACTIVATE'
         else:
             return False
+
+    def prep_on_shuttle_check(self, lane: AFCLane) -> str:
+        """
+        This helper method should only be called during PREP as it's a helper to check
+        if toolhead is on the shuttle or not and will set toolhead leds correctly.
+
+        This method also already assumes that current extruder lane_loaded matches
+        current lane name.
+
+        :param lane: AFCLane for current extruder to easily set leds though its unit object
+        :return str: Message string if lane is loaded to toolhead or in toolhead and on shuttle
+        """
+        msg = ""
+        on_shuttle = ""
+        if (self.tool_obj
+            and self.tc_unit_name):
+            lane.unit_obj.lane_tool_loaded_idle(lane)
+            if self.on_shuttle():
+                on_shuttle = " and toolhead on shuttle"
+                lane.unit_obj.lane_tool_loaded(lane)
+        msg += f"<span class=primary--text> in ToolHead{on_shuttle}</span>"
+        return msg
 
     def is_standalone(self):
         """

--- a/tests/test_AFC_extruder.py
+++ b/tests/test_AFC_extruder.py
@@ -1196,3 +1196,61 @@ class TestNoteToolStartCallback:
         ext.note_tool_start_callback(True)
         args = ext.tool_start_callback.call_args.args
         assert args[1]
+
+class TestPrepOnShuttleCheck:
+
+    @pytest.fixture(autouse=True)
+    def patch_toolchanger_module(self):
+        """Inject a fake extras.toolchanger so the in-method import resolves."""
+        fake_mod = _make_toolchanger_module()
+        with patch.dict(sys.modules, {"extras.toolchanger": fake_mod}):
+            yield
+
+    def test_in_toolhead(self):
+        ext = _make_afc_extruder()
+        lane = MagicMock()
+        msg = ext.prep_on_shuttle_check(lane)
+
+        assert "<span class=primary--text> in ToolHead</span>" in msg
+        lane.unit_obj.lane_tool_loaded.assert_not_called()
+        lane.unit_obj.lane_tool_loaded_idle.assert_not_called()
+    
+    def test_in_toolhead_tool_obj(self):
+        ext = _make_afc_extruder()
+        ext.tool_obj = MagicMock()
+        lane = MagicMock()
+        msg = ext.prep_on_shuttle_check(lane)
+
+        lane.unit_obj.lane_tool_loaded.assert_not_called()
+        lane.unit_obj.lane_tool_loaded_idle.assert_not_called()
+
+    def test_in_toolhead_tc_unit_name(self):
+        ext = _make_afc_extruder()
+        ext.tc_unit_name = MagicMock()
+        lane = MagicMock()
+        msg = ext.prep_on_shuttle_check(lane)
+
+        lane.unit_obj.lane_tool_loaded.assert_not_called()
+        lane.unit_obj.lane_tool_loaded_idle.assert_not_called()
+    
+    def test_in_toolhead_tc_unit_name_tool_obj_not_on_shuttle(self):
+        ext = _make_afc_extruder()
+        ext.tc_unit_name = MagicMock()
+        ext.tool_obj = MagicMock()
+        lane = MagicMock()
+        msg = ext.prep_on_shuttle_check(lane)
+
+        lane.unit_obj.lane_tool_loaded.assert_not_called()
+        lane.unit_obj.lane_tool_loaded_idle.assert_called_once_with(lane)
+    
+    def test_in_toolhead_tc_unit_name_tool_obj_on_shuttle(self):
+        ext = _make_afc_extruder()
+        ext.tc_unit_name = MagicMock()
+        ext.tool_obj = MagicMock()
+        ext.tool_obj.detect_state = "mounted"
+        lane = MagicMock()
+        msg = ext.prep_on_shuttle_check(lane)
+
+        lane.unit_obj.lane_tool_loaded.assert_called_once_with(lane)
+        lane.unit_obj.lane_tool_loaded_idle.assert_called_once_with(lane)
+        assert "<span class=primary--text> in ToolHead and toolhead on shuttle</span>" in msg


### PR DESCRIPTION
## Major Changes in this PR
- Correctly sets toolhead leds depending on if filament is loaded and if toolhead is on shuttle(for toolchanges) during PREP
- Fix includes setting toolhead leds correctly for standalone toolheads
- Moved a check to a common method that's easily called by different units system_test methods.
- Adding unit tests

Fixes #734 

## How the changes in this PR are tested
Test on 2.4 toolchanger, made sure status reflected correctly between toolheads being on shuttle on docked between both standalone toolheads and toolheads that have units attached to them.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved consistency of “in ToolHead / on shuttle” status messaging across AFC components.

* **Bug Fixes**
  * Corrected tool-loaded LED behavior during the PREP phase for toolchangers.
  * Tightened “LOADED” status to only show when the expected lane tool is currently matched, with updated shuttle-prep messaging.

* **Tests**
  * Added coverage for shuttle status checking to validate returned messages and LED callback behavior across multiple tool/detection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->