### PR TITLE
(fix): Added ability to hysteresis for changing stepper rotation distance when using FPS/PSF buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-07-22]
+### Added
+- Ability to set hysteresis for FPS/PSF buffer's so that stepper rotation distance is not updates every 0.25s. Hystersis is defaulted to adjust rotation distance if ADC value is +/- 0.03% of current value.
+
 ## [2026-07-20]
 ### Added
 - Added `AFC_START_OAMS_FOLLOWER` and `AFC_STOP_OAMS_FOLLOWER` macros to manually control an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2026-07-22]
 ### Added
-- Configurable hysteresis for FPS/PSF buffers prevents rotation-distance updates every 0.25s when the computed multiplier changes by 0.3% or less from the last applied multiplier (default: 0.003).
+- Configurable hysteresis for FPS/PSF buffers prevents rotation-distance updates every 0.25s when the computed multiplier changes by 0.003 or less (absolute) from the last applied multiplier (default: 0.003).
 
 ## [2026-07-20]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2026-07-22]
 ### Added
-- Ability to set hysteresis for FPS/PSF buffer's so that stepper rotation distance is not updates every 0.25s. Hystersis is defaulted to adjust rotation distance if ADC value is +/- 0.03% of current value.
+- Configurable hysteresis for FPS/PSF buffers prevents rotation-distance updates every 0.25s when the computed multiplier changes by 0.3% or less from the last applied multiplier (default: 0.003).
 
 ## [2026-07-20]
 ### Added

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -44,7 +44,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 try: from extras.AFC_stats import AFCStats
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
 
-AFC_VERSION="1.1.34"
+AFC_VERSION="1.1.35"
 
 # Class for holding different states so its clear what all valid states are
 class State:

--- a/extras/AFC_buffer.py
+++ b/extras/AFC_buffer.py
@@ -912,6 +912,14 @@ class AFCFPSBuffer(AFCBuffer):
         self.multiplier_low: float = config.getfloat('multiplier_low', 0.85, minval=0.0, maxval=1.0)
         self.trailing_min_multiplier: float = config.getfloat('trailing_min_multiplier', 1.00, minval=1.0)
 
+        # Hysteresis on the applied multiplier: a correction is only sent to
+        # the stepper (update_rotation_distance) when it differs from the
+        # last *applied* multiplier by more than this fraction (e.g. 0.003
+        # = 0.3%). State tracking, logging, and LED updates still happen
+        # every tick regardless -- this only gates the stepper write.
+        self.multiplier_hysteresis: float = config.getfloat(
+            'multiplier_hysteresis', 0.003, minval=0.0, maxval=1.0)
+
         # Deadband — neutral window centered on set_point where no correction
         # is applied, giving headroom for retractions/tool changes.
         self.deadband: float = config.getfloat('deadband', 0.30, minval=0.0, maxval=0.6)
@@ -1200,44 +1208,55 @@ class AFCFPSBuffer(AFCBuffer):
             # Clamp the combined P+I output to the configured band.
             multiplier = max(self.multiplier_low, min(self.multiplier_high, multiplier))
 
-        log_event = False
-        if abs(self._last_multiplier - multiplier) > 0.001:
-            log_event = True
-        if integral != self._last_logged_integral:
-            log_event = True
 
-        # Apply multiplier
-        self.set_multiplier(multiplier)
+        # Apply multiplier -- gated by hysteresis so tiny, insignificant
+        # corrections don't trigger an update_rotation_distance call on
+        # every tick. State/LED/logging above still reflect the freshly
+        # computed multiplier regardless; this only gates the stepper write.
+        log_event = False
+        if self.multiplier_hysteresis <= 0.0:
+            self.set_multiplier(multiplier)
+            if abs(self._last_multiplier - multiplier) > 0.001:
+                log_event = True
+            if integral != self._last_logged_integral:
+                log_event = True
+        else:
+            last_applied = self._last_multiplier
+            rel_change = (abs(multiplier - last_applied) / last_applied
+                         if last_applied else 1.0)
+            if rel_change > self.multiplier_hysteresis:
+                self.set_multiplier(multiplier)
+                log_event = True
 
         # Update state flags
         if target_direction == ADVANCING_STATE_NAME:
             if self.last_state != ADVANCING_STATE_NAME:
                 log_event = True
+                if self.led:
+                    self.afc.function.afc_led(self.led_advancing, self.led_index)
             self.last_state = ADVANCING_STATE_NAME
             self.advance_state = False
             self.trailing_state = True
 
             self._last_correction_direction = ADVANCING_STATE_NAME
-            if self.led:
-                self.afc.function.afc_led(self.led_advancing, self.led_index)
         elif target_direction == TRAILING_STATE_NAME:
             if self.last_state != TRAILING_STATE_NAME:
                 log_event = True
+                if self.led:
+                    self.afc.function.afc_led(self.led_trailing, self.led_index)
             self.last_state = TRAILING_STATE_NAME
             self.advance_state = True
             self.trailing_state = False
             self._last_correction_direction = TRAILING_STATE_NAME
