### PR TITLE
Support tollhead runout protections in bypass mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-07-11]
+### Added
+- Added `disable_tool_runout_in_bypass` configuration option (defaults to `False`) to allow users to toggle toolhead filament sensor runout pausing when printing in bypass/manual mode.
+
+### Fixed
+- Fixed toolhead filament sensor runout pausing print when printing in bypass/manual mode (where no AFC lane is registered as loaded).
+
 ## [2026-07-03]
 ### Added
 - Defaulting `tool_max_unload_attempts` to zero in Snapmaker U1 AFC config file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2026-07-11]
 ### Added
-- Added `disable_tool_runout_in_bypass` configuration option (defaults to `False`) to allow users to toggle toolhead filament sensor runout pausing when printing in bypass/manual mode.
+- Added `enable_runout_in_bypass` configuration option (defaults to `False`) to allow users to enable toolhead filament sensor runout pausing when printing in bypass/manual mode.
 
 ### Fixed
-- Fixed toolhead filament sensor runout pausing print when printing in bypass/manual mode (where no AFC lane is registered as loaded).
+- Fixed unexpected toolhead filament sensor runout pausing when printing in bypass/manual mode by defaulting the behavior to disabled.
 
 ## [2026-07-03]
 ### Added

--- a/config/AFC.cfg
+++ b/config/AFC.cfg
@@ -30,6 +30,7 @@ load_to_hub: True               # Fast loads filament to hub when inserted, set 
 
 assisted_unload: True           # If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool. This is a global setting and can be overridden at the unit and stepper level.
 #pause_when_bypass_active: True  # When True AFC pauses print when change tool is called and bypass is loaded
+#disable_tool_runout_in_bypass: False # When True, AFC will not pause print when toolhead sensor runout is triggered in bypass/manual mode
 #unload_on_runout: True          # When True AFC will unload lane and then pause when runout is triggered and spool to swap to is not set(infinite spool)
 #print_short_stats: True          # Set to true to print AFC_STATS in short form instead of wide form, printing short form is better for consoles that are small in width
 #debug: True                     # Setting to True turns on more debugging to show on console

--- a/config/AFC.cfg
+++ b/config/AFC.cfg
@@ -30,7 +30,7 @@ load_to_hub: True               # Fast loads filament to hub when inserted, set 
 
 assisted_unload: True           # If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool. This is a global setting and can be overridden at the unit and stepper level.
 #pause_when_bypass_active: True  # When True AFC pauses print when change tool is called and bypass is loaded
-#disable_tool_runout_in_bypass: False # When True, AFC will not pause print when toolhead sensor runout is triggered in bypass/manual mode
+#enable_runout_in_bypass: False     # When True, AFC will pause print when toolhead sensor runout is triggered in bypass/manual mode
 #unload_on_runout: True          # When True AFC will unload lane and then pause when runout is triggered and spool to swap to is not set(infinite spool)
 #print_short_stats: True          # Set to true to print AFC_STATS in short form instead of wide form, printing short form is better for consoles that are small in width
 #debug: True                     # Setting to True turns on more debugging to show on console

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -262,7 +262,7 @@ class afc:
         self.enable_assist_weight   = config.getfloat("enable_assist_weight",   500.0)
         self.enable_hub_runout      = config.getboolean("enable_hub_runout",    True)
         self.enable_tool_runout     = config.getboolean("enable_tool_runout",   True)
-        self.disable_tool_runout_in_bypass = config.getboolean("disable_tool_runout_in_bypass", False)
+        self.enable_runout_in_bypass = config.getboolean("enable_runout_in_bypass", False)
         self.debounce_delay         = config.getfloat("debounce_delay",         0.)
 
         self.td1_when_loaded        = config.getboolean("capture_td1_when_loaded", False)

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -262,6 +262,7 @@ class afc:
         self.enable_assist_weight   = config.getfloat("enable_assist_weight",   500.0)
         self.enable_hub_runout      = config.getboolean("enable_hub_runout",    True)
         self.enable_tool_runout     = config.getboolean("enable_tool_runout",   True)
+        self.disable_tool_runout_in_bypass = config.getboolean("disable_tool_runout_in_bypass", False)
         self.debounce_delay         = config.getfloat("debounce_delay",         0.)
 
         self.td1_when_loaded        = config.getboolean("capture_td1_when_loaded", False)

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -233,7 +233,7 @@ class AFCExtruder:
         self.buffer_name                = config.get('buffer', None)                                                    # Buffer to use for extruder, this variable can be overridden per lane
         self.enable_sensors_in_gui      = config.getboolean("enable_sensors_in_gui",    self.afc.enable_sensors_in_gui) # Set to True toolhead sensors switches as filament sensors in mainsail/fluidd gui, overrides value set in AFC.cfg
         self.enable_runout              = config.getboolean("enable_tool_runout",       self.afc.enable_tool_runout)
