### PR TITLE
(feat): Adding Tool temp check when printing, grabs temperatures from file's moonraker metadata 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-07-24]
+### Added
+- Now checks and sets extruder temperature during prints using per-tool temperatures from
+  the sliced file's metadata (does not fall back to the lane's default material temp while
+  printing if no per-tool temperature is available).
+- Added `disable_print_temp_check` config option to restore the previous skip-during-print behavior.
+
 ## [2026-07-22]
 ### Added
 - Configurable hysteresis for FPS/PSF buffers prevents rotation-distance updates every 0.25s when the computed multiplier changes by 0.003 or less (absolute) from the last applied multiplier (default: 0.003).

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -35,10 +35,10 @@ except: raise error(ERROR_STR.format(import_lib="AFC_logger", trace=traceback.fo
 try: from extras.AFC_logger import AFC_logger
 except: raise error(ERROR_STR.format(import_lib="AFC_logger", trace=traceback.format_exc()))
 
-try: from extras.AFC_functions import afcDeltaTime
+try: from extras.AFC_functions import afcDeltaTime, round_floats
 except: raise error(ERROR_STR.format(import_lib="AFC_functions", trace=traceback.format_exc()))
 
-try: from extras.AFC_utils import add_filament_switch, AFC_moonraker
+try: from extras.AFC_utils import add_filament_switch, AFC_moonraker, AFC_PrintFileMetaData
 except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.format_exc()))
 
 try: from extras.AFC_stats import AFCStats
@@ -94,6 +94,7 @@ class afc:
         self.position_saved     = False
         self.spoolman           = None
         self.moonraker: Optional[AFC_moonraker] = None
+        self.print_data_metadata : Optional[AFC_PrintFileMetaData] = None
         self.td1_defined        = False
         self._td1_present       = False
         self._last_td1_query:float    = 0
@@ -118,6 +119,7 @@ class afc:
         self.monitoring = False
         self.number_of_toolchanges  = 0
         self.current_toolchange     = 0
+        self.print_tool_temperatures: list[int] = []
 
         # tool position when tool change was requested
         self.change_tool_pos = None
@@ -154,6 +156,7 @@ class afc:
 
         self.disable_weight_check   = config.getboolean("disable_weight_check", False) # Set to True to disable weight check when loading filament into lane/toolhead
         self.disable_ooze_check     = config.getboolean("disable_ooze_check", False) # Disable ooze check for lanes being on the same extruder in M104/M109 commands
+        self.disable_print_temp_check = config.getboolean("disable_print_temp_check", False) # Disables print temperature check when swapping lanes while printing
 
         # Auto spool switch settings
         self.auto_spool_switch: bool              = config.getboolean("auto_spool_switch", False)                    # Trigger spool switch based on remaining filament weight
@@ -400,6 +403,8 @@ class afc:
                     self.toolhead.dwell(1)
             self.td1_defined, self._td1_present, self.lane_data_enabled = self.moonraker.check_for_td1()
             self.afc_stats = AFCStats(self.moonraker, self.logger, len(self.tools) > 1)
+            self.print_data_metadata = AFC_PrintFileMetaData(moonraker=self.moonraker,
+                                                             logger=self.logger)
 
             self.printer.send_event("afc:moonraker_connect")
         except Exception as e:
@@ -603,13 +608,16 @@ class afc:
         self.gcode.run_script_from_command("CLEAR_PAUSE")
         self.number_of_toolchanges = 0
         self.current_toolchange    = -1
+        self.print_tool_temperatures = []
+        if self.print_data_metadata:
+            self.print_data_metadata.reset()
         self.save_vars()
 
     def in_print_reactor_timer(self, eventtime):
         """
         Print timer callback to check if printer is currently in a print. If printer is in a print,
         current filename is looked up and metadata is pulled from moonraker to get total filament change
-        count. Once this is done timer callback is stopped and unregistered.
+        count and per-tool temperatures. Once this is done timer callback is stopped and unregistered.
         """
         # Remove timer from reactor
         self.reactor.unregister_timer(self.in_print_timer)
@@ -618,9 +626,11 @@ class afc:
         self.logger.debug("In print: {}, Filename: {}".format(in_print, print_filename))
         if in_print:
             self.number_of_toolchanges = 0
-            if self.moonraker is not None:
-                # Gather file filament change count from moonraker
-                self.number_of_toolchanges  = self.moonraker.get_file_filament_change_count(print_filename)
+            if (self.moonraker is not None
+                and self.print_data_metadata):
+                self.print_data_metadata.filename = print_filename
+                self.number_of_toolchanges = self.print_data_metadata.tool_change_count
+                self.print_tool_temperatures = self.print_data_metadata.tool_temperatures
             self.current_toolchange     = -1 # Reset
             self.logger.info("Total number of toolchanges set to {}".format(self.number_of_toolchanges))
 
@@ -673,7 +683,10 @@ class afc:
 
     def _check_extruder_temp(self, cur_lane: AFCLane, no_wait: bool=False):
         """
-        Helper function that check to see if extruder needs to be heated, and wait for hotend to get to temp if needed
+        Helper function that check to see if extruder needs to be heated, and wait for hotend
+        to get to temp if needed. During a print with per-tool temperatures available from the
+        sliced file's metadata, target temp is looked up from `print_tool_temperatures` instead
+        of the lane's configured/default material temp.
         """
 
         # Prepare extruder and heater.
@@ -683,10 +696,42 @@ class afc:
         pheaters = self.printer.lookup_object('heaters')
         wait = False
 
-        # If extruder can extrude and printing, return and do not update temperature. Don't want to modify extruder temperature during prints
-        if self.heater.can_extrude and self.function.is_printing():
+        # If extruder can extrude and printing, return and do not update temperature.
+        # Don't want to modify extruder temperature during prints, only want to modify/verify if
+        # print_tool_temperatures have valid temperatures as its safe to set hotends to a value
+        # based off extruder mapping since this is what the slicer will do anyways.
+        if (self.heater.can_extrude
+            and self.function.is_printing()
+            and not self.print_tool_temperatures
+            and self.disable_print_temp_check):
             return
-        target_temp, using_min_value = self._get_default_material_temps(cur_lane)
+
+        if (self.function.is_printing()
+            and self.print_tool_temperatures):
+            using_min_value = False
+            target_temp = None
+            try:
+                # cur_lane.map is expected to be the tool number as "T<n>" (e.g. "T3"),
+                # used here as the index into print_tool_temperatures from the sliced
+                # file's metadata. Custom user-assigned maps may not follow this format.
+                idx = int(cur_lane.map.lstrip("T"))
+                target_temp = self.print_tool_temperatures[idx]
+                self.logger.info(f"Checking Temperature for {cur_lane.map}")
+            except (ValueError, IndexError):
+                self.logger.info(
+                    f"Could not resolve print_tool_temperatures index for map {cur_lane.map}"
+                )
+                # Returning instead of trying to lookup from default material
+                return
+
+            if target_temp is None:
+                self.logger.info(f"No print_tool_temperatures entry for map {cur_lane.map}")
+                # Returning instead of trying to lookup from default material,
+                # don't want to modify extruder temperature to temperatures that could be wrong
+                # during prints
+                return
+        else:
+            target_temp, using_min_value = self._get_default_material_temps(cur_lane)
 
         current_temp = self.heater.get_temp(self.reactor.monotonic())
 
@@ -1044,7 +1089,8 @@ class afc:
 
         :param e_amount: Amount to move extruder either positive(extruder) or negative(retract)
         :param speed: Speed to perform move at
-        :param log_string: Additional string or name to log to logger when recording toolhead position in log
+        :param log_string: Additional string or name to log to logger when recording toolhead
+            position in log
         :param wait_tool: Set to True to wait on toolhead moves
         """
         newpos = self.gcode_move.last_position
@@ -1056,10 +1102,13 @@ class afc:
 
     def save_pos(self):
         """
-        Only save previous location on the first toolchange call to keep an error state from overwriting the location
+        Only save previous location on the first toolchange call to keep an error state from
+        overwriting the location
         """
         if not self.in_toolchange:
-            if not self.error_state and not self.function.is_paused() and not self.position_saved:
+            if (not self.error_state 
+                and not self.function.is_paused()
+                and not self.position_saved):
                 self.position_saved         = True
                 self.last_toolhead_position = self.toolhead.get_position()
                 self.base_position          = list(self.gcode_move.base_position)
@@ -1070,21 +1119,29 @@ class afc:
                 self.absolute_coord         = self.gcode_move.absolute_coord
                 self.absolute_extrude       = self.gcode_move.absolute_extrude
                 self.extrude_factor         = self.gcode_move.extrude_factor
-                msg = "Saving position {}".format(self.last_toolhead_position)
-                msg += " Base position: {}".format(self.base_position)
-                msg += " last_gcode_position: {}".format(self.last_gcode_position)
-                msg += " homing_position: {}".format(self.homing_position)
-                msg += " speed: {}".format(self.speed)
-                msg += " speed_factor: {}".format(self.speed_factor)
-                msg += " absolute_coord: {}".format(self.absolute_coord)
-                msg += " absolute_extrude: {}".format(self.absolute_extrude)
-                msg += " extrude_factor: {}\n".format(self.extrude_factor)
+                # Only rounded for the log message below, stored position values keep full precision
+                msg = f"Saving position {round_floats(self.last_toolhead_position)}"
+                msg += f" Base position: {round_floats(self.base_position)}"
+                msg += f" last_gcode_position: {round_floats(self.last_gcode_position)}"
+                msg += f" homing_position: {round_floats(self.homing_position)}"
+                msg += f" speed: {round_floats(self.speed)}"
+                msg += f" speed_factor: {round_floats(self.speed_factor)}"
+                msg += f" absolute_coord: {self.absolute_coord}"
+                msg += f" absolute_extrude: {self.absolute_extrude}"
+                msg += f" extrude_factor: {round_floats(self.extrude_factor)}\n"
                 self.logger.debug(msg)
             else:
-                self.function.log_toolhead_pos("Not Saving, Error State: {}, Is Paused {}, Position_saved {}, POS: ".format(self.error_state, self.function.is_paused(), self.position_saved))
+                self.function.log_toolhead_pos(
+                    f"Not Saving, Error State: {self.error_state}, "
+                    f"Is Paused {self.function.is_paused()}, "
+                    f"Position_saved {self.position_saved}, POS: "
+                )
         else:
-            self.function.log_toolhead_pos("Not Saving In a toolchange, Error State: {}, Is Paused {}, Position_saved {}, in toolchange: {}, POS: ".format(
-                self.error_state, self.function.is_paused(), self.position_saved, self.in_toolchange ))
+            self.function.log_toolhead_pos(
+                f"Not Saving In a toolchange, Error State: {self.error_state}, "
+                f"Is Paused {self.function.is_paused()}, Position_saved {self.position_saved}, "
+                f"in toolchange: {self.in_toolchange}, POS: "
+            )
 
     def restore_pos(self, move_z_first=True):
         """
