### PR TITLE
(fix): Updating code to only enable/disable motor current, sync and disable when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The ability to purge on next toolchange for standalone toolheads
 - When running bowden calibration on Snapmaker printers, the toolhead is now moved to Y120 so filament can reach the gears during calibration. Without this move, filament can catch on the inside lip of the toolhead and produce an inaccurate bowden length.
 
+### Fixed
+- Improved extruder stepper enable/disable handling to avoid redundant updates and gracefully handle missing enable lines.
+- Fixed extruder sync/unsync so repeated calls don’t re-trigger the same actions.
+- Improved TMC current switching to reliably alternate between load and print modes.
+
 ## [2026-06-21]
 ### Added
 - Ability to have AFC_extruder config section a custom name thats not `extruder(x)`, if `extruder(x)` is not being used then `extruder_name` variable needs to have the correct toolhead extruder name.

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -44,7 +44,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 try: from extras.AFC_stats import AFCStats
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
 
-AFC_VERSION="1.1.26"
+AFC_VERSION="1.1.27"
 
 # Class for holding different states so its clear what all valid states are
 class State:

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -97,6 +97,8 @@ class AFCExtruderStepper(AFCLane):
 
         self.extruder_stepper   = extruder.ExtruderStepper(config)
         self.stepper_enable     = self.printer.lookup_object('stepper_enable')
+        self._synced_to_extruder= False
+        self._print_current_set = False
 
         # Homing-related configuration
         self.default_homing_endstop = config.get('default_homing_endstop', 'load')
@@ -253,12 +255,20 @@ class AFCExtruderStepper(AFCLane):
 
         :param enable: Enables/disables stepper motor
         """
+        stepper_name = f"AFC_stepper {self.name}"
+        enabled = self.stepper_enable.enable_lines.get(stepper_name, None)
+        if enabled is None:
+            return
+
+        if enabled.is_motor_enabled() == enable:
+            return
+
         if hasattr(self.stepper_enable, "set_motors_enable"):
             # New klipper enable function
-            self.stepper_enable.set_motors_enable([f"AFC_stepper {self.name}"], enable)
+            self.stepper_enable.set_motors_enable([stepper_name], enable)
         else:
             # Old klipper and kalico enable function
-            self.stepper_enable.motor_debug_enable(f"AFC_stepper {self.name}", enable)
+            self.stepper_enable.motor_debug_enable(stepper_name, enable)
 
     def sync_print_time(self):
         """
@@ -283,6 +293,7 @@ class AFCExtruderStepper(AFCLane):
             th_extruder_name = self.extruder_obj.th_extruder_name
 
         self.extruder_stepper.sync_to_extruder(th_extruder_name)
+        self._synced_to_extruder = True
         if update_current: self.set_print_current()
 
     def unsync_to_extruder(self, update_current=True):
@@ -291,7 +302,9 @@ class AFCExtruderStepper(AFCLane):
 
         :param update_current: Sets current to specified load current when True
         """
-        self.extruder_stepper.sync_to_extruder(None)
+        if self._synced_to_extruder:
+            self.extruder_stepper.sync_to_extruder(None)
+            self._synced_to_extruder = False
         if update_current: self.set_load_current()
 
     def _set_current(self, current):
@@ -309,13 +322,16 @@ class AFCExtruderStepper(AFCLane):
         """
         Helper function to update TMC current to use run current value
         """
-        self._set_current( self.tmc_load_current )
+        if self._print_current_set:
+            self._set_current( self.tmc_load_current )
+            self._print_current_set = False
 
     def set_print_current(self):
         """
         Helper function to update TMC current to use print current value
         """
         self._set_current( self.tmc_print_current )
+        self._print_current_set = True
 
     def update_rotation_distance(self, multiplier):
         """

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -292,8 +292,10 @@ class AFCExtruderStepper(AFCLane):
         if th_extruder_name is None:
             th_extruder_name = self.extruder_obj.th_extruder_name
 