-        self.disable_runout_in_bypass   = config.getboolean("disable_tool_runout_in_bypass", self.afc.disable_tool_runout_in_bypass)
+        self.enable_runout_in_bypass    = config.getboolean("enable_runout_in_bypass", self.afc.enable_runout_in_bypass)
         self.debounce_delay             = config.getfloat("debounce_delay",             self.afc.debounce_delay)
         self.deadband                   = config.getfloat("deadband", 2)                                                # Deadband for extruder heater, default is 2 degrees Celsius
         self.toolchange_temp_drop: float = config.getfloat("toolchange_temp_drop",    self.afc.toolchange_temp_drop)  # Degrees to drop this extruder's temperature after it is the old extruder in a toolchange. Overrides global toolchange_temp_drop in AFC.cfg
@@ -492,6 +492,8 @@ class AFCExtruder:
         """
         Handles runout detection at the toolhead sensors (tool_start or tool_end).
         Notifies the currently loaded lane if filament is missing at the toolhead sensor.
+        If no lane is loaded (bypass/manual printing mode) and enable_runout_in_bypass
+        is set to True, raises an AFC error and pauses the print while printing.
         :param state: Boolean indicating sensor state (True = filament present, False = runout)
         :param sensor_name: Name of the triggering sensor ("tool_start" or "tool_end")
         """
@@ -501,7 +503,8 @@ class AFCExtruder:
                 lane = self.lanes[self.lane_loaded]
                 if hasattr(lane, "handle_toolhead_runout"):
                     lane.handle_toolhead_runout(sensor=sensor_name)
-            elif not self.disable_runout_in_bypass and self.afc.function.is_printing():
+            elif (self.enable_runout_in_bypass
+                  and self.afc.function.is_printing()):
                 # We are printing, but no lane is loaded (bypass/manual printing mode).
                 # Trigger an AFC error and pause the print.
                 msg = f"Toolhead runout detected by {sensor_name} sensor in bypass/manual mode."

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -509,8 +509,14 @@ class AFCExtruder:
                   and not self.afc.error_state
                   and self.on_shuttle()
                   and self.afc.function.is_printing()):
-                # We are printing, but no lane is loaded (bypass/manual printing mode).
-                # Trigger an AFC error and pause the print.
+                # We are printing in bypass/manual mode (no lane is loaded).
+                # Only pause the print if:
+                #   1. Toolhead runout is globally enabled (enable_runout).
+                #   2. Bypass runout protection is explicitly enabled (enable_runout_in_bypass).
+                #   3. We are NOT in a toolchange sequence (which would cause false pauses during unloads).
+                #   4. We are NOT already in an error state (prevents duplicate pauses during async transitions).
+                #   5. The toolhead is active on the shuttle (prevents docked/parked toolheads from pausing in multi-tool setups).
+                #   6. The printer is actively printing.
                 msg = f"Toolhead runout detected by {sensor_name} sensor in bypass/manual mode."
                 self.afc.error.AFC_error(msg)
 

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -233,6 +233,7 @@ class AFCExtruder:
         self.buffer_name                = config.get('buffer', None)                                                    # Buffer to use for extruder, this variable can be overridden per lane
         self.enable_sensors_in_gui      = config.getboolean("enable_sensors_in_gui",    self.afc.enable_sensors_in_gui) # Set to True toolhead sensors switches as filament sensors in mainsail/fluidd gui, overrides value set in AFC.cfg
         self.enable_runout              = config.getboolean("enable_tool_runout",       self.afc.enable_tool_runout)
+        self.disable_runout_in_bypass   = config.getboolean("disable_tool_runout_in_bypass", self.afc.disable_tool_runout_in_bypass)
         self.debounce_delay             = config.getfloat("debounce_delay",             self.afc.debounce_delay)
         self.deadband                   = config.getfloat("deadband", 2)                                                # Deadband for extruder heater, default is 2 degrees Celsius
         self.toolchange_temp_drop: float = config.getfloat("toolchange_temp_drop",    self.afc.toolchange_temp_drop)  # Degrees to drop this extruder's temperature after it is the old extruder in a toolchange. Overrides global toolchange_temp_drop in AFC.cfg