-            if self.led:
-                self.afc.function.afc_led(self.led_trailing, self.led_index)
         else:
             if self.last_state != NEUTRAL_STATE_NAME:
                 log_event = True
+                if self.led:
+                    self.afc.function.afc_led(self.led_neutral, self.led_index)
             self.last_state = NEUTRAL_STATE_NAME
             self.advance_state = False
             self.trailing_state = False
             self._last_correction_direction = NEUTRAL_STATE_NAME
-            if self.led:
-                self.afc.function.afc_led(self.led_neutral, self.led_index)
 
         if (log_event
             and self.debug):

--- a/extras/AFC_buffer.py
+++ b/extras/AFC_buffer.py
@@ -1253,7 +1253,7 @@ class AFCFPSBuffer(AFCBuffer):
             and self.debug):
             self.logger.debug(
                 f"FPS_buffer {self.name}: fps={self.fps_value:.3f} smoothed={self.smoothed_fps:.3f} "
-                f"integral={integral:+.4f} multiplier={multiplier:.4f} state={self.last_state}"
+                f"integral={integral:+.4f} multiplier={self._last_multiplier:.4f} state={self.last_state}"
             )
             self._last_logged_integral = integral
 

--- a/extras/AFC_buffer.py
+++ b/extras/AFC_buffer.py
@@ -1209,14 +1209,14 @@ class AFCFPSBuffer(AFCBuffer):
             multiplier = max(self.multiplier_low, min(self.multiplier_high, multiplier))
 
 
-        # Apply multiplier -- gated by hysteresis so tiny, insignificant
+        # Apply multiplier, gated by hysteresis when set so tiny, insignificant
         # corrections don't trigger an update_rotation_distance call on
-        # every tick. State/LED/logging above still reflect the freshly
-        # computed multiplier regardless; this only gates the stepper write.
+        # every tick.
         log_event = False
         if self.multiplier_hysteresis <= 0.0:
+            last_applied = self._last_multiplier
             self.set_multiplier(multiplier)
-            if abs(self._last_multiplier - multiplier) > 0.001:
+            if abs(last_applied - multiplier) > 0.001:
                 log_event = True
             if integral != self._last_logged_integral:
                 log_event = True

--- a/extras/AFC_buffer.py
+++ b/extras/AFC_buffer.py
@@ -912,13 +912,11 @@ class AFCFPSBuffer(AFCBuffer):
         self.multiplier_low: float = config.getfloat('multiplier_low', 0.85, minval=0.0, maxval=1.0)
         self.trailing_min_multiplier: float = config.getfloat('trailing_min_multiplier', 1.00, minval=1.0)
 
-        # Hysteresis on the applied multiplier: a correction is only sent to
-        # the stepper (update_rotation_distance) when it differs from the
-        # last *applied* multiplier by more than this fraction (e.g. 0.003
-        # = 0.3%). State tracking, logging, and LED updates still happen
-        # every tick regardless -- this only gates the stepper write.
-        self.multiplier_hysteresis: float = config.getfloat(
-            'multiplier_hysteresis', 0.003, minval=0.0, maxval=1.0)
+        # Hysteresis on the applied multiplier: a correction is only sent to the stepper
+        # (update_rotation_distance) when it differs from the last *applied* multiplier by more
+        # than this fraction (e.g. 0.003 = 0.3%).
+        self.multiplier_hysteresis: float = config.getfloat('multiplier_hysteresis', 0.003,
+                                                            minval=0.0, maxval=1.0)
 
         # Deadband — neutral window centered on set_point where no correction
         # is applied, giving headroom for retractions/tool changes.
@@ -971,7 +969,6 @@ class AFCFPSBuffer(AFCBuffer):
         self.integral_extrusion_threshold: float = config.getfloat(
             'integral_extrusion_threshold', 0.02, minval=0.0)
         self._integral_last_extruder_pos: Optional[float] = None
-        self._last_correction_direction: str = NEUTRAL_STATE_NAME
 
         # ---- Fault detection ----
         self.min_event_systime: float = self.reactor.NEVER
@@ -1213,15 +1210,14 @@ class AFCFPSBuffer(AFCBuffer):
         # corrections don't trigger an update_rotation_distance call on
         # every tick.
         log_event = False
+        last_applied = self._last_multiplier
         if self.multiplier_hysteresis <= 0.0:
-            last_applied = self._last_multiplier
             self.set_multiplier(multiplier)
             if abs(last_applied - multiplier) > 0.001:
                 log_event = True
             if integral != self._last_logged_integral:
                 log_event = True
         else:
-            last_applied = self._last_multiplier
             rel_change = (abs(multiplier - last_applied) / last_applied
                          if last_applied else 1.0)
             if rel_change > self.multiplier_hysteresis:
