### PR TITLE
(feat): Added ability to use AFC load sequence with Snapmaker U1 side feeders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,9 +13,41 @@
    surrounding file's conventions rather than imposing a different style.
 - **Correct typing** — including things like `Optional[float]` instead of
    `float = None`.
+- **Use f-strings, not `str.format()`** — `f"Lane {self.name}"` rather than
+   `"Lane {}".format(self.name)`.
+- **Format error/exception strings before raising, not inline** — build the
+   message into a variable first, then raise it as its own statement, rather
+   than constructing the string inside the `raise` call.
+
+   ```python
+   # Bad
+   raise error(f"Lane {self.name}: [filament_feed {self.feed_module}] not found")
+
+   # Good
+   error_str = f"Lane {self.name}: [filament_feed {self.feed_module}] not found"
+   raise error(error_str)
+   ```
 - **Keep comments short and succinct** — a sentence or two at most. Comments
    still need to make sense to the developer reading them, just don't let
    them turn into paragraphs.
+- **Docstring every method** — a short summary line, then a `:param name:`
+   line for each parameter and a `:return type:` (or `:return:`) line for any
+   non-`None` return value, matching the Sphinx-style convention already used
+   throughout `extras/` (e.g. `AFC_lane.py`, `AFC_assist.py`). Skip the
+   `:return:` line when the method returns `None`. A method that raises uses
+   a plain `raises error if ...` line rather than a `:raises:` tag, matching
+   existing convention.
+
+   ```python
+   def _feed_channel_present(self):
+       """
+       Checks whether the feeder currently reports filament present in this
+       lane's channel.
+
+       :return bool: True when the feeder reports filament present, False if
+                     absent, not found, or the feeder can't be queried
+       """
+   ```
 - **All new code needs unit tests** — any code added must come with unit
    tests that follow the Unit Test Rules below.
 
@@ -44,6 +76,15 @@
    for something like `if A and B:`, there need to be tests proving A alone
    can't satisfy the condition and B alone can't either, not just one test
    where both happen to be true together.
+- **One test class per method** — every method on the class under test needs
+   its own dedicated test class (or clearly delimited section for
+   module-level functions), named after the method
+   (`_apply_staged` → `TestAFCU1LaneApplyStaged`). This makes it possible to
+   scan a test file and immediately see which methods have no coverage at
+   all, rather than relying on line/branch coverage tooling alone — a method
+   invoked only as a side effect of testing a caller can hit 100% branch
+   coverage while never being independently verified. When a method gains a
+   new method (or a class gains one), add its test class in the same change.
 - **No `__new__` bypass for construction** — build test objects through the
    real `__init__` (mocking dependencies like config/printer/reactor as
    needed), rather than using `SomeClass.__new__(SomeClass)` and hand-setting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-07-19]
+## Added
+- Ability to use Snapmaker U1 side feeders to load filament to toolhead through AFC
+
 ## [2026-07-18]
 ### Fixed
 - Issue where assist move would crash klipper if user didn't define `afc_motor_fwd` variable

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -38,7 +38,7 @@ except: raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".f
 try: from extras.AFC_utils import add_filament_switch
 except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.format_exc()))
 
-try: from extras.AFC_lane import AFCLane
+try: from extras.AFC_lane import AFCLane, AFCU1Lane
 except: raise error(ERROR_STR.format(import_lib="AFC_lane", trace=traceback.format_exc()))
 
 try: from extras.AFC import AFCLaneState
@@ -327,7 +327,10 @@ class AFCExtruder:
             config.fileconfig.set(config.section, "extruder", self.name)
             config.fileconfig.set(config.section, "hub", "direct")
             config.fileconfig.set(config.section, "standalone", "True")
-            self.tc_lane = AFCLane(config)
+            if self.afc.snapmaker_printer:
+                self.tc_lane = AFCU1Lane(config)
+            else:
+                self.tc_lane = AFCLane(config)
             self.printer.objects[f"AFC_lane {self.name}"] = self.tc_lane
             # TODO: Once homing is in create common function for this and AFC_stepper
 
@@ -570,7 +573,18 @@ class AFCExtruder:
                     if (self.tc_lane._afc_prep_done
                         and not actively_printing):
                         if state:
-                            if not self.load_active:
+                            # A extruder config with a custom_load_cmd drives the entire
+                            # load including the tool_stn advance to the nozzle
+                            # and should also return temp back to starting temp.
+                            #
+                            # This check is mainly for users that have a U1 printer and want to have
+                            # their standalone extruder still automatically load into the toolhead.
+                            #
+                            # If this did not exist then an automatic load without this can crash
+                            # klipper since more than one thing is trying to control the toolhead
+                            # extruder at once.
+                            if (not self.load_active
+                                and not getattr(self.tc_lane, 'custom_load_cmd', None)):
                                 self.load_unload_sequence(self.tool_stn)
                         else:
                             self.tc_lane.set_tool_unloaded()

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -2159,5 +2159,110 @@ class AFCLane:
 
         return response
 
