### PR TITLE
(feat): For Snapmaker U1 printers, treat filament staged in the bay as lane presence

### DIFF
--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -394,6 +394,46 @@ class AFCExtruder:
             self.afc.lanes.pop(self.tc_lane.name)
             self.printer.objects.pop(f"AFC_lane {self.name}")
 
+    def _u1_bay_filament_exist(self):
+        """
+        Snapmaker U1: check if filament is staged in this toolhead's rear bay.
+
+        The U1 stages filament in its rear bay feeder before it is ever fed to
+        the toolhead, so the toolhead motion sensor (u1_filament_sensor_name)
+        cannot see it there. Bay presence is reported by print_task_config's
+        filament_exist array, indexed by physical extruder number.
+
+        :return: True when filament is staged in the bay, False otherwise
+        """
+        if self.filament_sensor_name is None:
+            return False
+        ptc = self.printer.lookup_object("print_task_config", None)
+        if ptc is None:
+            return False
+        try:
+            idx = int(self.name.replace("extruder", "") or 0)
+            return bool(ptc.get_status()["filament_exist"][idx])
+        except Exception:
+            return False
+
+    def _u1_bay_poll(self, eventtime):
+        """
+        Periodically OR bay presence into the standalone lane's prep/load state
+        so a staged (but not tool-loaded) bay shows as present in the UIs and
+        CHANGE_TOOL/TOOL_LOAD can start a load from it instead of refusing with
+        "LOAD TRIGGER NOT TRIGGERED" (which was unrecoverable from gcode, as
+        the toolhead sensor can only trigger after a load already happened).
+
+        :param eventtime: Current event time from the reactor
+        :return: Next time to run this poll
+        """
+        if self.tc_lane is not None:
+            present = self.tool_start_state or self._u1_bay_filament_exist()
+            if present != self.tc_lane.prep_state:
+                self.tc_lane.prep_state = present
+                self.tc_lane._load_state = present
+        return eventtime + 2.
+
     def handle_ready(self):
         # Check to see if extruder name is currently in `self.lanes`, if it is then that means that
         # no other lanes are setup for this extruder, and that this is a "standalone" toolhead
@@ -402,11 +442,16 @@ class AFCExtruder:
             self.logger.info(f"{self.name} no lanes")
             # Due to race conditions at startup, these variables might not be set correctly,
             #  set to current tool start state
-            self.tc_lane._load_state = self.tc_lane.prep_state = self.tool_start_state
+            self.tc_lane._load_state = self.tc_lane.prep_state = self.tool_start_state or self._u1_bay_filament_exist()
 
             if self.tool_start_state:
                 self.tc_lane.set_tool_loaded()
                 self.tc_lane.set_loaded()
+
+            # Snapmaker U1: filament staged in the rear bay is invisible to the
+            # toolhead sensor - keep lane presence in sync with the bay state
+            if self.filament_sensor_name is not None:
+                self.reactor.register_timer(self._u1_bay_poll, self.reactor.NOW)
 
             if self.tool_start == "buffer":
                 raise error(


### PR DESCRIPTION
## Problem

On the Snapmaker U1, standalone toolchanger lanes derive **both** `prep` and `load` state from the single toolhead motion sensor (`u1_filament_sensor_name`), in `handle_ready` and `note_tool_start_callback`.

Filament staged in the rear bay feeder the U1's normal resting state after inserting a spool (the bay motor grabs it, RFID reads it, but it is not fed to the toolhead) is invisible to that sensor. Two consequences:

1. The lane shows as **empty** in Fluidd/Mainsail/HelixScreen even though the machine itself knows the filament is there.
2. `TOOL_LOAD` refuses the lane (`Current lane not loaded, LOAD TRIGGER NOT TRIGGERED`), and that refusal is unrecoverable from gcode: for these lanes the toolhead sensor can only become true *after* a load has already happened, so `T<n>` to a staged bay can never succeed.

## Solution

Bay presence is already available from `print_task_config`'s `filament_exist` array (indexed by physical extruder number). This PR polls it every 2 s and ORs it into the standalone lane's `prep`/`load` state (also at `handle_ready` for the initial sync). `tool_loaded` stays driven by the toolhead sensor, so the staged-vs-loaded distinction is preserved:

- staged in bay → `prep`/`load` true, `tool_loaded` false → shows *Ready* with its spool info
- fed to toolhead → `tool_loaded` true → *In Tool* as before

The poll is only registered for lanes configured with `u1_filament_sensor_name`, so non-U1 setups are untouched.

## Testing

On a Snapmaker U1 (paxx12 extended firmware, AFC 1.1.27 with this change, hybrid setup: Box Turtle on tool 0 + three native tool bays):

- Spool inserted into bay 1 only (bay feeder grabbed it, not fed to toolhead): lane `extruder1` reports `prep: true, load: true, tool_loaded: false`, filament_status *Ready*, spool visible in the UIs.
- `T<n>` to that tool: passes the load-trigger check, picks the toolhead, feeds from the bay through the existing Snapmaker feed path, ends `Tooled` / *In Tool*, no errors.
- Bays without filament and Box Turtle lanes behave exactly as before.

Marked draft for feedback on the approach happy to move the sync into `note_tool_start_callback`/event handlers instead of a reactor poll if preferred.