@@ -1237,8 +1233,6 @@ class AFCFPSBuffer(AFCBuffer):
             self.last_state = ADVANCING_STATE_NAME
             self.advance_state = False
             self.trailing_state = True
-
-            self._last_correction_direction = ADVANCING_STATE_NAME
         elif target_direction == TRAILING_STATE_NAME:
             if self.last_state != TRAILING_STATE_NAME:
                 log_event = True
@@ -1247,7 +1241,6 @@ class AFCFPSBuffer(AFCBuffer):
             self.last_state = TRAILING_STATE_NAME
             self.advance_state = True
             self.trailing_state = False
-            self._last_correction_direction = TRAILING_STATE_NAME
         else:
             if self.last_state != NEUTRAL_STATE_NAME:
                 log_event = True
@@ -1256,7 +1249,6 @@ class AFCFPSBuffer(AFCBuffer):
             self.last_state = NEUTRAL_STATE_NAME
             self.advance_state = False
             self.trailing_state = False
-            self._last_correction_direction = NEUTRAL_STATE_NAME
 
         if (log_event
             and self.debug):
@@ -1312,7 +1304,6 @@ class AFCFPSBuffer(AFCBuffer):
         self.enable = True
         self._latch_enabled = False
         self._advance_latched = False
-        self._last_correction_direction = NEUTRAL_STATE_NAME
         has_stepper = self._lane_has_rotation_control(lane)
 
         if self.led:

--- a/extras/AFC_buffer.py
+++ b/extras/AFC_buffer.py
@@ -914,7 +914,8 @@ class AFCFPSBuffer(AFCBuffer):
 
         # Hysteresis on the applied multiplier: a correction is only sent to the stepper
         # (update_rotation_distance) when it differs from the last *applied* multiplier by more
-        # than this fraction (e.g. 0.003 = 0.3%).
+        # than this absolute amount (e.g. 0.003 means a multiplier of 1.050 -> 1.052 is
+        # suppressed, but 1.050 -> 1.054 is not).
         self.multiplier_hysteresis: float = config.getfloat('multiplier_hysteresis', 0.003,
                                                             minval=0.0, maxval=1.0)
 
@@ -1218,9 +1219,7 @@ class AFCFPSBuffer(AFCBuffer):
             if integral != self._last_logged_integral:
                 log_event = True
         else:
-            rel_change = (abs(multiplier - last_applied) / last_applied
-                         if last_applied else 1.0)
-            if rel_change > self.multiplier_hysteresis:
+            if abs(multiplier - last_applied) > self.multiplier_hysteresis:
                 self.set_multiplier(multiplier)
                 log_event = True
 
@@ -1253,11 +1252,8 @@ class AFCFPSBuffer(AFCBuffer):
         if (log_event
             and self.debug):
             self.logger.debug(
-                "FPS_buffer {}: fps={:.3f} smoothed={:.3f} integral={:+.4f} "
-                "multiplier={:.4f} state={}".format(
-                    self.name, self.fps_value, self.smoothed_fps, integral,
-                    multiplier, self.last_state
-                )
+                f"FPS_buffer {self.name}: fps={self.fps_value:.3f} smoothed={self.smoothed_fps:.3f} "
+                f"integral={integral:+.4f} multiplier={multiplier:.4f} state={self.last_state}"
             )
             self._last_logged_integral = integral
 

--- a/tests/test_AFC_buffer.py
+++ b/tests/test_AFC_buffer.py
@@ -160,7 +160,6 @@ def _make_fps_buffer(name="FPS_buffer1", **overrides):
     buf._last_logged_integral = 0.0
     buf.integral_extrusion_threshold = 1.0
     buf._integral_last_extruder_pos = None
-    buf._last_correction_direction = NEUTRAL_STATE_NAME
 
     buf.adv_filament_switch_name = f"{name}_expanded"
     buf.fila_adv = MagicMock()
@@ -2459,7 +2458,6 @@ class TestCorrectionEvent:
         assert buf.last_state == TRAILING_STATE_NAME
         assert buf.advance_state is True
         assert buf.trailing_state is False
-        assert buf._last_correction_direction == TRAILING_STATE_NAME
         afc.function.afc_led.assert_called_once_with(buf.led_trailing, buf.led_index)
 
     def test_reading_inside_deadband_is_neutral(self):
@@ -2470,12 +2468,10 @@ class TestCorrectionEvent:
         buf.led = True
         buf.advance_state = True  # seed True so both resets to False are proven
         buf.trailing_state = True
-        buf._last_correction_direction = "something_else"
         buf._correction_event(100.0)
         assert buf.last_state == NEUTRAL_STATE_NAME
         assert buf.advance_state is False
         assert buf.trailing_state is False
-        assert buf._last_correction_direction == NEUTRAL_STATE_NAME
         afc.function.afc_led.assert_called_once_with(buf.led_neutral, buf.led_index)
 
     def test_led_disabled_skips_afc_led_call(self):
