### PR TITLE
(feat): For Snapmaker U1 printers, move toolhead when calibrating PTFE to toolhead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2026-06-27]
 ### Added
 - The ability to purge on next toolchange for standalone toolheads
+- When running bowden calibration on Snapmaker printers, toolhead is now moved to Y120 so that filament can go all the way to the gears when calibration. Without this move, it has been found that sometimes filament gets caught on the inside lip of the toolhead and does not give an accurate bowden length.
 
 ## [2026-06-21]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2026-06-27]
 ### Added
 - The ability to purge on next toolchange for standalone toolheads
-- When running bowden calibration on Snapmaker printers, toolhead is now moved to Y120 so that filament can go all the way to the gears when calibration. Without this move, it has been found that sometimes filament gets caught on the inside lip of the toolhead and does not give an accurate bowden length.
+- When running bowden calibration on Snapmaker printers, the toolhead is now moved to Y120 so filament can reach the gears during calibration. Without this move, filament can catch on the inside lip of the toolhead and produce an inaccurate bowden length.
 
 ## [2026-06-21]
 ### Added

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -44,7 +44,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 try: from extras.AFC_stats import AFCStats
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
 
-AFC_VERSION="1.1.25"
+AFC_VERSION="1.1.26"
 
 # Class for holding different states so its clear what all valid states are
 class State:

--- a/extras/AFC_Toolchanger.py
+++ b/extras/AFC_Toolchanger.py
@@ -131,7 +131,13 @@ class AfcToolchanger(afcUnit):
         ```
         """
         tool_key = gcmd.get("TOOL")
-        tool = self.afc.tools.get(tool_key)
+        tool = None
+        # Since adding custom AFC_extruder name, tools need to be looked up this way now since
+        # the key for tools is extruder name not AFC_extruder name
+        for afc_extruder in self.afc.tools.values():
+            if afc_extruder.name == tool_key:
+                tool = afc_extruder
+                break
 
         if tool:
             if hasattr(tool, 'tc_lane') and tool.tc_lane is not None:

--- a/extras/AFC_Toolchanger.py
+++ b/extras/AFC_Toolchanger.py
@@ -131,13 +131,16 @@ class AfcToolchanger(afcUnit):
         ```
         """
         tool_key = gcmd.get("TOOL")
-        tool = None
-        # Since adding custom AFC_extruder name, tools need to be looked up this way now since
-        # the key for tools is extruder name not AFC_extruder name
-        for afc_extruder in self.afc.tools.values():
-            if afc_extruder.name == tool_key:
-                tool = afc_extruder
-                break
+        # First try by dictionary key
+        tool = self.afc.tools.get(tool_key)
+        # Now try with afc_extruder.name since adding custom AFC_extruder name, tools need to be
+        # looked up this way now since the key for tools is extruder name not AFC_extruder name.
+        # This way both extruder and e0 should lookup successfully.
+        if tool is None:
+            for afc_extruder in self.afc.tools.values():
+                if afc_extruder.name == tool_key:
+                    tool = afc_extruder
+                    break
 
         if tool:
             if hasattr(tool, 'tc_lane') and tool.tc_lane is not None:

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -1360,8 +1360,8 @@ class afcFunction:
                                                 "to toolhead", pause=False)
                         return
                     self.afc.gcode.run_script_from_command(f"AFC_SELECT_TOOL TOOL={cur_lane.extruder_obj.name}")
-                    self.afc.gcode.run_script_from_command(f"{self.afc.park_pre_load_cmd}")
                     snapmaker_tool_selected = True
+                    self.afc.gcode.run_script_from_command(f"{self.afc.park_pre_load_cmd}")
 
                 self.logger.info('Starting AFC distance Calibrations')
 
@@ -1377,9 +1377,9 @@ class afcFunction:
 
                 self.logger.info("Bowden length calibration Done!")
 
+            finally:
                 if set_tool_start_back_to_none:
                     cur_lane.extruder_obj.tool_start = None
-            finally:
                 if snapmaker_tool_selected:
                     self.afc.gcode.run_script_from_command("AFC_UNSELECT_TOOL")
 

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -1023,6 +1023,36 @@ class afcFunction:
                 length = float(new_length)
 
         return length
+
+    def _calibration_check_tool_start(self, cur_lane: AFCLane) -> tuple[bool, bool, str]:
+        """
+        Helper method for bowden calibration to verify that tool_start pin exists. If tool_end
+        exists and current lane has a buffer, buffer will be assigned to tool_start if tool_start
+        is None
+
+        :param cur_lane: Current lane that bowden calibration is being calibrated with
+        :return tuple(bool,bool, str):
+            bool: Error set to true when tool_start is None, tool_end is set, but lane does note have a
+                valid buffer object
+            bool: Set to true when tool_start is none, tool_end is set and lane has a valid buffer object
+            str: Error message when error is set to True
+        """
+        set_tool_start_back_to_none = False
+        error = False
+        failed_msg = ""
+        if cur_lane.extruder_obj.tool_start is None:
+            if cur_lane.extruder_obj.tool_end is not None and cur_lane.buffer_obj is not None:
+                self.logger.info("Cannot run calibration using post extruder sensor, using buffer to calibrate bowden length")
+                cur_lane.extruder_obj.tool_start = "buffer"
+                set_tool_start_back_to_none = True
+            else:
+                # Cannot calibrate
+                failed_msg = (
+                    "\nBowden Calibration Error:"
+                    "\nCannot calibrate with only post extruder sensor and no turtleneck buffer defined in config"
+                )
+                error = True
+        return error, set_tool_start_back_to_none, failed_msg
     # ---------------------------------------------------------------------------------------------
     # Macros only below
     # ---------------------------------------------------------------------------------------------
@@ -1305,6 +1335,7 @@ class afcFunction:
         checked     = False
         title       = "AFC Calibration"
         additional_msg = []
+        td1_lane_valid = False
 
         # Check to make sure lane and unit is valid
         if lanes is not None and lanes != 'all' and lanes not in self.afc.lanes:
@@ -1325,107 +1356,114 @@ class afcFunction:
             self.afc.error.AFC_error("'{}' is not a valid lane to calibrate bowden length".format(afc_bl), pause=False)
             return
 
-        if td1 is not None and not self.afc.td1_present:
-            self.afc.error.AFC_error("TD-1 is not present, will not be able to calibrate bowden length for TD-1", pause=False)
+        if td1 is not None:
+            if not self.afc.td1_present:
+                self.afc.error.AFC_error("TD-1 is not present, will not be able to calibrate bowden length for TD-1", pause=False)
+            else:
+                if td1 not in self.afc.lanes:
+                    self.afc.error.AFC_error(f"'{td1}' is not a valid lane to calibrate TD-1 bowden length", pause=False)
+                else:
+                    td1_lane_valid = True
 
         # Determine if a specific lane is provided
-        if lanes is not None:
-            checked, calibrated, additional_msg = self._lane_calibration(lanes, unit, tol, dis)
-        else:
-            self.logger.info('No lanes selected to calibrate dist_hub')
-
-        # Calibrate Bowden length with specified lane
-        if afc_bl is not None:
-            set_tool_start_back_to_none = False
-            cur_lane=self.afc.lanes[afc_bl]
-
-            # Setting tool start to buffer if only tool_end is set and user has buffer so calibration can run
-            if cur_lane.extruder_obj.tool_start is None:
-                if cur_lane.extruder_obj.tool_end is not None and cur_lane.buffer_obj is not None:
-                    self.logger.info("Cannot run calibration using post extruder sensor, using buffer to calibrate bowden length")
-                    cur_lane.extruder_obj.tool_start = "buffer"
-                    set_tool_start_back_to_none = True
-                else:
-                    # Cannot calibrate
-                    self.afc.error.AFC_error("Cannot calibrate with only post extruder sensor and no turtleneck buffer defined in config", pause=False)
-                    return
-            # Need to select the tool first before calibrating for Snapmaker printers. This requires
-            # the printer to be homed first. Toolhead needs to be selected because filament can be
-            # caught on the inside lip of the toolhead if its docked. By moving the toolhead to Y 120
-            # it has been found to make loading filament into the toolhead more reliable.
-            snapmaker_tool_selected = False
-            try:
-                if (self.afc.snapmaker_printer
-                    and self.afc.park_pre_load):
-                    error_msg = ("Printer needs to be homed before calibrating PTFE length "
-                                "to toolhead")
-                    if not self.check_homed(error_msg):
-                        return
-                    self.afc.gcode.run_script_from_command(f"AFC_SELECT_TOOL TOOL={cur_lane.extruder_obj.name}")
-                    snapmaker_tool_selected = True
-                    selected_tool = self.get_current_extruder_obj()
-                    if (selected_tool is None
-                        or selected_tool.name != cur_lane.extruder_obj.name):
-                        self.afc.error.AFC_error(
-                            f"Failed to select tool '{cur_lane.extruder_obj.name}' before Bowden calibration",
-                            pause=False,
-                        )
-                        return
-                    self.afc.gcode.run_script_from_command(f"{self.afc.park_pre_load_cmd}")
-
-                self.logger.info('Starting AFC distance Calibrations')
-
-                checked, msg, pos = cur_lane.unit_obj.calibrate_bowden(cur_lane, dis, tol)
-                if not checked:
-                    msg = '{} failed to calibrate bowden length {}'.format(afc_bl, msg)
-                    self.afc.error.AFC_error(msg, pause=False)
-
-                    self._afc_cali_fail(cali=cur_lane.name, dis=abs(pos), reset_lane=(pos!=0),
-                                        title="AFC Bowden Calibration Failed", fail_message=msg)
-                    return
-                else: calibrated.append('Bowden_length: {}'.format(afc_bl))
-
-                self.logger.info("Bowden length calibration Done!")
-
-            finally:
-                if set_tool_start_back_to_none:
-                    cur_lane.extruder_obj.tool_start = None
-                if snapmaker_tool_selected:
-                    self.afc.gcode.run_script_from_command("AFC_UNSELECT_TOOL")
-
-        # Calibration for TD-1 bowden length
-        if td1 is not None:
-            title = "TD-1 Calibration"
-            td1_lane = self.afc.lanes[td1]
-            if (td1_lane.is_direct_hub()
-                and td1_lane.tool_loaded):
-                msg = f"{td1_lane.name} loaded to toolhead, unload from toolhead before "
-                msg += "trying to calibrate td1_bowden_length."
-                self.afc.error.AFC_error(msg, pause=False)
-                return
-            if td1_lane.hub_obj.state:
-                msg = f"{td1_lane.hub_obj.name} hub is triggered, make sure hub is clear before trying to calibrate TD-1 bowden length"
-                self.afc.error.AFC_error(msg, pause=False)
-                self.afc.gcode.run_script_from_command(f"AFC_CALI_FAIL TITLE='{title} Failed' FAIL={td1} DISTANCE=0 msg='{msg}' RESET=0")
-                return
-
-            checked, msg, pos = td1_lane.unit_obj.calibrate_td1( td1_lane, dis, tol)
-            if not checked:
-                fail_string = f"{td1} failed to calibrate TD-1 bowden length, {msg}"
-                self.afc.error.AFC_error(fail_string, pause=False)
-                self.afc.gcode.run_script_from_command(f"AFC_CALI_FAIL TITLE='{title} Failed' FAIL={td1} DISTANCE={pos} msg='{fail_string}' RESET=1")
-                return
+        try:
+            if lanes is not None:
+                checked, calibrated, additional_msg = self._lane_calibration(lanes, unit, tol, dis)
             else:
-                calibrated.append(f"'TD1_Bowden_length: {td1}'")
+                self.logger.info('No lanes selected to calibrate dist_hub')
 
-        if checked:
-            lanes_calibrated = ', '.join(calibrated)
+            # Calibrate Bowden length with specified lane
+            if afc_bl is not None:
+                set_tool_start_back_to_none = False
+                cur_lane=self.afc.lanes[afc_bl]
 
-            msg = ""
-            if additional_msg:
-                msg = " ".join(additional_msg)
+                # Setting tool start to buffer if only tool_end is set and user has buffer so calibration can run
+                failed_check, set_tool_start_back_to_none, msg = self._calibration_check_tool_start(cur_lane)
+                if failed_check:
+                    additional_msg.append(msg)
+                    self.afc.error.AFC_error(msg, pause=False)
+                    return
 
-            self._afc_cali_comp(lanes_calibrated, title, msg)
+                # Need to select the tool first before calibrating for Snapmaker printers. This requires
+                # the printer to be homed first. Toolhead needs to be selected because filament can be
+                # caught on the inside lip of the toolhead if its docked. By moving the toolhead to Y 120
+                # it has been found to make loading filament into the toolhead more reliable.
+                snapmaker_tool_selected = False
+                try:
+                    if (self.afc.snapmaker_printer
+                        and self.afc.park_pre_load):
+                        error_msg = ("Printer needs to be homed before calibrating PTFE length "
+                                    "to toolhead")
+                        if not self.check_homed(error_msg):
+                            return
+                        self.afc.gcode.run_script_from_command(f"AFC_SELECT_TOOL TOOL={cur_lane.extruder_obj.name}")
+                        snapmaker_tool_selected = True
+                        selected_tool = self.get_current_extruder_obj()
+                        if (selected_tool is None
+                            or selected_tool.name != cur_lane.extruder_obj.name):
+                            self.afc.error.AFC_error(
+                                f"Failed to select tool '{cur_lane.extruder_obj.name}' before Bowden calibration",
+                                pause=False,
+                            )
+                            return
+                        if self.afc.park_pre_load_cmd:
+                            self.afc.gcode.run_script_from_command(f"{self.afc.park_pre_load_cmd}")
+
+                    self.logger.info('Starting AFC distance Calibrations')
+
+                    checked, msg, pos = cur_lane.unit_obj.calibrate_bowden(cur_lane, dis, tol)
+                    if not checked:
+                        msg = '{} failed to calibrate bowden length {}'.format(afc_bl, msg)
+                        self.afc.error.AFC_error(msg, pause=False)
+
+                        self._afc_cali_fail(cali=cur_lane.name, dis=abs(pos), reset_lane=(pos!=0),
+                                            title="AFC Bowden Calibration Failed", fail_message=msg)
+                        return
+                    else: calibrated.append('Bowden_length: {}'.format(afc_bl))
+
+                    self.logger.info("Bowden length calibration Done!")
+
+                finally:
+                    if set_tool_start_back_to_none:
+                        cur_lane.extruder_obj.tool_start = None
+                    if snapmaker_tool_selected:
+                        self.afc.gcode.run_script_from_command("AFC_UNSELECT_TOOL")
+
+            # Calibration for TD-1 bowden length
+            if (td1 is not None
+                and td1_lane_valid
+                and self.afc.td1_present):
+                title = "TD-1 Calibration"
+                td1_lane = self.afc.lanes[td1]
+                if (td1_lane.is_direct_hub()
+                    and td1_lane.tool_loaded):
+                    msg = f"{td1_lane.name} loaded to toolhead, unload from toolhead before "
+                    msg += "trying to calibrate td1_bowden_length."
+                    self.afc.error.AFC_error(msg, pause=False)
+                    return
+                if td1_lane.hub_obj.state:
+                    msg = f"{td1_lane.hub_obj.name} hub is triggered, make sure hub is clear before trying to calibrate TD-1 bowden length"
+                    self.afc.error.AFC_error(msg, pause=False)
+                    self.afc.gcode.run_script_from_command(f"AFC_CALI_FAIL TITLE='{title} Failed' FAIL={td1} DISTANCE=0 msg='{msg}' RESET=0")
+                    return
+
+                checked, msg, pos = td1_lane.unit_obj.calibrate_td1( td1_lane, dis, tol)
+                if not checked:
+                    fail_string = f"{td1} failed to calibrate TD-1 bowden length, {msg}"
+                    self.afc.error.AFC_error(fail_string, pause=False)
+                    self.afc.gcode.run_script_from_command(f"AFC_CALI_FAIL TITLE='{title} Failed' FAIL={td1} DISTANCE={pos} msg='{fail_string}' RESET=1")
+                    return
+                else:
+                    calibrated.append(f"'TD1_Bowden_length: {td1}'")
+        finally:
+            if checked:
+                lanes_calibrated = ', '.join(calibrated)
+
+                msg = ""
+                if additional_msg:
+                    msg = " ".join(additional_msg)
+
+                self._afc_cali_comp(lanes_calibrated, title, msg)
 
     cmd_AFC_HAPPY_P_help = 'Opens prompt after calibration is complete'
     def cmd_AFC_HAPPY_P(self, gcmd):

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -267,7 +267,7 @@ class afcFunction:
         except Exception:
             return False
 
-    def check_homed(self):
+    def check_homed(self, error_msg=None):
         """
         Helper function to determine if printer is currently homed, if not, then apply G28
 
