### PR TITLE
(feat): Adding ability to add custom extruder name for AFC_extruder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-21]
+### Added
+- Ability to have AFC_extruder config section a custom name thats not `extruder(x)`, if `extruder(x)` is not being used then `extruder_name` variable needs to have the correct toolhead extruder name.
+
 ## [2026-06-20]
 ### Fixed
 - Setting toolhead leds correctly during PREP for toolchangers

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1369,7 +1369,7 @@ class afc:
         self.function.check_absolute_mode("TOOL_LOAD")
 
         # If the current extruder is not the one associated with the lane, switch to it.
-        if self.function.get_current_extruder() != cur_lane.extruder_obj.name:
+        if self.function.get_current_extruder() != cur_lane.extruder_obj.th_extruder_name:
             cur_lane.tool_swap()
 
         # After a tool swap the newly active extruder may already have a different lane
@@ -1788,7 +1788,7 @@ class afc:
                                     pause=self.function.in_print())
                 return False
 
-            next_extruder   = next_lane.extruder_obj.name
+            next_extruder   = next_lane.extruder_obj.th_extruder_name
             # TODO: need to check if its just a tool swap, or tool swap with a lane unload
 
             # If the next extruder is specified and it is not the current extruder, perform a tool swap.
@@ -2227,7 +2227,7 @@ class afc:
                 return
 
             self.next_lane_load = cur_lane.name
-            next_extruder = cur_lane.extruder_obj.name
+            next_extruder = cur_lane.extruder_obj.th_extruder_name
             infinite_runout: bool = cur_lane.status == AFCLaneState.INFINITE_RUNOUT
             adjusting_temperature: bool = new_extruder_temp is not None or \
                 (infinite_runout and self.function.get_current_extruder() != next_extruder)
@@ -2253,7 +2253,7 @@ class afc:
                     # Now cool down the old extruder when not doing infinite runout
                     if (_last_lane is not None
                         and not infinite_runout
-                        and _last_lane.extruder_obj.name != next_extruder):
+                        and _last_lane.extruder_obj.th_extruder_name != next_extruder):
                         self._cooldown_last_extruder(_last_lane.extruder_obj, infinite_runout)
 
             # If the requested lane is not the current lane, proceed with the tool change.