@@ -2484,14 +2480,6 @@ class TestCorrectionEvent:
         buf.smoothed_fps = 0.5
         buf._correction_event(100.0)
         afc.function.afc_led.assert_not_called()
-
-    def test_last_correction_direction_tracks_target(self):
-        buf, afc, reactor, printer, lane = self._ready()
-        buf.set_point = 0.5
-        buf.deadband = 0.3
-        buf.smoothed_fps = 0.2
-        buf._correction_event(100.0)
-        assert buf._last_correction_direction == ADVANCING_STATE_NAME
 
     def test_already_advancing_does_not_force_log_event_via_state(self):
         buf, afc, reactor, printer, lane = self._ready()
@@ -2638,7 +2626,6 @@ class TestCorrectionEventHysteresis:
 
         lane.update_rotation_distance.assert_not_called()
         assert buf.last_state == ADVANCING_STATE_NAME
-        assert buf._last_correction_direction == ADVANCING_STATE_NAME
 
 
 class TestCorrectionEventIntegral:
@@ -2987,7 +2974,6 @@ class TestAFCFPSBufferInit:
         assert buf._last_logged_integral == 0.0
         assert buf.integral_extrusion_threshold == 0.02
         assert buf._integral_last_extruder_pos is None
-        assert buf._last_correction_direction == NEUTRAL_STATE_NAME
         assert buf.min_event_systime == buf.reactor.NEVER
         from extras.AFC_utils import VirtualFilamentSensor
         assert isinstance(buf.fila_adv, VirtualFilamentSensor)
@@ -3134,14 +3120,6 @@ class TestFPSEnableBuffer:
         buf.enable_buffer(lane)
         assert buf._latch_enabled is False
         assert buf._advance_latched is False
-
-    def test_resets_last_correction_direction(self):
-        buf, afc, reactor, printer = _make_fps_buffer()
-        lane = _make_lane(buf)
-        buf._lane_has_rotation_control = MagicMock(return_value=False)
-        buf._last_correction_direction = ADVANCING_STATE_NAME
-        buf.enable_buffer(lane)
-        assert buf._last_correction_direction == NEUTRAL_STATE_NAME
 
     def test_led_enabled_sets_neutral_led(self):
         buf, afc, reactor, printer = _make_fps_buffer()

--- a/tests/test_AFC_buffer.py
+++ b/tests/test_AFC_buffer.py
@@ -2537,7 +2537,7 @@ class TestCorrectionEventHysteresis:
         buf.multiplier_high = 1.2
         buf._last_multiplier = 1.05
 
-        buf.smoothed_fps = 0.394  # multiplier ~1.053 -> delta ~0.003, not over the 0.003 default
+        buf.smoothed_fps = 0.396  # multiplier ~1.052 -> delta ~0.002, clearly under the 0.003 default
         buf._correction_event(100.0)
 
         lane.update_rotation_distance.assert_not_called()
@@ -2610,24 +2610,25 @@ class TestCorrectionEventHysteresis:
         lane.update_rotation_distance.assert_called_once()
 
     def test_hysteresis_is_absolute_not_relative(self):
-        """A large-magnitude last-applied multiplier must not shrink the
-        effective gate the way a relative/percentage comparison would --
-        the same absolute delta is gated identically regardless of baseline."""
+        """A delta that is small *relative* to a large last-applied baseline
+        must still clear the gate, since it's compared against
+        multiplier_hysteresis as an absolute amount. Chosen so a
+        relative-scaled gate (delta/last_applied > threshold) would
+        disagree: delta=0.05 against last_multiplier=10.0 is only a 0.5%
+        relative change (would be suppressed by a 2% relative gate), but
+        0.05 > 0.02 absolute, so it must be applied."""
         buf, afc, reactor, printer, lane = self._ready()
         buf.multiplier_hysteresis = 0.02  # absolute delta
         buf.set_point = 0.5
         buf.trailing_min_multiplier = 1.0
         buf.low_point = 0.1
-        buf.multiplier_high = 1.2
-        # Seed a baseline far from 1.0. Under the old relative comparison this
-        # would make small absolute deltas look proportionally tiny and get
-        # filtered; the absolute comparison must gate purely on magnitude.
-        buf._last_multiplier = 0.05
+        buf.multiplier_high = 10.05
+        buf._last_multiplier = 10.0
 
-        buf.smoothed_fps = 0.394  # multiplier ~1.053 -> delta ~1.003, clearly over 0.02
+        buf.smoothed_fps = 0.05  # saturates the P-term -> multiplier == multiplier_high == 10.05
         buf._correction_event(100.0)
 
