### PR TITLE
(feat): Adding flag so that standalone toolhead will purge after being loaded the first time with switching to tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-27]
+### Added
+- The ability to purge on next toolchange for standalone toolheads
+
 ## [2026-06-21]
 ### Added
 - Ability to have AFC_extruder config section a custom name thats not `extruder(x)`, if `extruder(x)` is not being used then `extruder_name` variable needs to have the correct toolhead extruder name.

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1524,7 +1524,8 @@ class afc:
                      " See AFC.log for error trace."),
                     pause=self.function.in_print()
                 )
-                self.logger.debug(f"Exception: {e}")
+                self.logger.debug(f"Exception: {e}\n{traceback.format_exc()}")
+                return False
             finally:
                 self.restore_toolhead_temp(temp_state)
                 self.save_vars()

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1318,7 +1318,6 @@ class afc:
             else:
                 self.gcode.run_script_from_command("{} EXTRUDER={}".format(self.poop_cmd, cur_extruder.name))
 
-            cur_lane.need_purge = False
 
             self.afcDeltaTime.log_with_time("TOOL_LOAD: After poop")
             self.function.log_toolhead_pos()
@@ -1340,6 +1339,8 @@ class afc:
 
         # Wait for moves to finish
         self.toolhead.wait_moves()
+        # Always clear since some people could have poop turned off
+        cur_lane.need_purge = False
 
     cmd_TOOL_LOAD_help = "Load lane into tool"
     def cmd_TOOL_LOAD(self, gcmd):
@@ -1513,10 +1514,11 @@ class afc:
                     self.afcDeltaTime.log_with_time("Done heating toolhead")
                 self.do_poop_kick_wipe(cur_lane=cur_lane, cur_extruder=cur_lane.extruder_obj,
                                     purge_length=purge_length)
-            finally:
+
                 if self.post_load_macro is not None:
                     self.gcode.run_script_from_command(self.post_load_macro)
                     # TODO: Add afcDeltaTime log
+            finally:
                 self.restore_toolhead_temp(temp_state)
                 self.save_vars()
 

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1514,7 +1514,6 @@ class afc:
                 self.do_poop_kick_wipe(cur_lane=cur_lane, cur_extruder=cur_lane.extruder_obj,
                                     purge_length=purge_length)
             finally:
-                cur_lane.need_purge = False
                 if self.post_load_macro is not None:
                     self.gcode.run_script_from_command(self.post_load_macro)
                     # TODO: Add afcDeltaTime log

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1302,6 +1302,45 @@ class afc:
 
         self.current_state = State.IDLE
 
