### PR TITLE
fix: guarantee heat on toolchange to cold destination extruder

### DIFF
--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -2279,6 +2279,22 @@ class afc:
             adjusting_temperature: bool = new_extruder_temp is not None or \
                 (infinite_runout and self.function.get_current_extruder() != next_extruder)
 
+            # Ensure heat when driving a toolchange to a different physical
+            # extruder whose current target is below its min_extrude_temp.
+            # Rationale: AFC owns the toolchange, so it must guarantee the
+            # destination is safe to extrude regardless of whether the slicer's
+            # M109/M104 arrived and successfully set a target on it. The
+            # existing gate above only fires for infinite_runout or when a
+            # caller explicitly passes new_extruder_temp; in a normal
+            # slicer-driven T(n) change to a cold standby extruder, neither
+            # applies and the following extrusion would fail cold.
+            if (not adjusting_temperature
+                and self.function.get_current_extruder() != next_extruder):
+                _next_heater = cur_lane.extruder_obj.get_heater()
+                _, _next_target = _next_heater.get_temp(self.reactor.monotonic())
+                if _next_target < _next_heater.min_extrude_temp:
+                    adjusting_temperature = True
+
             _last_lane = None
             if adjusting_temperature:
                 # Heat the next extruder FIRST so that _heat_next_extruder reads the


### PR DESCRIPTION
## Summary

`CHANGE_TOOL` only invokes `_heat_next_extruder` when the caller passed
`new_extruder_temp` or when the change is an infinite-runout event across
physical extruders. Neither is true for a normal slicer-driven `T(n)`
sequence, so cross-extruder tool changes to a cold-standby destination
end in a cold-extrude fault.

This PR extends the `adjusting_temperature` gate: if AFC is switching to
a different physical extruder and that extruder's current heater target
is below its `min_extrude_temp`, also trigger `_heat_next_extruder`.
`_cooldown_last_extruder` already fires symmetrically on the old
extruder, so this restores the invariant that AFC owns both sides of
the temperature transition when it drives the toolchange.

## Reproduction

Environment: Snapmaker U1 with paxx12 extended firmware, current DEV
tip of AFC-Klipper-Add-On, Mainsail v2.18.0's start-print dialog
mapping T0 through a BoxTurtle lane (feeds `extruder`) and T2 to
standalone `extruder2`. Slicer: Snapmaker Orca 2.3.4.

1. Start a 2-tool print on T2; extruder2 heats to 220 °C and prints.
2. Slicer emits `M400 / M109 T0 S220 / M400 / T0` for the tool change.
3. `M109 T0 S220` does not raise `extruder`'s target from its 130 °C
   standby (root cause is orthogonal see notes below).
4. AFC's `CHANGE_TOOL` fires: park `extruder2`, pick `extruder`, sync
   `lane1`. `_heat_next_extruder` is NOT called because
   `adjusting_temperature` is False.
5. `SM_PRINT_PREEXTRUDE_FILAMENT` extrudes → Klipper aborts:
   `extruder below minimum temp, temperature: 130.10`

Klippy log excerpt:

```
20:22:19.884: extruder2 -> extruder
20:22:19.886: park extruder2 !!!
20:22:21.694: pick extruder !!!
20:22:24.285: Activating extruder extruder
20:22:24.373: AFC_stepper lane1 has been manually enabled
20:22:25.034: extruder below minimum temp, temperature: 130.10,
              See the 'min_extrude_temp' config option for details
```

Throughout the entire window `extruder: target=130 temp≈130`. No M109
successfully raised the target on the destination.

## Fix

```python
adjusting_temperature: bool = new_extruder_temp is not None or \
    (infinite_runout and self.function.get_current_extruder() != next_extruder)

# Ensure heat when driving a toolchange to a different physical
# extruder whose current target is below its min_extrude_temp.
if (not adjusting_temperature
    and self.function.get_current_extruder() != next_extruder):
    _next_heater = cur_lane.extruder_obj.get_heater()
    _, _next_target = _next_heater.get_temp(self.reactor.monotonic())
    if _next_target < _next_heater.min_extrude_temp:
        adjusting_temperature = True
```

Idempotent: no-op when the destination target is already at a valid
print temp, so slicers/start-gcode that correctly heat the next tool
before the T change see no behavior change.

## Why not fix the M109 handler directly

I could not conclusively trace why `M109 T0 S220` failed to raise the
destination's target in this scenario. Candidates include the ooze
check in `elif lane is not None:` and races with `_cooldown_last_extruder`,
but neither reproduces cleanly in isolation. Rather than guess at the
M109 handler, this PR restores the invariant that matters AFC never
drives extrusion on a cold destination regardless of which upstream
path dropped the write. That also matches the existing shape of the
code (`_cooldown_last_extruder` is unconditional; `_heat_next_extruder`
now becomes so when the destination needs it).

## Testing

- Applied on Snapmaker U1, Klipper restarts cleanly.
- Manual toolchange sequences do not regress on same-extruder lane swaps
  (no change of behavior path).
- Full multi-tool print test pending; will follow up with results.

## Draft status

Marking as draft while I collect a full multi-tool print run on the
U1 to confirm the exact failure sequence is fixed end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tool changes now more reliably trigger heating checks when switching to a different extruder.
  * Prevents cases where the destination extruder could remain below a safe extrusion temperature if no new temperature was set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->