-        lane.update_rotation_distance.assert_called_once_with(pytest.approx(1.053))
+        lane.update_rotation_distance.assert_called_once_with(pytest.approx(10.05))
 
     def test_state_and_led_still_update_when_stepper_call_is_gated(self):
         """State/LED tracking must reflect the freshly computed target
@@ -2768,6 +2769,28 @@ class TestCorrectionEventLogging:
         buf.smoothed_fps = 0.2  # produces a multiplier well past 1.001
         buf._correction_event(100.0)
         buf.logger.debug.assert_called_once()
+
+    def test_log_reports_applied_multiplier_not_gated_target(self):
+        """When hysteresis suppresses set_multiplier() but a state
+        transition still sets log_event=True, the debug line must report
+        the multiplier actually applied to the stepper (_last_multiplier),
+        not the freshly computed target that was gated out -- otherwise
+        diagnostics show a value that was never sent to the stepper."""
+        buf, afc, reactor, printer, lane = self._ready()
+        buf.debug = True
+        buf.multiplier_hysteresis = 0.1  # coarse enough to gate the ~0.06 delta below
+        buf._last_multiplier = 1.0
+        buf.last_state = NEUTRAL_STATE_NAME  # differs from the Advancing result -> log_event
+
+        buf.smoothed_fps = 0.34  # target=Advancing, computed multiplier ~1.06 (gated, unapplied)
+        buf._correction_event(100.0)
+
+        lane.update_rotation_distance.assert_not_called()  # gate held -- multiplier not applied
+        assert buf._last_multiplier == pytest.approx(1.0)  # unchanged by the gate
+        buf.logger.debug.assert_called_once_with(
+            "FPS_buffer FPS_buffer1: fps=0.000 smoothed=0.340 integral=+0.0000 "
+            "multiplier=1.0000 state=Advancing"
+        )
 
     def test_hysteresis_disabled_still_suppresses_log_for_sub_threshold_delta(self):
         """With multiplier_hysteresis explicitly disabled, set_multiplier()

--- a/tests/test_AFC_buffer.py
+++ b/tests/test_AFC_buffer.py
@@ -2267,10 +2267,13 @@ class TestAdcCallback:
         assert buf.advance_state == "untouched"
         assert buf.trailing_state == "untouched"
     
-    def test_has_stepper_does_not_skip_logic(self):
-        """When has_stepper=True, enable=True and correction_running=False,
-        last_state/advance_state/trailing_state
-        are left untouched by _adc_callback (the correction loop owns them)."""
+    def test_correction_not_running_still_runs_fallback_classifier(self):
+        """When enable=False (correction isn't running), the fallback
+        classifier in _adc_callback still updates last_state/advance_state/
+        trailing_state from the raw reading -- even though has_stepper=True
+        would normally mean the correction loop owns that job. This is
+        what keeps state accurate during load/calibration before printing
+        starts, when the correction loop hasn't been enabled yet."""
         buf, afc, reactor, printer = _make_fps_buffer()
         buf._lane_has_rotation_control = MagicMock(return_value=True)
         buf.enable = False  # avoid the lazy-timer-start branch complicating this
@@ -2390,6 +2393,8 @@ class TestCorrectionEvent:
 
     def test_at_set_point_multiplier_is_exactly_one(self):
         buf, afc, reactor, printer, lane = self._ready()
+        buf.multiplier_hysteresis = 0.0  # isolate from the default filter -- this
+                                         # test is about the P-term math, not hysteresis
         buf.set_point = 0.5
         buf.smoothed_fps = 0.5
         buf.trailing_min_multiplier = 1.0
@@ -2514,6 +2519,128 @@ class TestCorrectionEvent:
         buf.logger.debug.assert_not_called()
 
 