@@ -2296,7 +2296,7 @@ class afc:
                     # TOOL_UNLOAD should now be done
                     if (_last_lane is not None
                         and infinite_runout
-                        and _last_lane.extruder_obj.name != next_extruder):
+                        and _last_lane.extruder_obj.th_extruder_name != next_extruder):
                         self._cooldown_last_extruder(_last_lane.extruder_obj, infinite_runout)
 
                     self.logger.info("Heating and waiting for {} for {}".format(next_extruder_obj.name,
@@ -2402,7 +2402,7 @@ class afc:
         str['units'] = list(unitdisplay)
         str['lanes'] = list(self.lanes.keys())
         str["maps"] = list(self.tool_cmds.keys())
-        str["extruders"] = list(self.tools.keys())
+        str["extruders"] = [e.name for e in self.tools.values()]
         str["hubs"] = list(self.hubs.keys())
         str["buffers"] = list(self.buffers.keys())
         str["message"] = self._get_message()
@@ -2530,12 +2530,12 @@ class afc:
             # to a different toolhead.
             if (snapmaker_param_a is not None
                 and self.snapmaker_printer):
-                extruder_name = "extruder"
+                th_extruder_name = "extruder"
                 if toolnum > 0:
-                    extruder_name = f"extruder{toolnum}"
-                self.logger.debug(f"Snapmaker Temp extruder name {extruder_name}")
+                    th_extruder_name = f"extruder{toolnum}"
+                self.logger.debug(f"Snapmaker Temp extruder name {th_extruder_name}")
 
-                extruder = self.tools.get(extruder_name, self.toolhead.get_extruder())
+                extruder = self.tools.get(th_extruder_name, self.toolhead.get_extruder())
             elif lane is not None:
                 extruder = lane.extruder_obj
 

--- a/extras/AFC_OpenAMS.py
+++ b/extras/AFC_OpenAMS.py
@@ -469,7 +469,7 @@ class afcAMS(afcUnit):
         if not extruder_name:
             return False
 
-        lane_extruder = getattr(lane, "extruder_name", None)
+        lane_extruder = getattr(lane, "afc_extruder_name", None)
         if lane_extruder is None:
             lane_extruder_obj = getattr(lane, "extruder_obj", None)
             lane_extruder = getattr(lane_extruder_obj, "name", None)

--- a/extras/AFC_Toolchanger.py
+++ b/extras/AFC_Toolchanger.py
@@ -203,7 +203,7 @@ class AfcToolchanger(afcUnit):
             self.afc.last_gcode_position[i] -= self.afc.gcode_move.base_position[i]
         # Perform a tool swap by selecting the appropriate extruder based on the lane's extruder object.
         self.afc.afcDeltaTime.log_with_time("Performing tool swap")
-        name = lane.extruder_obj.name
+        name = lane.extruder_obj.th_extruder_name
         tool_index = 0 if name == "extruder" else int(name.replace("extruder", ""))
 
         if lane.extruder_obj.custom_tool_swap:

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -221,6 +221,8 @@ class AFCExtruder:
 
         self.name: str                  = self.fullname.split(' ')[-1]
         self.th_extruder_name: str      = config.get("extruder_name", self.name)
+        self._check_extruder_name()
+
         self.tool_start                 = config.get('pin_tool_start', None)                                            # Pin for sensor before(pre) extruder gears
         self.tool_end                   = config.get('pin_tool_end', None)                                              # Pin for sensor after(post) extruder gears (optional)
         self.tool_stn                   = config.getfloat("tool_stn", 72)                                               # Distance in mm from the toolhead sensor to the tip of the nozzle in mm, if `tool_end` is defined then distance is from this sensor
@@ -364,6 +366,19 @@ class AFCExtruder:
 
     def __str__(self):
         return self.name
+
+    def _check_extruder_name(self):
+        """
+        Helper method the verify that "extruder" exists in either the config name or in
+        extruder_name variable. If "extruder" is not found, raises a ConfigParser.Error with
+        a message to display to the user.
+        """
+        if "extruder" not in self.th_extruder_name:
+            error_str = (f"Missing extruder reference in [{self.fullname}] section. The word " \
+                         "extruder must appear either in the section name " \
+                         "([AFC_extruder extruder(n)]) or in the extruder_name variable " \
+                         "(extruder_name: extruder(n)).")
+            raise error(error_str)
 
     def check_lanes(self):
         # Checks to see if there are multiple lanes per toolhead, remove self created lane if

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -418,6 +418,13 @@ class AFCExtruder:
         and assigns it to the instance variable `self.AFC`.
         """
         self.reactor = self.afc.reactor
+        existing = self.afc.tools.get(self.th_extruder_name)
+        if (existing is not None
+            and existing is not self):
+            error_str = (f"Duplicate toolhead extruder mapping '{self.th_extruder_name}' "
+                         f"between [{existing.fullname}] and [{self.fullname}]. "
+                         "Each AFC_extruder section must map to a unique toolhead extruder.")
+            raise error(error_str)
         self.afc.tools[self.th_extruder_name] = self
 
         self.toolhead_extruder = self.printer.lookup_object(self.th_extruder_name, None)

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -220,7 +220,7 @@ class AFCExtruder:
         self.fullname                   = config.get_name()
 
         self.name: str                  = self.fullname.split(' ')[-1]
-        # self.extruder_name: str         = config.get("extruder_name", self.name)    # Add support for this, not sure where all this will have to be updated
+        self.th_extruder_name: str      = config.get("extruder_name", self.name)
         self.tool_start                 = config.get('pin_tool_start', None)                                            # Pin for sensor before(pre) extruder gears
         self.tool_end                   = config.get('pin_tool_end', None)                                              # Pin for sensor after(post) extruder gears (optional)
         self.tool_stn                   = config.getfloat("tool_stn", 72)                                               # Distance in mm from the toolhead sensor to the tip of the nozzle in mm, if `tool_end` is defined then distance is from this sensor
@@ -276,7 +276,7 @@ class AFCExtruder:
         self.lanes: Dict                = {}
         self.load_active                = False
         self.current_move_distance: float = 0
-        self.estats = AFCExtruderStats(self.name, self, self.afc.tool_cut_threshold)
+        self.estats = AFCExtruderStats(self.th_extruder_name, self, self.afc.tool_cut_threshold)
 
         # U1 only related variables
         self.park_detector_obj   = None
@@ -322,6 +322,7 @@ class AFCExtruder:
             config.fileconfig.set(config.section, "unit", self.tc_unit_name.split()[-1])
             config.fileconfig.set(config.section, "extruder", self.name)
             config.fileconfig.set(config.section, "hub", "direct")
+            config.fileconfig.set(config.section, "standalone", "True")
             self.tc_lane = AFCLane(config)
             self.printer.objects[f"AFC_lane {self.name}"] = self.tc_lane
             # TODO: Once homing is in create common function for this and AFC_stepper
@@ -402,11 +403,11 @@ class AFCExtruder:
         and assigns it to the instance variable `self.AFC`.
         """
         self.reactor = self.afc.reactor
-        self.afc.tools[self.name] = self
+        self.afc.tools[self.th_extruder_name] = self
 
-        self.toolhead_extruder = self.printer.lookup_object(self.name, None)
+        self.toolhead_extruder = self.printer.lookup_object(self.th_extruder_name, None)
         if not self.toolhead_extruder:
-            error_str = self.common_error.format(self.name, self.fullname)
+            error_str = self.common_error.format(self.th_extruder_name, self.fullname)
             raise error(error_str)
 
         if self.tool:
@@ -673,7 +674,7 @@ class AFCExtruder:
         if self.motion_queuing is not None:
             self.motion_queuing.wipe_trapq(self.trapq)
 
-        self.function.do_enable(False, self.name)
+        self.function.do_enable(False, self.th_extruder_name)
         self.load_active = False
 
         self.afc.restore_toolhead_temp(temp_state=self._captured_toolhead_temp, async_restore=True)
@@ -708,7 +709,7 @@ class AFCExtruder:
             and current_temp <= target_temp + self.afc.temp_wait_tolerance):
             if self.tool_start_state:
                 info_str = "loading to" if self.current_move_distance > 0 else "unloading from"
-                self.logger.info(f"{self.name} temp within range, {info_str} nozzle")
+                self.logger.info(f"{self.th_extruder_name} temp within range, {info_str} nozzle")
                 self.move_extruder(self.current_move_distance)
                 if self.current_move_distance > 0:
                     self.tc_lane.set_loaded()
@@ -725,7 +726,7 @@ class AFCExtruder:
                 )
             return self.reactor.NEVER
         else:
-            self.logger.debug(f"{self.name}: waiting for temp: {current_temp}")
+            self.logger.debug(f"{self.th_extruder_name}: waiting for temp: {current_temp}")
 
         return self.reactor.monotonic() + 1
 

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -408,9 +408,9 @@ class afcFunction:
 
         :return Object: Object of current extruder/tool, None if no extruder/tool
         """
-        extruder_name = self.get_current_extruder()
-        if extruder_name:
-            return self.afc.tools.get(extruder_name, None)
+        th_extruder_name = self.get_current_extruder()
+        if th_extruder_name:
+            return self.afc.tools.get(th_extruder_name, None)
         return None
 
     def get_current_extruder(self) -> Optional[str]:

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -150,7 +150,8 @@ class AFCLane:
             self.index              = 0
             pass
 
-        self.extruder_name      = config.get('extruder', None)                          # Extruder name(AFC_extruder) that belongs to this stepper, overrides extruder that is set in unit(AFC_BoxTurtle/NightOwl/etc) section.
+        self.afc_extruder_name    = config.get('extruder', None)                          # Extruder name(AFC_extruder) that belongs to this stepper, overrides extruder that is set in unit(AFC_BoxTurtle/NightOwl/etc) section.
+        self.standalone_lane      = config.getboolean("standalone", False)
         self.remember_spool :bool = config.getboolean('remember_spool', None)             # remember_spool that is set in AFC_Stepper section, overrides remember_spool that is set in unit(AFC_BoxTurtle/NightOwl/etc) section.
         self.map                = config.get('cmd', None)                               # Keeping this in so it does not break others config that may have used this, use map instead
         # Saving to self._map so that if a user has it defined it will be reset back to this when
@@ -296,8 +297,8 @@ class AFCLane:
             self._set_homing_endstop(query_endstops, ppins,
                                      self.buffer_obj.advance_pin, AFCHomingPoints.BUFFER)
 
-        if (self.extruder_name
-            and "extruder" not in self.name): # Protects against standalone lanes
+        if (self.afc_extruder_name
+            and not self.standalone_lane): # Protects against standalone lanes
             self._get_extruder_object()
             pin = self.extruder_obj.tool_start
             if pin and "buffer" not in pin:
@@ -434,13 +435,13 @@ class AFCLane:
         if not hasattr(self, "extruder_obj") or self.extruder_obj is None:
             return extruder_index
 
-        extruder_name = self.extruder_obj.name
+        th_extruder_name = self.extruder_obj.th_extruder_name
 
-        if extruder_name == "extruder":
+        if th_extruder_name == "extruder":
             return extruder_index
 
         try:
-            return int(extruder_name.replace("extruder", ""))
+            return int(th_extruder_name.replace("extruder", ""))
         except ValueError:
             return extruder_index
 
@@ -504,10 +505,10 @@ class AFCLane:
         raises error if extruder is not found
         """
         try:
-            self.extruder_obj = self.printer.load_object(self._config, 'AFC_extruder {}'.format(self.extruder_name))
-        except:
-            error_string = 'Error: No config found for extruder: {extruder} in [{stepper}]. Please make sure [AFC_extruder {extruder}] section exists in your config'.format(
-                extruder=self.extruder_name, stepper=self.fullname )
+            self.extruder_obj = self.printer.load_object(self._config, 'AFC_extruder {}'.format(self.afc_extruder_name))
+        except Exception as e:
+            error_string = 'Error: No config found for extruder: {extruder} in [{stepper}]. Please make sure [AFC_extruder {extruder}] section exists in your config\nKlippy error: {e}'.format(
+                extruder=self.afc_extruder_name, stepper=self.fullname, e=e )
             raise error(error_string)
 
     def _set_homing_endstop(self, query_endstops: QueryEndstops, ppins: PrinterPins,
@@ -603,7 +604,7 @@ class AFCLane:
             self.hub_obj.hub_clear_move_dis = 65
 
         self.extruder_obj = self.unit_obj.extruder_obj
-        if self.extruder_name is not None:
+        if self.afc_extruder_name is not None:
             self._get_extruder_object()
         elif self.extruder_obj is None:
             error_string = "Error: Extruder has not been configured for stepper {name}, please add extruder variable to either [AFC_stepper {name}] or [AFC_{unit_type} {unit_name}] in your config file".format(
@@ -611,7 +612,7 @@ class AFCLane:
             raise error(error_string)
 
         # Assigning extruder name just in case stepper is using extruder defined in units config
-        self.extruder_name = self.extruder_obj.name
+        self.afc_extruder_name = self.extruder_obj.name
         if add_to_other_obj:
             self.extruder_obj.lanes[self.name] = self
             self.extruder_obj.check_lanes()
@@ -1270,7 +1271,8 @@ class AFCLane:
         :param update_current: Sets current to specified print current when True
         """
         if self.drive_stepper is not None:
-            self.drive_stepper.sync_to_extruder(update_current, extruder_name=self.extruder_name)
+            self.drive_stepper.sync_to_extruder(update_current,
+                                                th_extruder_name=self.extruder_obj.th_extruder_name)
 
     def unsync_to_extruder(self, update_current=True):
         """
@@ -2109,7 +2111,7 @@ class AFCLane:
         response['name'] = self.name
         response['unit'] = self.unit
         response['hub'] = self.hub
-        response['extruder'] = self.extruder_name
+        response['extruder'] = self.afc_extruder_name
         response['buffer'] = self.buffer_name
         response['buffer_status'] = self.buffer_status()
         response['lane'] = self.index

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -129,9 +129,9 @@ class afcPrep:
             extruder_obj.set_status_led( self.afc.led_tool_unloaded )
             if extruder_obj.on_shuttle():
                 # Calls ACTIVATE_EXTRUDER if current toolhead on shuttle is not the active extruder
-                if self.afc.function.get_current_extruder() != extruder_obj.name:
+                if self.afc.function.get_current_extruder() != extruder_obj.th_extruder_name:
                     self.afc.gcode.run_script_from_command(
-                        f"ACTIVATE_EXTRUDER EXTRUDER={extruder_obj.name}"
+                        f"ACTIVATE_EXTRUDER EXTRUDER={extruder_obj.th_extruder_name}"
                     )
             if 'system' in units and "extruders" in units["system"]:
                 # Check to see if lane_loaded is in dictionary and its not an empty string

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -273,16 +273,16 @@ class AFCExtruderStepper(AFCLane):
         else:
             self.next_cmd_time = print_time
 
-    def sync_to_extruder(self, update_current=True, extruder_name=None):
+    def sync_to_extruder(self, update_current=True, th_extruder_name=None):
         """
         Helper function to sync lane to extruder and set print current if specified.
 
         :param update_current: Sets current to specified print current when True
         """
-        if extruder_name is None:
-            extruder_name = self.extruder_name
+        if th_extruder_name is None:
+            th_extruder_name = self.extruder_obj.th_extruder_name
 
-        self.extruder_stepper.sync_to_extruder(extruder_name)
+        self.extruder_stepper.sync_to_extruder(th_extruder_name)
         if update_current: self.set_print_current()
 
     def unsync_to_extruder(self, update_current=True):
@@ -518,14 +518,14 @@ class AFCExtruderStepper(AFCLane):
             hub_pin = self._get_section_value('AFC_hub', hub_name, 'switch_pin')
 
         # Toolhead endstops from AFC_extruder (tool_start/tool_end)
-        extruder_name = getattr(self, 'extruder_name', None) or self._inherit_from_unit('extruder')
-        tool_start_pin = self._get_section_value('AFC_extruder', extruder_name, 'pin_tool_start')
-        tool_end_pin   = self._get_section_value('AFC_extruder', extruder_name, 'pin_tool_end')
+        afc_extruder_name = getattr(self, 'afc_extruder_name', None) or self._inherit_from_unit('extruder')
+        tool_start_pin = self._get_section_value('AFC_extruder', afc_extruder_name, 'pin_tool_start')
+        tool_end_pin   = self._get_section_value('AFC_extruder', afc_extruder_name, 'pin_tool_end')
 
         # Buffer endstops from AFC_buffer (advance/trailing), inherit from extruder or unit if needed
         buffer_name = getattr(self, 'buffer_name', None)
         if not buffer_name:
-            buffer_name = self._get_section_value('AFC_extruder', extruder_name, 'buffer') or self._inherit_from_unit('buffer')
+            buffer_name = self._get_section_value('AFC_extruder', afc_extruder_name, 'buffer') or self._inherit_from_unit('buffer')
         buffer_adv_pin   = self._get_section_value('AFC_buffer', buffer_name, 'advance_pin')
         buffer_trail_pin = self._get_section_value('AFC_buffer', buffer_name, 'trailing_pin')
 
@@ -539,7 +539,7 @@ class AFCExtruderStepper(AFCLane):
             if buffer_adv_pin is not None:
                 self._add_endstop('tool_start', buffer_adv_pin, 'tool_start')
             else:
-                error_string = f"Error: buffer set as pin_tool_start in [AFC_extruder {extruder_name}] config section,"
+                error_string = f"Error: buffer set as pin_tool_start in [AFC_extruder {afc_extruder_name}] config section,"
                 error_string += f" but [AFC_buffer {buffer_name}] is not found in config. Please make sure config "
                 error_string += f"section exists or remove `buffer: {buffer_name}` variable from your extruder config section."
                 raise error(error_string)

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -267,7 +267,7 @@ class afcUnit:
 
         for lane in self.lanes.values():
             if lane.hub is not None and not lane.is_direct_hub() and lane.hub not in response["hubs"]: response["hubs"].append(lane.hub)
-            if lane.extruder_name is not None and lane.extruder_name not in response["extruders"]: response["extruders"].append(lane.extruder_name)
+            if lane.afc_extruder_name is not None and lane.afc_extruder_name not in response["extruders"]: response["extruders"].append(lane.afc_extruder_name)
             if lane.buffer_name is not None and lane.buffer_name not in response["buffers"]: response["buffers"].append(lane.buffer_name)
 
         return response

--- a/templates/AFC_Hardware_U1.cfg
+++ b/templates/AFC_Hardware_U1.cfg
@@ -3,7 +3,7 @@ enable_force_move: True
 
 [AFC_Toolchanger Tools]
 
-[AFC_extruder extruder]
+[AFC_extruder e0]
 u1_filament_sensor_name: e0_filament
 tool_stn: 50                    # See documentation for details on how to calculate this value. https://armoredturtle.xyz/docs/afc-klipper-add-on/toolhead/calculation.html
 tool_stn_unload: 60             # See documentation for details on how to calculate this value. https://armoredturtle.xyz/docs/afc-klipper-add-on/toolhead/calculation.html
@@ -14,8 +14,9 @@ toolchanger_unit: Tools
 custom_tool_swap : PICK_EXTRUDER
 custom_unselect : PARK_EXTRUDER
 u1_park_detector_name: extruder
+extruder_name: extruder
 
-[AFC_extruder extruder1]
+[AFC_extruder e1]
 u1_filament_sensor_name: e1_filament
 tool_stn: 50                    # See documentation for details on how to calculate this value. https://armoredturtle.xyz/docs/afc-klipper-add-on/toolhead/calculation.html
 tool_stn_unload: 60             # See documentation for details on how to calculate this value. https://armoredturtle.xyz/docs/afc-klipper-add-on/toolhead/calculation.html
@@ -26,8 +27,9 @@ toolchanger_unit: Tools
 custom_tool_swap : PICK_EXTRUDER1
 custom_unselect : PARK_EXTRUDER1
 u1_park_detector_name: extruder1
+extruder_name: extruder1
 
-[AFC_extruder extruder2]
+[AFC_extruder e2]
 u1_filament_sensor_name: e2_filament
 tool_stn: 50                    # See documentation for details on how to calculate this value. https://armoredturtle.xyz/docs/afc-klipper-add-on/toolhead/calculation.html
 tool_stn_unload: 60             # See documentation for details on how to calculate this value. https://armoredturtle.xyz/docs/afc-klipper-add-on/toolhead/calculation.html
@@ -38,8 +40,9 @@ toolchanger_unit: Tools
 custom_tool_swap : PICK_EXTRUDER2
 custom_unselect : PARK_EXTRUDER2
 u1_park_detector_name: extruder2
+extruder_name: extruder2
 
-[AFC_extruder extruder3]
+[AFC_extruder e3]
 u1_filament_sensor_name: e3_filament
 tool_stn: 50                    # See documentation for details on how to calculate this value. https://armoredturtle.xyz/docs/afc-klipper-add-on/toolhead/calculation.html
 tool_stn_unload:60              # See documentation for details on how to calculate this value. https://armoredturtle.xyz/docs/afc-klipper-add-on/toolhead/calculation.html
@@ -50,6 +53,7 @@ toolchanger_unit: Tools
 custom_tool_swap : PICK_EXTRUDER3
 custom_unselect : PARK_EXTRUDER3
 u1_park_detector_name: extruder3
+extruder_name: extruder3
 
 #[filament_switch_sensor bypass]
 #switch_pin: turtleneck:PB5

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -599,7 +599,7 @@ def _make_afc_for_change_tool(lane_name="lane2", next_extruder_name="extruder1",
 
     # Current (old) lane/extruder
     current_extruder = MagicMock()
-    current_extruder.name = current_extruder_name
+    current_extruder.th_extruder_name = current_extruder.name = current_extruder_name
     current_extruder.get_heater = MagicMock(return_value=MagicMock())
     current_extruder.deadband = 2.0
     current_extruder.estats = MagicMock()
@@ -611,7 +611,7 @@ def _make_afc_for_change_tool(lane_name="lane2", next_extruder_name="extruder1",
 
     # Next (new) lane/extruder
     next_extruder = MagicMock()
-    next_extruder.name = next_extruder_name
+    next_extruder.th_extruder_name = next_extruder.name = next_extruder_name
     next_extruder.get_heater = MagicMock(return_value=MagicMock())
     next_extruder.deadband = 2.0
     next_extruder.estats = MagicMock()
@@ -2539,7 +2539,7 @@ class TestUnitOrdering:
     def add_lane_to_unit(self, unit, lane_name, extruder_name="extruder"):
         lane = MagicMock()
         lane.name = lane_name
-        lane.extruder_obj.name = extruder_name
+        lane.extruder_obj.th_extruder_name = lane.extruder_obj.name = extruder_name
         unit.lanes.update({lane_name: lane})
         
     def test_unit_lane_ordering(self):

--- a/tests/test_AFC_extruder.py
+++ b/tests/test_AFC_extruder.py
@@ -27,7 +27,7 @@ def _make_extruder_obj(name="extruder"):
     afc = MockAFC()
     afc.afc_stats = MagicMock()
     obj = MagicMock()
-    obj.name = name
+    obj.th_extruder_name = obj.name = name
     obj.afc = afc
     obj.logger = MockLogger()
     obj.park_detector_obj = None
@@ -224,7 +224,7 @@ def _make_afc_extruder(name="extruder"):
     ext.logger = MockLogger()
     ext.reactor = reactor
     ext.fullname = f"AFC_extruder {name}"
-    ext.name = name
+    ext.th_extruder_name = ext.name = name
     # Toolchanger fields – default mirrors single-toolhead state
     ext.tool_obj     = None
     ext.tc_unit_name = None

--- a/tests/test_AFC_extruder.py
+++ b/tests/test_AFC_extruder.py
@@ -335,6 +335,15 @@ class TestAFCExtruderHandleConnect:
         ext.reactor = None
         ext.handle_connect()
         assert ext.reactor is ext.afc.reactor
+    
+    def test_handel_connect_duplicate_entry(self):
+        ext1 = _make_afc_extruder("extruder")
+        ext2 = _make_afc_extruder("extruder")
+        ext2.afc = ext1.afc
+        ext1.afc.tools[ext1.th_extruder_name] = ext1
+        with pytest.raises(KlipperError) as exc:
+            ext2.handle_connect()
+        assert "Duplicate toolhead extruder mapping" in str(exc.value)
 
 
 # ── handle_moonraker_connect ───────────────────────────────────────────────────

--- a/tests/test_AFC_extruder.py
+++ b/tests/test_AFC_extruder.py
@@ -11,15 +11,14 @@ Covers:
 from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
+from configparser import Error as KlipperError
 import pytest
 import sys
 import types
 
 from extras.AFC_extruder import AFCExtruderStats, AFCExtruder
 from tests.test_AFC_lane import _make_afc_lane, AFCLane
-
-
-# ── Helpers ───────────────────────────────────────────────────────────────────
+# ── Helpers ─────────────────────────────────────────────────────────
 
 def _make_extruder_obj(name="extruder"):
     """Minimal AFCExtruder-like mock."""
@@ -1196,6 +1195,29 @@ class TestNoteToolStartCallback:
         ext.note_tool_start_callback(True)
         args = ext.tool_start_callback.call_args.args
         assert args[1]
+
+class TestCheckExtruderName:
+    def test_no_extruder_in_config_name(self):
+        ext = _make_afc_extruder(name="e0")
+        with pytest.raises(KlipperError) as exc:
+            ext._check_extruder_name()
+        assert "Missing extruder reference" in str(exc.value)
+
+    def test_no_extruder_in_extruder_name_variable(self):
+        ext = _make_afc_extruder(name="extruder")
+        ext.th_extruder_name = "e0"
+        with pytest.raises(KlipperError) as exc:
+            ext._check_extruder_name()
+        assert "Missing extruder reference" in str(exc.value)
+    
+    def test_extruder_in_config_name(self):
+        ext = _make_afc_extruder(name="extruder")
+        ext._check_extruder_name()
+
+    def test_extruder_in_extruder_name_variable(self):
+        ext = _make_afc_extruder(name="e0")
+        ext.th_extruder_name = "extruder1"
+        ext._check_extruder_name()
 
 class TestPrepOnShuttleCheck:
 

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -377,7 +377,7 @@ class TestAFCLaneIndexProperty:
 class TestAFCLaneExtruderIndexProperty:
     def test_lane_extruder_index_property_is_int(self):
         lane = _make_afc_lane()
-        lane.extruder_obj.name = "extruder1"
+        lane.extruder_obj.th_extruder_name = lane.extruder_obj.name = "extruder1"
         assert isinstance(lane.lane_extruder_index, int)
 
     def test_lane_extruder_index_property_is_none(self):
@@ -387,17 +387,17 @@ class TestAFCLaneExtruderIndexProperty:
     
     def test_lane_extruder_index_property_extruder(self):
         lane = _make_afc_lane()
-        lane.extruder_obj.name = "extruder"
+        lane.extruder_obj.th_extruder_name = lane.extruder_obj.name = "extruder"
         assert lane.lane_extruder_index == 0
     
     def test_lane_extruder_index_property_extruder1(self):
         lane = _make_afc_lane()
-        lane.extruder_obj.name = "extruder1"
+        lane.extruder_obj.th_extruder_name = lane.extruder_obj.name = "extruder1"
         assert lane.lane_extruder_index == 1
     
     def test_lane_extruder_index_property_value_error(self):
         lane = _make_afc_lane()
-        lane.extruder_obj.name = "extruderT"
+        lane.extruder_obj.th_extruder_name = lane.extruder_obj.name = "extruderT"
         assert lane.lane_extruder_index == 0    
 
 # ── get_color ─────────────────────────────────────────────────────────────────
@@ -649,7 +649,7 @@ def _make_lane_for_moonraker(extruder_name="extruder", map_value="T0"):
     lane = _make_afc_lane("AFC_stepper lane1")
     lane.map = map_value
     lane.extruder_obj = MagicMock()
-    lane.extruder_obj.name = extruder_name
+    lane.extruder_obj.th_extruder_name = lane.extruder_obj.name = extruder_name
     lane.color = "#FF0000"
     lane._material = "PLA"
     lane.bed_temp = 60

--- a/tests/test_AFC_stepper.py
+++ b/tests/test_AFC_stepper.py
@@ -21,7 +21,7 @@ from extras.AFC_stepper import AFCExtruderStepper, TrapqAppendWrapper
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
-def _make_stepper(name="lane1"):
+def _make_stepper(name="lane1", extruder_name="extruder"):
     """Build an AFCExtruderStepper bypassing the complex __init__."""
     stepper = AFCExtruderStepper.__new__(AFCExtruderStepper)
 
@@ -38,6 +38,9 @@ def _make_stepper(name="lane1"):
     stepper.fullname = name
     stepper.next_cmd_time = 0.0
     stepper._manual_axis_pos = 0.0
+    stepper.extruder_obj = MagicMock()
+    stepper.extruder_obj.th_extruder_name = stepper.extruder_obj.name = extruder_name
+    stepper.afc_extruder_name = extruder_name
 
     # Extruder stepper mock
     stepper.extruder_stepper = MagicMock()
@@ -284,32 +287,28 @@ class TestGetLastMoveTime:
 
 class TestSyncUnsync:
     def test_sync_calls_extruder_stepper_sync(self):
-        s = _make_stepper()
-        s.extruder_name = "extruder"
+        s = _make_stepper(extruder_name="extruder")
         s._set_current = MagicMock()
         s.set_print_current = MagicMock()
         s.sync_to_extruder(update_current=False)
         s.extruder_stepper.sync_to_extruder.assert_called_once_with("extruder")
 
     def test_sync_calls_set_print_current_when_update_current(self):
-        s = _make_stepper()
-        s.extruder_name = "extruder"
+        s = _make_stepper(extruder_name="extruder")
         s.set_print_current = MagicMock()
         s.sync_to_extruder(update_current=True)
         s.set_print_current.assert_called_once()
 
     def test_sync_skips_set_print_current_when_update_current_false(self):
-        s = _make_stepper()
-        s.extruder_name = "extruder"
+        s = _make_stepper(extruder_name="extruder")
         s.set_print_current = MagicMock()
         s.sync_to_extruder(update_current=False)
         s.set_print_current.assert_not_called()
 
     def test_sync_uses_override_extruder_name(self):
-        s = _make_stepper()
-        s.extruder_name = "extruder"
+        s = _make_stepper(extruder_name="extruder")
         s.set_print_current = MagicMock()
-        s.sync_to_extruder(update_current=False, extruder_name="extruder2")
+        s.sync_to_extruder(update_current=False, th_extruder_name="extruder2")
         s.extruder_stepper.sync_to_extruder.assert_called_once_with("extruder2")
 
     def test_unsync_calls_sync_with_none(self):

--- a/tests/test_AFC_unit.py
+++ b/tests/test_AFC_unit.py
@@ -59,7 +59,7 @@ def _make_lane(name="lane1", hub="hub1", extruder="ext1", buffer_name="buf1"):
     lane.unit_obj = MagicMock()
     lane.name = name
     lane.hub = hub
-    lane.extruder_name = extruder
+    lane.afc_extruder_name = extruder
     lane.buffer_name = buffer_name
     lane.led_ready = "0,1,0,0"
     lane.led_not_ready = "0,0,0,0.25"


### PR DESCRIPTION
## Major Changes in this PR
- Added ability to add custom extruder name for AFC_extruder, eg. [AFC_extruder custom_name]
- Added check to verify user has specified `extruder_name` variable when using custom naming and that `extruder` string is in the `extruder_name` variable.
- Updated Snapmaker U1 default template to reflect how they have their extruder naming (e0,e1,e2,e3)
- Added unit tests

Documentation PR https://github.com/AFCProject/Documentation/pull/13

## How the changes in this PR are tested
Changed to use custom names, did some swaps on my U1 printer to verify this works with multiple extruders

Error that displays when user does not have `extruder` in either config name or extruder_name variable
<img width="1439" height="144" alt="image" src="https://github.com/user-attachments/assets/b8f5f3ee-c77b-4619-88ca-f3d6135e3815" />

Error message when user has the same extruder_name for multiple AFC_extruder config sections:
<img width="1418" height="117" alt="image" src="https://github.com/user-attachments/assets/858a6280-3fba-4645-9508-44bc53fecbac" />

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for giving AFC’s `AFC_extruder` config section a custom name (not limited to `extruder(x)`).
  * Added/extended `extruder_name` configuration to use a custom toolhead extruder identifier (`extruder_name` must match the toolhead’s extruder name when not using `extruder(x)`).

* **Improvements**
  * Enhanced extruder identity handling across tool changes and temperature checks.
  * Status output now reports extruders using the configured AFC extruder identifiers.

* **Bug Fixes**
  * Added stricter validation for duplicate toolhead/extruder mappings and missing extruder references.

* **Tests**
  * Updated and expanded coverage for the new naming/validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->