@@ -287,7 +287,9 @@ class afcFunction:
                         return False
                 return True
             else:
-                self.afc.error.AFC_error("Please home printer before doing a tool load",
+                if error_msg is None:
+                    error_msg = "Please home printer before doing a tool load"
+                self.afc.error.AFC_error(error_msg,
                                          False, stack_name=inspect.currentframe().f_back.f_code.co_name)
                 return False
         else:
@@ -1355,11 +1357,19 @@ class afcFunction:
             try:
                 if (self.afc.snapmaker_printer
                     and self.afc.park_pre_load):
-                    if not self.is_homed():
-                        self.afc.error.AFC_error("Printer needs to be homed before calibrating PTFE length "
-                                                "to toolhead", pause=False)
+                    error_msg = ("Printer needs to be homed before calibrating PTFE length "
+                                "to toolhead")
+                    if not self.check_homed(error_msg):
                         return
                     self.afc.gcode.run_script_from_command(f"AFC_SELECT_TOOL TOOL={cur_lane.extruder_obj.name}")
+                    selected_tool = self.get_current_extruder_obj()
+                    if (selected_tool is None
+                        or selected_tool.name != cur_lane.extruder_obj.name):
+                        self.afc.error.AFC_error(
+                            f"Failed to select tool '{cur_lane.extruder_obj.name}' before Bowden calibration",
+                            pause=False,
+                        )
+                        return
                     snapmaker_tool_selected = True
                     self.afc.gcode.run_script_from_command(f"{self.afc.park_pre_load_cmd}")
 

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -1351,34 +1351,37 @@ class afcFunction:
             # the printer to be homed first. Toolhead needs to be selected because filament can be
             # caught on the inside lip of the toolhead if its docked. By moving the toolhead to Y 120
             # it has been found to make loading filament into the toolhead more reliable.
-            if (self.afc.snapmaker_printer
-                and self.afc.park_pre_load):
-                if not self.is_homed():
-                    self.afc.error.AFC_error("Printer needs to be homed before calibrating PTFE length "
-                                            "to toolhead", pause=False)
+            snapmaker_tool_selected = False
+            try:
+                if (self.afc.snapmaker_printer
+                    and self.afc.park_pre_load):
+                    if not self.is_homed():
+                        self.afc.error.AFC_error("Printer needs to be homed before calibrating PTFE length "
+                                                "to toolhead", pause=False)
+                        return
+                    self.afc.gcode.run_script_from_command(f"AFC_SELECT_TOOL TOOL={cur_lane.extruder_obj.name}")
+                    self.afc.gcode.run_script_from_command(f"{self.afc.park_pre_load_cmd}")
+                    snapmaker_tool_selected = True
+
+                self.logger.info('Starting AFC distance Calibrations')
+
+                checked, msg, pos = cur_lane.unit_obj.calibrate_bowden(cur_lane, dis, tol)
+                if not checked:
+                    msg = '{} failed to calibrate bowden length {}'.format(afc_bl, msg)
+                    self.afc.error.AFC_error(msg, pause=False)
+
+                    self._afc_cali_fail(cali=cur_lane.name, dis=abs(pos), reset_lane=(pos!=0),
+                                        title="AFC Bowden Calibration Failed", fail_message=msg)
                     return
-                self.afc.gcode.run_script_from_command(f"AFC_SELECT_TOOL TOOL={cur_lane.extruder_obj.name}")
-                self.afc.gcode.run_script_from_command(f"{self.afc.park_pre_load_cmd}")
+                else: calibrated.append('Bowden_length: {}'.format(afc_bl))
 
-            self.logger.info('Starting AFC distance Calibrations')
+                self.logger.info("Bowden length calibration Done!")
 
-            checked, msg, pos = cur_lane.unit_obj.calibrate_bowden(cur_lane, dis, tol)
-            if not checked:
-                msg = '{} failed to calibrate bowden length {}'.format(afc_bl, msg)
-                self.afc.error.AFC_error(msg, pause=False)
-
-                self._afc_cali_fail(cali=cur_lane.name, dis=abs(pos), reset_lane=(pos!=0),
-                                    title="AFC Bowden Calibration Failed", fail_message=msg)
-                return
-            else: calibrated.append('Bowden_length: {}'.format(afc_bl))
-
-            self.logger.info("Bowden length calibration Done!")
-
-            if set_tool_start_back_to_none:
-                cur_lane.extruder_obj.tool_start = None
-
-            if self.afc.snapmaker_printer:
-                self.afc.gcode.run_script_from_command("AFC_UNSELECT_TOOL")
+                if set_tool_start_back_to_none:
+                    cur_lane.extruder_obj.tool_start = None
+            finally:
+                if snapmaker_tool_selected:
+                    self.afc.gcode.run_script_from_command("AFC_UNSELECT_TOOL")
 
         # Calibration for TD-1 bowden length
         if td1 is not None:

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -1362,6 +1362,7 @@ class afcFunction:
                     if not self.check_homed(error_msg):
                         return
                     self.afc.gcode.run_script_from_command(f"AFC_SELECT_TOOL TOOL={cur_lane.extruder_obj.name}")
+                    snapmaker_tool_selected = True
                     selected_tool = self.get_current_extruder_obj()
                     if (selected_tool is None
                         or selected_tool.name != cur_lane.extruder_obj.name):
@@ -1370,7 +1371,6 @@ class afcFunction:
                             pause=False,
                         )
                         return
-                    snapmaker_tool_selected = True
                     self.afc.gcode.run_script_from_command(f"{self.afc.park_pre_load_cmd}")
 
                 self.logger.info('Starting AFC distance Calibrations')

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -1347,6 +1347,18 @@ class afcFunction:
                     # Cannot calibrate
                     self.afc.error.AFC_error("Cannot calibrate with only post extruder sensor and no turtleneck buffer defined in config", pause=False)
                     return
+            # Need to select the tool first before calibrating for Snapmaker printers. This requires
+            # the printer to be homed first. Toolhead needs to be selected because filament can be
+            # caught on the inside lip of the toolhead if its docked. By moving the toolhead to Y 120
+            # it has been found to make loading filament into the toolhead more reliable.
+            if (self.afc.snapmaker_printer
+                and self.afc.park_pre_load):
+                if not self.is_homed():
+                    self.afc.error.AFC_error("Printer needs to be homed before calibrating PTFE length "
+                                            "to toolhead", pause=False)
+                    return
+                self.afc.gcode.run_script_from_command(f"AFC_SELECT_TOOL TOOL={cur_lane.extruder_obj.name}")
+                self.afc.gcode.run_script_from_command(f"{self.afc.park_pre_load_cmd}")
 
             self.logger.info('Starting AFC distance Calibrations')
 
