### PR TITLE
(fix) Fixes #739, always return tuple when creating filament sensor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2026-06-21]
 ### Added
 - Ability to have AFC_extruder config section a custom name thats not `extruder(x)`, if `extruder(x)` is not being used then `extruder_name` variable needs to have the correct toolhead extruder name.
+### Fixed
+- Issue where adding `enable_tool_runout: False` would cause klipper to crash with message `Internal error during connect: cannot unpack non-iterable SwitchSensor object`
 
 ## [2026-06-20]
 ### Fixed

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -424,12 +424,16 @@ class afc:
 
         # Check if hardware bypass is configured, if not create a virtual bypass sensor
         try:
-            self.bypass = self.printer.lookup_object('filament_switch_sensor bypass').runout_helper
+            self.bypass = self.printer.lookup_object('filament_switch_sensor bypass')[0].runout_helper
         except:
-            self.bypass = add_filament_switch("virtual_bypass", "afc_virtual_bypass:virtual_bypass", self.printer ).runout_helper
+            self.bypass = add_filament_switch("virtual_bypass",
+                                              "afc_virtual_bypass:virtual_bypass",
+                                              self.printer )[0].runout_helper
 
         if self.show_quiet_mode:
-            self.quiet_switch = add_filament_switch("quiet_mode", "afc_quiet_mode:afc_quiet_mode", self.printer ).runout_helper
+            self.quiet_switch = add_filament_switch("quiet_mode",
+                                                    "afc_quiet_mode:afc_quiet_mode",
+                                                    self.printer )[0].runout_helper
 
         # Register G-Code commands for macros we don't want to show up in mainsail/fluidd
         self.gcode.register_command('TOOL_UNLOAD',          self.cmd_TOOL_UNLOAD,           desc=self.cmd_TOOL_UNLOAD_help)

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -44,7 +44,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 try: from extras.AFC_stats import AFCStats
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
 
-AFC_VERSION="1.1.22"
+AFC_VERSION="1.1.24"
 
 # Class for holding different states so its clear what all valid states are
 class State:

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -424,8 +424,8 @@ class afc:
 
         # Check if hardware bypass is configured, if not create a virtual bypass sensor
         try:
-            self.bypass = self.printer.lookup_object('filament_switch_sensor bypass')[0].runout_helper
-        except:
+            self.bypass = self.printer.lookup_object('filament_switch_sensor bypass').runout_helper
+        except Exception:
             self.bypass = add_filament_switch("virtual_bypass",
                                               "afc_virtual_bypass:virtual_bypass",
                                               self.printer )[0].runout_helper

--- a/extras/AFC_HTLF.py
+++ b/extras/AFC_HTLF.py
@@ -63,7 +63,8 @@ class AFC_HTLF(afcBoxTurtle):
         self.home_endstop           = None
         self.home_endstop_name      = None
         if self.home_pin is not None:
-            self.home_sensor = add_filament_switch(f"{self.name}_home_pin", self.home_pin, self.printer, self.enable_sensors_in_gui )
+            self.home_sensor, _ = add_filament_switch(f"{self.name}_home_pin", self.home_pin,
+                                                      self.printer, self.enable_sensors_in_gui )
 
             ppins.allow_multi_use_pin(self.home_pin.strip("!^"))
             ppins.parse_pin(self.home_pin, True, True)

--- a/extras/AFC_OpenAMS.py
+++ b/extras/AFC_OpenAMS.py
@@ -370,7 +370,7 @@ class afcAMS(afcUnit):
             debounce = getattr(extruder, "debounce_delay", 0.0)
 
             try:
-                created = add_filament_switch(
+                created, _ = add_filament_switch(
                     normalized,
                     f"afc_virtual_ams:{normalized}",
                     self.printer,
@@ -381,7 +381,7 @@ class afcAMS(afcUnit):
                 )
             except TypeError:
                 try:
-                    created = add_filament_switch(
+                    created, _ = add_filament_switch(
                         normalized,
                         f"afc_virtual_ams:{normalized}",
                         self.printer,

--- a/extras/AFC_buffer.py
+++ b/extras/AFC_buffer.py
@@ -76,10 +76,12 @@ class AFCTrigger:
         self.multiplier_low     = config.getfloat("multiplier_low", default=0.9, minval=0.0, maxval=1.0)
 
         self.adv_filament_switch_name = "{}_{}".format(self.name, "expanded")
-        self.fila_avd = add_filament_switch(self.adv_filament_switch_name, self.advance_pin, self.printer, show_sensor=self.enable_sensors_in_gui )
+        self.fila_avd, _ = add_filament_switch(self.adv_filament_switch_name, self.advance_pin,
+                                               self.printer, show_sensor=self.enable_sensors_in_gui )
 
         self.trail_filament_switch_name = "{}_{}".format(self.name, "compressed")
-        self.fila_trail = add_filament_switch(self.trail_filament_switch_name, self.trailing_pin, self.printer, show_sensor=self.enable_sensors_in_gui )
+        self.fila_trail, _ = add_filament_switch(self.trail_filament_switch_name, self.trailing_pin,
+                                                 self.printer, show_sensor=self.enable_sensors_in_gui )
 
         self.printer.register_event_handler("klippy:ready", self._handle_ready)
 

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -281,8 +281,8 @@ class AFCLane:
             show_sensor = True
             if not self.enable_sensors_in_gui or (self.sensor_to_show is not None and 'selector' not in self.sensor_to_show):
                 show_sensor = False
-            self.fila_selector = add_filament_switch(f"{self.name}_selector", self.selector,
-                                                     self.printer, show_sensor)
+            self.fila_selector, _ = add_filament_switch(f"{self.name}_selector", self.selector,
+                                                        self.printer, show_sensor)
             self._set_homing_endstop(query_endstops, ppins,
                                      self.selector, AFCHomingPoints.SELECTOR)
             buttons.register_buttons([self.selector], self.selector_callback)

--- a/extras/AFC_utils.py
+++ b/extras/AFC_utils.py
@@ -26,25 +26,36 @@ from urllib.error import (
     HTTPError
 )
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Callable
 
 if TYPE_CHECKING:
     from extras.AFC_logger import AFC_logger
     from configfile import ConfigWrapper
+    from extras.filament_switch_sensor import SwitchSensor
+    from klippy import Printer
 
 ERROR_STR = "Error trying to import {import_lib}, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper\n\n{trace}"
 
-def add_filament_switch(switch_name, switch_pin, printer, show_sensor=True,
-                        runout_callback = None, enable_runout=False,
-                        debounce_delay=0., extruder="extruder" ):
+def add_filament_switch(switch_name: str, switch_pin: str, printer: Printer,
+                        show_sensor: bool=True, runout_callback: Callable = None,
+                        enable_runout: bool=False, debounce_delay: float=0.
+                        ) -> tuple[SwitchSensor, DebounceButton]:
     """
     Helper function to register pins as filament switch sensor so it will show up in web guis
 
     :param switch_name: Name of switch to register, should be in the following format: `filament_switch_sensor <name>`
     :param switch_pin: Pin to add to config for switch
     :param printer: printer object
+    :param show_sensor: Controls weather or not this sensor will show up in Fluidd/Mainsail UI,
+                        True to show sensor, False to hide sensor from showing up.
+    :param runout_callback: Pass in method to replace existing _runout_event_handler in klippers
+                            runout_helper class.
+    :param enable_runout: If True automatically turns off runout, user can always reenable from UI
+                          if sensor is showing or from klipper macro.
+    :param debounce_delay: A period of time in seconds to debounce switches prior to detecting
+                           runouts
 
-    :return returns filament_switch_sensor object
+    :return tuple: filament_switch_sensor object and DebounceButton object
     """
     import configparser
     import configfile
@@ -85,10 +96,7 @@ def add_filament_switch(switch_name, switch_pin, printer, show_sensor=True,
         fila.runout_helper.runout_gcode = 1
         fila.runout_helper._runout_event_handler = runout_callback # Overriding filament event handler with AFC handler
 
-    if enable_runout:
-        return fila, debounce_button
-
-    return fila
+    return fila, debounce_button
 
 
 def check_and_return( value_str:str, data_values:dict ) -> str:

--- a/tests/klippy/afc_with_buffer.cfg
+++ b/tests/klippy/afc_with_buffer.cfg
@@ -133,6 +133,8 @@ cooling_moves: 4
 # ---------------------------------------------------------------------------
 
 [AFC_extruder extruder]
+pin_tool_start: ^PC5
+enable_tool_runout: False
 
 [AFC_BoxTurtle unit_1]
 hub: hub_1


### PR DESCRIPTION
## Major Changes in this PR
- Changed code to always return tuple when creating filament sensors
- Updated rest of code to accept the returned tuple
- Added `pin_tool_start` and `enable_tool_runout: False` to klipper tests to verify that change fixed error.

Resolves #739 

## How the changes in this PR are tested
Duplicated in local klipper test and verified fix made the test pass. Also was able to duplicate on my 2.4 and verified fix fixed issue.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a Klipper crash when `enable_tool_runout` was set to `False`.
* **Chores**
  * Version bumped to 1.1.24.
  * Updated test configuration to include `pin_tool_start` and set `enable_tool_runout` to `False`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->