@@ -1093,15 +1150,16 @@ class afc:
 
         :param move_z_first: Enable to move z before moving x,y
         """
-        msg = "Restoring Position {}".format(self.last_toolhead_position)
-        msg += " Base position: {}".format(self.base_position)
-        msg += " last_gcode_position: {}".format(self.last_gcode_position)
-        msg += " homing_position: {}".format(self.homing_position)
-        msg += " speed: {}".format(self.speed)
-        msg += " speed_factor: {}".format(self.speed_factor)
-        msg += " absolute_coord: {}".format(self.absolute_coord)
-        msg += " absolute_extrude: {}".format(self.absolute_extrude)
-        msg += " extrude_factor: {}\n".format(self.extrude_factor)
+        # Only rounded for the log message below, restore logic below uses full precision
+        msg = f"Restoring Position {round_floats(self.last_toolhead_position)}"
+        msg += f" Base position: {round_floats(self.base_position)}"
+        msg += f" last_gcode_position: {round_floats(self.last_gcode_position)}"
+        msg += f" homing_position: {round_floats(self.homing_position)}"
+        msg += f" speed: {round_floats(self.speed)}"
+        msg += f" speed_factor: {round_floats(self.speed_factor)}"
+        msg += f" absolute_coord: {self.absolute_coord}"
+        msg += f" absolute_extrude: {self.absolute_extrude}"
+        msg += f" extrude_factor: {round_floats(self.extrude_factor)}\n"
         self.logger.debug(msg)
         self.function.log_toolhead_pos("Resume initial pos: ")
 
@@ -1134,8 +1192,12 @@ class afc:
         self.gcode_move.last_position[:3] = self.last_gcode_position[:3]
 
         # Return to previous xyz
-        self.gcode_move.move_with_transform(self.gcode_move.last_position, self._get_resume_speedz() )
-        self.function.log_toolhead_pos("Resume final z, Error State: {}, Is Paused {}, Position_saved {}, in toolchange: {}, POS: ".format(self.error_state, self.function.is_paused(), self.position_saved, self.in_toolchange))
+        self.gcode_move.move_with_transform(self.gcode_move.last_position,
+                                            self._get_resume_speedz() )
+        self.function.log_toolhead_pos(
+            f"Resume final z, Error State: {self.error_state}, Is Paused {self.function.is_paused()}, "
+            f"Position_saved {self.position_saved}, in toolchange: {self.in_toolchange}, POS: "
+        )
 
         self.current_state = State.IDLE
         self.position_saved = False

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -12,7 +12,7 @@ from functools import cached_property
 from configfile import error
 from klippy import Printer
 
-from typing import Dict, TYPE_CHECKING, Union, Any, Optional, Tuple
+from typing import Dict, TYPE_CHECKING, Union, Any, Optional, Tuple, List
 
 if TYPE_CHECKING:
     from configfile import ConfigWrapper
@@ -119,7 +119,7 @@ class afc:
         self.monitoring = False
         self.number_of_toolchanges  = 0
         self.current_toolchange     = 0
-        self.print_tool_temperatures: list[int] = []
+        self.print_tool_temperatures: List[int] = []
 
         # tool position when tool change was requested
         self.change_tool_pos = None

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -703,8 +703,7 @@ class afc:
         # based off extruder mapping since this is what the slicer will do anyways.
         if (self.heater.can_extrude
             and self.function.is_printing()
-            and not self.print_tool_temperatures
-            and self.disable_print_temp_check):
+            and (self.disable_print_temp_check or not self.print_tool_temperatures)):
             return
 
         if (self.function.is_printing()

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -696,7 +696,8 @@ class afc:
         pheaters = self.printer.lookup_object('heaters')
         wait = False
 
-        # If extruder can extrude and printing, return and do not update temperature.
+        # If extruder can extrude, printing, tool temp is not set or check is disabled, 
+        #   return and do not update temperature.
         # Don't want to modify extruder temperature during prints, only want to modify/verify if
         # print_tool_temperatures have valid temperatures as its safe to set hotends to a value
         # based off extruder mapping since this is what the slicer will do anyways.

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -715,18 +715,20 @@ class afc:
                 # cur_lane.map is expected to be the tool number as "T<n>" (e.g. "T3"),
                 # used here as the index into print_tool_temperatures from the sliced
                 # file's metadata. Custom user-assigned maps may not follow this format.
-                idx = int(cur_lane.map.lstrip("T"))
+                idx = int(str(cur_lane.map).lstrip("T"))
+                if idx < 0: raise ValueError("Negative tool index")
                 target_temp = self.print_tool_temperatures[idx]
-                self.logger.info(f"Checking Temperature for {cur_lane.map}")
-            except (ValueError, IndexError):
+            except (ValueError, IndexError, TypeError, AttributeError) as e:
+                # Logging lane.name/e rather than cur_lane.map here: if the error came from
+                # resolving cur_lane.map itself, referencing it again would raise the same error.
                 self.logger.info(
-                    f"Could not resolve print_tool_temperatures index for map {cur_lane.map}"
+                    f"Could not resolve print_tool_temperatures index for lane {cur_lane.name}: {e}"
                 )
                 # Returning instead of trying to lookup from default material
                 return
 
             if target_temp is None:
-                self.logger.info(f"No print_tool_temperatures entry for map {cur_lane.map}")
+                self.logger.info(f"No print_tool_temperatures entry for lane {cur_lane.name}")
                 # Returning instead of trying to lookup from default material,
                 # don't want to modify extruder temperature to temperatures that could be wrong
                 # during prints

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -696,7 +696,7 @@ class afc:
         pheaters = self.printer.lookup_object('heaters')
         wait = False
 
-        # If extruder can extrude, printing, tool temp is not set or check is disabled, 
+        # If extruder can extrude, printing, tool temp is not set or check is disabled,
         #   return and do not update temperature.
         # Don't want to modify extruder temperature during prints, only want to modify/verify if
         # print_tool_temperatures have valid temperatures as its safe to set hotends to a value
@@ -1107,7 +1107,7 @@ class afc:
         overwriting the location
         """
         if not self.in_toolchange:
-            if (not self.error_state 
+            if (not self.error_state
                 and not self.function.is_paused()
                 and not self.position_saved):
                 self.position_saved         = True

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -44,7 +44,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 try: from extras.AFC_stats import AFCStats
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
 
-AFC_VERSION="1.1.35"
+AFC_VERSION="1.1.36"
 
 # Class for holding different states so its clear what all valid states are
 class State:

--- a/extras/AFC_OpenAMS.py
+++ b/extras/AFC_OpenAMS.py
@@ -718,13 +718,13 @@ class afcAMS(afcUnit):
         self._engagement_length = config.getfloat("engagement_length", 20.0, minval=1.0)
         self._engagement_speed = config.getfloat("engagement_speed", 300.0, minval=10.0)
         self._defer_engagement = config.getboolean("defer_engagement", False)
-        self._engagement_params: dict[str, tuple[float, float]] = {}
+        self._engagement_params: Dict[str, tuple[float, float]] = {}
 
         # Runtime state
         self.oams: AFC_OAMS = None  # type: ignore[assignment]  # resolved in handle_ready()
         self._follower: Optional[FollowerController] = None
         self._monitor: Optional[OAMSMonitor] = None
-        self._spool_map: dict[str, int] = {}
+        self._spool_map: Dict[str, int] = {}
 
         self.gcode = self.printer.lookup_object('gcode')
         self.gcode.register_mux_command(
@@ -760,7 +760,7 @@ class afcAMS(afcUnit):
         self._operation_active = False
         self._prev_states_stale = False
         self._hub_load_suppressed: set[str] = set()
-        self._pending_spool_loaded_timers: dict[str, Any] = {}
+        self._pending_spool_loaded_timers: Dict[str, Any] = {}
         self._td1_last_capture_time = None
 
         # Register temperature_oams sensor factory during config parsing

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -21,7 +21,7 @@ from configfile import error
 from datetime import datetime
 from pathlib import Path
 
-from typing import TYPE_CHECKING, Union, Optional, Any
+from typing import TYPE_CHECKING, Union, Optional, Any, List
 
 if TYPE_CHECKING:
     from extras.AFC import afc
@@ -464,7 +464,7 @@ class afcFunction:
             error_string = "Error: Cannot find [{}] in config, make sure led_index in config is correct".format(afc_object)
         return error_string, led
 
-    def _get_led_indexes(self, index_values: str) -> list[int]:
+    def _get_led_indexes(self, index_values: str) -> List[int]:
         """
         Helper function for creating a list for index values that have dashes and commas
         so the led's can be set correctly.

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -21,7 +21,7 @@ from configfile import error
 from datetime import datetime
 from pathlib import Path
 
-from typing import TYPE_CHECKING, Union, Optional
+from typing import TYPE_CHECKING, Union, Optional, Any
 
 if TYPE_CHECKING:
     from extras.AFC import afc
@@ -43,6 +43,25 @@ except: raise error(ERROR_STR.format(import_lib="AFC_lane", trace=traceback.form
 
 try: from extras.AFC_unit import CALI_WARN
 except: raise error(ERROR_STR.format(import_lib="AFC_unit", trace=traceback.format_exc()))
+
+
+def round_floats(value: Any, digits: int = 6) -> Any:
+    """
+    Recursively rounds floats to the given number of digits, used to keep
+    debug logging of toolhead/gcode_move position data readable.
+
+    :param value: Float, or an iterable of floats, to round
+    :param digits: Number of decimal digits to round to
+    :return Any: Rounded float, list of rounded values, or the original
+                value unchanged if it isn't a float or list/tuple
+    """
+    if isinstance(value, float):
+        return round(value, digits)
+    if isinstance(value, (list, tuple)):
+        # Always returned as a list since toolhead.get_position() returns a namedtuple,
+        # whose constructor takes fixed positional args rather than an iterable.
+        return [round_floats(v, digits) for v in value]
+    return value
 
 
 def load_config(config):
@@ -596,20 +615,20 @@ class afcFunction:
             current_lane.unit_obj.select_lane(current_lane)
             current_lane.set_print_current() # Set current back to print current after lane move
 
-    def log_toolhead_pos(self, move_pre=""):
+    def log_toolhead_pos(self, move_pre: str = "") -> None:
         """
         Helper function for printing position data to log
 
         :param move_pre: String that get appended before the position data
         """
-        msg = "{}Position: {}".format(move_pre, self.afc.toolhead.get_position())
-        msg += " base_position: {}".format(self.afc.gcode_move.base_position)
-        msg += " last_position: {}".format(self.afc.gcode_move.last_position)
-        msg += " speed: {}".format(self.afc.gcode_move.speed)
-        msg += " speed_factor: {}".format(self.afc.gcode_move.speed_factor)
-        msg += " extrude_factor: {}".format(self.afc.gcode_move.extrude_factor)
-        msg += " absolute_coord: {}".format(self.afc.gcode_move.absolute_coord)
-        msg += " absolute_extrude: {}\n".format(self.afc.gcode_move.absolute_extrude)
+        msg = f"{move_pre}Position: {round_floats(self.afc.toolhead.get_position())}"
+        msg += f" base_position: {round_floats(self.afc.gcode_move.base_position)}"
+        msg += f" last_position: {round_floats(self.afc.gcode_move.last_position)}"
+        msg += f" speed: {round_floats(self.afc.gcode_move.speed)}"
+        msg += f" speed_factor: {round_floats(self.afc.gcode_move.speed_factor)}"
+        msg += f" extrude_factor: {round_floats(self.afc.gcode_move.extrude_factor)}"
+        msg += f" absolute_coord: {self.afc.gcode_move.absolute_coord}"
+        msg += f" absolute_extrude: {self.afc.gcode_move.absolute_extrude}\n"
         self.logger.debug(msg, only_debug=True)
 
     def check_absolute_mode( self, func_name:str="" ):

--- a/extras/AFC_utils.py
+++ b/extras/AFC_utils.py
@@ -718,7 +718,7 @@ class AFC_PrintFileMetaData:
         self._filename = value
         if (self._moonraker
             and value):
-            self._metadata = self._moonraker.get_file_metadata(self._filename)
+            self._metadata = self._moonraker.get_file_metadata(self._filename) or {}
 
     @property
     def tool_change_count(self) -> int:

--- a/extras/AFC_utils.py
+++ b/extras/AFC_utils.py
@@ -26,7 +26,7 @@ from urllib.error import (
     HTTPError
 )
 
-from typing import TYPE_CHECKING, Optional, Callable
+from typing import TYPE_CHECKING, Optional, Callable, List
 
 if TYPE_CHECKING:
     from extras.AFC_logger import AFC_logger
@@ -735,9 +735,9 @@ class AFC_PrintFileMetaData:
         return change_count
 
     @property
-    def tool_temperatures(self) -> list[int]:
+    def tool_temperatures(self) -> List[int]:
         """
-        :return list[int]: Per-tool temperatures from cached metadata, empty list if not found
+        :return List[int]: Per-tool temperatures from cached metadata, empty list if not found
         """
         temperature_list = []
         if self._metadata:

--- a/extras/AFC_utils.py
+++ b/extras/AFC_utils.py
@@ -388,6 +388,7 @@ class AFC_moonraker:
         self.last_stats_time= None
         self._lane_data     = False
         self.logger.debug(f"Moonraker url: {self.host}")
+        self.FILENAME_PATH: str = "server/files/metadata?filename="
 
     def _get_results(self, url_string, print_error=True):
         """
@@ -455,22 +456,15 @@ class AFC_moonraker:
             self.logger.debug("Spoolman server is not defined")
             return None
 
-    def get_file_filament_change_count(self, filename:str ):
+    def get_file_metadata(self, filename: str) -> dict:
         """
-        Queries moonraker for files metadata and returns filament change count
+        Queries moonraker for a print file's metadata.
 
         :param filename: Filename to query moonraker and pull metadata
-        :return: Returns number of filament change counts if `filament_change_count` is in metadata.
-                 Returns zero if not found in metadata.
+        :return dict: Metadata dictionary returned by moonraker, None if the query fails
         """
-        change_count = 0
-        resp = self._get_results(urljoin(self.host,
-                                    'server/files/metadata?filename={}'.format(quote(filename))))
-        if resp is not None and 'filament_change_count' in resp:
-            change_count =  resp['filament_change_count']
-        else:
-            self.logger.debug(f"Filament change count metadata not found for file:{filename}")
-        return change_count
+        resp: dict = self._get_results(urljoin(self.host, f"{self.FILENAME_PATH}{quote(filename)}"))
+        return resp
 
     def get_afc_stats(self) -> Optional[dict]:
         """
@@ -690,3 +684,73 @@ class AFC_moonraker:
             self.logger.debug(f"{e}")
             error = True
         return error
+
+class AFC_PrintFileMetaData:
+    """
+    Wraps moonraker's file metadata lookup for the file currently being printed,
+    caching the result so tool change count/temperatures can be read repeatedly
+    without re-querying moonraker.
+    """
+    def __init__(self, moonraker: AFC_moonraker, logger: AFC_logger):
+        """
+        :param moonraker: Moonraker object to query file metadata from
+        :param logger: Logger object to print debug/info messages to
+        """
+        self._moonraker = moonraker
+        self.logger = logger
+        self._filename: str = ""
+        self._metadata: dict = {}
+
+    @property
+    def filename(self) -> str:
+        """
+        :return str: Filename that metadata is currently cached for
+        """
+        return self._filename
+    @filename.setter
+    def filename(self, value: str) -> None:
+        """
+        Sets current filename and queries moonraker for its metadata, caching
+        the result for the `tool_change_count`/`tool_temperatures` properties.
+
+        :param value: Filename to query moonraker and pull metadata for
+        """
+        self._filename = value
+        if (self._moonraker
+            and value):
+            self._metadata = self._moonraker.get_file_metadata(self._filename)
+
+    @property
+    def tool_change_count(self) -> int:
+        """
+        :return int: Number of filament change counts if `filament_change_count` is in
+                     cached metadata, zero if not found
+        """
+        change_count = 0
+        if (self._metadata
+            and "filament_change_count" in self._metadata):
+            change_count = self._metadata.get("filament_change_count", 0)
+        else:
+            self.logger.debug(f"Filament change count metadata not found for file:{self._filename}")
+        return change_count
+
+    @property
+    def tool_temperatures(self) -> list[int]:
+        """
+        :return list[int]: Per-tool temperatures from cached metadata, empty list if not found
+        """
+        temperature_list = []
+        if self._metadata:
+            temperature_list = self._metadata.get("filament_temps", [])
+            if not temperature_list:
+                # Try and get variable thats used for snapmaker U1
+                temperature_list = self._metadata.get("nozzle_temp", [])
+        return temperature_list
+
+    def reset(self) -> None:
+        """
+        Clears cached filename and metadata, used when a print ends/is reset so
+        stale tool change/temperature data isn't reused for the next print.
+        """
+        self._filename = ""
+        self._metadata = {}

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -491,10 +491,12 @@ class TestCheckExtruderTemp:
         assert result is True
 
     # ── disable_print_temp_check ──────────────────────────────────────────────
-    # disable_print_temp_check only affects the early-return guard: it's one of
-    # four conditions (can_extrude, is_printing, not print_tool_temperatures,
-    # disable_print_temp_check) that must ALL be true for the guard to fire.
-    # It plays no part in the separate per-tool-lookup branch below the guard.
+    # The early-return guard fires whenever can_extrude AND is_printing are both
+    # true AND EITHER disable_print_temp_check is set OR print_tool_temperatures
+    # is invalid/empty -- the two are independent triggers, not a combined
+    # requirement. disable_print_temp_check=True always wins, even with valid
+    # per-tool data; conversely, invalid per-tool data always returns early,
+    # even with disable_print_temp_check=False.
 
     def test_disable_print_temp_check_true_triggers_early_return_guard(self):
         """Covers the `disable_print_temp_check` condition of the early-return
@@ -513,10 +515,10 @@ class TestCheckExtruderTemp:
         pheaters.set_temperature.assert_not_called()
         assert result is None
 
-    def test_disable_print_temp_check_false_does_not_trigger_early_return_guard(self):
-        """disable_print_temp_check=False (the default) never lets the early-return
-        guard fire; with no per-tool data it instead falls through to the
-        default-material-temp branch. Proven independently of the True case above."""
+    def test_disable_print_temp_check_false_with_invalid_tool_temp_still_triggers_guard(self):
+        """disable_print_temp_check=False does NOT suppress the guard on its own:
+        while printing with invalid/empty print_tool_temperatures, the guard
+        still fires regardless of the disable flag's value."""
         obj, heater, extruder, pheaters, lane = _make_afc_for_check_extruder_temp(
             heater_target_temp=150, actual_temp=148, target_material_temp=210,
             disable_print_temp_check=False,
@@ -526,16 +528,14 @@ class TestCheckExtruderTemp:
         obj.print_tool_temperatures = []
         lane.map = "T0"
         result = obj._check_extruder_temp(lane)
-        obj._get_default_material_temps.assert_called_once_with(lane)
-        pheaters.set_temperature.assert_called_once_with(heater, 210.0)
-        assert result is True
+        obj._get_default_material_temps.assert_not_called()
+        pheaters.set_temperature.assert_not_called()
+        assert result is None
 
-    def test_disable_print_temp_check_true_does_not_affect_per_tool_lookup(self):
-        """disable_print_temp_check has no bearing on the per-tool-lookup branch
-        once print_tool_temperatures is non-empty during a print. can_extrude is
-        set True so every other guard condition is satisfied too, proving it's
-        specifically the non-empty print_tool_temperatures that bypasses the
-        guard here rather than can_extrude already being false."""
+    def test_disable_print_temp_check_true_triggers_guard_even_with_valid_tool_temp(self):
+        """disable_print_temp_check=True always triggers the early-return guard
+        while printing, even when print_tool_temperatures holds a valid entry
+        for the lane -- it is not limited to the invalid/empty-data case."""
         obj, heater, extruder, pheaters, lane = _make_afc_for_check_extruder_temp(
             heater_target_temp=150, actual_temp=148, target_material_temp=999,
             disable_print_temp_check=True,
@@ -546,8 +546,8 @@ class TestCheckExtruderTemp:
         lane.map = "T0"
         result = obj._check_extruder_temp(lane)
         obj._get_default_material_temps.assert_not_called()
-        pheaters.set_temperature.assert_called_once_with(heater, 230.0)
-        assert result is True
+        pheaters.set_temperature.assert_not_called()
+        assert result is None
 
     # ── lane.map parsing failures ─────────────────────────────────────────────
 

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -583,7 +583,71 @@ class TestCheckExtruderTemp:
         obj._get_default_material_temps.assert_not_called()
         assert result is None
         infos = [m for lvl, m in obj.logger.messages if lvl == "info"]
-        assert any("T5" in m for m in infos)
+        # Message logs lane.name + the caught exception, not cur_lane.map directly
+        # (see test_lane_map_attribute_error_returns_without_setting_temp for why).
+        assert any(lane.name in m and "index out of range" in m for m in infos)
+
+    def test_negative_lane_map_index_returns_without_setting_temp(self):
+        """lane.map that parses to a negative index (e.g. "T-1") is explicitly
+        rejected rather than silently wrapping around to the last entry in
+        print_tool_temperatures via Python's negative-index semantics."""
+        obj, heater, extruder, pheaters, lane = _make_afc_for_check_extruder_temp(
+            heater_target_temp=150, actual_temp=148, target_material_temp=210
+        )
+        obj.function.is_printing.return_value = True
+        obj.print_tool_temperatures = [230, 999]
+        lane.map = "T-1"
+        result = obj._check_extruder_temp(lane)
+        pheaters.set_temperature.assert_not_called()
+        obj._wait_for_temp_within_tolerance.assert_not_called()
+        obj._get_default_material_temps.assert_not_called()
+        assert result is None
+        infos = [m for lvl, m in obj.logger.messages if lvl == "info"]
+        assert any(lane.name in m and "Negative tool index" in m for m in infos)
+
+    def test_non_subscriptable_print_tool_temperatures_returns_without_setting_temp(self):
+        """A TypeError raised by indexing print_tool_temperatures (e.g. it holds
+        a non-subscriptable type) is caught and returns without touching the
+        heater rather than propagating."""
+        obj, heater, extruder, pheaters, lane = _make_afc_for_check_extruder_temp(
+            heater_target_temp=150, actual_temp=148, target_material_temp=210
+        )
+        obj.function.is_printing.return_value = True
+        obj.print_tool_temperatures = {230}  # set: truthy but not subscriptable
+        lane.map = "T0"
+        result = obj._check_extruder_temp(lane)
+        pheaters.set_temperature.assert_not_called()
+        obj._wait_for_temp_within_tolerance.assert_not_called()
+        obj._get_default_material_temps.assert_not_called()
+        assert result is None
+        infos = [m for lvl, m in obj.logger.messages if lvl == "info"]
+        assert any(lane.name in m and "not subscriptable" in m for m in infos)
+
+    def test_lane_map_attribute_error_returns_without_setting_temp(self):
+        """An AttributeError raised while resolving lane.map (e.g. a custom
+        object whose __str__ blows up) is caught and returns without touching
+        the heater rather than propagating. The except handler must log via
+        lane.name/the caught exception rather than cur_lane.map -- referencing
+        cur_lane.map again here would re-raise the same AttributeError and
+        escape the try/except entirely."""
+
+        class _RaisesAttributeError:
+            def __str__(self):
+                raise AttributeError("boom")
+
+        obj, heater, extruder, pheaters, lane = _make_afc_for_check_extruder_temp(
+            heater_target_temp=150, actual_temp=148, target_material_temp=210
+        )
+        obj.function.is_printing.return_value = True
+        obj.print_tool_temperatures = [230]
+        lane.map = _RaisesAttributeError()
+        result = obj._check_extruder_temp(lane)
+        pheaters.set_temperature.assert_not_called()
+        obj._wait_for_temp_within_tolerance.assert_not_called()
+        obj._get_default_material_temps.assert_not_called()
+        assert result is None
+        infos = [m for lvl, m in obj.logger.messages if lvl == "info"]
+        assert any(lane.name in m and "boom" in m for m in infos)
 
     def test_none_value_in_print_tool_temperatures_returns_without_setting_temp(self):
         """A None entry in print_tool_temperatures (e.g. slicer had no data for
@@ -602,7 +666,7 @@ class TestCheckExtruderTemp:
         obj._wait_for_temp_within_tolerance.assert_not_called()
         assert result is None
         infos = [m for lvl, m in obj.logger.messages if lvl == "info"]
-        assert any("T0" in m for m in infos)
+        assert any(lane.name in m for m in infos)
 
 
 # ── _cooldown_last_extruder ───────────────────────────────────────────────────

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -137,6 +137,9 @@ def _make_afc():
     obj.afcDeltaTime = MagicMock()
     obj.toolhead = MagicMock()
     obj.error = MagicMock()
+    obj.print_tool_temperatures = []
+    obj.print_data_metadata = None
+    obj.disable_print_temp_check = False
     return obj
 
 
@@ -267,11 +270,13 @@ def _make_afc_for_check_extruder_temp(
     target_material_temp,
     lower_extruder_temp_on_change=True,
     using_min_value=False,
+    disable_print_temp_check=False,
 ):
     from tests.test_AFC_lane import _make_afc_lane
     """Build an afc instance wired up for _check_extruder_temp tests."""
     obj = _make_afc()
     obj.lower_extruder_temp_on_change = lower_extruder_temp_on_change
+    obj.disable_print_temp_check = disable_print_temp_check
     obj._wait_for_temp_within_tolerance = MagicMock()
 
     heater = MagicMock()
@@ -393,10 +398,13 @@ class TestCheckExtruderTemp:
 
     # ── Early-return guard ────────────────────────────────────────────────────
 
-    def test_no_change_when_printing(self):
-        """can_extrude=True + is_printing=True → early return, no temp change."""
+    def test_no_change_when_printing_and_disable_print_temp_check_set(self):
+        """can_extrude=True + is_printing=True + disable_print_temp_check=True and
+        no per-tool data → early return, no temp change (legacy skip-during-print
+        behavior, restored via the disable flag)."""
         obj, heater, extruder, pheaters, lane = _make_afc_for_check_extruder_temp(
-            heater_target_temp=150, actual_temp=148, target_material_temp=210
+            heater_target_temp=150, actual_temp=148, target_material_temp=210,
+            disable_print_temp_check=True,
         )
         heater.can_extrude = True
         obj.function.is_printing.return_value = True
@@ -405,6 +413,196 @@ class TestCheckExtruderTemp:
         obj._wait_for_temp_within_tolerance.assert_not_called()
         assert result is None
     # TODO: add passing in a no_wait variable
+
+    # ── print_tool_temperatures (per-tool temps from print metadata) ─────────
+
+    def test_no_early_return_when_printing_and_print_tool_temperatures_set(self):
+        """can_extrude=True + is_printing=True but print_tool_temperatures is set →
+        early-return guard is bypassed and the per-tool target temp is used."""
+        obj, heater, extruder, pheaters, lane = _make_afc_for_check_extruder_temp(
+            heater_target_temp=150, actual_temp=148, target_material_temp=210
+        )
+        heater.can_extrude = True
+        obj.function.is_printing.return_value = True
+        obj.print_tool_temperatures = [230]
+        lane.map = "T0"
+        result = obj._check_extruder_temp(lane)
+        pheaters.set_temperature.assert_called_once_with(heater, 230.0)
+        obj._wait_for_temp_within_tolerance.assert_called_once_with(obj.heater, 230,
+                                                                    obj.temp_wait_tolerance*2)
+        assert result is True
+
+    def test_print_tool_temperatures_uses_lane_map_index(self):
+        """Target temp is looked up in print_tool_temperatures using the lane's
+        map index (e.g. "T1" → index 1), not _get_default_material_temps."""
+        obj, heater, extruder, pheaters, lane = _make_afc_for_check_extruder_temp(
+            heater_target_temp=150, actual_temp=148, target_material_temp=999
+        )
+        obj.function.is_printing.return_value = True
+        obj.print_tool_temperatures = [180, 220, 260]
+        lane.map = "T1"
+        result = obj._check_extruder_temp(lane)
+        obj._get_default_material_temps.assert_not_called()
+        pheaters.set_temperature.assert_called_once_with(heater, 220.0)
+        assert result is True
+
+    def test_print_tool_temperatures_not_using_min_value_so_lower_applies(self):
+        """using_min_value is always False for print_tool_temperatures, so a
+        heater set above target+tolerance is lowered even though it wouldn't
+        be for a min_extrude_temp fallback."""
+        obj, heater, extruder, pheaters, lane = _make_afc_for_check_extruder_temp(
+            heater_target_temp=250, actual_temp=248, target_material_temp=210,
+        )
+        obj.function.is_printing.return_value = True
+        obj.print_tool_temperatures = [210]
+        lane.map = "T0"
+        result = obj._check_extruder_temp(lane)
+        pheaters.set_temperature.assert_called_once_with(heater, 210.0)
+        obj._wait_for_temp_within_tolerance.assert_not_called()
+        assert result is False
+
+    def test_falls_back_to_default_material_temps_when_not_printing(self):
+        """print_tool_temperatures set but not printing → still uses
+        _get_default_material_temps, not the per-tool list."""
+        obj, heater, extruder, pheaters, lane = _make_afc_for_check_extruder_temp(
+            heater_target_temp=150, actual_temp=148, target_material_temp=210
+        )
+        obj.function.is_printing.return_value = False
+        obj.print_tool_temperatures = [999]
+        lane.map = "T0"
+        result = obj._check_extruder_temp(lane)
+        obj._get_default_material_temps.assert_called_once_with(lane)
+        pheaters.set_temperature.assert_called_once_with(heater, 210.0)
+        assert result is True
+
+    def test_falls_back_to_default_material_temps_when_print_tool_temperatures_empty(self):
+        """Covers the `print_tool_temperatures` half of the printing-branch condition
+        being falsy on its own (can_extrude=False so the early-return guard never
+        applies here regardless of disable_print_temp_check)."""
+        obj, heater, extruder, pheaters, lane = _make_afc_for_check_extruder_temp(
+            heater_target_temp=150, actual_temp=148, target_material_temp=210
+        )
+        obj.function.is_printing.return_value = True
+        obj.print_tool_temperatures = []
+        lane.map = "T0"
+        result = obj._check_extruder_temp(lane)
+        obj._get_default_material_temps.assert_called_once_with(lane)
+        pheaters.set_temperature.assert_called_once_with(heater, 210.0)
+        assert result is True
+
+    # ── disable_print_temp_check ──────────────────────────────────────────────
+    # disable_print_temp_check only affects the early-return guard: it's one of
+    # four conditions (can_extrude, is_printing, not print_tool_temperatures,
+    # disable_print_temp_check) that must ALL be true for the guard to fire.
+    # It plays no part in the separate per-tool-lookup branch below the guard.
+
+    def test_disable_print_temp_check_true_triggers_early_return_guard(self):
+        """Covers the `disable_print_temp_check` condition of the early-return
+        guard being true, with can_extrude/is_printing True and
+        print_tool_temperatures empty (the other three conditions also true)."""
+        obj, heater, extruder, pheaters, lane = _make_afc_for_check_extruder_temp(
+            heater_target_temp=150, actual_temp=148, target_material_temp=210,
+            disable_print_temp_check=True,
+        )
+        heater.can_extrude = True
+        obj.function.is_printing.return_value = True
+        obj.print_tool_temperatures = []
+        lane.map = "T0"
+        result = obj._check_extruder_temp(lane)
+        obj._get_default_material_temps.assert_not_called()
+        pheaters.set_temperature.assert_not_called()
+        assert result is None
+
+    def test_disable_print_temp_check_false_does_not_trigger_early_return_guard(self):
+        """disable_print_temp_check=False (the default) never lets the early-return
+        guard fire; with no per-tool data it instead falls through to the
+        default-material-temp branch. Proven independently of the True case above."""
+        obj, heater, extruder, pheaters, lane = _make_afc_for_check_extruder_temp(
+            heater_target_temp=150, actual_temp=148, target_material_temp=210,
+            disable_print_temp_check=False,
+        )
+        heater.can_extrude = True
+        obj.function.is_printing.return_value = True
+        obj.print_tool_temperatures = []
+        lane.map = "T0"
+        result = obj._check_extruder_temp(lane)
+        obj._get_default_material_temps.assert_called_once_with(lane)
+        pheaters.set_temperature.assert_called_once_with(heater, 210.0)
+        assert result is True
+
+    def test_disable_print_temp_check_true_does_not_affect_per_tool_lookup(self):
+        """disable_print_temp_check has no bearing on the per-tool-lookup branch
+        once print_tool_temperatures is non-empty during a print. can_extrude is
+        set True so every other guard condition is satisfied too, proving it's
+        specifically the non-empty print_tool_temperatures that bypasses the
+        guard here rather than can_extrude already being false."""
+        obj, heater, extruder, pheaters, lane = _make_afc_for_check_extruder_temp(
+            heater_target_temp=150, actual_temp=148, target_material_temp=999,
+            disable_print_temp_check=True,
+        )
+        heater.can_extrude = True
+        obj.function.is_printing.return_value = True
+        obj.print_tool_temperatures = [230]
+        lane.map = "T0"
+        result = obj._check_extruder_temp(lane)
+        obj._get_default_material_temps.assert_not_called()
+        pheaters.set_temperature.assert_called_once_with(heater, 230.0)
+        assert result is True
+
+    # ── lane.map parsing failures ─────────────────────────────────────────────
+
+    def test_non_numeric_lane_map_returns_without_setting_temp(self):
+        """lane.map that doesn't parse to an int after stripping "T" (ValueError)
+        logs and returns without touching the heater."""
+        obj, heater, extruder, pheaters, lane = _make_afc_for_check_extruder_temp(
+            heater_target_temp=150, actual_temp=148, target_material_temp=210
+        )
+        obj.function.is_printing.return_value = True
+        obj.print_tool_temperatures = [230]
+        lane.map = "custom_lane"
+        result = obj._check_extruder_temp(lane)
+        pheaters.set_temperature.assert_not_called()
+        obj._wait_for_temp_within_tolerance.assert_not_called()
+        obj._get_default_material_temps.assert_not_called()
+        assert result is None
+        infos = [m for lvl, m in obj.logger.messages if lvl == "info"]
+        assert any("custom_lane" in m for m in infos)
+
+    def test_lane_map_index_out_of_range_returns_without_setting_temp(self):
+        """lane.map index beyond print_tool_temperatures' length (IndexError)
+        logs and returns without touching the heater."""
+        obj, heater, extruder, pheaters, lane = _make_afc_for_check_extruder_temp(
+            heater_target_temp=150, actual_temp=148, target_material_temp=210
+        )
+        obj.function.is_printing.return_value = True
+        obj.print_tool_temperatures = [230]
+        lane.map = "T5"
+        result = obj._check_extruder_temp(lane)
+        pheaters.set_temperature.assert_not_called()
+        obj._wait_for_temp_within_tolerance.assert_not_called()
+        obj._get_default_material_temps.assert_not_called()
+        assert result is None
+        infos = [m for lvl, m in obj.logger.messages if lvl == "info"]
+        assert any("T5" in m for m in infos)
+
+    def test_none_value_in_print_tool_temperatures_returns_without_setting_temp(self):
+        """A None entry in print_tool_temperatures (e.g. slicer had no data for
+        that tool) still resolves via the index lookup, but the None result is
+        not used and does NOT fall back to _get_default_material_temps while
+        printing -- it returns without touching the heater instead."""
+        obj, heater, extruder, pheaters, lane = _make_afc_for_check_extruder_temp(
+            heater_target_temp=150, actual_temp=148, target_material_temp=210
+        )
+        obj.function.is_printing.return_value = True
+        obj.print_tool_temperatures = [None, 220]
+        lane.map = "T0"
+        result = obj._check_extruder_temp(lane)
+        obj._get_default_material_temps.assert_not_called()
+        pheaters.set_temperature.assert_not_called()
+        obj._wait_for_temp_within_tolerance.assert_not_called()
+        assert result is None
+        infos = [m for lvl, m in obj.logger.messages if lvl == "info"]
+        assert any("T0" in m for m in infos)
 
 
 # ── _cooldown_last_extruder ───────────────────────────────────────────────────
@@ -2364,6 +2562,303 @@ class TestGetDefaultMaterialTemps:
             assert using_min is False
 
 
+# save_pos
+
+def _make_afc_for_save_pos():
+    """Build an afc instance wired up for save_pos tests."""
+    obj = _make_afc()
+    obj.gcode_move = MagicMock()
+    obj.gcode_move.base_position = [-0.075907456, 0.072678123, 0.0, 2847.634679999981]
+    obj.gcode_move.last_position = [165.174093123, 256.300678987, 2.94, 2882.80021999998]
+    obj.gcode_move.homing_position = [0.0, 0.0, 0.0, 0.0]
+    obj.gcode_move.speed = 350.0
+    obj.gcode_move.speed_factor = 0.016666666666666666
+    obj.gcode_move.absolute_coord = True
+    obj.gcode_move.absolute_extrude = False
+    obj.gcode_move.extrude_factor = 1.0
+    obj.toolhead.get_position.return_value = [
+        165.174093123, 256.300678987, 3.0715305953986847, 2882.80021999998,
+    ]
+    return obj
+
+
+class TestSavePos:
+    def test_saves_position_with_full_precision_when_not_in_toolchange_error_or_paused(self):
+        """Happy path: not in a toolchange, no error, not paused, position not already
+        saved -> attributes are stored at full precision, position_saved flips True."""
+        obj = _make_afc_for_save_pos()
+        obj.in_toolchange = False
+        obj.error_state = False
+        obj.function.is_paused.return_value = False
+        obj.position_saved = False
+
+        obj.save_pos()
+
+        assert obj.position_saved is True
+        assert obj.last_toolhead_position == [
+            165.174093123, 256.300678987, 3.0715305953986847, 2882.80021999998,
+        ]
+        assert obj.base_position == [-0.075907456, 0.072678123, 0.0, 2847.634679999981]
+        assert obj.last_gcode_position == [165.174093123, 256.300678987, 2.94, 2882.80021999998]
+        assert obj.homing_position == [0.0, 0.0, 0.0, 0.0]
+        assert obj.speed == 350.0
+        assert obj.speed_factor == 0.016666666666666666
+        assert obj.absolute_coord is True
+        assert obj.absolute_extrude is False
+        assert obj.extrude_factor == 1.0
+
+    def test_logged_message_has_rounded_values_not_full_precision(self):
+        """The debug log message rounds the position data for readability, while the
+        stored attributes (checked above) keep full precision."""
+        obj = _make_afc_for_save_pos()
+        obj.in_toolchange = False
+        obj.error_state = False
+        obj.function.is_paused.return_value = False
+        obj.position_saved = False
+
+        obj.save_pos()
+
+        expected = (
+            "Saving position [165.174093, 256.300679, 3.071531, 2882.80022]"
+            " Base position: [-0.075907, 0.072678, 0.0, 2847.63468]"
+            " last_gcode_position: [165.174093, 256.300679, 2.94, 2882.80022]"
+            " homing_position: [0.0, 0.0, 0.0, 0.0]"
+            " speed: 350.0"
+            " speed_factor: 0.016667"
+            " absolute_coord: True"
+            " absolute_extrude: False"
+            " extrude_factor: 1.0\n"
+        )
+        assert obj.logger.messages == [("debug", expected)]
+
+    def test_does_not_save_when_error_state_true(self):
+        """Covers the `error_state` half of the not-error/not-paused/not-saved
+        condition being falsy on its own, with the other two still passing."""
+        obj = _make_afc_for_save_pos()
+        obj.in_toolchange = False
+        obj.error_state = True
+        obj.function.is_paused.return_value = False
+        obj.position_saved = False
+
+        obj.save_pos()
+
+        assert obj.position_saved is False
+        assert not hasattr(obj, "last_toolhead_position")
+        obj.function.log_toolhead_pos.assert_called_once()
+
+    def test_does_not_save_when_paused(self):
+        """Covers the `is_paused()` half of the condition being falsy on its own,
+        with error_state and position_saved still passing."""
+        obj = _make_afc_for_save_pos()
+        obj.in_toolchange = False
+        obj.error_state = False
+        obj.function.is_paused.return_value = True
+        obj.position_saved = False
+
+        obj.save_pos()
+
+        assert obj.position_saved is False
+        assert not hasattr(obj, "last_toolhead_position")
+        obj.function.log_toolhead_pos.assert_called_once()
+
+    def test_does_not_save_when_position_already_saved(self):
+        """Covers the `position_saved` half of the condition being falsy on its
+        own, with error_state and is_paused() still passing."""
+        obj = _make_afc_for_save_pos()
+        obj.in_toolchange = False
+        obj.error_state = False
+        obj.function.is_paused.return_value = False
+        obj.position_saved = True
+
+        obj.save_pos()
+
+        assert obj.position_saved is True
+        assert not hasattr(obj, "last_toolhead_position")
+        obj.function.log_toolhead_pos.assert_called_once()
+
+    def test_logs_not_saving_message_when_error_paused_or_already_saved(self):
+        """Verifies the exact log_toolhead_pos() call made on the not-saving branch."""
+        obj = _make_afc_for_save_pos()
+        obj.in_toolchange = False
+        obj.error_state = True
+        obj.function.is_paused.return_value = False
+        obj.position_saved = False
+
+        obj.save_pos()
+
+        expected = (
+            f"Not Saving, Error State: {obj.error_state}, "
+            f"Is Paused {obj.function.is_paused()}, "
+            f"Position_saved {obj.position_saved}, POS: "
+        )
+        obj.function.log_toolhead_pos.assert_called_once_with(expected)
+
+    def test_does_not_save_when_in_toolchange(self):
+        """When in_toolchange is True, the outer branch is taken regardless of
+        error_state/is_paused/position_saved."""
+        obj = _make_afc_for_save_pos()
+        obj.in_toolchange = True
+        obj.error_state = False
+        obj.function.is_paused.return_value = False
+        obj.position_saved = False
+
+        obj.save_pos()
+
+        assert obj.position_saved is False
+        assert not hasattr(obj, "last_toolhead_position")
+        obj.function.log_toolhead_pos.assert_called_once()
+
+    def test_logs_not_saving_in_toolchange_message(self):
+        """Verifies the exact log_toolhead_pos() call made on the in_toolchange branch."""
+        obj = _make_afc_for_save_pos()
+        obj.in_toolchange = True
+        obj.error_state = False
+        obj.function.is_paused.return_value = False
+        obj.position_saved = False
+
+        obj.save_pos()
+
+        expected = (
+            f"Not Saving In a toolchange, Error State: {obj.error_state}, "
+            f"Is Paused {obj.function.is_paused()}, "
+            f"Position_saved {obj.position_saved}, "
+            f"in toolchange: {obj.in_toolchange}, POS: "
+        )
+        obj.function.log_toolhead_pos.assert_called_once_with(expected)
+
+
+# restore_pos
+
+def _make_afc_for_restore_pos():
+    """Build an afc instance wired up for restore_pos tests, with the "saved"
+    position attributes (as save_pos would have populated them) at full precision."""
+    obj = _make_afc()
+    obj.gcode_move = MagicMock()
+    obj.gcode_move.last_position = [10.0, 20.0, 5.0, 100.0]
+    obj.gcode_move.base_position = [0.0, 0.0, 0.0, 0.0]
+    obj.resume_speed = 0
+    obj.resume_z_speed = 0
+    obj.z_hop = 0.4
+    obj.last_toolhead_position = [
+        165.174093123, 256.300678987, 3.0715305953986847, 2882.80021999998,
+    ]
+    obj.base_position = [-0.075907456, 0.072678123, 0.0, 2847.634679999981]
+    obj.last_gcode_position = [165.174093123, 256.300678987, 2.94, 2882.80021999998]
+    obj.homing_position = [0.0, 0.0, 0.0, 0.0]
+    obj.speed = 350.0
+    obj.speed_factor = 0.016666666666666666
+    obj.absolute_coord = True
+    obj.absolute_extrude = False
+    obj.extrude_factor = 1.0
+    obj.position_saved = True
+    obj.current_state = State.IDLE
+    obj.move_z_pos = MagicMock(return_value=3.34)
+    return obj
+
+
+class TestRestorePos:
+    def test_logged_message_has_rounded_values_not_full_precision(self):
+        """The debug log message rounds the position data for readability, while the
+        gcode_move state restored below (checked separately) keeps full precision."""
+        obj = _make_afc_for_restore_pos()
+
+        obj.restore_pos(move_z_first=False)
+
+        expected = (
+            "Restoring Position [165.174093, 256.300679, 3.071531, 2882.80022]"
+            " Base position: [-0.075907, 0.072678, 0.0, 2847.63468]"
+            " last_gcode_position: [165.174093, 256.300679, 2.94, 2882.80022]"
+            " homing_position: [0.0, 0.0, 0.0, 0.0]"
+            " speed: 350.0"
+            " speed_factor: 0.016667"
+            " absolute_coord: True"
+            " absolute_extrude: False"
+            " extrude_factor: 1.0\n"
+        )
+        debug_msgs = [m for lvl, m in obj.logger.messages if lvl == "debug"]
+        assert debug_msgs == [expected]
+
+    def test_restores_gcode_state_at_full_precision(self):
+        """Verifies gcode_move fields are restored from the saved attributes
+        unrounded, proving the rounding is scoped to the log message only."""
+        obj = _make_afc_for_restore_pos()
+
+        obj.restore_pos(move_z_first=False)
+
+        assert obj.gcode_move.base_position[:3] == [-0.075907456, 0.072678123, 0.0]
+        assert obj.gcode_move.homing_position == [0.0, 0.0, 0.0, 0.0]
+        assert obj.gcode_move.absolute_coord is True
+        assert obj.gcode_move.absolute_extrude is False
+        assert obj.gcode_move.extrude_factor == 1.0
+        assert obj.gcode_move.speed == 350.0
+        assert obj.gcode_move.speed_factor == 0.016666666666666666
+
+    def test_restores_relative_e_position_and_xyz(self):
+        """Covers the e_diff/base_position[3] bookkeeping and final xyz restore,
+        computed independently of restore_pos's own formula."""
+        obj = _make_afc_for_restore_pos()
+
+        obj.restore_pos(move_z_first=False)
+
+        # e_diff = new gcode last_position[3] (100.0, untouched by xy-only restore)
+        # minus saved last_gcode_position[3] (2882.80021999998)
+        assert obj.gcode_move.base_position[3] == pytest.approx(64.83446000000095)
+        assert obj.gcode_move.last_position[:3] == [165.174093123, 256.300678987, 2.94]
+
+    def test_move_z_first_true_calls_move_z_pos(self):
+        """Covers the move_z_first=True branch: z is moved via move_z_pos before xy."""
+        obj = _make_afc_for_restore_pos()
+
+        obj.restore_pos(move_z_first=True)
+
+        obj.move_z_pos.assert_called_once_with(
+            obj.last_gcode_position[2] + obj.z_hop, "restore_pos"
+        )
+        assert obj.gcode_move.last_position[2] == 2.94
+
+    def test_move_z_first_false_skips_move_z_pos(self):
+        """Covers the move_z_first=False branch: move_z_pos is never called."""
+        obj = _make_afc_for_restore_pos()
+
+        obj.restore_pos(move_z_first=False)
+
+        obj.move_z_pos.assert_not_called()
+
+    def test_current_state_and_position_saved_reset_on_completion(self):
+        obj = _make_afc_for_restore_pos()
+        obj.current_state = State.RESTORING_POS
+        obj.position_saved = True
+
+        obj.restore_pos(move_z_first=False)
+
+        assert obj.current_state == State.IDLE
+        assert obj.position_saved is False
+
+    def test_logs_resume_checkpoints_via_log_toolhead_pos(self):
+        """restore_pos logs three checkpoints via function.log_toolhead_pos as it
+        progresses: initial pos, after xy move, and after final z move."""
+        obj = _make_afc_for_restore_pos()
+        # Captured before the call since restore_pos resets position_saved at the end,
+        # but the final log message is built with the value as it was at log time.
+        error_state_before = obj.error_state
+        is_paused_before = obj.function.is_paused()
+        position_saved_before = obj.position_saved
+        in_toolchange_before = obj.in_toolchange
+
+        obj.restore_pos(move_z_first=False)
+
+        calls = obj.function.log_toolhead_pos.call_args_list
+        assert calls[0].args[0] == "Resume initial pos: "
+        assert calls[1].args[0] == "Resume prev xy: "
+        expected_final = (
+            f"Resume final z, Error State: {error_state_before}, "
+            f"Is Paused {is_paused_before}, "
+            f"Position_saved {position_saved_before}, "
+            f"in toolchange: {in_toolchange_before}, POS: "
+        )
+        assert calls[2].args[0] == expected_final
+
+
 # in_print_reactor_timer: moonraker None guard
 
 class TestInPrintReactorTimer:
@@ -2388,24 +2883,43 @@ class TestInPrintReactorTimer:
         assert result == obj.reactor.NEVER
 
     def test_calls_moonraker_when_in_print_and_moonraker_set(self):
-        """Happy path: moonraker is queried when both in_print and moonraker are set."""
+        """Happy path: print_data_metadata is queried when both in_print and moonraker are set."""
         obj = self._make()
         obj.moonraker = MagicMock()
-        obj.moonraker.get_file_filament_change_count.return_value = 7
+        obj.print_data_metadata = MagicMock()
+        obj.print_data_metadata.tool_change_count = 7
+        obj.print_data_metadata.tool_temperatures = [210]
         obj.function.in_print.return_value = (True, "test.gcode")
         obj.function.get_current_lane_obj.return_value = None
         obj.in_print_reactor_timer(0.0)
-        obj.moonraker.get_file_filament_change_count.assert_called_once_with("test.gcode")
+        assert obj.print_data_metadata.filename == "test.gcode"
         assert obj.number_of_toolchanges == 7
+        assert obj.print_tool_temperatures == [210]
         assert obj.current_toolchange == -1
 
     def test_does_not_call_moonraker_when_not_in_print(self):
-        """When not in a print, moonraker should not be queried."""
+        """When not in a print, print_data_metadata should not be queried."""
         obj = self._make()
         obj.moonraker = MagicMock()
+        obj.print_data_metadata = MagicMock()
         obj.function.in_print.return_value = (False, None)
         obj.in_print_reactor_timer(0.0)
-        obj.moonraker.get_file_filament_change_count.assert_not_called()
+        assert not obj.print_data_metadata.method_calls
+        assert obj.number_of_toolchanges == 0
+
+    def test_skips_metadata_lookup_when_print_data_metadata_is_none(self):
+        """Covers the `self.print_data_metadata` half of
+        `if self.moonraker is not None and self.print_data_metadata` being
+        falsy while `self.moonraker` alone is truthy."""
+        obj = self._make()
+        obj.moonraker = MagicMock()
+        obj.print_data_metadata = None
+        obj.function.in_print.return_value = (True, "test.gcode")
+        obj.function.get_current_lane_obj.return_value = None
+        result = obj.in_print_reactor_timer(0.0)
+        assert obj.number_of_toolchanges == 0
+        assert obj.current_toolchange == -1
+        assert result == obj.reactor.NEVER
 
 
 # cmd_LANE_MOVE

--- a/tests/test_AFC_functions.py
+++ b/tests/test_AFC_functions.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch, call
 import pytest
 
-from extras.AFC_functions import afcFunction, afcDeltaTime
+from extras.AFC_functions import afcFunction, afcDeltaTime, round_floats
 from extras.AFC_respond import AFCprompt
 
 from tests.test_AFC import _make_afc
@@ -44,6 +44,78 @@ def _make_func():
     func.pause = False
     func.mcu = MagicMock()
     return func
+
+
+# ── round_floats ─────────────────────────────────────────────────────────────
+
+class TestRoundFloats:
+    def test_rounds_single_float(self):
+        assert round_floats(2.882800219999981234) == 2.8828
+
+    def test_leaves_int_unchanged(self):
+        assert round_floats(5) == 5
+
+    def test_rounds_list_of_floats(self):
+        result = round_floats([165.1740931234, 256.3006781234, 3.0715305953986847])
+        assert result == [165.174093, 256.300678, 3.071531]
+
+    def test_rounds_tuple_of_floats(self):
+        result = round_floats((165.1740931234, 256.3006781234))
+        assert result == [165.174093, 256.300678]
+
+    def test_custom_digit_count(self):
+        assert round_floats(1.23456789, digits=2) == 1.23
+
+    def test_non_numeric_passthrough(self):
+        assert round_floats(True) is True
+        assert round_floats("abc") == "abc"
+        assert round_floats(None) is None
+
+
+# ── log_toolhead_pos ──────────────────────────────────────────────────────────
+
+class TestLogToolheadPos:
+    def _wire_positions(self, func):
+        func.afc.toolhead.get_position.return_value = [
+            165.174093123, 256.300678987, 3.0715305953986847, 2882.80021999998,
+        ]
+        func.afc.gcode_move.base_position = [-0.075907456, 0.072678123, 0.0, 2847.634679999981]
+        func.afc.gcode_move.last_position = [165.174093123, 256.300678987, 2.94, 2882.80021999998]
+        func.afc.gcode_move.speed = 350.0
+        func.afc.gcode_move.speed_factor = 0.016666666666666666
+        func.afc.gcode_move.extrude_factor = 1.0
+        func.afc.gcode_move.absolute_coord = True
+        func.afc.gcode_move.absolute_extrude = False
+
+    def test_logs_expected_message_with_move_pre(self):
+        func = _make_func()
+        self._wire_positions(func)
+
+        func.log_toolhead_pos("Before toolswap: ")
+
+        expected = (
+            "Before toolswap: Position: [165.174093, 256.300679, 3.071531, 2882.80022] "
+            "base_position: [-0.075907, 0.072678, 0.0, 2847.63468] "
+            "last_position: [165.174093, 256.300679, 2.94, 2882.80022] "
+            "speed: 350.0 speed_factor: 0.016667 extrude_factor: 1.0 "
+            "absolute_coord: True absolute_extrude: False\n"
+        )
+        assert func.logger.messages == [("debug", expected)]
+
+    def test_logs_expected_message_with_default_move_pre(self):
+        func = _make_func()
+        self._wire_positions(func)
+
+        func.log_toolhead_pos()
+
+        expected = (
+            "Position: [165.174093, 256.300679, 3.071531, 2882.80022] "
+            "base_position: [-0.075907, 0.072678, 0.0, 2847.63468] "
+            "last_position: [165.174093, 256.300679, 2.94, 2882.80022] "
+            "speed: 350.0 speed_factor: 0.016667 extrude_factor: 1.0 "
+            "absolute_coord: True absolute_extrude: False\n"
+        )
+        assert func.logger.messages == [("debug", expected)]
 
 
 # ── HexConvert ────────────────────────────────────────────────────────────────

--- a/tests/test_AFC_utils.py
+++ b/tests/test_AFC_utils.py
@@ -19,7 +19,7 @@ import pytest
 # conftest installs Klipper mocks; extras is on sys.path via REPO_ROOT
 from extras.AFC_utils import (
     check_and_return, section_in_config, DebounceButton, AFC_moonraker,
-    VirtualRunoutHelper, VirtualFilamentSensor,
+    VirtualRunoutHelper, VirtualFilamentSensor, AFC_PrintFileMetaData,
 )
 
 
@@ -367,16 +367,6 @@ class TestAFCMoonraker:
         result = mr.get_spoolman_server()
         assert result == "http://spoolman:7912"
 
-    def test_get_file_filament_change_count_default_zero(self):
-        mr = self._make_moonraker()
-        mr._get_results = MagicMock(return_value=None)
-        assert mr.get_file_filament_change_count("test.gcode") == 0
-
-    def test_get_file_filament_change_count_from_metadata(self):
-        mr = self._make_moonraker()
-        mr._get_results = MagicMock(return_value={"filament_change_count": 5})
-        assert mr.get_file_filament_change_count("test.gcode") == 5
-
     def test_get_afc_stats_returns_none_on_empty_db(self):
         mr = self._make_moonraker()
         mr._get_results = MagicMock(return_value=None)
@@ -616,6 +606,115 @@ class TestAFCMoonraker:
         assert error is True
         errors = [m for lvl, m in mr.logger.messages if lvl == "error"]
         assert len(errors) >= 1
+
+# ── AFC_PrintFileMetaData ───────────────────────────────────────────────────
+
+def _make_print_file_metadata(moonraker=None):
+    from tests.conftest import MockLogger
+    if moonraker is None:
+        moonraker = MagicMock()
+    logger = MockLogger()
+    return AFC_PrintFileMetaData(moonraker, logger), moonraker
+
+
+class TestAFCPrintFileMetaDataInit:
+    def test_init_defaults(self):
+        meta, _ = _make_print_file_metadata()
+        assert meta.filename == ""
+        assert meta.tool_change_count == 0
+        assert meta.tool_temperatures == []
+
+
+class TestAFCPrintFileMetaDataFilename:
+    def test_setting_filename_queries_moonraker_metadata(self):
+        meta, moonraker = _make_print_file_metadata()
+        moonraker.get_file_metadata.return_value = {"filament_change_count": 3}
+        meta.filename = "test.gcode"
+        moonraker.get_file_metadata.assert_called_once_with("test.gcode")
+        assert meta.filename == "test.gcode"
+
+    def test_setting_empty_filename_does_not_query_moonraker(self):
+        """Covers the `value` half of `if self._moonraker and value` being falsy
+        while `self._moonraker` alone is truthy."""
+        meta, moonraker = _make_print_file_metadata()
+        meta.filename = ""
+        moonraker.get_file_metadata.assert_not_called()
+        assert meta.tool_change_count == 0
+
+    def test_setting_filename_with_no_moonraker_does_not_raise(self):
+        """Covers the `self._moonraker` half of `if self._moonraker and value`
+        being falsy while `value` alone is truthy."""
+        from tests.conftest import MockLogger
+        meta = AFC_PrintFileMetaData(None, MockLogger())
+        meta.filename = "test.gcode"
+        assert meta.filename == "test.gcode"
+        assert meta.tool_change_count == 0
+        assert meta.tool_temperatures == []
+
+    def test_updating_filename_refreshes_metadata(self):
+        meta, moonraker = _make_print_file_metadata()
+        moonraker.get_file_metadata.side_effect = [
+            {"filament_change_count": 2},
+            {"filament_change_count": 9},
+        ]
+        meta.filename = "first.gcode"
+        assert meta.tool_change_count == 2
+        meta.filename = "second.gcode"
+        assert meta.tool_change_count == 9
+        assert moonraker.get_file_metadata.call_count == 2
+
+
+class TestAFCPrintFileMetaDataToolChangeCount:
+    def test_tool_change_count_from_metadata(self):
+        meta, moonraker = _make_print_file_metadata()
+        moonraker.get_file_metadata.return_value = {"filament_change_count": 5}
+        meta.filename = "test.gcode"
+        assert meta.tool_change_count == 5
+
+    def test_tool_change_count_default_zero_when_missing(self):
+        meta, moonraker = _make_print_file_metadata()
+        moonraker.get_file_metadata.return_value = {}
+        meta.filename = "test.gcode"
+        assert meta.tool_change_count == 0
+
+    def test_tool_change_count_default_zero_when_metadata_empty_dict(self):
+        """Covers the falsy-`self._metadata` half of
+        `if self._metadata and "filament_change_count" in self._metadata`."""
+        meta, moonraker = _make_print_file_metadata()
+        moonraker.get_file_metadata.return_value = None
+        meta.filename = "test.gcode"
+        assert meta.tool_change_count == 0
+        debug_msgs = [m for lvl, m in meta.logger.messages if lvl == "debug"]
+        assert any("test.gcode" in m for m in debug_msgs)
+
+
+class TestAFCPrintFileMetaDataToolTemperatures:
+    def test_tool_temperatures_from_filament_temps(self):
+        meta, moonraker = _make_print_file_metadata()
+        moonraker.get_file_metadata.return_value = {"filament_temps": [200, 210, 220]}
+        meta.filename = "test.gcode"
+        assert meta.tool_temperatures == [200, 210, 220]
+
+    def test_tool_temperatures_falls_back_to_nozzle_temp(self):
+        """Snapmaker U1 files use `nozzle_temp` instead of `filament_temps`."""
+        meta, moonraker = _make_print_file_metadata()
+        moonraker.get_file_metadata.return_value = {"nozzle_temp": [215]}
+        meta.filename = "test.gcode"
+        assert meta.tool_temperatures == [215]
+
+    def test_tool_temperatures_empty_when_neither_key_present(self):
+        meta, moonraker = _make_print_file_metadata()
+        moonraker.get_file_metadata.return_value = {}
+        meta.filename = "test.gcode"
+        assert meta.tool_temperatures == []
+
+    def test_tool_temperatures_empty_when_metadata_none(self):
+        """Covers the falsy-`self._metadata` branch of `if self._metadata`."""
+        meta, moonraker = _make_print_file_metadata()
+        moonraker.get_file_metadata.return_value = None
+        meta.filename = "test.gcode"
+        assert meta.tool_temperatures == []
+
 
 # ── VirtualRunoutHelper ─────────────────────────────────────────────────────
 class TestVirtualRunoutHelper:

--- a/tests/test_AFC_utils.py
+++ b/tests/test_AFC_utils.py
@@ -663,6 +663,30 @@ class TestAFCPrintFileMetaDataFilename:
         assert meta.tool_change_count == 9
         assert moonraker.get_file_metadata.call_count == 2
 
+    def test_none_metadata_response_normalized_to_empty_dict(self):
+        """moonraker.get_file_metadata() can return None (e.g. a failed query);
+        the cached metadata must still behave as an empty dict rather than
+        None so downstream property access doesn't operate on None."""
+        meta, moonraker = _make_print_file_metadata()
+        moonraker.get_file_metadata.return_value = None
+        meta.filename = "test.gcode"
+        assert meta.tool_change_count == 0
+        assert meta.tool_temperatures == []
+
+    def test_recovers_after_failed_metadata_query_followed_by_success(self):
+        """A failed query (None) for one filename must not leave stale/bad
+        state that breaks a subsequent successful query for another filename."""
+        meta, moonraker = _make_print_file_metadata()
+        moonraker.get_file_metadata.side_effect = [
+            None, {"filament_change_count": 7, "filament_temps": [220]},
+        ]
+        meta.filename = "first.gcode"
+        assert meta.tool_change_count == 0
+        assert meta.tool_temperatures == []
+        meta.filename = "second.gcode"
+        assert meta.tool_change_count == 7
+        assert meta.tool_temperatures == [220]
+
 
 class TestAFCPrintFileMetaDataToolChangeCount:
     def test_tool_change_count_from_metadata(self):
@@ -713,6 +737,18 @@ class TestAFCPrintFileMetaDataToolTemperatures:
         meta, moonraker = _make_print_file_metadata()
         moonraker.get_file_metadata.return_value = None
         meta.filename = "test.gcode"
+        assert meta.tool_temperatures == []
+
+class TestAFCPrintFileMetaDataReset:
+    def test_reset_clears_filename_and_metadata(self):
+        meta, moonraker = _make_print_file_metadata()
+        moonraker.get_file_metadata.return_value = {
+            "filament_change_count": 4, "filament_temps": [200, 210],
+        }
+        meta.filename = "test.gcode"
+        meta.reset()
+        assert meta.filename == ""
+        assert meta.tool_change_count == 0
         assert meta.tool_temperatures == []
 
 


### PR DESCRIPTION
## Major Changes in this PR
- Added ability to automatically check and verify that hotend is set to correct value when printing. This is done by looking up temperature based off the tools T(n) index. If temperature is not set correctly, then temperature will be set to the correct temp during load/unload routines.
- Added `disable_print_temp_check` variable so users have the option to disable this check, which would put AFC back to not checking/setting temperature when printing.
- Added new class to help with grabbing files metadata and storing so that its not looked up multiple times while printing which could lead to a TTC if the response takes too long to return.
- Added rounding function so that positions can be rounded to specified decimal place when logging.
- Added unit tests with the help of claude, also some of the added AFC code was added with claude's help.

## Notes to Code Reviewers

## How the changes in this PR are tested
Tested on U1 printer, set `disable_ooze_check: True` and make sure that there was not a temperature wait before changing lanes in slicer.
Results below where you can see the temperature getting set to 70 since this is Orca's ooze prevention doing this set, but then AFC goes back and set the temperature to the right value before unloading/loading.
<img width="1368" height="553" alt="image" src="https://github.com/user-attachments/assets/b13dcc22-4510-4c02-89fe-b908fc2d2a5b" />

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AFC now sets per-tool extruder temperature targets during prints using sliced-file print metadata, and uses print metadata to determine tool-change counts during active prints.
  * Added `disable_print_temp_check` to revert to the prior “skip during print” behavior when per-tool temperatures aren’t available.
* **Bug Fixes**
  * Improved temperature selection/fallback behavior and refined full-precision position save/restore.
* **Documentation**
  * Updated `CHANGELOG.md` with the new print-time temperature checking behavior.
* **Tests**
  * Expanded unit tests for metadata-driven temperature/tool-change handling and save/restore behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->