### PR TITLE
(fixes): Misc changes based off users feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-07-03]
+### Added
+- Defaulting `tool_max_unload_attempts` to zero in Snapmaker U1 AFC config file.
+- Defaulting `restore_extruder_temp_on_load_or_unload` to True in Snapmaker U1 AFC config file.
+- Defaulting print_current for EMU lanes to 0.4 since having print current at 0.8 can risk melting PLA filament.
+- Ability to disable purging after first toolswap for standalone toolheads. This is enabled by default, to disable add `enable_standalone_purge: False` to AFC.cfg or per toolhead in AFC_extruder config sections.
+
 ## [2026-06-27]
 ### Added
 - The ability to purge on next toolchange for standalone toolheads

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -196,6 +196,7 @@ class afc:
         self.wipe_cmd               = config.get('wipe_cmd', None)                  # Macro to use when nozzle wiping. Change macro name if you would like to use your own wipe macro
         self.poop                   = config.getboolean("poop", False)              # Set to True to enable pooping(purging color) after lane loads
         self.poop_cmd               = config.get('poop_cmd', None)                  # Macro to use when pooping. Change macro name if you would like to use your own poop/purge macro
+        self.enable_standalone_purge: bool = config.getboolean("enable_standalone_purge", True)
 
         self.post_load_macro        = config.get("post_load_macro", None)
         self.post_unload_macro      = config.get("post_unload_macro", None)

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -273,6 +273,7 @@ class AFCExtruder:
         self.no_lanes                   = False
         self.custom_tool_swap: Optional[str] = config.get("custom_tool_swap", None)
         self.custom_unselect: Optional[str] = config.get("custom_unselect", None)
+        self.enable_standalone_purge: bool  = config.getboolean("enable_standalone_purge", self.afc.enable_standalone_purge)
 
         self.lane_loaded: Optional[str] = None
         self.lanes: Dict                = {}
@@ -340,6 +341,7 @@ class AFCExtruder:
                 ffi_lib.cartesian_stepper_alloc(b'x'), ffi_lib.free)
 
             trapq_append_wrapper = TrapqAppendWrapper()
+            self.prev_sk = self.prev_trapq = None
             if self.motion_queuing is not None:
                 self.trapq          = self.motion_queuing.allocate_trapq()
                 _trapq_append       = self.motion_queuing.lookup_trapq_append()