@@ -1364,6 +1376,9 @@ class afcFunction:
 
             if set_tool_start_back_to_none:
                 cur_lane.extruder_obj.tool_start = None
+
+            if self.afc.snapmaker_printer:
+                self.afc.gcode.run_script_from_command("AFC_UNSELECT_TOOL")
 
         # Calibration for TD-1 bowden length
         if td1 is not None:

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -129,6 +129,8 @@ def _make_afc():
     obj.park_cmd = None
     obj.wipe = False
     obj.wipe_cmd = None
+    obj.park_pre_load = False
+    obj.park_pre_load_cmd = None
     obj.kick = False
     obj.kick_cmd = None
     obj.post_load_macro = None

--- a/tests/test_AFC_Toolchanger.py
+++ b/tests/test_AFC_Toolchanger.py
@@ -1,10 +1,8 @@
+# Unit tests for extras/AFC_Toolchanger.py
+
 from __future__ import annotations
 
 from unittest.mock import MagicMock
-import pytest
-
-
-from klippy import Printer
 
 from extras.AFC_Toolchanger import AfcToolchanger
 from tests.conftest import MockLogger

--- a/tests/test_AFC_Toolchanger.py
+++ b/tests/test_AFC_Toolchanger.py
@@ -69,6 +69,7 @@ class TestcmdAFCSelectTool:
         }.get(key, default)
 
         tool.cmd_AFC_SELECT_TOOL(gcmd)
+        tool.tool_swap.assert_not_called()
         error_msg = [m for lvl, m in tool.logger.messages if lvl == "error"]
         assert any(f"Key:{key_tool} invalid for TOOL" in m for m in error_msg)
 
@@ -86,5 +87,6 @@ class TestcmdAFCSelectTool:
         }.get(key, default)
 
         tool.cmd_AFC_SELECT_TOOL(gcmd)
+        tool.tool_swap.assert_not_called()
         error_msg = [m for lvl, m in tool.logger.messages if lvl == "error"]
         assert any(f"Tool '{key_tool}' does not have a valid 'tc_lane' attribute." in m for m in error_msg)

--- a/tests/test_AFC_Toolchanger.py
+++ b/tests/test_AFC_Toolchanger.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+import pytest
+
+
+from klippy import Printer
+
+from extras.AFC_Toolchanger import AfcToolchanger
+from tests.conftest import MockLogger
+from tests.test_AFC_extruder import _make_extruder_obj
+
+def _make_toolchanger():
+    obj = AfcToolchanger.__new__(AfcToolchanger)
+    obj.tool_swap = MagicMock()
+    obj.logger = MockLogger()
+    obj.afc = MagicMock()
+    obj.afc.tools = {}
+    return obj
+
+def _make_extruder_for_toolchanger(toolchanger, afc_name="e0", extruder_name="extruder"):
+    extruder = _make_extruder_obj(afc_name)
+    extruder.th_extruder_name = extruder_name
+    extruder.tc_lane = MagicMock()
+    toolchanger.afc.tools[extruder.th_extruder_name] = extruder
+    return extruder
+
+class TestcmdAFCSelectTool:
+    def test_dict_tool_name(self):
+        tool = _make_toolchanger()
+        tool.tool_swap = MagicMock()
+        extruder = _make_extruder_for_toolchanger(tool)
+        extruder1 = _make_extruder_for_toolchanger(tool, "e1", "extruder1")
+
+        key_tool = "extruder"
+        gcmd = MagicMock()
+        gcmd.get.side_effect = lambda key, default=None: {
+            "TOOL": key_tool
+        }.get(key, default)
+
+        tool.cmd_AFC_SELECT_TOOL(gcmd)
+        tool.tool_swap.assert_called_once_with(extruder.tc_lane)
+    
+    def test_afc_extruder_tool_name(self):
+        tool = _make_toolchanger()
+        tool.tool_swap = MagicMock()
+        extruder = _make_extruder_for_toolchanger(tool)
+        extruder1 = _make_extruder_for_toolchanger(tool, "e1", "extruder1")
+        
+        key_tool = "e1"
+        gcmd = MagicMock()
+        gcmd.get.side_effect = lambda key, default=None: {
+            "TOOL": key_tool
+        }.get(key, default)
+
+        tool.cmd_AFC_SELECT_TOOL(gcmd)
+        tool.tool_swap.assert_called_once_with(extruder1.tc_lane)
+    
+    def test_invalid_tool_name(self):
+        tool = _make_toolchanger()
+        tool.tool_swap = MagicMock()
+        extruder = _make_extruder_for_toolchanger(tool)
+        extruder1 = _make_extruder_for_toolchanger(tool, "e1", "extruder1")
+        
+        key_tool = "e2"
+        gcmd = MagicMock()
+        gcmd.get.side_effect = lambda key, default=None: {
+            "TOOL": key_tool
+        }.get(key, default)
+
+        tool.cmd_AFC_SELECT_TOOL(gcmd)
+        error_msg = [m for lvl, m in tool.logger.messages if lvl == "error"]
+        assert any(f"Key:{key_tool} invalid for TOOL" in m for m in error_msg)
+
+    def test_invalid_tc_lane(self):
+        tool = _make_toolchanger()
+        tool.tool_swap = MagicMock()
+        extruder = _make_extruder_for_toolchanger(tool)
+        extruder1 = _make_extruder_for_toolchanger(tool, "e1", "extruder1")
+        extruder1.tc_lane = None
+        
+        key_tool = "e1"
+        gcmd = MagicMock()
+        gcmd.get.side_effect = lambda key, default=None: {
+            "TOOL": key_tool
+        }.get(key, default)
+
+        tool.cmd_AFC_SELECT_TOOL(gcmd)
+        error_msg = [m for lvl, m in tool.logger.messages if lvl == "error"]
+        assert any(f"Tool '{key_tool}' does not have a valid 'tc_lane' attribute." in m for m in error_msg)

--- a/tests/test_AFC_functions.py
+++ b/tests/test_AFC_functions.py
@@ -13,11 +13,16 @@ Covers:
 
 from __future__ import annotations
 
-import time
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch, call
 import pytest
 
 from extras.AFC_functions import afcFunction, afcDeltaTime
+from extras.AFC_respond import AFCprompt
+
+from tests.test_AFC import _make_afc
+from tests.test_AFC_lane import _make_afc_lane
+
+from copy import deepcopy
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -554,3 +559,598 @@ class TestGetExtruderPos_ReturnValue:
 
         assert isinstance(result, float)
 # ── end get_extruder_pos ──────────────────────────────────────────────────────