+    def do_poop_kick_wipe(self, cur_lane: AFCLane, cur_extruder: AFCExtruder,
+                          purge_length: Optional[float]=None):
+        """
+        Helper method for easily calling poop,kick,wipe macros. Macros only run if users have them
+        enabled
+
+        :param cur_lane: Current lane that is in toolhead
+        :param cur_extruder: Current active toolhead extruder
+        :param purge_length: Length to purge filament
+        """
+        if self.poop:
+            if purge_length is not None:
+                self.gcode.run_script_from_command("{} PURGE_LENGTH={} EXTRUDER={}".format(self.poop_cmd, purge_length, cur_extruder.name))
+            else:
+                self.gcode.run_script_from_command("{} EXTRUDER={}".format(self.poop_cmd, cur_extruder.name))
+
+            cur_lane.need_purge = False
+
+            self.afcDeltaTime.log_with_time("TOOL_LOAD: After poop")
+            self.function.log_toolhead_pos()
+
+            if self.wipe:
+                self.gcode.run_script_from_command("{} EXTRUDER={}".format(self.wipe_cmd, cur_extruder.name))
+                self.afcDeltaTime.log_with_time("TOOL_LOAD: After first wipe")
+                self.function.log_toolhead_pos()
+
+        if self.kick:
+            self.gcode.run_script_from_command("{} EXTRUDER={}".format(self.kick_cmd, cur_extruder.name))
+            self.afcDeltaTime.log_with_time("TOOL_LOAD: After kick")
+            self.function.log_toolhead_pos()
+
+        if self.wipe:
+            self.gcode.run_script_from_command("{} EXTRUDER={}".format(self.wipe_cmd, cur_extruder.name))
+            self.afcDeltaTime.log_with_time("TOOL_LOAD: After second wipe")
+            self.function.log_toolhead_pos()
+
+        # Wait for moves to finish
+        self.toolhead.wait_moves()
+
     cmd_TOOL_LOAD_help = "Load lane into tool"
     def cmd_TOOL_LOAD(self, gcmd):
         """
@@ -1422,33 +1461,9 @@ class afc:
                     # Activate the tool-loaded LED and handle filament operations if enabled.
                     cur_lane.unit_obj.lane_tool_loaded( cur_lane )
                     cur_lane.espooler.do_assist_move()
-                    if self.poop:
-                        if purge_length is not None:
-                            self.gcode.run_script_from_command("{} PURGE_LENGTH={} EXTRUDER={}".format(self.poop_cmd, purge_length, cur_extruder.name))
 
-                        else:
-                            self.gcode.run_script_from_command("{} EXTRUDER={}".format(self.poop_cmd, cur_extruder.name))
-
-                        self.afcDeltaTime.log_with_time("TOOL_LOAD: After poop")
-                        self.function.log_toolhead_pos()
-
-                        if self.wipe:
-                            self.gcode.run_script_from_command("{} EXTRUDER={}".format(self.wipe_cmd, cur_extruder.name))
-                            self.afcDeltaTime.log_with_time("TOOL_LOAD: After first wipe")
-                            self.function.log_toolhead_pos()
-
-                    if self.kick:
-                        self.gcode.run_script_from_command("{} EXTRUDER={}".format(self.kick_cmd, cur_extruder.name))
-                        self.afcDeltaTime.log_with_time("TOOL_LOAD: After kick")
-                        self.function.log_toolhead_pos()
-
-                    if self.wipe:
-                        self.gcode.run_script_from_command("{} EXTRUDER={}".format(self.wipe_cmd, cur_extruder.name))
-                        self.afcDeltaTime.log_with_time("TOOL_LOAD: After second wipe")
-                        self.function.log_toolhead_pos()
-
-                    # Wait for moves to finish
-                    self.toolhead.wait_moves()
+                    self.do_poop_kick_wipe(cur_lane=cur_lane, cur_extruder=cur_extruder,
+                                           purge_length=purge_length)
 
                     cur_lane.enable_fault_detection()
                     # Update lane and extruder state for tracking.
@@ -1487,6 +1502,25 @@ class afc:
                         message += '\nOnce issue is resolved please manually load {} with {} macro and click resume to continue printing.'.format(cur_lane.name, cur_lane.map)
                     self.error.handle_lane_failure(cur_lane, message, pause=self.function.in_print())
                     return False
+
+        # Check if toolhead needs to purge, this normally should only apply for standalone toolheads
+        if cur_lane.need_purge:
+            temp_state = self.capture_toolhead_temp()
+            try:
+                self.logger.info(f"Flag set to purge for {cur_lane.extruder_obj}:{cur_lane.map}")
+                # Make sure toolhead is up to temp before purging
+                if self._check_extruder_temp(cur_lane):
+                    self.afcDeltaTime.log_with_time("Done heating toolhead")
+                self.do_poop_kick_wipe(cur_lane=cur_lane, cur_extruder=cur_lane.extruder_obj,
+                                    purge_length=purge_length)
+            finally:
+                cur_lane.need_purge = False
+                if self.post_load_macro is not None:
+                    self.gcode.run_script_from_command(self.post_load_macro)
+                    # TODO: Add afcDeltaTime log
+                self.restore_toolhead_temp(temp_state)
+                self.save_vars()
+
         return True
 
     def load_sequence(self, cur_lane: AFCLane, cur_hub: afc_hub, cur_extruder: AFCExtruder):
@@ -2318,6 +2352,7 @@ class afc:
                     self._wait_for_temp_within_tolerance(next_heater, target_temp, next_extruder_obj.deadband)
                     self.logger.info("{} heated and ready to print".format(next_extruder_obj.name))
 
+                    # TODO: should do_purge_kick_wipe be called here instead?
                     if (current_lane_name is not None
                         and infinite_runout
                         and self.wipe
@@ -2513,7 +2548,7 @@ class afc:
         M109 S250
         ```
         """
