### PR TITLE
(fix): Fixing install scripts for Snapmaker U1

### DIFF
--- a/include/U1_extended_firmware_install.sh
+++ b/include/U1_extended_firmware_install.sh
@@ -77,6 +77,7 @@ check_and_move_afc_files() {
         echo "Making AFC directories in printer_data/config directory"
         mkdir -p "${printer_config_dir}/AFC"
         mkdir -p "${printer_config_dir}/AFC/macros"
+        mkdir -p "${printer_config_dir}/AFC/mcu"
 
         echo "Copying AFC config files to printer_data/config/AFC directory"
         cp "${afc_dir}/templates/u1_macros/AFC.cfg" "${printer_config_dir}/AFC/"

--- a/include/utils.sh
+++ b/include/utils.sh
@@ -131,7 +131,7 @@ function copy_snapmaker_config() {
     mkdir -p "${afc_config_dir}/mcu"
     mkdir -p "${afc_config_dir}/macros"
     safe_copy "${afc_path}/templates/u1_macros/Snapmaker_macros.cfg" "${afc_config_dir}/macros/"
-    safe_copy "${afc_path}/config/macros/AFC_macros.cfg" "${afc_config_dir}/AFC/macros"
+    safe_copy "${afc_path}/config/macros/AFC_macros.cfg" "${afc_config_dir}/macros"
     safe_copy "${afc_path}/templates/AFC_Hardware_U1.cfg" "${afc_config_dir}/AFC_Hardware.cfg"
 }
 

--- a/templates/AFC_Hardware_U1.cfg
+++ b/templates/AFC_Hardware_U1.cfg
@@ -4,6 +4,7 @@ enable_force_move: True
 [AFC_Toolchanger Tools]
 
 [AFC_extruder e0]
+#pin_tool_start: buffer
 u1_filament_sensor_name: e0_filament
 tool_stn: 50                    # See documentation for details on how to calculate this value. https://armoredturtle.xyz/docs/afc-klipper-add-on/toolhead/calculation.html
 tool_stn_unload: 60             # See documentation for details on how to calculate this value. https://armoredturtle.xyz/docs/afc-klipper-add-on/toolhead/calculation.html
@@ -17,6 +18,7 @@ u1_park_detector_name: extruder
 extruder_name: extruder
 
 [AFC_extruder e1]
+#pin_tool_start: buffer
 u1_filament_sensor_name: e1_filament
 tool_stn: 50                    # See documentation for details on how to calculate this value. https://armoredturtle.xyz/docs/afc-klipper-add-on/toolhead/calculation.html
 tool_stn_unload: 60             # See documentation for details on how to calculate this value. https://armoredturtle.xyz/docs/afc-klipper-add-on/toolhead/calculation.html
@@ -30,6 +32,7 @@ u1_park_detector_name: extruder1
 extruder_name: extruder1
 
 [AFC_extruder e2]
+#pin_tool_start: buffer
 u1_filament_sensor_name: e2_filament
 tool_stn: 50                    # See documentation for details on how to calculate this value. https://armoredturtle.xyz/docs/afc-klipper-add-on/toolhead/calculation.html
 tool_stn_unload: 60             # See documentation for details on how to calculate this value. https://armoredturtle.xyz/docs/afc-klipper-add-on/toolhead/calculation.html
@@ -43,6 +46,7 @@ u1_park_detector_name: extruder2
 extruder_name: extruder2
 
 [AFC_extruder e3]
+#pin_tool_start: buffer
 u1_filament_sensor_name: e3_filament
 tool_stn: 50                    # See documentation for details on how to calculate this value. https://armoredturtle.xyz/docs/afc-klipper-add-on/toolhead/calculation.html
 tool_stn_unload:60              # See documentation for details on how to calculate this value. https://armoredturtle.xyz/docs/afc-klipper-add-on/toolhead/calculation.html


### PR DESCRIPTION
## Major Changes in this PR
- Added creating mcu folder when initially installing AFC on a U1
- Removing additional AFC name when copying files to macros folder

## How the changes in this PR are tested
- Went through install and adding additional units on my U1

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved setup of AFC configuration folders during firmware installation, including creating the required MCU subdirectory.
  * Corrected where AFC macro configuration files are copied so they land in the expected location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->