+class TestCorrectionEventHysteresis:
+    """multiplier_hysteresis gates whether _correction_event actually calls
+    update_rotation_distance, without affecting the state/LED tracking that
+    happens every tick regardless."""
+
+    def _ready(self, **overrides):
+        buf, afc, reactor, printer = _make_fps_buffer(**overrides)
+        buf.enable = True
+        lane = _make_lane(buf)
+        lane.update_rotation_distance = MagicMock()
+        buf.current_lane = lane
+        buf._lane_has_rotation_control = MagicMock(return_value=True)
+        buf.fault_detection_enabled = MagicMock(return_value=False)
+        buf._update_virtual_sensors = MagicMock()
+        return buf, afc, reactor, printer, lane
+
+    def test_default_hysteresis_is_0_3_percent(self):
+        buf, afc, reactor, printer, lane = self._ready()
+        assert buf.multiplier_hysteresis == pytest.approx(0.003)
+
+    def test_default_hysteresis_filters_a_sub_threshold_change(self):
+        buf, afc, reactor, printer, lane = self._ready()
+        buf.set_point = 0.5
+        buf.low_point = 0.1
+        buf.multiplier_high = 1.2
+        buf._last_multiplier = 1.05
+
+        buf.smoothed_fps = 0.394  # multiplier ~1.053 -> ~0.286%, under the 0.3% default
+        buf._correction_event(100.0)
+
+        lane.update_rotation_distance.assert_not_called()
+
+    def test_default_hysteresis_still_applies_a_large_change(self):
+        buf, afc, reactor, printer, lane = self._ready()
+        buf.set_point = 0.5
+        buf.low_point = 0.1
+        buf.multiplier_high = 1.2
+        buf._last_multiplier = 1.05
+
+        buf.smoothed_fps = 0.3  # multiplier ~1.10 -> ~4.76%, well over the 0.3% default
+        buf._correction_event(100.0)
+
+        lane.update_rotation_distance.assert_called_once_with(pytest.approx(1.10))
+
+    def test_small_change_below_threshold_does_not_apply(self):
+        buf, afc, reactor, printer, lane = self._ready()
+        buf.multiplier_hysteresis = 0.005  # 0.5%
+        buf.set_point = 0.5
+        buf.trailing_min_multiplier = 1.0
+        buf.low_point = 0.1
+        buf.multiplier_high = 1.2
+        buf._last_multiplier = 1.05  # seed a known non-default baseline directly
+
+        buf.smoothed_fps = 0.394  # computes multiplier=1.053 -> 0.286% change, under threshold
+        buf._correction_event(100.0)
+
+        lane.update_rotation_distance.assert_not_called()
+        assert buf._last_multiplier == pytest.approx(1.05)  # unchanged
+
+    def test_large_change_above_threshold_applies_and_updates_last_multiplier(self):
+        buf, afc, reactor, printer, lane = self._ready()
+        buf.multiplier_hysteresis = 0.005  # 0.5%
+        buf.set_point = 0.5
+        buf.trailing_min_multiplier = 1.0
+        buf.low_point = 0.1
+        buf.multiplier_high = 1.2
+        buf._last_multiplier = 1.05  # seed a known non-default baseline directly
+
+        buf.smoothed_fps = 0.3  # computes multiplier=1.10 -> 4.76% change, over threshold
+        buf._correction_event(100.0)
+
+        lane.update_rotation_distance.assert_called_once_with(pytest.approx(1.10))
+        assert buf._last_multiplier == pytest.approx(1.10)
+
+    def test_just_under_threshold_does_not_apply_just_over_does(self):
+        """Proves the comparison is strictly greater-than by bracketing the
+        threshold with two realistic computed multipliers, rather than
+        relying on an exact floating-point boundary value (which is fragile
+        to construct/compare precisely)."""
+        buf, afc, reactor, printer, lane = self._ready()
+        buf.multiplier_hysteresis = 0.005  # 0.5%
+        buf.set_point = 0.5
+        buf.trailing_min_multiplier = 1.0
+        buf.low_point = 0.1
+        buf.multiplier_high = 1.2
+        buf._last_multiplier = 1.05
+
+        buf.smoothed_fps = 0.3985  # multiplier ~1.0505 -> ~0.048%, clearly under 0.5%
+        buf._correction_event(100.0)
+        lane.update_rotation_distance.assert_not_called()
+
+        buf.smoothed_fps = 0.394  # multiplier ~1.053 -> ~0.286%, still under 0.5%
+        buf._correction_event(100.25)
+        lane.update_rotation_distance.assert_not_called()
+
+        buf.smoothed_fps = 0.35  # multiplier ~1.075 -> ~2.4%, clearly over 0.5%
+        buf._correction_event(100.5)
+        lane.update_rotation_distance.assert_called_once()
+
+    def test_state_and_led_still_update_when_stepper_call_is_gated(self):
+        """State/LED tracking must reflect the freshly computed target
+        direction every tick, even when the hysteresis gate suppresses the
+        actual update_rotation_distance call."""
+        buf, afc, reactor, printer, lane = self._ready()
+        buf.multiplier_hysteresis = 0.5  # very coarse -- essentially always gated
+        buf.set_point = 0.5
+        buf.deadband = 0.3
+        buf.led = False
+
+        buf.smoothed_fps = 0.5  # settle baseline first
+        buf._correction_event(100.0)
+        lane.update_rotation_distance.reset_mock()
+
+        buf.smoothed_fps = 0.2  # clearly advancing, but too small a multiplier
+                                # change to clear the 50% hysteresis gate
+        buf._correction_event(100.25)
+
+        lane.update_rotation_distance.assert_not_called()
+        assert buf.last_state == ADVANCING_STATE_NAME
+        assert buf._last_correction_direction == ADVANCING_STATE_NAME
+
+
 class TestCorrectionEventIntegral:
     def _ready(self, **overrides):
         buf, afc, reactor, printer = _make_fps_buffer(**overrides)
@@ -2530,6 +2657,8 @@ class TestCorrectionEventIntegral:
 
     def test_disabled_integral_correction_leaves_pure_p_term(self):
         buf, afc, reactor, printer, lane = self._ready()
+        buf.multiplier_hysteresis = 0.0  # isolate from the default filter -- this
+                                         # test is about the integral gate, not hysteresis
         buf.enable_integral_correction = False
         buf._integral_terms[lane.name] = 0.5  # seed a bias that must NOT apply
         buf.smoothed_fps = 0.5  # neutral -> pure P multiplier is exactly 1.0