@@ -495,10 +496,16 @@ class AFCExtruder:
         :param sensor_name: Name of the triggering sensor ("tool_start" or "tool_end")
         """
         # Notify the currently loaded lane if filament is missing at toolhead
-        if not state and self.lane_loaded and self.lane_loaded in self.lanes:
-            lane = self.lanes[self.lane_loaded]
-            if hasattr(lane, "handle_toolhead_runout"):
-                lane.handle_toolhead_runout(sensor=sensor_name)
+        if not state:
+            if self.lane_loaded and self.lane_loaded in self.lanes:
+                lane = self.lanes[self.lane_loaded]
+                if hasattr(lane, "handle_toolhead_runout"):
+                    lane.handle_toolhead_runout(sensor=sensor_name)
+            elif not self.disable_runout_in_bypass and self.afc.function.is_printing():
+                # We are printing, but no lane is loaded (bypass/manual printing mode).
+                # Trigger an AFC error and pause the print.
+                msg = f"Toolhead runout detected by {sensor_name} sensor in bypass/manual mode."
+                self.afc.error.AFC_error(msg)
 
     def handle_start_runout( self, eventtime):
         """

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -503,7 +503,11 @@ class AFCExtruder:
                 lane = self.lanes[self.lane_loaded]
                 if hasattr(lane, "handle_toolhead_runout"):
                     lane.handle_toolhead_runout(sensor=sensor_name)
-            elif (self.enable_runout_in_bypass
+            elif (self.enable_runout
+                  and self.enable_runout_in_bypass
+                  and not self.afc.in_toolchange
+                  and not self.afc.error_state
+                  and self.on_shuttle()
                   and self.afc.function.is_printing()):
                 # We are printing, but no lane is loaded (bypass/manual printing mode).
                 # Trigger an AFC error and pause the print.

--- a/templates/u1_macros/AFC.cfg
+++ b/templates/u1_macros/AFC.cfg
@@ -26,6 +26,7 @@ load_to_hub: True               # Fast loads filament to hub when inserted, set 
 
 assisted_unload: True           # If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool. This is a global setting and can be overridden at the unit and stepper level.
 #pause_when_bypass_active: True  # When True AFC pauses print when change tool is called and bypass is loaded
+#disable_tool_runout_in_bypass: False # When True, AFC will not pause print when toolhead sensor runout is triggered in bypass/manual mode
 #unload_on_runout: True          # When True AFC will unload lane and then pause when runout is triggered and spool to swap to is not set(infinite spool)
 #print_short_stats: True          # Set to true to print AFC_STATS in short form instead of wide form, printing short form is better for consoles that are small in width
 #debug: True                     # Setting to True turns on more debugging to show on console

--- a/templates/u1_macros/AFC.cfg
+++ b/templates/u1_macros/AFC.cfg
@@ -26,7 +26,7 @@ load_to_hub: True               # Fast loads filament to hub when inserted, set 
 
 assisted_unload: True           # If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool. This is a global setting and can be overridden at the unit and stepper level.
 #pause_when_bypass_active: True  # When True AFC pauses print when change tool is called and bypass is loaded
-#disable_tool_runout_in_bypass: False # When True, AFC will not pause print when toolhead sensor runout is triggered in bypass/manual mode
+#enable_runout_in_bypass: False     # When True, AFC will pause print when toolhead sensor runout is triggered in bypass/manual mode
 #unload_on_runout: True          # When True AFC will unload lane and then pause when runout is triggered and spool to swap to is not set(infinite spool)
 #print_short_stats: True          # Set to true to print AFC_STATS in short form instead of wide form, printing short form is better for consoles that are small in width
 #debug: True                     # Setting to True turns on more debugging to show on console

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -368,6 +368,8 @@ class MockAFC:
         self.enable_sensors_in_gui = False
         self.debounce_delay = 0.1
         self.enable_hub_runout = False
+        self.enable_tool_runout = True
+        self.disable_tool_runout_in_bypass = False
         self.show_macros = True
         self.message_queue: list = []
         self.log_frame_data = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -369,7 +369,7 @@ class MockAFC:
         self.debounce_delay = 0.1
         self.enable_hub_runout = False
         self.enable_tool_runout = True
-        self.disable_tool_runout_in_bypass = False
+        self.enable_runout_in_bypass = False
         self.show_macros = True
         self.message_queue: list = []
         self.log_frame_data = True

--- a/tests/test_AFC_extruder.py
+++ b/tests/test_AFC_extruder.py
@@ -241,6 +241,8 @@ def _make_afc_extruder(name="extruder"):
     ext.tool_unload_speed = 25.0
     ext.tool_load_speed = 25.0
     ext.buffer_name = None
+    ext.enable_runout = True
+    ext.disable_runout_in_bypass = False
     ext.common_save_msg = f"\nRun SAVE_EXTRUDER_VALUES EXTRUDER={name} once done."
     ext.estats = MagicMock()
     ext.function = afc.function

--- a/tests/test_AFC_extruder.py
+++ b/tests/test_AFC_extruder.py
@@ -242,7 +242,7 @@ def _make_afc_extruder(name="extruder"):
     ext.tool_load_speed = 25.0
     ext.buffer_name = None
     ext.enable_runout = True
-    ext.disable_runout_in_bypass = False
+    ext.enable_runout_in_bypass = False
     ext.common_save_msg = f"\nRun SAVE_EXTRUDER_VALUES EXTRUDER={name} once done."
     ext.estats = MagicMock()
     ext.function = afc.function
@@ -399,6 +399,24 @@ class TestHandleToolheadSensorRunout:
         ext.lane_loaded = None
         ext._handle_toolhead_sensor_runout(False, "tool_start")
         lane.handle_toolhead_runout.assert_not_called()
+
+    def test_bypass_runout_does_not_pause_when_disabled_by_default(self):
+        ext = _make_afc_extruder()
+        ext.lane_loaded = None
+        ext.enable_runout_in_bypass = False
+        ext.afc.function.is_printing.return_value = True
+        ext._handle_toolhead_sensor_runout(False, "tool_start")
+        ext.afc.error.AFC_error.assert_not_called()
+
+    def test_bypass_runout_pauses_when_enabled(self):
+        ext = _make_afc_extruder()
+        ext.lane_loaded = None
+        ext.enable_runout_in_bypass = True
+        ext.afc.function.is_printing.return_value = True
+        ext._handle_toolhead_sensor_runout(False, "tool_start")
+        ext.afc.error.AFC_error.assert_called_once_with(
+            "Toolhead runout detected by tool_start sensor in bypass/manual mode."
+        )
 
     def test_no_runout_when_lane_not_in_lanes_dict(self):
         ext = _make_afc_extruder()

--- a/tests/test_AFC_extruder.py
+++ b/tests/test_AFC_extruder.py
@@ -418,6 +418,33 @@ class TestHandleToolheadSensorRunout:
             "Toolhead runout detected by tool_start sensor in bypass/manual mode."
         )
 