+
+class TestCalibrateAFC:
+    # ------------------------------------------------------------------
+    # Fixtures / builders
+    # ------------------------------------------------------------------
+
+    def _make_afc_lane_for_calibration(self, standalone=False):
+        afc = _make_afc()
+        afc.error = MagicMock()
+        lane = _make_afc_lane()
+        lane.is_direct_hub = MagicMock()
+        lane.hub_obj = MagicMock()
+
+        afc.function.get_current_lane = MagicMock(return_value=None)
+        lane.extruder_obj.is_standalone = MagicMock(return_value=standalone)
+        lane.extruder_obj.name = "extruder"
+
+        afc.lanes[lane.name] = lane
+
+        return afc, lane
+
+    def _make_gcmd_for_calibration(self, distance=25, tolerance=5, bowden=None, lane=None,
+                                   unit=None, TD1=None):
+        gcmd = MagicMock()
+        gcmd.get.side_effect = lambda key, default=None: {
+            "BOWDEN": bowden,
+            "LANE": lane,
+            "UNIT": unit,
+            "TD1": TD1
+        }.get(key, default)
+
+        gcmd.get_float.side_effect = lambda key, default=None: {
+            "DISTANCE": distance,
+            "TOLERANCE": tolerance,
+        }.get(key, default)
+        return gcmd
+
+    def _setup_calibration(self, standalone=False, td1_present=False, moonraker=None):
+        """Builds func/afc/lane with the defaults nearly every test relies on."""
+        func = _make_func()
+        func._lane_calibration = MagicMock()
+        func._afc_cali_comp = MagicMock()
+        func._afc_cali_fail = MagicMock()
+        afc, lane = self._make_afc_lane_for_calibration(standalone=standalone)
+        func.afc = afc
+        func.afc._td1_present = td1_present
+        func.afc.moonraker = moonraker
+        return func, afc, lane
+
+    # ------------------------------------------------------------------
+    # Action helper
+    # ------------------------------------------------------------------
+
+    def _call_cmd_calibrate_afc(self, func, gcmd):
+        """Runs cmd_CALIBRATE_AFC and verifies the AFCprompt wrapper, which
+        every test does regardless of outcome."""
+        with patch("extras.AFC_functions.AFCprompt") as mocked_afc_prompt:
+            func.cmd_CALIBRATE_AFC(gcmd)
+        mocked_afc_prompt.assert_called_once_with(gcmd, func.logger)
+        mocked_afc_prompt.return_value.p_end.assert_called_once()
+        return mocked_afc_prompt
+
+    # ------------------------------------------------------------------
+    # Logger assertions
+    # ------------------------------------------------------------------
+
+    def _get_messages(self, func, level):
+        return [m for lvl, m in func.logger.messages if lvl == level]
+
+    def _assert_info_contains(self, func, substring):
+        assert any(substring in m for m in self._get_messages(func, "info"))
+
+    def _assert_info_not_contains(self, func, substring):
+        assert not any(substring in m for m in self._get_messages(func, "info"))
+
+    def _assert_error_contains(self, func, substring):
+        assert any(substring in m for m in self._get_messages(func, "error"))
+
+    def _assert_afc_error(self, func, message):
+        func.afc.error.AFC_error.assert_called_once_with(message, pause=False)
+
+    # ------------------------------------------------------------------
+    # _lane_calibration helpers
+    # ------------------------------------------------------------------
+
+    def _set_lane_calibration_result(self, func, result):
+        func._lane_calibration = MagicMock(return_value=deepcopy(result))
+
+    def _assert_lane_calibration_called(self, func, lane_name, bowden=None, tolerance=5, distance=25):
+        func._lane_calibration.assert_called_once_with(lane_name, bowden, tolerance, distance)
+
+    def _assert_lane_calibration_not_called(self, func):
+        func._lane_calibration.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # Bowden / direct-hub helpers
+    # ------------------------------------------------------------------
+
+    def _set_calibrate_bowden_result(self, lane, result):
+        lane.unit_obj.calibrate_bowden = MagicMock(return_value=result)
+
+    def _assert_calibrate_bowden_called(self, lane, distance=25, tolerance=5):
+        lane.unit_obj.calibrate_bowden.assert_called_once_with(lane, distance, tolerance)
+
+    def _assert_calibrate_bowden_not_called(self, lane):
+        lane.unit_obj.calibrate_bowden.assert_not_called()
+
+    def _assert_calibrate_td1_not_called(self, lane):
+        lane.unit_obj.calibrate_td1.assert_not_called()
+
+    def _assert_bowden_calibration_not_attempted(self, lane):
+        """Neither the standard nor the direct-hub bowden path ran."""
+        self._assert_calibrate_bowden_not_called(lane)
+        self._assert_calibrate_td1_not_called(lane)
+
+    def _assert_no_calibration_attempted(self, func, lane):
+        """Calibration was aborted before any lane/bowden work happened."""
+        self._assert_lane_calibration_not_called(func)
+        self._assert_bowden_calibration_not_attempted(lane)
+
+    def _assert_select_unselect_tool_called(self, func, lane):
+        expected = [
+            call(f"AFC_SELECT_TOOL TOOL={lane.extruder_obj.name}"),
+            call("AFC_UNSELECT_TOOL")
+        ]
+        assert func.afc.gcode.run_script_from_command.call_args_list == expected
+
+    def _assert_afc_cali_comp_called(self, func, lanes, messages, title="AFC Calibration"):
+        func._afc_cali_comp.assert_called_once_with(
+            ", ".join(lanes),
+            title,
+            " ".join(messages)
+        )
+
+    # ------------------------------------------------------------------
+    # Tests
+    # ------------------------------------------------------------------
+
+    def test_calibration_current_lane(self):
+        func, afc, lane = self._setup_calibration()
+        gcmd = self._make_gcmd_for_calibration()
+        afc.function.get_current_lane = MagicMock(return_value=lane.name)
+
+        self._call_cmd_calibrate_afc(func, gcmd)
+
+        self._assert_info_contains(func, f"current afc {lane.name} is not None, cannot calibrate")
+        self._assert_error_contains(func, "Tool must be unloaded to calibrate system")
+
+    def test_calibration_current_none_lane_none(self):
+        func, afc, lane = self._setup_calibration()
+        gcmd = self._make_gcmd_for_calibration()
+
+        self._call_cmd_calibrate_afc(func, gcmd)
+
+        self._assert_info_contains(func, "No lanes selected to calibrate dist_hub")
+        self._assert_no_calibration_attempted(func, lane)
+
+    def test_calibration_lane_not_in_afc(self):
+        func, afc, lane = self._setup_calibration()
+        lane_name = "lane2"
+        gcmd = self._make_gcmd_for_calibration(lane=lane_name)
+
+        self._call_cmd_calibrate_afc(func, gcmd)
+
+        self._assert_afc_error(func, f"'{lane_name}' is not a valid lane")
+        self._assert_no_calibration_attempted(func, lane)
+
+    def test_calibration_lane_is_standalone(self):
+        func, afc, lane = self._setup_calibration(standalone=True)
+        gcmd = self._make_gcmd_for_calibration(lane=lane.name)
+
+        self._call_cmd_calibrate_afc(func, gcmd)
+
+        self._assert_afc_error(func, f"{lane.name} is a standalone lane, cannot calibrate")
+        self._assert_no_calibration_attempted(func, lane)
+
+    def test_calibration_unit_not_valid(self):
+        func, afc, lane = self._setup_calibration()
+        unit_name = "test"
+        gcmd = self._make_gcmd_for_calibration(lane=lane.name, unit=unit_name)
+
+        self._call_cmd_calibrate_afc(func, gcmd)
+
+        self._assert_afc_error(func, f"'{unit_name}' is not a valid unit")
+        self._assert_no_calibration_attempted(func, lane)
+
+    def test_calibration_bowden_no_in_lanes(self):
+        func, afc, lane = self._setup_calibration()
+        lane_name = "lane2"
+        gcmd = self._make_gcmd_for_calibration(bowden=lane_name)
+
+        self._call_cmd_calibrate_afc(func, gcmd)
+
+        self._assert_afc_error(func, f"'{lane_name}' is not a valid lane to calibrate bowden length")
+        self._assert_no_calibration_attempted(func, lane)
+
+    def test_calibration_td1_not_present(self):
+        func, afc, lane = self._setup_calibration()
+        gcmd = self._make_gcmd_for_calibration(TD1="lane2")
+
+        self._call_cmd_calibrate_afc(func, gcmd)
+
+        self._assert_afc_error(func, "TD-1 is not present, will not be able to calibrate bowden length for TD-1")
+        self._assert_no_calibration_attempted(func, lane)
+    
+    def test_calibration_td1_lane_not_valid(self):
+        func, afc, lane = self._setup_calibration(td1_present=True)
+        gcmd = self._make_gcmd_for_calibration(TD1="lane2")
+
+        self._call_cmd_calibrate_afc(func, gcmd)
+
+        self._assert_afc_error(func, "'lane2' is not a valid lane to calibrate TD-1 bowden length")
+        self._assert_no_calibration_attempted(func, lane)
+
+    def test_calibration_lane_valid_success(self):
+        func, afc, lane = self._setup_calibration()
+        lane_name = lane.name
+        gcmd = self._make_gcmd_for_calibration(lane=lane_name)
+        lane_calibration_call = (True, [lane_name], ["success"])
+        self._set_lane_calibration_result(func, lane_calibration_call)
+
+        self._call_cmd_calibrate_afc(func, gcmd)
+
+        self._assert_lane_calibration_called(func, lane_name)
+        self._assert_afc_cali_comp_called(func, lane_calibration_call[1], lane_calibration_call[2])
+        self._assert_bowden_calibration_not_attempted(lane)
+
+    def test_calibration_lane_valid_success_no_additional_msg(self):
+        func, afc, lane = self._setup_calibration()
+        lane_name = lane.name
+        gcmd = self._make_gcmd_for_calibration(lane=lane_name)
+        lane_calibration_call = (True, [lane_name], [])
+        self._set_lane_calibration_result(func, lane_calibration_call)
+
+        self._call_cmd_calibrate_afc(func, gcmd)
+
+        self._assert_lane_calibration_called(func, lane_name)
+        self._assert_afc_cali_comp_called(func, lane_calibration_call[1], [])
+        self._assert_bowden_calibration_not_attempted(lane)
+
+    def test_calibration_lane_valid_checked_false(self):
+        func, afc, lane = self._setup_calibration()
+        lane_name = lane.name
+        gcmd = self._make_gcmd_for_calibration(lane=lane_name)
+        lane_calibration_call = (False, [lane_name], [])
+        self._set_lane_calibration_result(func, lane_calibration_call)
+
+        self._call_cmd_calibrate_afc(func, gcmd)
+
+        self._assert_lane_calibration_called(func, lane_name)
+        func._afc_cali_comp.assert_not_called()
+        self._assert_bowden_calibration_not_attempted(lane)
+
+    def test_calibration_all_lanes_valid_success(self):
+        func, afc, lane = self._setup_calibration()
+        lane_name = "all"
+        gcmd = self._make_gcmd_for_calibration(lane=lane_name)
+        lane_calibration_call = (True, [lane_name], ["success"])
+        self._set_lane_calibration_result(func, lane_calibration_call)
+
+        self._call_cmd_calibrate_afc(func, gcmd)
+
+        self._assert_lane_calibration_called(func, lane_name)
+        self._assert_afc_cali_comp_called(func, lane_calibration_call[1], lane_calibration_call[2])
+        self._assert_bowden_calibration_not_attempted(lane)
+
+    def test_calibration_lanes_valid_bowden_fail_tool_start_and_tool_end_none(self):
+        func, afc, lane = self._setup_calibration()
+        lane.extruder_obj.tool_start = None
+        lane.extruder_obj.tool_end = None
+        lane_name = "all"
+        bowden_lane = lane.name
+        gcmd = self._make_gcmd_for_calibration(lane=lane_name, bowden=bowden_lane)
+        lane_calibration_call = (True, [lane_name], ["success"])
+        self._set_lane_calibration_result(func, lane_calibration_call)
+        bowden_error = (
+            "\nBowden Calibration Error:"
+             "\nCannot calibrate with only post extruder sensor and no turtleneck buffer defined in config"
+        )
+        additional_msg = [
+            lane_calibration_call[2][0],
+            bowden_error
+        ]
+
+        self._call_cmd_calibrate_afc(func, gcmd)
+
+        self._assert_lane_calibration_called(func, lane_name)
+        self._assert_afc_cali_comp_called(func, lane_calibration_call[1], additional_msg)
+        self._assert_bowden_calibration_not_attempted(lane)
+        self._assert_afc_error(func, bowden_error)
+
+    def test_calibration_lanes_valid_bowden_success_tool_start_none_tool_end_buffer_set_lane(self):
+        func, afc, lane = self._setup_calibration()
+        lane.extruder_obj.tool_start = None
+        lane.extruder_obj.tool_end = MagicMock(return_value="Turtle_1:SW1")
+        lane.buffer_obj = "Test"
+        lane_name = "all"
+        bowden_lane = lane.name
+        gcmd = self._make_gcmd_for_calibration(lane=lane_name, bowden=bowden_lane)
+        lane_calibration_call = (True, [lane_name], ["success"])
+        calibrated_msg = [lane_calibration_call[1][0], f"Bowden_length: {bowden_lane}"]
+        self._set_lane_calibration_result(func, lane_calibration_call)
+        self._set_calibrate_bowden_result(lane, (True, "afc_bowden_length successful", 1000))
+
+        self._call_cmd_calibrate_afc(func, gcmd)
+
+        assert lane.extruder_obj.tool_start is None
+        self._assert_lane_calibration_called(func, lane_name)
+        self._assert_calibrate_bowden_called(lane)
+        self._assert_afc_cali_comp_called(func, calibrated_msg, lane_calibration_call[2])
+        self._assert_info_contains(func, "Cannot run calibration using post extruder sensor, using buffer to calibrate bowden length")
+        self._assert_info_contains(func, "Starting AFC distance Calibrations")
+        self._assert_info_contains(func, "Bowden length calibration Done!")
+        self._assert_calibrate_td1_not_called(lane)
+
+    def test_calibration_lanes_valid_bowden_success_tool_start_buffer(self):
+        func, afc, lane = self._setup_calibration()
+        lane.extruder_obj.tool_start = MagicMock(return_value="buffer")
+        lane_name = "all"
+        bowden_lane = lane.name
+        gcmd = self._make_gcmd_for_calibration(lane=lane_name, bowden=bowden_lane)
+        lane_calibration_call = (True, [lane_name], ["success"])
+        calibrated_msg = [lane_calibration_call[1][0], f"Bowden_length: {bowden_lane}"]
+        self._set_lane_calibration_result(func, lane_calibration_call)
+        self._set_calibrate_bowden_result(lane, (True, "afc_bowden_length successful", 1000))
+
+        self._call_cmd_calibrate_afc(func, gcmd)
+
+        self._assert_lane_calibration_called(func, lane_name)
+        self._assert_calibrate_bowden_called(lane)
+        self._assert_afc_cali_comp_called(func, calibrated_msg, lane_calibration_call[2])
+        self._assert_info_not_contains(func, "Cannot run calibration using post extruder sensor, using buffer to calibrate bowden length")
+        self._assert_info_contains(func, "Starting AFC distance Calibrations")
+        self._assert_info_contains(func, "Bowden length calibration Done!")
+        self._assert_calibrate_td1_not_called(lane)
+
+    def test_calibration_lanes_valid_bowden_fail_tool_start_buffer(self):
+        func, afc, lane = self._setup_calibration()
+        lane.extruder_obj.tool_start = MagicMock(return_value="buffer")
+        lane_name = "all"
+        bowden_lane = lane.name
+        gcmd = self._make_gcmd_for_calibration(lane=lane_name, bowden=bowden_lane)
+        lane_calibration_call = (True, [lane_name], ["success"])
+        fail_msg = f"{bowden_lane} failed to calibrate bowden length Bowden Calibration Failed"
+        self._set_lane_calibration_result(func, lane_calibration_call)
+        self._set_calibrate_bowden_result(lane, (False, "Bowden Calibration Failed", 0))
+
+        self._call_cmd_calibrate_afc(func, gcmd)
+
+        self._assert_lane_calibration_called(func, lane_name)
+        self._assert_calibrate_bowden_called(lane)
+        self._assert_afc_error(func, fail_msg)
+        func._afc_cali_fail.assert_called_once_with(
+            cali=lane.name, dis=0, reset_lane=False, title= "AFC Bowden Calibration Failed",
+            fail_message=fail_msg
+        )
+        func._afc_cali_comp.assert_not_called()
+        self._assert_info_not_contains(func, "Cannot run calibration using post extruder sensor, using buffer to calibrate bowden length")
+        self._assert_info_contains(func, "Starting AFC distance Calibrations")
+        self._assert_info_not_contains(func, "Bowden length calibration Done!")
+        self._assert_calibrate_td1_not_called(lane)
+
+    def test_calibration_lanes_valid_bowden_success_tool_start_buffer_snapmaker_no_park_pre_load(self):
+        func, afc, lane = self._setup_calibration()
+        lane.extruder_obj.tool_start = MagicMock(return_value="buffer")
+        lane_name = "all"
+        bowden_lane = lane.name
+        gcmd = self._make_gcmd_for_calibration(lane=lane_name, bowden=bowden_lane)
+        lane_calibration_call = (True, [lane_name], ["success"])
+        calibrated_msg = [lane_calibration_call[1][0], f"Bowden_length: {bowden_lane}"]
+        self._set_lane_calibration_result(func, lane_calibration_call)
+        self._set_calibrate_bowden_result(lane, (True, "afc_bowden_length successful", 1000))
+        func.afc.snapmaker_printer = MagicMock(return_value=True)
+        func.afc.park_pre_load = False
+        func.check_homed = MagicMock()
+
+        self._call_cmd_calibrate_afc(func, gcmd)
+
+        self._assert_lane_calibration_called(func, lane_name)
+        self._assert_calibrate_bowden_called(lane)
+        func.check_homed.assert_not_called()
+        self._assert_afc_cali_comp_called(func, calibrated_msg, lane_calibration_call[2])
+        self._assert_info_not_contains(func, "Cannot run calibration using post extruder sensor, using buffer to calibrate bowden length")
+        self._assert_info_contains(func, "Starting AFC distance Calibrations")
+        self._assert_info_contains(func, "Bowden length calibration Done!")
+        self._assert_calibrate_td1_not_called(lane)
+
+    def test_calibration_lanes_valid_bowden_success_tool_start_buffer_snapmaker_fail_check_home(self):
+        func, afc, lane = self._setup_calibration()
+        lane.extruder_obj.tool_start = MagicMock(return_value="buffer")
+        lane_name = "all"
+        bowden_lane = lane.name
+        gcmd = self._make_gcmd_for_calibration(lane=lane_name, bowden=bowden_lane)
+        lane_calibration_call = (True, [lane_name], ["success"])
+        self._set_lane_calibration_result(func, lane_calibration_call)
+        self._set_calibrate_bowden_result(lane, (True, "afc_bowden_length successful", 1000))
+        func.afc.snapmaker_printer = MagicMock(return_value=True)
+        func.afc.park_pre_load = True
+        func.check_homed = MagicMock(return_value=False)
+
+        self._call_cmd_calibrate_afc(func, gcmd)
+
+        self._assert_lane_calibration_called(func, lane_name)
+        func.check_homed.assert_called_once_with(
+            "Printer needs to be homed before calibrating PTFE length to toolhead")
+        self._assert_info_not_contains(func, "Starting AFC distance Calibrations")
+        self._assert_bowden_calibration_not_attempted(lane)
+
+    def test_calibration_lanes_valid_bowden_success_tool_start_buffer_snapmaker_homed_selected_tool_none_fail(self):
+        func, afc, lane = self._setup_calibration()
+        lane.extruder_obj.tool_start = MagicMock(return_value="buffer")
+        lane_name = "all"
+        bowden_lane = lane.name
+        func.get_current_extruder_obj = MagicMock(return_value=None)
+        gcmd = self._make_gcmd_for_calibration(lane=lane_name, bowden=bowden_lane)
+        lane_calibration_call = (True, [lane_name], ["success"])
+        self._set_lane_calibration_result(func, lane_calibration_call)
+        self._set_calibrate_bowden_result(lane, (True, "afc_bowden_length successful", 1000))
+        func.afc.snapmaker_printer = MagicMock(return_value=True)
+        func.afc.park_pre_load = True
+        func.check_homed = MagicMock(return_value=True)
+
+        self._call_cmd_calibrate_afc(func, gcmd)
+
+        self._assert_lane_calibration_called(func, lane_name)
+        func.check_homed.assert_called_once_with(
+            "Printer needs to be homed before calibrating PTFE length to toolhead")
+        self._assert_select_unselect_tool_called(func, lane)
+        self._assert_info_not_contains(func, "Starting AFC distance Calibrations")
+        self._assert_afc_error(func, f"Failed to select tool '{lane.extruder_obj.name}' before Bowden calibration")
+        self._assert_bowden_calibration_not_attempted(lane)
+
+    def test_calibration_lanes_valid_bowden_success_tool_start_buffer_snapmaker_homed_fail_selected_tool_extruder1_fail(self):
+        func, afc, lane = self._setup_calibration()
+        lane.extruder_obj.tool_start = MagicMock(return_value="buffer")
+        lane_name = "all"
+        bowden_lane = lane.name
+        func.get_current_extruder_obj = MagicMock(return_value=MagicMock())
+        gcmd = self._make_gcmd_for_calibration(lane=lane_name, bowden=bowden_lane)
+        lane_calibration_call = (True, [lane_name], ["success"])
+        self._set_lane_calibration_result(func, lane_calibration_call)
+        self._set_calibrate_bowden_result(lane, (True, "afc_bowden_length successful", 1000))
+        func.afc.snapmaker_printer = MagicMock(return_value=True)
+        func.afc.park_pre_load = True
+        func.check_homed = MagicMock(return_value=True)
+
+        self._call_cmd_calibrate_afc(func, gcmd)
+
+        self._assert_lane_calibration_called(func, lane_name)
+        func.check_homed.assert_called_once_with(
+            "Printer needs to be homed before calibrating PTFE length to toolhead")
+        self._assert_select_unselect_tool_called(func, lane)
+        self._assert_info_not_contains(func, "Starting AFC distance Calibrations")
+        self._assert_afc_error(func, f"Failed to select tool '{lane.extruder_obj.name}' before Bowden calibration")
+        self._assert_bowden_calibration_not_attempted(lane)
+
+    def test_calibration_lanes_valid_bowden_success_tool_start_buffer_snapmaker_homed_fail_selected_tool_success_park_pre_load_cmd_none(self):
+        func, afc, lane = self._setup_calibration()
+        lane.extruder_obj.tool_start = MagicMock(return_value="buffer")
+        lane_name = "all"
+        bowden_lane = lane.name
+        func.get_current_extruder_obj = MagicMock(return_value=lane.extruder_obj)
+        gcmd = self._make_gcmd_for_calibration(lane=lane_name, bowden=bowden_lane)
+        lane_calibration_call = (True, [lane_name], ["success"])
+        self._set_lane_calibration_result(func, lane_calibration_call)
+        self._set_calibrate_bowden_result(lane, (True, "afc_bowden_length successful", 1000))
+        func.afc.snapmaker_printer = MagicMock(return_value=True)
+        func.afc.park_pre_load = True
+        func.check_homed = MagicMock(return_value=True)
+
+        self._call_cmd_calibrate_afc(func, gcmd)
+
+        self._assert_lane_calibration_called(func, lane_name)
+        func.check_homed.assert_called_once_with(
+            "Printer needs to be homed before calibrating PTFE length to toolhead")
+        self._assert_select_unselect_tool_called(func, lane)
+        self._assert_info_contains(func, "Starting AFC distance Calibrations")
+        func.afc.error.AFC_error.assert_not_called()
+        lane.unit_obj.calibrate_bowden.assert_called_once()
+        self._assert_calibrate_td1_not_called(lane)
+
+    def test_calibration_lanes_valid_bowden_success_tool_start_buffer_snapmaker_homed_fail_selected_tool_success(self):
+        func, afc, lane = self._setup_calibration()
+        lane.extruder_obj.tool_start = MagicMock(return_value="buffer")
+        lane_name = "all"
+        bowden_lane = lane.name
+        func.get_current_extruder_obj = MagicMock(return_value=lane.extruder_obj)
+        gcmd = self._make_gcmd_for_calibration(lane=lane_name, bowden=bowden_lane)
+        lane_calibration_call = (True, [lane_name], ["success"])
+        self._set_lane_calibration_result(func, lane_calibration_call)
+        self._set_calibrate_bowden_result(lane, (True, "afc_bowden_length successful", 1000))
+        func.afc.snapmaker_printer = MagicMock(return_value=True)
+        func.afc.park_pre_load = True
+        func.afc.park_pre_load_cmd = "AFC_PARK_PRE_LOAD"
+        func.check_homed = MagicMock(return_value=True)
+
+        self._call_cmd_calibrate_afc(func, gcmd)
+
+        self._assert_lane_calibration_called(func, lane_name)
+        func.check_homed.assert_called_once_with(
+            "Printer needs to be homed before calibrating PTFE length to toolhead")
+        expected_calls = [
+            call(f"AFC_SELECT_TOOL TOOL={lane.extruder_obj.name}"),
+            call("AFC_PARK_PRE_LOAD"),
+            call("AFC_UNSELECT_TOOL")
+        ]
+        assert func.afc.gcode.run_script_from_command.call_args_list == expected_calls
+        self._assert_info_contains(func, "Starting AFC distance Calibrations")
+        func.afc.error.AFC_error.assert_not_called()
+        lane.unit_obj.calibrate_bowden.assert_called_once()
+        self._assert_calibrate_td1_not_called(lane)
+
+    def test_calibration_td1_valid_direct_hub_loaded_toolhead(self):
+        func, afc, lane = self._setup_calibration(td1_present=True)
+        lane.extruder_obj.tool_start = MagicMock(return_value="buffer")
+        lane.is_direct_hub = MagicMock(return_value=True)
+        lane.tool_loaded = True
+        gcmd = self._make_gcmd_for_calibration(TD1=lane.name)
+
+        self._call_cmd_calibrate_afc(func, gcmd)
+
+        self._assert_afc_error(
+            func,
+            f"{lane.name} loaded to toolhead, unload from toolhead before "
+            "trying to calibrate td1_bowden_length."
+        )
+        self._assert_lane_calibration_not_called(func)
+        self._assert_calibrate_bowden_not_called(lane)
+        func._afc_cali_comp.assert_not_called()
+
+    def test_calibration_td1_valid_direct_hub_toolhead_not_loaded_hub_true(self):
+        func, afc, lane = self._setup_calibration(td1_present=True)
+        lane.extruder_obj.tool_start = MagicMock(return_value="buffer")
+        lane.is_direct_hub = MagicMock(return_value=True)
+        lane.tool_loaded = False
+        lane.hub_obj.state = True
+        lane.hub_obj.name = "Hub_1"
+        gcmd = self._make_gcmd_for_calibration(TD1=lane.name)
+
+        error_message = (f"{lane.hub_obj.name} hub is triggered, make sure hub is clear "
+                          "before trying to calibrate TD-1 bowden length")
+
+        self._call_cmd_calibrate_afc(func, gcmd)
+
+        self._assert_afc_error(func, error_message)
+        func.afc.gcode.run_script_from_command.assert_called_once_with(
+            f"AFC_CALI_FAIL TITLE='TD-1 Calibration Failed' FAIL={lane.name} DISTANCE=0 msg='{error_message}' RESET=0"
+        )
+        self._assert_lane_calibration_not_called(func)
+        self._assert_calibrate_bowden_not_called(lane)
+        func._afc_cali_comp.assert_not_called()
+
+    def test_calibration_td1_valid_direct_hub_toolhead_not_loaded_hub_not_loaded_calibration_fail(self):
+        func, afc, lane = self._setup_calibration(td1_present=True)
+        lane.extruder_obj.tool_start = MagicMock(return_value="buffer")
+        lane.is_direct_hub = MagicMock(return_value=True)
+        lane.tool_loaded = False
+        lane.hub_obj.state = False
+        lane.hub_obj.name = "Hub_1"
+        gcmd = self._make_gcmd_for_calibration(TD1=lane.name)
+
+        cal_td1_return = (False, "TD-1 failed to detect filament after moving 1000mm", 1000)
+        lane.unit_obj.calibrate_td1 = MagicMock(return_value=cal_td1_return)
+        error_message = f"{lane.name} failed to calibrate TD-1 bowden length, {cal_td1_return[1]}"
+
+        self._call_cmd_calibrate_afc(func, gcmd)
+
+        self._assert_afc_error(func, error_message)
+        func.afc.gcode.run_script_from_command.assert_called_once_with(
+            f"AFC_CALI_FAIL TITLE='TD-1 Calibration Failed' FAIL={lane.name} DISTANCE={cal_td1_return[2]} msg='{error_message}' RESET=1"
+        )
+        self._assert_lane_calibration_not_called(func)
+        self._assert_calibrate_bowden_not_called(lane)
+        func._afc_cali_comp.assert_not_called()
+
+    def test_calibration_td1_valid_direct_hub_toolhead_not_loaded_hub_not_loaded_calibration_pass(self):
+        func, afc, lane = self._setup_calibration(td1_present=True)
+        lane.extruder_obj.tool_start = MagicMock(return_value="buffer")
+        lane.is_direct_hub = MagicMock(return_value=True)
+        lane.tool_loaded = False
+        lane.hub_obj.state = False
+        lane.hub_obj.name = "Hub_1"
+        gcmd = self._make_gcmd_for_calibration(TD1=lane.name)
+
+        cal_td1_return = (True, "td1_bowden_length calibration successful", 1000)
+        lane.unit_obj.calibrate_td1 = MagicMock(return_value=cal_td1_return)
+
+        self._call_cmd_calibrate_afc(func, gcmd)
+
+        func.afc.error.AFC_error.assert_not_called()
+        self._assert_lane_calibration_not_called(func)
+        self._assert_calibrate_bowden_not_called(lane)
+        self._assert_afc_cali_comp_called(
+            func, [f"'TD1_Bowden_length: {lane.name}'"], [], title="TD-1 Calibration"
+        )


### PR DESCRIPTION
## Major Changes in this PR
- To allow for accurate filament length for PTFE going to toolheads, this PR incorporates moving the toolhead to Y120 as this has been found to help not get the filament caught on the inside lip of the toolhead which could cause an inaccurate length.

New bug created when adding unit tests for `CALIBRATE_AFC` macro https://github.com/AFCProject/AFC-Klipper-Add-On/issues/747

## How the changes in this PR are tested
- Verified toolheads move on my Snapmaker U1 and verified that toolheads are not moved for non U1 printers.

Video of this in action:

https://github.com/user-attachments/assets/08042ca9-938c-4cf2-bfac-59e9a774e078



## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enhanced Snapmaker Bowden-length calibration by positioning the toolhead at **Y120**, enforcing correct lane tool selection, and applying pre-load parking where enabled.
* **Bug Fixes**
  * Improved tool resolution during tool changes with better handling of invalid tool requests and missing lane mappings.
  * Strengthened calibration safety by enforcing homing with clearer guidance and ensuring tool state is restored after calibration.
* **Tests**
  * Added unit tests for tool selection behavior and expanded calibration coverage.
* **Chores**
  * Updated versioning and the changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->