+class AFCU1Lane(AFCLane):
+    def __init__(self, config):
+        super().__init__(config)
+
+        # ── External-feeder prep/load source (standalone lanes, e.g. U1) ──────
+        # A standalone/direct lane has no AFC prep or load switch; an external
+        # feeder module (the U1 `[filament_feed left|right]`) reports filament
+        # presence per channel via get_status. Point feed_module + feed_channel
+        # at that module's status channel and this lane mirrors the feeder's
+        # presence into prep_state/_load_state so AFC sees the lane as
+        # loaded-and-ready — TOOL_LOAD then proceeds and runs custom_load_cmd to
+        # drive the final leg to the toolhead sensor, instead of bailing out as
+        # an empty lane. We trust the feeder to stage the filament correctly, so
+        # a present channel is treated as ready with no wait for preload_finish.
+        self.feed_module  = config.get('feed_module', None)    # 'left' or 'right'
+        self.feed_channel = config.get('feed_channel', None)   # AFC extruder name ('e1') or raw feeder key ('extruder1')
+        self._feed_obj = None
+        self._feed_ch_index = None       # int channel index the feeder event carries
+        self._feed_staged_last = None
+        if (self.feed_module
+            and self.feed_channel):
+            # State is driven by the feeder, not the (absent) load switch.
+            self._load_state = False
+
+    def _handle_ready(self):
+        super()._handle_ready()
+        # Wire up the external-feeder prep/load source for standalone lanes.
+        # The U1 feeder announces filament *presence* changes via the
+        # "filament_feed:port" event. We trust the feeder to stage the filament
+        # correctly, so both edges come straight from that event — presence
+        # marks the lane ready, absence marks it empty — with no stage-watch
+        # timer bridging up to preload_finish.
+        if (self.feed_module
+            and self.feed_channel):
+            self._feed_obj = self.printer.lookup_object(f"filament_feed {self.feed_module}", None)
+            if self._feed_obj is None:
+                error_str = (f"Lane {self.name}: [filament_feed {self.feed_module}] not found for "
+                            "feed_module")
+                raise error(error_str)
+            # feed_channel may be given as an AFC extruder name (e.g. 'e2') or as
+            # the raw feeder channel key ('extruder2'). If it names an
+            # AFC_extruder, resolve to that extruder's physical channel key —
+            # 'extruder<index>', which is how filament_feed keys its channels
+            # (note e0 -> 'extruder0' even though its klipper extruder is
+            # 'extruder'). A raw key that isn't an AFC_extruder is used as-is.
+            ext_obj = self.printer.lookup_object( "AFC_extruder {}".format(self.feed_channel), None)
+            if ext_obj is not None:
+                kext = getattr(ext_obj, 'toolhead_extruder', None)
+                idx = getattr(kext, 'extruder_index', None)
+                if idx is None:
+                    suffix = getattr(ext_obj, 'th_extruder_name', 'extruder')[len('extruder'):]
+                    idx = int(suffix) if suffix.isdigit() else 0
+                self.feed_channel = f"extruder{idx}"
+            # Integer channel index the feeder passes with its event.
+            suffix = self.feed_channel[len('extruder'):]
+            self._feed_ch_index = int(suffix) if suffix.isdigit() else None
+            self.printer.register_event_handler("filament_feed:port", self._feed_port_event)
+            # Seed from the current feeder state — no event fires for filament
+            # that is already present at startup.
+            self._feed_reevaluate()
+
+    def _feed_channel_present(self):
+        """
+        True when the feeder reports filament present in this lane's channel.
+        We trust the feeder to have staged it correctly, so presence alone is
+        enough to read the lane as ready — regardless of channel_state.
+        """
+        try:
+            ch = self._feed_obj.get_status(self.reactor.monotonic()).get(self.feed_channel, {})
+        except Exception:
+            return False
+        return ch.get('filament_detected') is True
+
+    def _feed_port_event(self, channel_index:int, detected: bool):
+        """
+        Feeder presence-change event ("filament_feed:port"). Fires for any
+        channel, so filter to ours when we know our index; then re-evaluate our
+        own channel from get_status rather than trusting the event's args.
+        """
+        if (self._feed_ch_index is not None
+            and channel_index != self._feed_ch_index):
+            return
+        self._apply_staged(detected)
+
+    def _feed_reevaluate(self):
+        """
+        Reconcile mirrored prep/load state to the feeder channel right now:
+        present: mark loaded-and-ready
+        absent: mark empty.
+        """
+        self._apply_staged(self._feed_channel_present())
+
+    def _apply_staged(self, staged: bool):
+        """
+        Edge-guarded mirror of the feeder's presence into prep/load.
+        On the rising edge TOOL_LOAD becomes valid (custom_load_cmd then drives
+        the final leg to the toolhead sensor); on the falling edge the lane
+        reads empty again. Persists only on an actual change.
+        """
+        if staged != self._feed_staged_last:
+            self._feed_staged_last = staged
+            self.prep_state = staged
+            self._load_state = staged
+            self.afc.save_vars()
+
 def load_config_prefix(config):
     return AFCLane(config)

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -2160,37 +2160,44 @@ class AFCLane:
         return response
 
 class AFCU1Lane(AFCLane):
-    def __init__(self, config):
+    def __init__(self, config: ConfigWrapper):
+        """
+        Initializes lane and, for standalone U1 lanes with no AFC prep/load
+        switch, configures the external-feeder prep/load source and subscribes to
+        its presence events.
+
+        :param config: Klipper config object for this lane's config section
+        """
         super().__init__(config)
 
-        # ── External-feeder prep/load source (standalone lanes, e.g. U1) ──────
-        # A standalone/direct lane has no AFC prep or load switch; an external
-        # feeder module (the U1 `[filament_feed left|right]`) reports filament
-        # presence per channel via get_status. Point feed_module + feed_channel
-        # at that module's status channel and this lane mirrors the feeder's
-        # presence into prep_state/_load_state so AFC sees the lane as
-        # loaded-and-ready — TOOL_LOAD then proceeds and runs custom_load_cmd to
-        # drive the final leg to the toolhead sensor, instead of bailing out as
-        # an empty lane. We trust the feeder to stage the filament correctly, so
-        # a present channel is treated as ready with no wait for preload_finish.
-        self.feed_module  = config.get('feed_module', None)    # 'left' or 'right'
-        self.feed_channel = config.get('feed_channel', None)   # AFC extruder name ('e1') or raw feeder key ('extruder1')
+        # Standalone lanes (e.g. U1) have no AFC prep/load switch; an external
+        # feeder module ([filament_feed left|right]) reports filament presence
+        # per channel instead. feed_module/feed_channel point at that channel,
+        # and this lane mirrors the feeder's presence into prep_state/_load_state.
+
+        # 'left' or 'right'
+        self.feed_module  = config.get('feed_module', None)
+        # AFC extruder name ('e1') or raw feeder key ('extruder1')
+        self.feed_channel = config.get('feed_channel', None)
         self._feed_obj = None
         self._feed_ch_index = None       # int channel index the feeder event carries
         self._feed_staged_last = None
         if (self.feed_module
             and self.feed_channel):