+    def test_bypass_runout_does_not_pause_during_toolchange(self):
+        ext = _make_afc_extruder()
+        ext.lane_loaded = None
+        ext.enable_runout_in_bypass = True
+        ext.afc.in_toolchange = True
+        ext.afc.function.is_printing.return_value = True
+        ext._handle_toolhead_sensor_runout(False, "tool_start")
+        ext.afc.error.AFC_error.assert_not_called()
+
+    def test_bypass_runout_does_not_pause_during_error_state(self):
+        ext = _make_afc_extruder()
+        ext.lane_loaded = None
+        ext.enable_runout_in_bypass = True
+        ext.afc.error_state = True
+        ext.afc.function.is_printing.return_value = True
+        ext._handle_toolhead_sensor_runout(False, "tool_start")
+        ext.afc.error.AFC_error.assert_not_called()
+
+    def test_bypass_runout_does_not_pause_when_not_on_shuttle(self):
+        ext = _make_afc_extruder()
+        ext.lane_loaded = None
+        ext.enable_runout_in_bypass = True
+        ext.on_shuttle = MagicMock(return_value=False)
+        ext.afc.function.is_printing.return_value = True
+        ext._handle_toolhead_sensor_runout(False, "tool_start")
+        ext.afc.error.AFC_error.assert_not_called()
+
     def test_no_runout_when_lane_not_in_lanes_dict(self):
         ext = _make_afc_extruder()
         ext.lanes = {}


### PR DESCRIPTION
## Major Changes in this PR

This adds support to enable on filament runnout detection on toolhead sensors in bypass mode.

* **Added `enable_runout_in_bypass` Option**: Introduces a new configuration parameter `enable_runout_in_bypass` (defaulting to `False`). When set to `True`, it   
  allows the toolhead filament sensor(s) to trigger a print pause if a runout occurs while printing in bypass/manual mode.
* **Robust State Guards for Bypass Runout**: Added safety guards to the toolhead runout handler to ensure we only pause during active bypass prints:
    * **`not self.afc.in_toolchange`**: Suppresses runout triggers during toolchange unloads (preventing false pauses).
    * **`not self.afc.error_state`**: Prevents duplicate pause commands during the asynchronous transition when the print is already pausing.
    * **`self.on_shuttle()`**: Ensures parked/inactive toolheads in multi-tool configurations do not trigger runout pauses while the active toolhead is printing. 


## Notes to Code Reviewers

## How the changes in this PR are tested

- Unit tests updated and ran
- Tested on a Box Turtle

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Documentation updated in AT-Documentation repository: https://github.com/AFCProject/Documentation/pull/18
- [ ] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added `enable_runout_in_bypass` configuration option to control whether toolhead sensor runout triggers pausing in bypass/manual mode (default: disabled).

- **Bug Fixes**
  - Prevented unexpected runout pausing in bypass/manual mode unless `enable_runout_in_bypass` is explicitly enabled during active printing.
  
- **Documentation**
  - Updated `CHANGELOG.md` and AFC configuration to document the new option and behavior.

- **Tests**
  - Expanded unit tests to cover runout handling in bypass/manual printing vs. toolchange and error/idle states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->