@@ -2623,10 +2752,29 @@ class TestCorrectionEventLogging:
     def test_logs_when_multiplier_delta_exceeds_threshold(self):
         buf, afc, reactor, printer, lane = self._ready()
         buf.debug = True
+        buf.multiplier_hysteresis = 0.0  # exercise the hysteresis-disabled
+                                         # branch specifically, not the default
         buf._last_multiplier = 1.0
         buf.smoothed_fps = 0.2  # produces a multiplier well past 1.001
         buf._correction_event(100.0)
         buf.logger.debug.assert_called_once()
+
+    def test_hysteresis_disabled_still_suppresses_log_for_sub_threshold_delta(self):
+        """With multiplier_hysteresis explicitly disabled, set_multiplier()
+        always runs, but log_event still only fires if the applied value
+        actually moved by more than the old fixed 0.001 absolute delta."""
+        buf, afc, reactor, printer, lane = self._ready()
+        buf.debug = True
+        buf.multiplier_hysteresis = 0.0
+        buf.low_point = 0.1
+        buf.multiplier_high = 1.2
+        buf._last_multiplier = 1.05
+        buf.last_state = NEUTRAL_STATE_NAME  # avoid a spurious Unknown->Neutral
+                                             # "transition" from the initial default
+        buf.smoothed_fps = 0.3995  # multiplier ~1.0503 -> delta ~0.0003, under 0.001
+        buf._correction_event(100.0)
+        lane.update_rotation_distance.assert_called_once()  # still applied
+        buf.logger.debug.assert_not_called()  # but not logged
 
     def test_no_log_when_nothing_changed(self):
         buf, afc, reactor, printer, lane = self._ready()

--- a/tests/test_AFC_buffer.py
+++ b/tests/test_AFC_buffer.py
@@ -2510,7 +2510,10 @@ class TestCorrectionEvent:
 class TestCorrectionEventHysteresis:
     """multiplier_hysteresis gates whether _correction_event actually calls
     update_rotation_distance, without affecting the state/LED tracking that
-    happens every tick regardless."""
+    happens every tick regardless. The gate compares the *absolute* delta
+    between the newly computed multiplier and the last applied multiplier
+    against multiplier_hysteresis -- it is not a relative/percentage
+    comparison."""
 
     def _ready(self, **overrides):
         buf, afc, reactor, printer = _make_fps_buffer(**overrides)
@@ -2523,7 +2526,7 @@ class TestCorrectionEventHysteresis:
         buf._update_virtual_sensors = MagicMock()
         return buf, afc, reactor, printer, lane
 
-    def test_default_hysteresis_is_0_3_percent(self):
+    def test_default_hysteresis_is_0_003(self):
         buf, afc, reactor, printer, lane = self._ready()
         assert buf.multiplier_hysteresis == pytest.approx(0.003)
 
@@ -2534,7 +2537,7 @@ class TestCorrectionEventHysteresis:
         buf.multiplier_high = 1.2
         buf._last_multiplier = 1.05
 
-        buf.smoothed_fps = 0.394  # multiplier ~1.053 -> ~0.286%, under the 0.3% default
+        buf.smoothed_fps = 0.394  # multiplier ~1.053 -> delta ~0.003, not over the 0.003 default
         buf._correction_event(100.0)
 
         lane.update_rotation_distance.assert_not_called()
@@ -2546,21 +2549,21 @@ class TestCorrectionEventHysteresis:
         buf.multiplier_high = 1.2
         buf._last_multiplier = 1.05
 
-        buf.smoothed_fps = 0.3  # multiplier ~1.10 -> ~4.76%, well over the 0.3% default
+        buf.smoothed_fps = 0.3  # multiplier ~1.10 -> delta ~0.05, well over the 0.003 default
         buf._correction_event(100.0)
 
         lane.update_rotation_distance.assert_called_once_with(pytest.approx(1.10))
 
     def test_small_change_below_threshold_does_not_apply(self):
         buf, afc, reactor, printer, lane = self._ready()
-        buf.multiplier_hysteresis = 0.005  # 0.5%
+        buf.multiplier_hysteresis = 0.005  # absolute delta
         buf.set_point = 0.5
         buf.trailing_min_multiplier = 1.0
         buf.low_point = 0.1
         buf.multiplier_high = 1.2
         buf._last_multiplier = 1.05  # seed a known non-default baseline directly
 
-        buf.smoothed_fps = 0.394  # computes multiplier=1.053 -> 0.286% change, under threshold
+        buf.smoothed_fps = 0.394  # computes multiplier=1.053 -> delta 0.003, under threshold
         buf._correction_event(100.0)
 
         lane.update_rotation_distance.assert_not_called()
@@ -2568,14 +2571,14 @@ class TestCorrectionEventHysteresis:
 
     def test_large_change_above_threshold_applies_and_updates_last_multiplier(self):
         buf, afc, reactor, printer, lane = self._ready()
-        buf.multiplier_hysteresis = 0.005  # 0.5%
+        buf.multiplier_hysteresis = 0.005  # absolute delta
         buf.set_point = 0.5
         buf.trailing_min_multiplier = 1.0
         buf.low_point = 0.1
         buf.multiplier_high = 1.2
         buf._last_multiplier = 1.05  # seed a known non-default baseline directly
 
-        buf.smoothed_fps = 0.3  # computes multiplier=1.10 -> 4.76% change, over threshold
+        buf.smoothed_fps = 0.3  # computes multiplier=1.10 -> delta 0.05, over threshold
         buf._correction_event(100.0)
 
         lane.update_rotation_distance.assert_called_once_with(pytest.approx(1.10))
@@ -2587,24 +2590,44 @@ class TestCorrectionEventHysteresis:
         relying on an exact floating-point boundary value (which is fragile
         to construct/compare precisely)."""
         buf, afc, reactor, printer, lane = self._ready()