-            # State is driven by the feeder, not the (absent) load switch.
-            self._load_state = False
+            self._load_state = False    # driven by the feeder, not a load switch
+            # Register event call back
+            self.printer.register_event_handler("filament_feed:port", self._feed_port_event)
 
     def _handle_ready(self):
+        """
+        Klippy ready callback. Runs base AFCLane setup, then resolves the
+        configured feeder module/channel and seeds prep/load state from its
+        current status.
+
+        raises error if feed_module/feed_channel are set but the
+        [filament_feed <feed_module>] object is not found
+        """
         super()._handle_ready()
-        # Wire up the external-feeder prep/load source for standalone lanes.
-        # The U1 feeder announces filament *presence* changes via the
-        # "filament_feed:port" event. We trust the feeder to stage the filament
-        # correctly, so both edges come straight from that event — presence
-        # marks the lane ready, absence marks it empty — with no stage-watch
-        # timer bridging up to preload_finish.
         if (self.feed_module
             and self.feed_channel):
             self._feed_obj = self.printer.lookup_object(f"filament_feed {self.feed_module}", None)
@@ -2198,13 +2205,10 @@ class AFCU1Lane(AFCLane):
                 error_str = (f"Lane {self.name}: [filament_feed {self.feed_module}] not found for "
                             "feed_module")
                 raise error(error_str)
-            # feed_channel may be given as an AFC extruder name (e.g. 'e2') or as
-            # the raw feeder channel key ('extruder2'). If it names an
-            # AFC_extruder, resolve to that extruder's physical channel key —
-            # 'extruder<index>', which is how filament_feed keys its channels
-            # (note e0 -> 'extruder0' even though its klipper extruder is
-            # 'extruder'). A raw key that isn't an AFC_extruder is used as-is.
-            ext_obj = self.printer.lookup_object( "AFC_extruder {}".format(self.feed_channel), None)
+            # feed_channel may name an AFC_extruder (e.g. 'e2'); resolve it to the
+            # feeder's channel key 'extruder<index>' (e0 -> 'extruder0'). A raw
+            # feeder key is used as-is.
+            ext_obj = self.printer.lookup_object(f"AFC_extruder {self.feed_channel}", None)
             if ext_obj is not None:
                 kext = getattr(ext_obj, 'toolhead_extruder', None)
                 idx = getattr(kext, 'extruder_index', None)
@@ -2212,19 +2216,17 @@ class AFCU1Lane(AFCLane):
                     suffix = getattr(ext_obj, 'th_extruder_name', 'extruder')[len('extruder'):]
                     idx = int(suffix) if suffix.isdigit() else 0
                 self.feed_channel = f"extruder{idx}"
-            # Integer channel index the feeder passes with its event.
             suffix = self.feed_channel[len('extruder'):]
             self._feed_ch_index = int(suffix) if suffix.isdigit() else None
-            self.printer.register_event_handler("filament_feed:port", self._feed_port_event)
-            # Seed from the current feeder state — no event fires for filament
-            # that is already present at startup.
-            self._feed_reevaluate()
+            self._feed_reevaluate()    # seed from current feeder state at startup
 
     def _feed_channel_present(self):
         """
-        True when the feeder reports filament present in this lane's channel.
-        We trust the feeder to have staged it correctly, so presence alone is
-        enough to read the lane as ready — regardless of channel_state.
+        Checks whether the feeder currently reports filament present in this
+        lane's channel.
+
+        :return bool: True when the feeder reports filament present, False if
+                      absent, not found, or the feeder can't be queried
         """
         try:
             ch = self._feed_obj.get_status(self.reactor.monotonic()).get(self.feed_channel, {})
@@ -2234,29 +2236,33 @@ class AFCU1Lane(AFCLane):
 
     def _feed_port_event(self, channel_index:int, detected: bool):
         """
-        Feeder presence-change event ("filament_feed:port"). Fires for any
-        channel, so filter to ours when we know our index; then re-evaluate our
-        own channel from get_status rather than trusting the event's args.
+        Callback for the feeder's "filament_feed:port" presence-change event.
+
+        :param channel_index: Feeder channel index the event fired for
+        :param detected: Presence flag from the event; unused, since presence
+                         is always re-read from the feeder's current status
         """
         if (self._feed_ch_index is not None
             and channel_index != self._feed_ch_index):
             return
+
+        self.afc.logger.debug(f"AFCU1Lane: feed_port_event: {self.name} {detected}")
         self._apply_staged(detected)
 
     def _feed_reevaluate(self):
         """
-        Reconcile mirrored prep/load state to the feeder channel right now:
-        present: mark loaded-and-ready
-        absent: mark empty.
+        Re-reads the feeder's current channel state and mirrors it into
+        prep_state/_load_state.
         """
         self._apply_staged(self._feed_channel_present())
 
     def _apply_staged(self, staged: bool):
         """
-        Edge-guarded mirror of the feeder's presence into prep/load.
-        On the rising edge TOOL_LOAD becomes valid (custom_load_cmd then drives
-        the final leg to the toolhead sensor); on the falling edge the lane
-        reads empty again. Persists only on an actual change.
+        Mirrors feeder presence into prep_state/_load_state, persisting the
+        change only when it differs from the last-applied state.
+
+        :param staged: True if the feeder channel currently has filament
+                       present, False if not
         """
         if staged != self._feed_staged_last:
             self._feed_staged_last = staged
@@ -2264,5 +2270,5 @@ class AFCU1Lane(AFCLane):
             self._load_state = staged
             self.afc.save_vars()
 
-def load_config_prefix(config):
+def load_config_prefix(config: ConfigWrapper):
     return AFCLane(config)