@@ -686,8 +688,6 @@ class AFCExtruder:
         :param eventtime: Event time when callback function is called, currently not used
         :return float: Always returns reactor NEVER to stop function from being called again
         """
-        # TODO: set a flag so that AFC knows to purge properly when switched to a toolhead that
-        # was asynchronously loaded
         toolhead: ToolHead = self.printer.lookup_object("toolhead")
         stepper = self.toolhead_extruder.extruder_stepper.stepper
         toolhead.flush_step_generation()
@@ -701,11 +701,10 @@ class AFCExtruder:
 
         self.afc.restore_toolhead_temp(temp_state=self._captured_toolhead_temp, async_restore=True)
         self._captured_toolhead_temp = None
-
         if self.current_move_distance > 0:
             info_str = "loading"
             self.tc_lane.status = AFCLaneState.TOOLED
-            self.tc_lane.need_purge = True
+            self.tc_lane.need_purge = bool(self.enable_standalone_purge)
         else:
             info_str = "unloading"
             self.tc_lane.status = AFCLaneState.NONE

--- a/include/emu_templater.sh
+++ b/include/emu_templater.sh
@@ -141,6 +141,7 @@ led_spool_index: ${unit_name}_Indicator_Box_${i}:1
 #led_spool_index: ${unit_name}_Indicator_${i}:2
 prep: ^!${unit_name}_lane${i}:TRG
 load: ^${unit_name}_lane${i}:LOAD
+print_current: 0.4
 
 [tmc2209 AFC_stepper lane${i}]
 uart_pin: ${unit_name}_lane${i}:MOT_UART
@@ -241,6 +242,7 @@ led_spool_index: ${unit_name}_Indicator_${i}:2
 #led_spool_index: ${unit_name}_Indicator_Box_${i}:1
 prep: ^!${unit_name}_lane${i}:TRG
 load: ^${unit_name}_lane${i}:LOAD
+print_current: 0.4
 
 [tmc2209 AFC_stepper lane${i}]
 uart_pin: ${unit_name}_lane${i}:MOT_UART

--- a/templates/EMU.cfg
+++ b/templates/EMU.cfg
@@ -39,6 +39,7 @@ led_spool_index: EMU_Indicator_1:2
 #led_spool_index: EMU_Indicator_Box_1:1
 prep: ^!emu_lane1:TRG
 load: ^emu_lane1:LOAD
+print_current: 0.4
 
 [tmc2209 AFC_stepper lane1]
 uart_pin: EMU_1_lane1:MOT_UART

--- a/templates/u1_macros/AFC.cfg
+++ b/templates/u1_macros/AFC.cfg
@@ -31,6 +31,9 @@ assisted_unload: True           # If True, the unload retract is assisted to pre
 #debug: True                     # Setting to True turns on more debugging to show on console
 force_assign_map: True
 
+restore_extruder_temp_on_load_or_unload: True
+tool_max_unload_attempts: 0
+
 #--=================================================================================-
 #------- TRSYNC Values --------------------------------------------------------------
 #--=================================================================================-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -437,12 +437,15 @@ class MockPrinter:
             "AFC": self._afc,
             "gcode": self._gcode,
         }
+        magic_mock_objects = (
+            "webhooks", "toolhead", "heaters", "pins", "buttons", "extruder"
+        )
         val = default
         if name in mapping:
             return mapping[name]
         if name in self._objects:
             return self._objects[name]
-        if name == "webhooks":
+        if name in magic_mock_objects:
             val = MagicMock()
         if name == "pause_resume":
             obj = MagicMock()
@@ -452,16 +455,6 @@ class MockPrinter:
             obj = MagicMock()
             obj.idle_timeout = 600
             val = obj
-        if name == "toolhead":
-            val = MagicMock()
-        if name == "heaters":
-            val = MagicMock()
-        if name == "pins":
-            val = MagicMock()
-        if name == "buttons":
-            val = MagicMock()
-        if name == "extruder":
-            val = MagicMock()
         if val is not default:
             self._objects[name] = val
         return val
@@ -469,7 +462,7 @@ class MockPrinter:
     def load_object(self, config, name):
         result = self.lookup_object(name)
         if result is None:
-            result = MagicMock()
+            result = self._objects[name] = MagicMock()
 
         return result
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -431,43 +431,46 @@ class MockPrinter:
         self.start_args: dict = {}
         self.objects: dict = {}
         self._event_handlers: dict = {}
-
-    # ------------------------------------------------------------------
+    
     def lookup_object(self, name, default=None):
         mapping = {
             "AFC": self._afc,
             "gcode": self._gcode,
         }
+        val = default
         if name in mapping:
             return mapping[name]
         if name in self._objects:
             return self._objects[name]
         if name == "webhooks":
-            return MagicMock()
+            val = MagicMock()
         if name == "pause_resume":
             obj = MagicMock()
             obj.send_pause_command = MagicMock()
-            return obj
+            val = obj
         if name == "idle_timeout":
             obj = MagicMock()
             obj.idle_timeout = 600
-            return obj
+            val = obj
         if name == "toolhead":
-            return MagicMock()
+            val = MagicMock()
         if name == "heaters":
-            return MagicMock()
+            val = MagicMock()
         if name == "pins":
-            return MagicMock()
+            val = MagicMock()
         if name == "buttons":
-            return MagicMock()
+            val = MagicMock()
         if name == "extruder":
-            return MagicMock()
-        return default
+            val = MagicMock()
+        if val is not default:
+            self._objects[name] = val
+        return val
 
     def load_object(self, config, name):
         result = self.lookup_object(name)
         if result is None:
             result = MagicMock()
+
         return result
 
     def get_reactor(self):
@@ -492,6 +495,8 @@ class MockConfig:
         self._printer = printer or MockPrinter()
         self._values: dict = values or {}
         self.fileconfig = _make_fileconfig()
+        self.section = "Test"
+        self.fileconfig.add_section(self.section)
 
     def get_printer(self):
         return self._printer
@@ -500,7 +505,11 @@ class MockConfig:
         return self._name
 
     def get(self, option, default=None):
-        return self._values.get(option, default)
+        try:
+            val = self.fileconfig.get(self.section, option)
+        except:
+            val = self._values.get(option, default)
+        return val
 
     def getfloat(self, option, default=0.0, **kwargs):
         val = self._values.get(option, default)
@@ -518,11 +527,18 @@ class MockConfig:
 
     def getint(self, option, default=0, **kwargs):
         val = self._values.get(option, default)
-        return int(val)
+        if val is not None:
+            return int(val)
+        else:
+            return val
 
     def getlist(self, option, default=None, **kwargs):
         val = self._values.get(option, default)
         return val if val is not None else []
+
+    def getlists(self, option, default=None, **kwargs):
+        val = self._values.get(option, default)
+        return val if val is not None else ()
 
     def error(self, msg):
         from configfile import error as KlipperError

--- a/tests/test_AFC_extruder.py
+++ b/tests/test_AFC_extruder.py
@@ -257,10 +257,13 @@ def _make_afc_extruder(name="extruder"):
     ext.mutex = MagicMock()
     return ext
 
-def _make_afc_extruder_as_standalone(name="extruder", extruder_values={}, afc_values={}):
+def _make_afc_extruder_as_standalone(name="extruder", extruder_values=None, afc_values=None):
     """Build an AFCExtruder bypassing __init__."""
     from extras import AFC
     from tests.conftest import MockAFC, MockPrinter, MockLogger, MockReactor, MockConfig
+
+    extruder_values = extruder_values or {}
+    afc_values = afc_values or {}
 
     afc_config = MockConfig("AFC", MockPrinter())
     afc = AFC.load_config(afc_config)
@@ -1391,9 +1394,9 @@ class TestExtruderMoveCB:
         assert any(f"{ext.name} loading done" in m for m in info_msgs)
 
     def test_standalone_purge_disabled(self):
-        ext = self._make_afc_extruder_for_move_cb()
+        extruder_values = {"enable_standalone_purge": False}
+        ext = self._make_afc_extruder_for_move_cb(extruder_values=extruder_values)
         ext.current_move_distance = 100
-        ext.enable_standalone_purge = False
 
         assert ext.reactor.NEVER == ext.extruder_move_cb(100)
 

--- a/tests/test_AFC_extruder.py
+++ b/tests/test_AFC_extruder.py
@@ -17,7 +17,7 @@ import sys
 import types
 
 from extras.AFC_extruder import AFCExtruderStats, AFCExtruder
-from tests.test_AFC_lane import _make_afc_lane, AFCLane
+from tests.test_AFC_lane import _make_afc_lane, AFCLaneState
 # ── Helpers ─────────────────────────────────────────────────────────
 
 def _make_extruder_obj(name="extruder"):
@@ -210,7 +210,7 @@ class TestResetStats:
 
 def _make_afc_extruder(name="extruder"):
     """Build an AFCExtruder bypassing __init__."""
-    from tests.conftest import MockAFC, MockPrinter, MockLogger, MockReactor
+    from tests.conftest import MockAFC, MockPrinter, MockLogger, MockReactor, MockConfig
 
     afc = MockAFC()
     reactor = MockReactor()
@@ -257,6 +257,27 @@ def _make_afc_extruder(name="extruder"):
     ext.mutex = MagicMock()
     return ext
 
+def _make_afc_extruder_as_standalone(name="extruder", extruder_values={}, afc_values={}):
+    """Build an AFCExtruder bypassing __init__."""
+    from extras import AFC
+    from tests.conftest import MockAFC, MockPrinter, MockLogger, MockReactor, MockConfig
+
+    afc_config = MockConfig("AFC", MockPrinter())
+    afc = AFC.load_config(afc_config)
+    for key, value in afc_values.items():
+        if hasattr(afc, key):
+            setattr(afc, key, value)
+
+    reactor = MockReactor()
+    printer = MockPrinter(afc=afc)
+    printer._reactor = reactor
+    
+    config = MockConfig(f"AFC_extruder {name}", printer, extruder_values)
+
+    ext = AFCExtruder(config)
+
+    ext.logger = MockLogger()
+    return ext
 
 # ── AFCExtruder.__str__ ────────────────────────────────────────────────────────
 
@@ -1285,3 +1306,108 @@ class TestPrepOnShuttleCheck:
         lane.unit_obj.lane_tool_loaded.assert_called_once_with(lane)
         lane.unit_obj.lane_tool_loaded_idle.assert_called_once_with(lane)
         assert "<span class=primary--text> in ToolHead and toolhead on shuttle</span>" in msg
+
+class TestExtruderMoveCB:
+    def _make_afc_extruder_for_move_cb(self, extruder_values={}, afc_values={}):
+        values = {
+            "toolchanger_unit": "Tools"
+        }
+        values = values | extruder_values
+        ext = _make_afc_extruder_as_standalone(extruder_values=values, afc_values=afc_values)
+        ext.function = MagicMock()
+        ext.afc.restore_toolhead_temp = MagicMock()
+        ext.printer.lookup_object = MagicMock()
+        ext.toolhead_extruder = MagicMock()
+        ext.afc.save_vars = MagicMock()
+        ext.tc_lane = _make_afc_lane(fullname="AFC_stepper extruder")
+        return ext
+
+    def test_motion_queue_current_move_is_none(self):
+        ext = self._make_afc_extruder_for_move_cb()
+        ext.motion_queuing = None
+
+        assert ext.reactor.NEVER == ext.extruder_move_cb(100)
+        assert AFCLaneState.NONE == ext.tc_lane.status
+        assert None == ext.motion_queuing
+    
+    def test_motion_queue_current_move_is_none_check_asserts(self):
+        ext = self._make_afc_extruder_for_move_cb()
+        ext.motion_queuing = None
+        ext.current_move_distance = 0
+        ext.prev_trapq = MagicMock()
+        ext.prev_sk = MagicMock()
+        toolhead = ext.printer.lookup_object("toolhead")
+        stepper = ext.toolhead_extruder.extruder_stepper.stepper
+
+        assert ext.reactor.NEVER == ext.extruder_move_cb(100)
+        ext.toolhead_extruder.extruder_stepper.stepper.set_trapq.assert_called_once_with(ext.prev_trapq)
+        toolhead.flush_step_generation.assert_called_once()
+        stepper.set_trapq.assert_called_once_with(ext.prev_trapq)
+        stepper.set_stepper_kinematics.assert_called_once_with(ext.prev_sk)
+        ext.function.do_enable.assert_called_once_with(False, ext.th_extruder_name)
+        ext.afc.restore_toolhead_temp.assert_called_once_with(temp_state=ext._captured_toolhead_temp,
+                                                              async_restore=True)
+        assert ext.tc_lane.status == AFCLaneState.NONE
+        assert ext.tc_lane.need_purge == False
+        ext.afc.save_vars.assert_called_once()
+
+        info_msgs = [m for lvl, m in ext.logger.messages if lvl == "info"]
+        assert any(f"{ext.name} unloading done" in m for m in info_msgs)
+    
+    def test_motion_queue_not_none(self):
+        ext = self._make_afc_extruder_for_move_cb()
+
+        assert ext.reactor.NEVER == ext.extruder_move_cb(100)
+        ext.motion_queuing.wipe_trapq.assert_called_once_with(ext.trapq)
+    
+    def test_load_active(self):
+        ext = self._make_afc_extruder_for_move_cb()
+        ext.load_active = True
+
+        assert ext.reactor.NEVER == ext.extruder_move_cb(100)
+        assert not ext.load_active
+    
+    def test_captured_toolhead_temp(self):
+        ext = self._make_afc_extruder_for_move_cb()
+        capture_toolhead = True
+        ext._captured_toolhead_temp = capture_toolhead
+
+        assert ext.reactor.NEVER == ext.extruder_move_cb(100)
+        ext.afc.restore_toolhead_temp.assert_called_once_with(temp_state=capture_toolhead,
+                                                              async_restore=True)
+        assert None == ext._captured_toolhead_temp
+    
+    def test_current_move_not_zero_loading(self):
+        ext = self._make_afc_extruder_for_move_cb()
+        ext.current_move_distance = 100
+
+        assert ext.reactor.NEVER == ext.extruder_move_cb(100)
+
+        assert AFCLaneState.TOOLED == ext.tc_lane.status
+        assert ext.tc_lane.need_purge
+        assert 0 == ext.current_move_distance
+
+        info_msgs = [m for lvl, m in ext.logger.messages if lvl == "info"]
+        assert any(f"{ext.name} loading done" in m for m in info_msgs)
+
+    def test_standalone_purge_disabled(self):
+        ext = self._make_afc_extruder_for_move_cb()
+        ext.current_move_distance = 100
+        ext.enable_standalone_purge = False
+
+        assert ext.reactor.NEVER == ext.extruder_move_cb(100)
+
+        assert AFCLaneState.TOOLED == ext.tc_lane.status
+        assert not ext.tc_lane.need_purge
+        assert 0 == ext.current_move_distance
+    
+    def test_standalone_purge_disabled_from_afc(self):
+        afc_values = {"enable_standalone_purge": False}
+        ext = self._make_afc_extruder_for_move_cb(afc_values=afc_values)
+        ext.current_move_distance = 100
+
+        assert ext.reactor.NEVER == ext.extruder_move_cb(100)
+
+        assert AFCLaneState.TOOLED == ext.tc_lane.status
+        assert not ext.tc_lane.need_purge
+        assert 0 == ext.current_move_distance


### PR DESCRIPTION
## Major Changes in this PR
- Defaulting `tool_max_unload_attempts` to zero in Snapmaker U1 AFC config file.
- Defaulting `restore_extruder_temp_on_load_or_unload` to True in Snapmaker U1 AFC config file.
- Defaulting print_current for EMU lanes to 0.4 since having print current at 0.8 can risk melting PLA filament.
- Ability to disable purging after first toolswap for standalone toolheads. This is enabled by default, to disable add `enable_standalone_purge: False` to AFC.cfg or per toolhead in AFC_extruder config sections.
- Added unit tests

## Notes to Code Reviewers

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added/updated AFC configuration defaults for Snapmaker U1, including safer lane print-current defaults for EMU.
  * Added an `enable_standalone_purge` option (enabled by default) to control whether purging occurs after the first standalone tool swap.
* **Bug Fixes**
  * Standalone purge behavior now follows the configured `enable_standalone_purge` setting instead of always purging.
* **Tests**
  * Expanded extruder move-callback test coverage and improved mock configuration/object reuse behavior.
* **Documentation**
  * Added a new dated changelog entry describing the above updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->