-        self.extruder_stepper.sync_to_extruder(th_extruder_name)
-        self._synced_to_extruder = True
+        if not self._synced_to_extruder:
+            self.extruder_stepper.sync_to_extruder(th_extruder_name)
+            self._synced_to_extruder = True
+
         if update_current: self.set_print_current()
 
     def unsync_to_extruder(self, update_current=True):
@@ -330,8 +332,9 @@ class AFCExtruderStepper(AFCLane):
         """
         Helper function to update TMC current to use print current value
         """
-        self._set_current( self.tmc_print_current )
-        self._print_current_set = True
+        if not self._print_current_set:
+            self._set_current( self.tmc_print_current )
+            self._print_current_set = True
 
     def update_rotation_distance(self, multiplier):
         """

--- a/tests/test_AFC_stepper.py
+++ b/tests/test_AFC_stepper.py
@@ -188,6 +188,17 @@ class TestCurrentHelpers:
         s.set_load_current()
         s._set_current.assert_not_called()
 
+    def test_set_load_current_print_current_not_set_called_twice(self):
+        s = _make_stepper()
+        s.tmc_print_current = 0.8
+        s.tmc_load_current = 1.2
+        s._print_current_set = True
+        s._set_current = MagicMock()
+        s.set_load_current()
+        s.set_load_current()
+        s._set_current.assert_called_once_with(1.2)
+        assert not s._print_current_set
+
     def test_set_print_current_calls_set_current_with_print_value(self):
         s = _make_stepper()
         s.tmc_print_current = 0.5
@@ -196,6 +207,25 @@ class TestCurrentHelpers:
         s.set_print_current()
         s._set_current.assert_called_once_with(0.5)
         assert s._print_current_set
+
+    def test_set_print_current_calls_set_current_with_print_value_called_twice(self):
+        s = _make_stepper()
+        s.tmc_print_current = 0.5
+        s.tmc_load_current = 1.0
+        s._set_current = MagicMock()
+        s.set_print_current()
+        s.set_print_current()
+        s._set_current.assert_called_once_with(0.5)
+        assert s._print_current_set
+
+    def test_set_print_current_call_already_enabled(self):
+        s = _make_stepper()
+        s._print_current_set = True
+        s.tmc_print_current = 0.5
+        s.tmc_load_current = 1.0
+        s._set_current = MagicMock()
+        s.set_print_current()
+        s._set_current.assert_not_called()
 
 
 # ── update_rotation_distance ──────────────────────────────────────────────────
@@ -307,10 +337,43 @@ class TestSyncUnsync:
         s.sync_to_extruder(update_current=False)
         s.extruder_stepper.sync_to_extruder.assert_called_once_with("extruder")
 
+    def test_sync_calls_extruder_stepper_sync_already_synced(self):
+        s = _make_stepper(extruder_name="extruder")
+        s._synced_to_extruder = True
+        s._set_current = MagicMock()
+        s.set_print_current = MagicMock()
+        s.sync_to_extruder(update_current=True)
+        s.extruder_stepper.sync_to_extruder.assert_not_called()
+        s.set_print_current.assert_called_once()
+
+    def test_sync_calls_extruder_stepper_sync_called_twice(self):
+        s = _make_stepper(extruder_name="extruder")
+        s._set_current = MagicMock()
+        s.set_print_current = MagicMock()
+        s.sync_to_extruder(update_current=False)
+        s.sync_to_extruder(update_current=False)
+        s.extruder_stepper.sync_to_extruder.assert_called_once_with("extruder")
+        assert s._synced_to_extruder
+
     def test_sync_calls_set_print_current_when_update_current(self):
         s = _make_stepper(extruder_name="extruder")
         s.set_print_current = MagicMock()
         s.sync_to_extruder(update_current=True)
+        s.set_print_current.assert_called_once()
+
+    def test_sync_calls_set_print_current_when_update_current_called_twice(self):
+        s = _make_stepper(extruder_name="extruder")
+        s.set_print_current = MagicMock()
+        s.sync_to_extruder(update_current=True)
+        s.sync_to_extruder(update_current=True)
+        s.extruder_stepper.sync_to_extruder.assert_called_once_with("extruder")
+
+    def test_sync_calls_set_print_current_when_update_current_synced_set(self):
+        s = _make_stepper(extruder_name="extruder")
+        s._synced_to_extruder = True
+        s.set_print_current = MagicMock()
+        s.sync_to_extruder(update_current=True)
+        s.extruder_stepper.sync_to_extruder.assert_not_called()
         s.set_print_current.assert_called_once()
 
     def test_sync_skips_set_print_current_when_update_current_false(self):
@@ -345,6 +408,24 @@ class TestSyncUnsync:
         s.set_load_current = MagicMock()
         s.unsync_to_extruder(update_current=False)
         s.set_load_current.assert_not_called()
+
+    def test_unsync_synced_twice(self):
+        s = _make_stepper()
+        s._synced_to_extruder = True
+        s.set_load_current = MagicMock()
+        s.unsync_to_extruder(update_current=False)
+        s.unsync_to_extruder(update_current=False)
+        s.extruder_stepper.sync_to_extruder.assert_called_once_with(None)
+        assert not s._synced_to_extruder
+
+    def test_unsync_unsynced_twice(self):
+        s = _make_stepper()
+        s._synced_to_extruder = False
+        s.set_load_current = MagicMock()
+        s.unsync_to_extruder(update_current=False)
+        s.unsync_to_extruder(update_current=False)
+        s.extruder_stepper.sync_to_extruder.assert_not_called()
+        assert not s._synced_to_extruder
 
 # ── TrapqAppendWrapper  ───────────────────────────────────────────────────
  

--- a/tests/test_AFC_stepper.py
+++ b/tests/test_AFC_stepper.py
@@ -41,6 +41,8 @@ def _make_stepper(name="lane1", extruder_name="extruder"):
     stepper.extruder_obj = MagicMock()
     stepper.extruder_obj.th_extruder_name = stepper.extruder_obj.name = extruder_name
     stepper.afc_extruder_name = extruder_name
+    stepper._synced_to_extruder = False
+    stepper._print_current_set = False
 
     # Extruder stepper mock
     stepper.extruder_stepper = MagicMock()
@@ -171,9 +173,20 @@ class TestCurrentHelpers:
         s = _make_stepper()
         s.tmc_print_current = 0.8
         s.tmc_load_current = 1.2
+        s._print_current_set = True
         s._set_current = MagicMock()
         s.set_load_current()
         s._set_current.assert_called_once_with(1.2)
+        assert not s._print_current_set
+    
+    def test_set_load_current_print_current_not_set(self):
+        s = _make_stepper()
+        s.tmc_print_current = 0.8
+        s.tmc_load_current = 1.2
+        s._print_current_set = False
+        s._set_current = MagicMock()
+        s.set_load_current()
+        s._set_current.assert_not_called()
 
     def test_set_print_current_calls_set_current_with_print_value(self):
         s = _make_stepper()
@@ -182,6 +195,7 @@ class TestCurrentHelpers:
         s._set_current = MagicMock()
         s.set_print_current()
         s._set_current.assert_called_once_with(0.5)
+        assert s._print_current_set
 
 
 # ── update_rotation_distance ──────────────────────────────────────────────────
@@ -310,12 +324,15 @@ class TestSyncUnsync:
         s.set_print_current = MagicMock()
         s.sync_to_extruder(update_current=False, th_extruder_name="extruder2")
         s.extruder_stepper.sync_to_extruder.assert_called_once_with("extruder2")
+        assert s._synced_to_extruder
 
     def test_unsync_calls_sync_with_none(self):
         s = _make_stepper()
         s.set_load_current = MagicMock()
+        s._synced_to_extruder = True
         s.unsync_to_extruder(update_current=False)
         s.extruder_stepper.sync_to_extruder.assert_called_once_with(None)
+        assert not s._synced_to_extruder
 
     def test_unsync_calls_set_load_current_when_update_current(self):
         s = _make_stepper()
@@ -418,3 +435,116 @@ class TestTrapqAppend:
         fn = MagicMock()
         obj.trapq_append(fn, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14)
         assert fn.call_count == 1
+
+class TestDoEnable:
+    def test_do_enable_enable_lines_is_none(self):
+        s = _make_stepper()
+        stepper_name = f"AFC_stepper {s.name}"
+        extruder_stepper = MagicMock()
+        s.stepper_enable = MagicMock()
+        s.stepper_enable.set_motors_enable = MagicMock()
+        s.stepper_enable.enable_lines = {}
+        s.do_enable(True)
+
+        s.stepper_enable.set_motors_enable.assert_not_called()
+        s.stepper_enable.motor_debug_enable.assert_not_called()
+
+    def test_do_enable_motor_is_enabled_noop_klipper(self):
+        s = _make_stepper()
+        stepper_name = f"AFC_stepper {s.name}"
+        extruder_stepper = MagicMock()
+        s.stepper_enable = MagicMock()
+        s.stepper_enable.set_motors_enable = MagicMock()
+        s.stepper_enable.enable_lines = {stepper_name: extruder_stepper}
+        extruder_stepper.is_motor_enabled = MagicMock(return_value=True)
+        s.do_enable(True)
+
+        s.stepper_enable.set_motors_enable.assert_not_called()
+        s.stepper_enable.motor_debug_enable.assert_not_called()
+    
+    def test_do_enable_motor_is_disabled_noop_klipper(self):
+        s = _make_stepper()
+        stepper_name = f"AFC_stepper {s.name}"
+        extruder_stepper = MagicMock()
+        s.stepper_enable = MagicMock()
+        s.stepper_enable.set_motors_enable = MagicMock()
+        s.stepper_enable.enable_lines = {stepper_name: extruder_stepper}
+        extruder_stepper.is_motor_enabled = MagicMock(return_value=False)
+        s.do_enable(False)
+
+        s.stepper_enable.set_motors_enable.assert_not_called()
+        s.stepper_enable.motor_debug_enable.assert_not_called()
+
+    def test_do_enable_motor_is_enabled_old_klipper(self):
+        s = _make_stepper()
+        stepper_name = f"AFC_stepper {s.name}"
+        extruder_stepper = MagicMock()
+        s.stepper_enable = MagicMock()
+        s.stepper_enable.motor_debug_enable = MagicMock()
+        s.stepper_enable.enable_lines = {stepper_name: extruder_stepper}
+        extruder_stepper.is_motor_enabled = MagicMock(return_value=True)
+
+        # Need to make sure hasattr always returns False for this test
+        with patch('builtins.hasattr', return_value=False):
+            s.do_enable(True)
+
+        s.stepper_enable.set_motors_enable.assert_not_called()
+        s.stepper_enable.motor_debug_enable.assert_not_called()
+
+    def test_do_enable_motor_is_enabled_disable_klipper(self):
+        s = _make_stepper()
+        stepper_name = f"AFC_stepper {s.name}"
+        extruder_stepper = MagicMock()
+        s.stepper_enable = MagicMock()
+        s.stepper_enable.set_motors_enable = MagicMock()
+        s.stepper_enable.enable_lines = {stepper_name: extruder_stepper}
+        extruder_stepper.is_motor_enabled = MagicMock(return_value=True)
+        s.do_enable(False)
+
+        s.stepper_enable.set_motors_enable.assert_called_once_with([stepper_name], False)
+        s.stepper_enable.motor_debug_enable.assert_not_called()
+
+    def test_do_enable_motor_is_enabled_disable_old_klipper(self):
+        s = _make_stepper()
+        stepper_name = f"AFC_stepper {s.name}"
+        extruder_stepper = MagicMock()
+        s.stepper_enable = MagicMock(autospec=True)
+        s.stepper_enable.motor_debug_enable = MagicMock()
+        s.stepper_enable.enable_lines = {stepper_name: extruder_stepper}
+        extruder_stepper.is_motor_enabled = MagicMock(return_value=True)
+
+        # Need to make sure hasattr always returns False for this test
+        with patch('builtins.hasattr', return_value=False):
+            s.do_enable(False)
+
+        s.stepper_enable.set_motors_enable.assert_not_called()
+        s.stepper_enable.motor_debug_enable.assert_called_once_with(stepper_name, False)
+
+    def test_do_enable_motor_is_disabled_enable_klipper(self):
+        s = _make_stepper()
+        stepper_name = f"AFC_stepper {s.name}"
+        extruder_stepper = MagicMock()
+        s.stepper_enable = MagicMock()
+        s.stepper_enable.set_motors_enable = MagicMock()
+        s.stepper_enable.enable_lines = {stepper_name: extruder_stepper}
+        extruder_stepper.is_motor_enabled = MagicMock(return_value=False)
+        s.do_enable(True)
+
+        s.stepper_enable.set_motors_enable.assert_called_once_with([stepper_name], True)
+        s.stepper_enable.motor_debug_enable.assert_not_called()
+
+    def test_do_enable_motor_is_disabled_enable_old_klipper(self):
+        s = _make_stepper()
+        stepper_name = f"AFC_stepper {s.name}"
+        extruder_stepper = MagicMock()
+        s.stepper_enable = MagicMock(autospec=True)
+        s.stepper_enable.motor_debug_enable = MagicMock()
+        s.stepper_enable.enable_lines = {stepper_name: extruder_stepper}
+        extruder_stepper.is_motor_enabled = MagicMock(return_value=False)
+
+        # Need to make sure hasattr always returns False for this test
+        with patch('builtins.hasattr', return_value=False):
+            s.do_enable(True)
+
+        s.stepper_enable.set_motors_enable.assert_not_called()
+        s.stepper_enable.motor_debug_enable.assert_called_once_with(stepper_name, True)


### PR DESCRIPTION
## Major Changes in this PR
- Fixes #726
- Put a guard for syncing to extruder and setting motor current so that these actions are only performed when needed. This help speed up toolchanger swapping toolheads. Before everything had it current set even when not needed.
- Put a check in to only disable steppers if they are enabled.

## How the changes in this PR are tested
Tested both on Snapmaker U1 and 2.4 toolchanger, tests were done with `global_print_current` set to 0.6 on both machines, Start/end/delta times is with using python time function. Videos are attached and difference this makes is very noticiable, espically on Snapmaker u1 since I have alot of units attach to this.


### Before/After Times:
Snapmaker U1 Before:
```
start_time: 1782590509.8096511 end_time: 1782590516.6061695 delta: 6.796518325805664
Tool swap done (Δt:16.514s, t:16.541)
```
https://github.com/user-attachments/assets/f8230b5e-f719-4bf5-b71e-212fe4a16a35

After Change:
```
start_time:1782587518.2913837 end_time:1782587518.7587209 delta: 0.46733713150024414
Tool swap done (Δt:4.985s, t:5.014)
```

https://github.com/user-attachments/assets/e1158637-a212-4dc3-95c9-6982223bb556

----
2.4 Toolchanger Before:
```
start_time:1782586905.5813375 end_time:1782586909.8748262 delta: 4.2934887409210205
Tool swap done (Δt:11.198s, t:11.213)
```

https://github.com/user-attachments/assets/a9706d81-13bb-4cd3-b8af-3d5972a5e2d9

After Change:
```
start_time:1782587643.0968544 end_time:1782587645.136584 delta: 2.039729595184326
Tool swap done (Δt:7.931s, t:7.943)
```

https://github.com/user-attachments/assets/44fb972e-8706-47cd-9d7c-165e33c7db08


## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extruder stepper enable/disable behavior, including correct lookup for enable lines and safe handling when enable lines are missing.
  * Fixed extruder sync/unsync to be idempotent so repeated calls don’t re-trigger actions.
  * Improved TMC current switching to more reliably alternate between load and print modes without unnecessary reconfiguration.
* **Tests**
  * Expanded unit test coverage for enable-line scenarios and repeated state transitions (including both newer and legacy enable control paths).
* **Documentation / Chores**
  * Updated the changelog and bumped the module version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->