-
+        self.logger.debug(f"AFC_M104/M109 raw cmd: {gcmd.get_commandline()}")
         # TODO: this currently does not work correctly when lanes are remapped and KTC calls M109
         toolnum: int = gcmd.get_int('T', None, minval=0)
         temp: float  = gcmd.get_float('S', 0.0)

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -44,7 +44,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 try: from extras.AFC_stats import AFCStats
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
 
-AFC_VERSION="1.1.24"
+AFC_VERSION="1.1.25"
 
 # Class for holding different states so its clear what all valid states are
 class State:

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1375,7 +1375,7 @@ class afc:
 
         self.TOOL_LOAD(cur_lane, purge_length)
 
-    def TOOL_LOAD(self, cur_lane: AFCLane, purge_length: int=None, set_start_time=False):
+    def TOOL_LOAD(self, cur_lane: AFCLane, purge_length: Optional[float]=None, set_start_time=False):
         """
         This function handles the loading of a specified lane into the tool. It performs
         several checks and movements to ensure the lane is properly loaded.
@@ -1508,7 +1508,7 @@ class afc:
         if cur_lane.need_purge:
             temp_state = self.capture_toolhead_temp()
             try:
-                self.logger.info(f"Flag set to purge for {cur_lane.extruder_obj}:{cur_lane.map}")
+                self.logger.info(f"Flag set to purge for {cur_lane.extruder_obj.name}:{cur_lane.map}")
                 # Make sure toolhead is up to temp before purging
                 if self._check_extruder_temp(cur_lane):
                     self.afcDeltaTime.log_with_time("Done heating toolhead")
@@ -1518,6 +1518,13 @@ class afc:
                 if self.post_load_macro is not None:
                     self.gcode.run_script_from_command(self.post_load_macro)
                     # TODO: Add afcDeltaTime log
+            except Exception as e:
+                self.error.AFC_error(
+                    (f"Error occurred when trying to purge {cur_lane.extruder_obj.name}."
+                     " See AFC.log for error trace."),
+                    pause=self.function.in_print()
+                )
+                self.logger.debug(f"Exception: {e}")
             finally:
                 self.restore_toolhead_temp(temp_state)
                 self.save_vars()

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -628,8 +628,10 @@ class AFCExtruder:
         if distance > 0:
             self.tc_lane.unit_obj.lane_loading(self.tc_lane)
             self.tc_lane.status = AFCLaneState.TOOL_LOADING
+            self.tc_lane.need_purge = True
         else:
             self.tc_lane.status = AFCLaneState.TOOL_UNLOADING
+            self.tc_lane.need_purge = False
 
         self._captured_toolhead_temp = self.afc.capture_toolhead_temp( extruder=self, async_capture=True)
         self.afc._check_extruder_temp(self.tc_lane, no_wait=True)

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -628,10 +628,8 @@ class AFCExtruder:
         if distance > 0:
             self.tc_lane.unit_obj.lane_loading(self.tc_lane)
             self.tc_lane.status = AFCLaneState.TOOL_LOADING
-            self.tc_lane.need_purge = True
         else:
             self.tc_lane.status = AFCLaneState.TOOL_UNLOADING
-            self.tc_lane.need_purge = False
 
         self._captured_toolhead_temp = self.afc.capture_toolhead_temp( extruder=self, async_capture=True)
         self.afc._check_extruder_temp(self.tc_lane, no_wait=True)
@@ -707,9 +705,11 @@ class AFCExtruder:
         if self.current_move_distance > 0:
             info_str = "loading"
             self.tc_lane.status = AFCLaneState.TOOLED
+            self.tc_lane.need_purge = True
         else:
             info_str = "unloading"
             self.tc_lane.status = AFCLaneState.NONE
+            self.tc_lane.need_purge = False
 
         self.logger.info(f"{self.name} {info_str} done")
 

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -134,6 +134,7 @@ class AFCLane:
         self.td1_data           = {}
         self.runout_lane        = None
         self.status             = AFCLaneState.NONE
+        self.need_purge         = False
         # END TODO
 
         self.multi_hubs_found   = False
@@ -2127,6 +2128,7 @@ class AFCLane:
             response["density"]=self.filament_density
             response["diameter"]=self.filament_diameter
             response["empty_spool_weight"]=self.empty_spool_weight
+            response["need_purge"] = self.need_purge
 
         response["remember_spool"]= bool(self.remember_spool)
         response["spool_id"]= int(self.spool_id) if self.spool_id else None

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -171,6 +171,7 @@ class afcPrep:
                             cur_lane.empty_spool_weight= units[cur_lane.unit][cur_lane.name]["empty_spool_weight"]
                         if 'bed_temp' in units[cur_lane.unit][cur_lane.name]: cur_lane.bed_temp = units[cur_lane.unit][cur_lane.name]['bed_temp']
                         if 'extruder_temp' in units[cur_lane.unit][cur_lane.name]: cur_lane.extruder_temp = units[cur_lane.unit][cur_lane.name]['extruder_temp']
+                        cur_lane.need_purge = units[cur_lane.unit][cur_lane.name].get("need_purge", False)
 
                         for attr_name in ("bed_temp", "extruder_temp", "weight"):
                             value = getattr(cur_lane, attr_name, None)

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -2678,9 +2678,8 @@ class TestDoPoopKickWipe:
             call("TOOL_LOAD: After first wipe"),
             call("TOOL_LOAD: After second wipe")
         ]
-        afc.gcode.run_script_from_command.assert_has_calls(gcode_calls)
-        afc.afcDeltaTime.log_with_time.assert_has_calls(log_with_time_calls)
-        
+        assert afc.gcode.run_script_from_command.call_args_list == gcode_calls
+        assert afc.afcDeltaTime.log_with_time.call_args_list == log_with_time_calls
         assert afc.function.log_toolhead_pos.call_count == 3
 
     def test_poop_kick_wipe(self):
@@ -2713,8 +2712,8 @@ class TestDoPoopKickWipe:
             call("TOOL_LOAD: After kick"),
             call("TOOL_LOAD: After second wipe")
         ]
-        afc.gcode.run_script_from_command.assert_has_calls(gcode_calls)
-        afc.afcDeltaTime.log_with_time.assert_has_calls(log_with_time_calls)
+        assert afc.gcode.run_script_from_command.call_args_list == gcode_calls
+        assert afc.afcDeltaTime.log_with_time.call_args_list == log_with_time_calls
         
         assert afc.function.log_toolhead_pos.call_count == 4
 
@@ -2741,8 +2740,8 @@ class TestDoPoopKickWipe:
             call("TOOL_LOAD: After kick"),
             call("TOOL_LOAD: After second wipe")
         ]
-        afc.gcode.run_script_from_command.assert_has_calls(gcode_calls)
-        afc.afcDeltaTime.log_with_time.assert_has_calls(log_with_time_calls)
+        assert afc.gcode.run_script_from_command.call_args_list == gcode_calls
+        assert afc.afcDeltaTime.log_with_time.call_args_list == log_with_time_calls
         
         assert afc.function.log_toolhead_pos.call_count == 2
-        assert lane.need_purge
+        assert not lane.need_purge

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -101,7 +101,6 @@ def _make_afc():
     obj.function = MagicMock()
     obj.gcode = MagicMock()
     obj.message_queue = []
-    # obj.current = MagicMock()
     obj.current_loading = None
     obj.next_lane_load = None
     obj.current_state = State.IDLE
@@ -132,8 +131,10 @@ def _make_afc():
     obj.wipe_cmd = None
     obj.kick = False
     obj.kick_cmd = None
+    obj.post_load_macro = None
     obj.afcDeltaTime = MagicMock()
     obj.toolhead = MagicMock()
+    obj.error = MagicMock()
     return obj
 
 
@@ -2745,3 +2746,149 @@ class TestDoPoopKickWipe:
         
         assert afc.function.log_toolhead_pos.call_count == 2
         assert not lane.need_purge
+
+
+
+class TestToolLoadNeedPurge:
+    def _make_afc_lane_for_need_purge(self, need_purge=True, check_extruder_temp_return=True,
+                                      printing=False):
+        afc = _make_afc()
+        afc.capture_toolhead_temp = MagicMock(return_value=100)
+        afc._check_extruder_temp = MagicMock(return_value=check_extruder_temp_return)
+        afc.afcDeltaTime = MagicMock()
+        afc.do_poop_kick_wipe = MagicMock()
+        afc.save_vars = MagicMock()
+        afc.restore_toolhead_temp = MagicMock()
+        afc.verify_macro_positions = MagicMock(return_value=False)
+        afc.function.in_print = MagicMock(return_value=printing)
+        lane = _make_afc_lane()
+        afc.function.get_current_lane.return_value = lane.name
+
+        afc.lanes[lane.name] = lane
+        lane.extruder_obj.name = "extruder"
+        lane.extruder_obj.lane_loaded = lane.name
+
+        lane.need_purge = need_purge
+        return afc,lane
+
+    def test_no_purge_needed(self):
+        afc, lane = self._make_afc_lane_for_need_purge(need_purge=False)
+        purge_length = None
+
+        assert afc.TOOL_LOAD(lane)
+
+        afc.capture_toolhead_temp.assert_not_called()
+        afc.restore_toolhead_temp.assert_not_called()
+        afc.save_vars.assert_not_called()        
+
+    def test_need_purge_no_purge_length(self):
+        afc, lane = self._make_afc_lane_for_need_purge()
+        purge_length = None
+
+        assert afc.TOOL_LOAD(lane)
+
+        afc.capture_toolhead_temp.assert_called_once()
+        afc._check_extruder_temp.assert_called_once_with(lane)
+        afc.afcDeltaTime.log_with_time.assert_called_once_with("Done heating toolhead")
+        afc.do_poop_kick_wipe.assert_called_once_with(cur_lane=lane, cur_extruder=lane.extruder_obj,
+                                                      purge_length=purge_length)
+        afc.restore_toolhead_temp.assert_called_once_with(100)
+        afc.save_vars.assert_called_once_with()
+        afc.gcode.run_script_from_command.assert_not_called()
+
+        info_msgs = [m for lvl, m in afc.logger.messages if lvl == "info"]
+        assert any(f"Flag set to purge for {lane.extruder_obj.name}:{lane.map}" in m for m in info_msgs)
+
+    def test_need_purge_with_purge_length(self):
+        afc, lane = self._make_afc_lane_for_need_purge()
+        purge_length = 100
+
+        assert afc.TOOL_LOAD(lane, purge_length=purge_length)
+
+        afc.capture_toolhead_temp.assert_called_once()
+        afc._check_extruder_temp.assert_called_once_with(lane)
+        afc.afcDeltaTime.log_with_time.assert_called_once_with("Done heating toolhead")
+        afc.do_poop_kick_wipe.assert_called_once_with(cur_lane=lane, cur_extruder=lane.extruder_obj,
+                                                      purge_length=purge_length)
+        afc.restore_toolhead_temp.assert_called_once_with(100)
+        afc.save_vars.assert_called_once_with()
+        afc.gcode.run_script_from_command.assert_not_called()
+    
+    def test_need_purge_with_purge_length_no_heating(self):
+        afc, lane = self._make_afc_lane_for_need_purge(check_extruder_temp_return=False)
+        purge_length = 100
+
+        assert afc.TOOL_LOAD(lane, purge_length=purge_length)
+
+        afc.capture_toolhead_temp.assert_called_once()
+        afc._check_extruder_temp.assert_called_once_with(lane)
+        afc.afcDeltaTime.log_with_time.assert_not_called()
+        afc.do_poop_kick_wipe.assert_called_once_with(cur_lane=lane, cur_extruder=lane.extruder_obj,
+                                                      purge_length=purge_length)
+        afc.restore_toolhead_temp.assert_called_once_with(100)
+        afc.save_vars.assert_called_once_with()
+        afc.gcode.run_script_from_command.assert_not_called()
+
+    def test_need_purge_with_purge_length_post_load_macro(self):
+        afc, lane = self._make_afc_lane_for_need_purge()
+        afc.post_load_macro = "AFC_TEST"
+        purge_length = 100
+
+        assert afc.TOOL_LOAD(lane, purge_length=purge_length)
+
+        afc.capture_toolhead_temp.assert_called_once()
+        afc._check_extruder_temp.assert_called_once_with(lane)
+        afc.afcDeltaTime.log_with_time.assert_called_once_with("Done heating toolhead")
+        afc.do_poop_kick_wipe.assert_called_once_with(cur_lane=lane, cur_extruder=lane.extruder_obj,
+                                                      purge_length=purge_length)
+        afc.restore_toolhead_temp.assert_called_once_with(100)
+        afc.save_vars.assert_called_once_with()
+        afc.gcode.run_script_from_command.assert_called_once_with(afc.post_load_macro)
+
+    def test_need_purge_raise_error_no_printing(self):
+        afc, lane = self._make_afc_lane_for_need_purge(check_extruder_temp_return=False)
+        purge_length = 100
+
+        afc._check_extruder_temp = MagicMock(side_effect = Exception("Error Occurred"))
+
+        assert afc.TOOL_LOAD(lane, purge_length=purge_length)
+
+        afc.capture_toolhead_temp.assert_called_once()
+        afc._check_extruder_temp.assert_called_once_with(lane)
+        afc.afcDeltaTime.log_with_time.assert_not_called()
+        afc.do_poop_kick_wipe.assert_not_called()
+        afc.restore_toolhead_temp.assert_called_once_with(100)
+        afc.save_vars.assert_called_once_with()
+        afc.gcode.run_script_from_command.assert_not_called()
+        afc.error.AFC_error.assert_called_once_with(
+            (f"Error occurred when trying to purge {lane.extruder_obj.name}."
+             " See AFC.log for error trace."),
+            pause=False
+        )
+
+        debug_msgs = [m for lvl, m in afc.logger.messages if lvl == "debug"]
+        assert any(f"Exception: Error Occurred" in m for m in debug_msgs)
+
+    def test_need_purge_raise_error_printing(self):
+        afc, lane = self._make_afc_lane_for_need_purge(check_extruder_temp_return=False, printing=True)
+        purge_length = 100
+
+        afc._check_extruder_temp = MagicMock(side_effect = Exception("Error Occurred"))
+
+        assert afc.TOOL_LOAD(lane, purge_length=purge_length)
+
+        afc.capture_toolhead_temp.assert_called_once()
+        afc._check_extruder_temp.assert_called_once_with(lane)
+        afc.afcDeltaTime.log_with_time.assert_not_called()
+        afc.do_poop_kick_wipe.assert_not_called()
+        afc.restore_toolhead_temp.assert_called_once_with(100)
+        afc.save_vars.assert_called_once_with()
+        afc.gcode.run_script_from_command.assert_not_called()
+        afc.error.AFC_error.assert_called_once_with(
+            (f"Error occurred when trying to purge {lane.extruder_obj.name}."
+             " See AFC.log for error trace."),
+            pause=True
+        )
+
+        debug_msgs = [m for lvl, m in afc.logger.messages if lvl == "debug"]
+        assert any(f"Exception: Error Occurred" in m for m in debug_msgs)

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -2851,7 +2851,7 @@ class TestToolLoadNeedPurge:
 
         afc._check_extruder_temp = MagicMock(side_effect = Exception("Error Occurred"))
 
-        assert afc.TOOL_LOAD(lane, purge_length=purge_length)
+        assert not afc.TOOL_LOAD(lane, purge_length=purge_length)
 
         afc.capture_toolhead_temp.assert_called_once()
         afc._check_extruder_temp.assert_called_once_with(lane)
@@ -2875,7 +2875,7 @@ class TestToolLoadNeedPurge:
 
         afc._check_extruder_temp = MagicMock(side_effect = Exception("Error Occurred"))
 
-        assert afc.TOOL_LOAD(lane, purge_length=purge_length)
+        assert not afc.TOOL_LOAD(lane, purge_length=purge_length)
 
         afc.capture_toolhead_temp.assert_called_once()
         afc._check_extruder_temp.assert_called_once_with(lane)

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -23,14 +23,14 @@ Covers:
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 import pytest
 
 from extras.AFC import afc, State, AFC_VERSION
 from extras.AFC_lane import AFCLaneState
 from klippy import Printer
 
-
+from tests.test_AFC_lane import _make_afc_lane
 # ── State constants ───────────────────────────────────────────────────────────
 
 class TestStateConstants:
@@ -124,10 +124,16 @@ def _make_afc():
     obj.in_toolchange = False
     obj.get_bypass_state = MagicMock(return_value=False)
     obj._get_quiet_mode = MagicMock(return_value=False)
+    obj.poop = False
+    obj.poop_cmd = None
     obj.park = False
     obj.park_cmd = None
     obj.wipe = False
     obj.wipe_cmd = None
+    obj.kick = False
+    obj.kick_cmd = None
+    obj.afcDeltaTime = MagicMock()
+    obj.toolhead = MagicMock()
     return obj
 
 
@@ -2608,4 +2614,135 @@ class TestUnitOrdering:
         key_order = list(obj.units.keys())
 
         assert key_order == ["Turtle_1", "Vivid_1", "HTLF_Claymore_1", "Tools", "EMU_1"], key_order
+
+class TestDoPoopKickWipe:
+    def test_poop_no_purge(self):
+        afc = _make_afc()
+        lane = _make_afc_lane()
+        lane.extruder_obj.name = "e0"
+        lane.need_purge = True
+
+        afc.poop = True
+        afc.poop_cmd = "AFC_POOP"
+
+        afc.do_poop_kick_wipe( lane, lane.extruder_obj)
+
+        afc.gcode.run_script_from_command.assert_called_once_with("AFC_POOP EXTRUDER=e0")
+        afc.afcDeltaTime.log_with_time.assert_called_once_with("TOOL_LOAD: After poop")
+        afc.function.log_toolhead_pos.assert_called_once()
+
+        afc.toolhead.wait_moves.assert_called_once()
+        assert not lane.need_purge
+    
+    def test_poop_purge_length(self):
+        afc = _make_afc()
+        lane = _make_afc_lane()
+        lane.extruder_obj.name = "e0"
+        lane.need_purge = True
+
+        afc.poop = True
+        afc.poop_cmd = "AFC_POOP"
+
+        afc.do_poop_kick_wipe( lane, lane.extruder_obj, 100)
+
+        afc.gcode.run_script_from_command.assert_called_once_with("AFC_POOP PURGE_LENGTH=100 EXTRUDER=e0")
+        afc.afcDeltaTime.log_with_time.assert_called_once_with("TOOL_LOAD: After poop")
+        afc.function.log_toolhead_pos.assert_called_once()
+
+        afc.toolhead.wait_moves.assert_called_once()
+
+        assert not lane.need_purge
+    
+    def test_poop_wipe(self):
+        afc = _make_afc()
+        lane = _make_afc_lane()
+        lane.extruder_obj.name = "e0"
+        lane.need_purge = True
+
+        afc.poop = True
+        afc.poop_cmd = "AFC_POOP"
+
+        afc.wipe = True
+        afc.wipe_cmd = "AFC_BRUSH"
+
+        afc.do_poop_kick_wipe( lane, lane.extruder_obj, 100)
+
+        gcode_calls = [
+            call("AFC_POOP PURGE_LENGTH=100 EXTRUDER=e0"),
+            call("AFC_BRUSH EXTRUDER=e0"),
+            call("AFC_BRUSH EXTRUDER=e0")
+        ]
+
+        log_with_time_calls = [
+            call("TOOL_LOAD: After poop"),
+            call("TOOL_LOAD: After first wipe"),
+            call("TOOL_LOAD: After second wipe")
+        ]
+        afc.gcode.run_script_from_command.assert_has_calls(gcode_calls)
+        afc.afcDeltaTime.log_with_time.assert_has_calls(log_with_time_calls)
         
+        assert afc.function.log_toolhead_pos.call_count == 3
+
+    def test_poop_kick_wipe(self):
+        afc = _make_afc()
+        lane = _make_afc_lane()
+        lane.extruder_obj.name = "e0"
+        lane.need_purge = True
+
+        afc.poop = True
+        afc.poop_cmd = "AFC_POOP"
+
+        afc.wipe = True
+        afc.wipe_cmd = "AFC_BRUSH"
+
+        afc.kick = True
+        afc.kick_cmd = "AFC_KICK"
+
+        afc.do_poop_kick_wipe( lane, lane.extruder_obj, 100)
+
+        gcode_calls = [
+            call("AFC_POOP PURGE_LENGTH=100 EXTRUDER=e0"),
+            call("AFC_BRUSH EXTRUDER=e0"),
+            call("AFC_KICK EXTRUDER=e0"),
+            call("AFC_BRUSH EXTRUDER=e0")
+        ]
+
+        log_with_time_calls = [
+            call("TOOL_LOAD: After poop"),
+            call("TOOL_LOAD: After first wipe"),
+            call("TOOL_LOAD: After kick"),
+            call("TOOL_LOAD: After second wipe")
+        ]
+        afc.gcode.run_script_from_command.assert_has_calls(gcode_calls)
+        afc.afcDeltaTime.log_with_time.assert_has_calls(log_with_time_calls)
+        
+        assert afc.function.log_toolhead_pos.call_count == 4
+
+    def test_kick_wipe(self):
+        afc = _make_afc()
+        lane = _make_afc_lane()
+        lane.extruder_obj.name = "e0"
+        lane.need_purge = True
+
+        afc.wipe = True
+        afc.wipe_cmd = "AFC_BRUSH"
+
+        afc.kick = True
+        afc.kick_cmd = "AFC_KICK"
+
+        afc.do_poop_kick_wipe( lane, lane.extruder_obj, 100)
+
+        gcode_calls = [
+            call("AFC_KICK EXTRUDER=e0"),
+            call("AFC_BRUSH EXTRUDER=e0")
+        ]
+
+        log_with_time_calls = [
+            call("TOOL_LOAD: After kick"),
+            call("TOOL_LOAD: After second wipe")
+        ]
+        afc.gcode.run_script_from_command.assert_has_calls(gcode_calls)
+        afc.afcDeltaTime.log_with_time.assert_has_calls(log_with_time_calls)
+        
+        assert afc.function.log_toolhead_pos.call_count == 2
+        assert lane.need_purge

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -220,6 +220,7 @@ def _make_afc_lane(fullname="AFC_stepper lane1"):
     lane.runout_lane = None
     lane.map = "T0"
     lane.gcode = MagicMock()
+    lane.need_purge = False
     return lane
 
 


### PR DESCRIPTION
## Major Changes in this PR
- Adding flag so that standalone toolhead will purge after being loaded the first time with switching to tool
- This is needed so that nozzle will be primed correctly and previous color gets flushed out

## How the changes in this PR are tested
- Tested on voron 2.4 and Snapmaker U1 printers
<img width="762" height="287" alt="image" src="https://github.com/user-attachments/assets/3ca186ee-cee9-47a5-ba07-fe804645c0ca" />

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent tracking for whether a lane needs a purge after tool changes, including across prep.
  * Enhanced standalone toolhead behavior to purge on the next toolchange, with configurable purge length.

* **Bug Fixes**
  * Corrected purge-needed flag behavior for load vs unload transitions.
  * Improved purge/kick/wipe flow to reliably manage toolhead temperature and saved settings, even on errors.

* **Tests**
  * Expanded unit tests to cover purge sequencing, purge-length handling, decisioning, and recovery.

* **Documentation**
  * Updated the changelog for the new standalone toolhead purge capability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->