-        buf.multiplier_hysteresis = 0.005  # 0.5%
+        buf.multiplier_hysteresis = 0.005  # absolute delta
         buf.set_point = 0.5
         buf.trailing_min_multiplier = 1.0
         buf.low_point = 0.1
         buf.multiplier_high = 1.2
         buf._last_multiplier = 1.05
 
-        buf.smoothed_fps = 0.3985  # multiplier ~1.0505 -> ~0.048%, clearly under 0.5%
+        buf.smoothed_fps = 0.3985  # multiplier ~1.0505 -> delta ~0.0005, clearly under 0.005
         buf._correction_event(100.0)
         lane.update_rotation_distance.assert_not_called()
 
-        buf.smoothed_fps = 0.394  # multiplier ~1.053 -> ~0.286%, still under 0.5%
+        buf.smoothed_fps = 0.394  # multiplier ~1.053 -> delta ~0.003, still under 0.005
         buf._correction_event(100.25)
         lane.update_rotation_distance.assert_not_called()
 
-        buf.smoothed_fps = 0.35  # multiplier ~1.075 -> ~2.4%, clearly over 0.5%
+        buf.smoothed_fps = 0.35  # multiplier ~1.075 -> delta ~0.025, clearly over 0.005
         buf._correction_event(100.5)
         lane.update_rotation_distance.assert_called_once()
+
+    def test_hysteresis_is_absolute_not_relative(self):
+        """A large-magnitude last-applied multiplier must not shrink the
+        effective gate the way a relative/percentage comparison would --
+        the same absolute delta is gated identically regardless of baseline."""
+        buf, afc, reactor, printer, lane = self._ready()
+        buf.multiplier_hysteresis = 0.02  # absolute delta
+        buf.set_point = 0.5
+        buf.trailing_min_multiplier = 1.0
+        buf.low_point = 0.1
+        buf.multiplier_high = 1.2
+        # Seed a baseline far from 1.0. Under the old relative comparison this
+        # would make small absolute deltas look proportionally tiny and get
+        # filtered; the absolute comparison must gate purely on magnitude.
+        buf._last_multiplier = 0.05
+
+        buf.smoothed_fps = 0.394  # multiplier ~1.053 -> delta ~1.003, clearly over 0.02
+        buf._correction_event(100.0)
+
+        lane.update_rotation_distance.assert_called_once_with(pytest.approx(1.053))
 
     def test_state_and_led_still_update_when_stepper_call_is_gated(self):
         """State/LED tracking must reflect the freshly computed target


### PR DESCRIPTION
## Major Changes in this PR
Noticed that current FPS/PSF code is updating stepper rotation distance every 0.25s, this is too much and could cause a TTC at some point. Added `multiplier_hysteresis` variable that defaults to 0.3%, so that stepper rotation distance only gets applied once the current calculated multiplier changes more that 0.3% from last calculated value. 
- Unit tests were updated with the help from claude

## Notes to Code Reviewers
`multiplier_hysteresis` variable will just be added to OpenAMS documentation PR

## How the changes in this PR are tested
This was how many changes happened over a 13h print, way to many (log was analyzed by claude)
<img width="674" height="61" alt="image" src="https://github.com/user-attachments/assets/998ff720-5811-49e4-8302-bac431f71ca6" />

Tested changes on a 3 hour print and only 304 correction events were recorded, changed about every 35 seconds. Graph below created with claude for this 3 hour print

<img width="1950" height="1950" alt="hex_tray_print_analysis" src="https://github.com/user-attachments/assets/ab3b9fdb-7bb2-4570-9fe2-deae56feaf66" />

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable `multiplier_hysteresis` (default `0.003`) for AFC FPS/PSF buffer corrections to reduce frequent stepper rotation-distance updates when multiplier changes are small.
  - Correction loop updates state/LED tracking each tick, while suppressing stepper multiplier updates until the absolute delta exceeds the configured threshold.
- **Documentation**
  - Updated the changelog with a new **2026-07-22** entry describing configurable hysteresis behavior.
- **Maintenance**
  - Bumped displayed/logged AFC version to **1.1.35**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->