--- a/templates/AFC_Hardware_U1.cfg
+++ b/templates/AFC_Hardware_U1.cfg
@@ -16,6 +16,9 @@ custom_tool_swap : PICK_EXTRUDER
 custom_unselect : PARK_EXTRUDER
 u1_park_detector_name: extruder
 extruder_name: extruder
+custom_load_cmd: AFC_STANDALONE_LOAD_U1
+feed_module: left               # left feeder (e1/e0); use right for e2/e3
+feed_channel: e0                # the get_status channel key for this lane
 
 [AFC_extruder e1]
 #pin_tool_start: buffer
@@ -30,6 +33,9 @@ custom_tool_swap : PICK_EXTRUDER1
 custom_unselect : PARK_EXTRUDER1
 u1_park_detector_name: extruder1
 extruder_name: extruder1
+custom_load_cmd: AFC_STANDALONE_LOAD_U1
+feed_module: left               # left feeder (e1/e0); use right for e2/e3
+feed_channel: e1                # the get_status channel key for this lane
 
 [AFC_extruder e2]
 #pin_tool_start: buffer
@@ -44,6 +50,9 @@ custom_tool_swap : PICK_EXTRUDER2
 custom_unselect : PARK_EXTRUDER2
 u1_park_detector_name: extruder2
 extruder_name: extruder2
+custom_load_cmd: AFC_STANDALONE_LOAD_U1
+feed_module: right              # left feeder (e1/e0); use right for e2/e3
+feed_channel: e2                # the get_status channel key for this lane
 
 [AFC_extruder e3]
 #pin_tool_start: buffer
@@ -58,6 +67,9 @@ custom_tool_swap : PICK_EXTRUDER3
 custom_unselect : PARK_EXTRUDER3
 u1_park_detector_name: extruder3
 extruder_name: extruder3
+custom_load_cmd: AFC_STANDALONE_LOAD_U1
+feed_module: right              # left feeder (e1/e0); use right for e2/e3
+feed_channel: e3                # the get_status channel key for this lane
 
 #[filament_switch_sensor bypass]
 #switch_pin: turtleneck:PB5

--- a/templates/u1_macros/Snapmaker_macros.cfg
+++ b/templates/u1_macros/Snapmaker_macros.cfg
@@ -67,3 +67,19 @@ gcode:
     INNER_CUTOFF_BASE_DISCARD
     INNER_ROUGHLY_CLEAN_NOZZLE_BASE_DISCARD ACTION={action}
     INNER_DISCARD_FILAMENT_BASE_DISCARD
+
+[gcode_macro AFC_STANDALONE_LOAD_U1]
+description: Standalone lane load — drive U1 feeder to nozzle (FEED_AUTO owns the state)
+gcode:
+    # Capture the AFC-set temp BEFORE FEED_AUTO (it turns the heater off at the end)
+    {% set ext_name   = printer.toolhead.extruder %}
+    {% set saved_temp = printer[ext_name].target | float %}
+    {% set ext        = printer[ext_name].extruder_index | int %}
+    {% set ffv        = printer['gcode_macro _FILAMENT_FEED_VARIABLE'] %}
+    {% set module     = ffv.module_sequence[ext] %}
+    {% set channel    = ffv.channel_sequence[ext] %}
+    FEED_AUTO MODULE={module} CHANNEL={channel} LOAD=1
+    # Restore the extruder target FEED_AUTO cleared, so the heater isn't left off
+    {% if saved_temp > 0 %}
+    SET_HEATER_TEMPERATURE HEATER={ext_name} TARGET={saved_temp}
+    {% endif %}

--- a/tests/test_AFC_extruder.py
+++ b/tests/test_AFC_extruder.py
@@ -974,6 +974,7 @@ def _make_ext_for_tool_start(name="extruder"):
     tc_lane._load_state   = False
     tc_lane.prep_state    = False
     tc_lane._afc_prep_done = False
+    tc_lane.custom_load_cmd = None
     ext.tc_lane           = tc_lane
 
     return ext
@@ -1008,6 +1009,12 @@ class TestToolStartCallback_StateUnchanged:
     def test_load_unload_sequence_not_called_when_state_unchanged(self):
         ext = _make_ext_for_tool_start()
         ext.tool_start_state = False
+        ext.tool_start_callback(100.0, False)
+        ext.load_unload_sequence.assert_not_called()
+    
+    def test_load_unload_sequence_not_called_when_lane_custom_load_cmd_is_not_none(self):
+        ext = _make_ext_for_tool_start()
+        ext.tc_lane.custom_load_cmd = "CUSTOM_COMMAND"
         ext.tool_start_callback(100.0, False)
         ext.load_unload_sequence.assert_not_called()
 

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -12,7 +12,7 @@ Covers:
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 import pytest
 
 from extras.AFC_lane import (
@@ -22,6 +22,7 @@ from extras.AFC_lane import (
     AFCLaneState,
     AFCHomingPoints,
     AFCLane,
+    AFCU1Lane,
     EXCLUDE_TYPES,
     AFCMoveWarning
 )
@@ -1717,3 +1718,483 @@ class TestPerformInfiniteRunout:
         assert afc.lanes.get.call_count == 2
         assert lane2.status is AFCLaneState.INFINITE_RUNOUT
         lane.gcode.run_script_from_command.assert_not_called()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# AFCU1Lane — external-feeder standalone lane (e.g. U1 side feeders)
+# ══════════════════════════════════════════════════════════════════════════════
+#
+# AFCU1Lane mirrors an external `[filament_feed left|right]` module's per-channel
+# filament presence into the lane's prep_state/_load_state so AFC reads the lane
+# as loaded-and-ready. Instances below are built through the real __init__ chain
+# (MockConfig/MockPrinter/MockAFC). Using "AFC_stepper" as the config section
+# name makes AFCLane.__init__ take its early-return path (no stepper/hub/buffer/
+# extruder pins configured), which keeps construction lightweight while still
+# running every line of real constructor logic AFCU1Lane depends on.
+
+from tests.conftest import MockReactor, MockConfig, MockPrinter
+
+
+def _make_u1_config(feed_module="left", feed_channel="extruder1",
+                    fullname="AFC_stepper lane1", extra_values=None):
+    """Build a MockConfig wired for AFCU1Lane's real __init__ chain."""
+    values = {"unit": "Turtle_1:0"}
+    if feed_module is not None:
+        values["feed_module"] = feed_module
+    if feed_channel is not None:
+        values["feed_channel"] = feed_channel
+    if extra_values:
+        values.update(extra_values)
+    afc = MockAFC()
+    afc.load_to_hub = False
+    printer = MockPrinter(afc=afc)
+    return MockConfig(name=fullname, printer=printer, values=values)
+
+
+def _make_afcu1_lane(feed_module="left", feed_channel="extruder1",
+                     fullname="AFC_stepper lane1", extra_values=None):
+    """Build an AFCU1Lane through its real __init__ chain."""
+    config = _make_u1_config(feed_module, feed_channel, fullname, extra_values)
+    return AFCU1Lane(config)
+
+
+# ── __init__ ──────────────────────────────────────────────────────────────────
+
+class TestAFCU1LaneInit:
+    def test_feed_module_read_from_config(self):
+        lane = _make_afcu1_lane(feed_module="left", feed_channel="e1")
+        assert lane.feed_module == "left"
+
+    def test_feed_channel_read_from_config(self):
+        lane = _make_afcu1_lane(feed_module="right", feed_channel="e2")
+        assert lane.feed_channel == "e2"
+
+    def test_feed_obj_starts_none(self):
+        lane = _make_afcu1_lane(feed_module="left", feed_channel="e1")
+        assert lane._feed_obj is None
+
+    def test_feed_ch_index_starts_none(self):
+        lane = _make_afcu1_lane(feed_module="left", feed_channel="e1")
+        assert lane._feed_ch_index is None
+
+    def test_feed_staged_last_starts_none(self):
+        lane = _make_afcu1_lane(feed_module="left", feed_channel="e1")
+        assert lane._feed_staged_last is None
+
+    def test_load_state_forced_false_when_feed_configured(self):
+        """A fully-configured feeder lane is driven by the feeder, so the
+        (absent) load switch state is seeded False instead of the AFCLane
+        default of True (no load pin configured)."""
+        lane = _make_afcu1_lane(feed_module="left", feed_channel="e1")
+        assert lane._load_state is False
+
+    def test_feed_module_none_when_unconfigured(self):
+        lane = _make_afcu1_lane(feed_module=None, feed_channel=None)
+        assert lane.feed_module is None
+
+    def test_feed_channel_none_when_unconfigured(self):
+        lane = _make_afcu1_lane(feed_module=None, feed_channel=None)
+        assert lane.feed_channel is None
+
+    def test_load_state_default_true_when_fully_unconfigured(self):
+        """Baseline AFCLane behavior (no load switch pin) is untouched when
+        neither feed_module nor feed_channel is set."""
+        lane = _make_afcu1_lane(feed_module=None, feed_channel=None)
+        assert lane._load_state is True
+
+    def test_load_state_not_overridden_when_only_module_configured(self):
+        """feed_module alone must not satisfy the guard."""
+        lane = _make_afcu1_lane(feed_module="left", feed_channel=None)
+        assert lane._load_state is True
+
+    def test_load_state_not_overridden_when_only_channel_configured(self):
+        """feed_channel alone must not satisfy the guard."""
+        lane = _make_afcu1_lane(feed_module=None, feed_channel="e1")
+        assert lane._load_state is True
+
+    def test_registers_port_event_handler_when_feed_configured(self):
+        lane = _make_afcu1_lane(feed_module="left", feed_channel="e1")
+        assert lane.printer._event_handlers["filament_feed:port"] == [lane._feed_port_event]
+
+    def test_no_port_event_handler_when_fully_unconfigured(self):
+        lane = _make_afcu1_lane(feed_module=None, feed_channel=None)
+        assert "filament_feed:port" not in lane.printer._event_handlers
+
+    def test_no_port_event_handler_when_only_module_configured(self):
+        lane = _make_afcu1_lane(feed_module="left", feed_channel=None)
+        assert "filament_feed:port" not in lane.printer._event_handlers
+
+    def test_no_port_event_handler_when_only_channel_configured(self):
+        lane = _make_afcu1_lane(feed_module=None, feed_channel="e1")
+        assert "filament_feed:port" not in lane.printer._event_handlers
+
+
+# ── _apply_staged ─────────────────────────────────────────────────────────────
+
+class TestAFCU1LaneApplyStaged:
+    def test_rising_edge_marks_loaded(self):
+        lane = _make_afcu1_lane()
+        lane._feed_staged_last = False
+        lane._apply_staged(True)
+        assert lane.prep_state is True
+        assert lane._load_state is True
+
+    def test_rising_edge_updates_last(self):
+        lane = _make_afcu1_lane()
+        lane._feed_staged_last = False
+        lane._apply_staged(True)
+        assert lane._feed_staged_last is True
+
+    def test_rising_edge_persists(self):
+        lane = _make_afcu1_lane()
+        lane._feed_staged_last = False
+        lane._apply_staged(True)
+        lane.afc.save_vars.assert_called_once()
+
+    def test_falling_edge_marks_empty(self):
+        lane = _make_afcu1_lane()
+        lane._feed_staged_last = True
+        lane.prep_state = True
+        lane._load_state = True
+        lane._apply_staged(False)
+        assert lane.prep_state is False
+        assert lane._load_state is False
+
+    def test_no_change_does_not_persist(self):
+        """Re-applying the same state must not write vars again."""
+        lane = _make_afcu1_lane()
+        lane._feed_staged_last = True
+        lane._apply_staged(True)
+        lane.afc.save_vars.assert_not_called()
+
+    def test_no_change_leaves_last_untouched(self):
+        lane = _make_afcu1_lane()
+        lane._feed_staged_last = True
+        lane._apply_staged(True)
+        assert lane._feed_staged_last is True
+
+    def test_first_apply_from_none_persists(self):
+        """Initial state is None, so even a False first reading is an edge."""
+        lane = _make_afcu1_lane()
+        lane._feed_staged_last = None
+        lane._apply_staged(False)
+        assert lane._feed_staged_last is False
+        lane.afc.save_vars.assert_called_once()
+
+
+# ── _feed_channel_present ─────────────────────────────────────────────────────
+
+class TestAFCU1LaneFeedChannelPresent:
+    def test_true_when_channel_detected(self):
+        lane = _make_afcu1_lane(feed_channel="extruder1")
+        lane._feed_obj = MagicMock()
+        lane._feed_obj.get_status.return_value = {
+            "extruder1": {"filament_detected": True},
+        }
+        assert lane._feed_channel_present() is True
+
+    def test_false_when_channel_not_detected(self):
+        lane = _make_afcu1_lane(feed_channel="extruder1")
+        lane._feed_obj = MagicMock()
+        lane._feed_obj.get_status.return_value = {
+            "extruder1": {"filament_detected": False},
+        }
+        assert lane._feed_channel_present() is False
+
+    def test_false_when_channel_missing(self):
+        lane = _make_afcu1_lane(feed_channel="extruder1")
+        lane._feed_obj = MagicMock()
+        lane._feed_obj.get_status.return_value = {"extruder0": {"filament_detected": True}}
+        assert lane._feed_channel_present() is False
+
+    def test_false_when_detected_key_absent(self):
+        lane = _make_afcu1_lane(feed_channel="extruder1")
+        lane._feed_obj = MagicMock()
+        lane._feed_obj.get_status.return_value = {"extruder1": {}}
+        assert lane._feed_channel_present() is False
+
+    def test_non_true_value_is_false(self):
+        """Only a literal True counts as present."""
+        lane = _make_afcu1_lane(feed_channel="extruder1")
+        lane._feed_obj = MagicMock()
+        lane._feed_obj.get_status.return_value = {"extruder1": {"filament_detected": 1}}
+        assert lane._feed_channel_present() is False
+
+    def test_false_when_get_status_raises(self):
+        lane = _make_afcu1_lane(feed_channel="extruder1")
+        lane._feed_obj = MagicMock()
+        lane._feed_obj.get_status.side_effect = RuntimeError("boom")
+        assert lane._feed_channel_present() is False
+
+    def test_false_when_feed_obj_none(self):
+        lane = _make_afcu1_lane(feed_channel="extruder1")
+        lane._feed_obj = None
+        assert lane._feed_channel_present() is False
+
+    def test_queries_status_at_current_monotonic(self):
+        lane = _make_afcu1_lane(feed_channel="extruder1")
+        lane._feed_obj = MagicMock()
+        lane._feed_obj.get_status.return_value = {"extruder1": {"filament_detected": True}}
+        lane._feed_channel_present()
+        lane._feed_obj.get_status.assert_called_once_with(lane.reactor.monotonic())
+
+
+# ── _feed_reevaluate ──────────────────────────────────────────────────────────
+
+class TestAFCU1LaneFeedReevaluate:
+    """_feed_reevaluate is _feed_channel_present() piped straight into
+    _apply_staged(); exercised end-to-end via the real feeder-object contract
+    rather than mocking either sub-method, so the assertions prove the actual
+    prep_state/_load_state outcome, not just that some method was invoked."""
+
+    def test_present_marks_loaded(self):
+        lane = _make_afcu1_lane(feed_channel="extruder1")
+        lane._feed_obj = MagicMock()
+        lane._feed_obj.get_status.return_value = {"extruder1": {"filament_detected": True}}
+        lane._feed_staged_last = False
+        lane._feed_reevaluate()
+        assert lane.prep_state is True
+        assert lane._load_state is True
+
+    def test_absent_marks_empty(self):
+        lane = _make_afcu1_lane(feed_channel="extruder1")
+        lane._feed_obj = MagicMock()
+        lane._feed_obj.get_status.return_value = {"extruder1": {"filament_detected": False}}
+        lane._feed_staged_last = True
+        lane.prep_state = True
+        lane._load_state = True
+        lane._feed_reevaluate()
+        assert lane.prep_state is False
+        assert lane._load_state is False
+
+    def test_no_feed_obj_marks_empty(self):
+        """A missing feeder object is treated as absent (defensive default)."""
+        lane = _make_afcu1_lane(feed_channel="extruder1")
+        lane._feed_obj = None
+        lane._feed_staged_last = True
+        lane.prep_state = True
+        lane._load_state = True
+        lane._feed_reevaluate()
+        assert lane.prep_state is False
+        assert lane._load_state is False
+
+
+# ── _feed_port_event ──────────────────────────────────────────────────────────
+
+class TestAFCU1LaneFeedPortEvent:
+    """_feed_port_event filters by channel index, then trusts the event's own
+    `detected` flag directly (no _feed_obj lookup — deliberately, so the
+    handler works even before _handle_ready has set _feed_obj up; see
+    TestAFCU1LaneEventBeforeReady). Tests assert on real prep_state/_load_state
+    outcomes so each would fail if the index guard let the wrong event
+    through or blocked the right one."""
+
+    def test_applies_when_index_matches(self):
+        lane = _make_afcu1_lane(feed_channel="extruder1")
+        lane._feed_ch_index = 1
+        lane._feed_staged_last = False
+        lane._feed_port_event(1, True)
+        assert lane.prep_state is True
+        assert lane._load_state is True
+        assert lane._feed_staged_last is True
+
+    def test_ignores_when_index_differs(self):
+        lane = _make_afcu1_lane(feed_channel="extruder1")
+        lane._feed_ch_index = 1
+        lane._feed_staged_last = False
+        lane.prep_state = False
+        lane._load_state = False
+        lane._feed_port_event(0, True)
+        assert lane.prep_state is False
+        assert lane._load_state is False
+        assert lane._feed_staged_last is False
+        lane.afc.save_vars.assert_not_called()
+
+    def test_applies_when_index_unknown(self):
+        """A None channel index means we can't filter, so every event applies."""
+        lane = _make_afcu1_lane(feed_channel="extruder1")
+        lane._feed_ch_index = None
+        lane._feed_staged_last = True
+        lane.prep_state = True
+        lane._load_state = True
+        lane._feed_port_event(5, False)
+        assert lane.prep_state is False
+        assert lane._load_state is False
+        assert lane._feed_staged_last is False
+
+    def test_passes_detected_true_through(self):
+        lane = _make_afcu1_lane(feed_channel="extruder1")
+        lane._feed_ch_index = 2
+        lane._feed_staged_last = False
+        lane._feed_port_event(2, True)
+        assert lane.prep_state is True
+        assert lane._load_state is True
+
+    def test_passes_detected_false_through(self):
+        lane = _make_afcu1_lane(feed_channel="extruder1")
+        lane._feed_ch_index = 2
+        lane._feed_staged_last = True
+        lane.prep_state = True
+        lane._load_state = True
+        lane._feed_port_event(2, False)
+        assert lane.prep_state is False
+        assert lane._load_state is False
+
+    def test_logs_debug_message_when_applied(self):
+        lane = _make_afcu1_lane(feed_channel="extruder1")
+        lane._feed_ch_index = 1
+        lane._feed_staged_last = False
+        lane._feed_port_event(1, True)
+        assert lane.logger.messages == [("debug", f"AFCU1Lane: feed_port_event: {lane.name} True")]
+
+    def test_no_debug_log_when_index_differs(self):
+        """A filtered-out event must return before the log call."""
+        lane = _make_afcu1_lane(feed_channel="extruder1")
+        lane._feed_ch_index = 1
+        lane._feed_port_event(0, True)
+        assert lane.logger.messages == []
+
+
+# ── _handle_ready ─────────────────────────────────────────────────────────────
+
+class TestAFCU1LaneHandleReady:
+    """_handle_ready is exercised for real, including the AFCLane base-class
+    portion (super()._handle_ready()) — the feeder module and AFC_extruder
+    lookups are injected via MockPrinter._objects, the same pattern other
+    AFC test files already use for wiring lookup_object() dependencies."""
+
+    def _ready_lane(self, feed_module="left", feed_channel="extruder1"):
+        lane = _make_afcu1_lane(feed_module=feed_module, feed_channel=feed_channel)
+        lane.unit_obj = MagicMock()  # normally set later via handle_unit_connect
+        return lane
+
+    def _register_feeder(self, lane, detected=False, channel=None):
+        channel = channel or lane.feed_channel
+        feeder = MagicMock()
+        feeder.get_status.return_value = {channel: {"filament_detected": detected}}
+        lane.printer._objects[f"filament_feed {lane.feed_module}"] = feeder
+        return feeder
+
+    def test_skips_wiring_when_not_configured(self):
+        lane = self._ready_lane(feed_module=None, feed_channel=None)
+        lane._handle_ready()
+        assert lane._feed_obj is None
+        assert "filament_feed:port" not in lane.printer._event_handlers
+
+    def test_base_handle_ready_runs(self):
+        """super()._handle_ready() actually executes: with no espooler motor
+        pins configured it logs instead of starting a stats timer."""
+        lane = self._ready_lane()
+        self._register_feeder(lane)
+        lane._handle_ready()
+        assert ("info", "Not starting timer for lane1") in lane.logger.messages
+
+    def test_raises_when_feeder_missing(self):
+        lane = self._ready_lane()
+        with pytest.raises(Exception) as exc:
+            lane._handle_ready()
+        assert lane.name in str(exc.value)
+
+    def test_raw_channel_key_kept_as_is(self):
+        lane = self._ready_lane(feed_channel="extruder2")
+        self._register_feeder(lane)
+        lane._handle_ready()
+        assert lane.feed_channel == "extruder2"
+
+    def test_raw_channel_index_derived(self):
+        lane = self._ready_lane(feed_channel="extruder2")
+        self._register_feeder(lane)
+        lane._handle_ready()
+        assert lane._feed_ch_index == 2
+
+    def test_afc_extruder_name_resolved_via_extruder_index(self):
+        """A channel given as an AFC extruder name resolves to 'extruder<index>'
+        using the toolhead extruder's extruder_index."""
+        lane = self._ready_lane(feed_channel="e3")
+        ext_obj = MagicMock()
+        ext_obj.toolhead_extruder.extruder_index = 3
+        lane.printer._objects["AFC_extruder e3"] = ext_obj
+        self._register_feeder(lane, channel="extruder3")
+        lane._handle_ready()
+        assert lane.feed_channel == "extruder3"
+        assert lane._feed_ch_index == 3
+
+    def test_afc_extruder_name_resolved_via_th_name_fallback(self):
+        """When extruder_index is None, fall back to the th_extruder_name suffix."""
+        lane = self._ready_lane(feed_channel="e2")
+        ext_obj = MagicMock()
+        ext_obj.toolhead_extruder.extruder_index = None
+        ext_obj.th_extruder_name = "extruder2"
+        lane.printer._objects["AFC_extruder e2"] = ext_obj
+        self._register_feeder(lane, channel="extruder2")
+        lane._handle_ready()
+        assert lane.feed_channel == "extruder2"
+        assert lane._feed_ch_index == 2
+
+    def test_afc_extruder_name_th_name_e0_maps_to_extruder0(self):
+        """The base klipper extruder ('extruder', no digit) maps to channel 0."""
+        lane = self._ready_lane(feed_channel="e0")
+        ext_obj = MagicMock()
+        ext_obj.toolhead_extruder.extruder_index = None
+        ext_obj.th_extruder_name = "extruder"
+        lane.printer._objects["AFC_extruder e0"] = ext_obj
+        self._register_feeder(lane, channel="extruder0")
+        lane._handle_ready()
+        assert lane.feed_channel == "extruder0"
+        assert lane._feed_ch_index == 0
+
+    def test_registers_port_event_handler(self):
+        lane = self._ready_lane()
+        self._register_feeder(lane)
+        lane._handle_ready()
+        assert lane.printer._event_handlers["filament_feed:port"] == [lane._feed_port_event]
+
+    def test_seeds_state_true_from_current_feeder(self):
+        lane = self._ready_lane()
+        self._register_feeder(lane, detected=True)
+        lane._handle_ready()
+        assert lane.prep_state is True
+        assert lane._load_state is True
+
+    def test_seeds_state_false_from_current_feeder(self):
+        lane = self._ready_lane()
+        self._register_feeder(lane, detected=False)
+        lane._handle_ready()
+        assert lane.prep_state is False
+        assert lane._load_state is False
+
+    def test_feed_obj_stored(self):
+        lane = self._ready_lane()
+        feeder = self._register_feeder(lane)
+        lane._handle_ready()
+        assert lane._feed_obj is feeder
+
+
+# ── event ordering: __init__ registers before _handle_ready is ready ─────────
+#
+# __init__ subscribes _feed_port_event to "filament_feed:port" before
+# _handle_ready has set up _feed_obj/_feed_ch_index — event registration order
+# does not guarantee callback order, so the feeder could fire that event in
+# the window between construction and klippy:ready. _feed_port_event is
+# deliberately self-contained (it trusts the event's own `detected` flag
+# instead of re-querying self._feed_obj), so it never touches the
+# not-yet-set feeder object and resolves correctly even this early.
+
+class TestAFCU1LaneEventBeforeReady:
+    def test_premature_event_does_not_touch_feed_obj(self):
+        lane = _make_afcu1_lane(feed_channel="extruder1")
+        assert lane._feed_obj is None
+        lane.printer.send_event("filament_feed:port", 0, True)  # must not raise
+        assert lane._feed_obj is None
+
+    def test_premature_event_true_resolves_loaded(self):
+        lane = _make_afcu1_lane(feed_channel="extruder1")
+        lane.printer.send_event("filament_feed:port", 0, True)
+        assert lane.prep_state is True
+        assert lane._load_state is True
+
+    def test_premature_event_false_resolves_empty(self):
+        lane = _make_afcu1_lane(feed_channel="extruder1")
+        lane.printer.send_event("filament_feed:port", 0, False)
+        assert lane.prep_state is False
+        assert lane._load_state is False

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -2081,13 +2081,46 @@ class TestAFCU1LaneHandleReady:
         assert lane._feed_obj is None
         assert "filament_feed:port" not in lane.printer._event_handlers
 
+    def test_skips_wiring_when_only_feed_module_configured(self):
+        lane = self._ready_lane(feed_module="left", feed_channel=None)
+        lane._handle_ready()
+        assert lane._feed_obj is None
+        assert lane._feed_ch_index is None
+        assert "filament_feed:port" not in lane.printer._event_handlers
+
+    def test_skips_wiring_when_only_feed_channel_configured(self):
+        lane = self._ready_lane(feed_module=None, feed_channel="extruder1")
+        lane._handle_ready()
+        assert lane._feed_obj is None
+        assert lane._feed_ch_index is None
+        assert "filament_feed:port" not in lane.printer._event_handlers
+
+    def test_feed_ch_indx_none_when_feed_channel_not_have_digit(self):
+        lane = self._ready_lane(feed_channel="extruder")
+        ext_obj = MagicMock()
+        ext_obj.toolhead_extruder.extruder_index = 3
+        lane.printer._objects["AFC_extruder e3"] = ext_obj
+        self._register_feeder(lane, channel="extruder")
+        lane._handle_ready()
+        assert lane._feed_ch_index is None
+
+    def test_feed_channel_is_extruder0_when_feed_channel_not_have_digit(self):
+        lane = self._ready_lane(feed_channel="extruder")
+        ext_obj = MagicMock()
+        ext_obj.toolhead_extruder.extruder_index = 0
+        lane.printer._objects["AFC_extruder extruder"] = ext_obj
+        self._register_feeder(lane, channel="extruder")
+        lane._handle_ready()
+        assert lane._feed_ch_index == 0
+        assert lane.feed_channel == "extruder0"
+
     def test_base_handle_ready_runs(self):
         """super()._handle_ready() actually executes: with no espooler motor
         pins configured it logs instead of starting a stats timer."""
         lane = self._ready_lane()
         self._register_feeder(lane)
         lane._handle_ready()
-        assert ("info", "Not starting timer for lane1") in lane.logger.messages
+        assert lane.logger.messages == [("info", "Not starting timer for lane1")]
 
     def test_raises_when_feeder_missing(self):
         lane = self._ready_lane()


### PR DESCRIPTION
## Major Changes in this PR
- Brought in changes for @lindnjoe to have the ability to load into standalone lanes on a Snapmaker U1 printer. Split out changes into a `AFCU1Lane` class to separate away from AFCLane.
- Updated Snapmaker U1 macros and AFC_hardware.cfg file for new changes needed to use this functionality.
- Added unit tests with help from claude
- Added a couple more rules to agents file

## How the changes in this PR are tested
- Tested on U1 printer

https://github.com/user-attachments/assets/70b24433-af6e-4b0d-acaf-2e62a03cc8b4

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for standalone U1 filament lanes using external feeder status to detect filament presence and drive AFC tool loading (including Snapmaker U1 side feeders).
* **Bug Fixes**
  * Prevented automatic tool-load triggering when a lane provides a custom load command.
  * Improved feeder-driven state handling, including reacting correctly to early feeder events.
* **Documentation**
  * Updated the changelog to reflect U1 side-feeder AFC loading support.
* **Tests**
  * Expanded coverage for U1 lane behavior and the custom-load regression scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->