### PR TITLE
(feat): Adding additional toolchanger states so that fluidd/mainsail can be updated correctly for toolchangers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2026-07-24]
 ### Added
+- Adding additional states and status so that fluidd/mainsail UIs can be updated to show what tools are being dropped off/picked up when swapping toolheads for toolchangers.
+- Added filament_name and initial_weight status for lanes.
 - Now checks and sets extruder temperature during prints using per-tool temperatures from
   the sliced file's metadata (does not fall back to the lane's default material temp while
   printing if no per-tool temperature is available).

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -45,7 +45,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 try: from extras.AFC_stats import AFCStats
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
 
-AFC_VERSION="1.1.36"
+AFC_VERSION="1.1.37"
 
 # Class for holding different states so its clear what all valid states are
 class State(str, Enum):

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -8,6 +8,7 @@ import json
 import re
 import traceback
 import inspect
+from enum import Enum
 from functools import cached_property
 from configfile import error
 from klippy import Printer
@@ -47,16 +48,23 @@ except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.for
 AFC_VERSION="1.1.36"
 
 # Class for holding different states so its clear what all valid states are
-class State:
+class State(str, Enum):
     INIT            = "Initialized"
     IDLE            = "Idle"
     ERROR           = "Error"
     LOADING         = "Loading"
     UNLOADING       = "Unloading"
-    TOOL_SWAP       = "Tool swap"
+    TOOL_SWAP       = "ToolSwap"
+    TOOL_DOCK       = "ToolDock"
+    TOOL_PICKUP     = "ToolPickup"
     EJECTING_LANE   = "Ejecting"
     MOVING_LANE     = "Moving"
     RESTORING_POS   = "Restoring"
+
+    def __str__(self) -> str:
+        # Without this, str(State.IDLE)/f"{State.IDLE}" return "State.IDLE" instead of
+        # "Idle" (a quirk of str+Enum mixins prior to Python 3.11's StrEnum).
+        return str.__str__(self)
 
 def load_config(config):
     return afc(config)

--- a/extras/AFC_Toolchanger.py
+++ b/extras/AFC_Toolchanger.py
@@ -143,10 +143,12 @@ class AfcToolchanger(afcUnit):
                     break
 
         if tool:
+            tool.status = State.TOOL_PICKUP
             if hasattr(tool, 'tc_lane') and tool.tc_lane is not None:
                 self.tool_swap(tool.tc_lane)
             else:
                 self.logger.error(f"Tool '{tool_key}' does not have a valid 'tc_lane' attribute.")
+            tool.status = State.IDLE
         else:
             self.logger.error(f"Key:{tool_key} invalid for TOOL")
 
@@ -168,6 +170,9 @@ class AfcToolchanger(afcUnit):
         #TODO: Update description text once moved away from KTC
         self._increase_unselect()
         current_extruder = self.afc.function.get_current_extruder_obj()
+        self.afc.current_state = State.TOOL_DOCK
+        if current_extruder:
+            current_extruder.status = State.TOOL_DOCK
         if (current_extruder
             and current_extruder.custom_unselect):
             self.logger.info(f"Running custom unselect: {current_extruder.custom_unselect}")
@@ -187,6 +192,10 @@ class AfcToolchanger(afcUnit):
                 lane_obj.extruder_obj.set_status_led(lane_obj.led_tool_unloaded)
 
         self.afc.spool.set_active_spool('')
+        self.afc.current_state = State.IDLE
+        if current_extruder:
+            current_extruder.status = State.IDLE
+
 
     def tool_swap(self, lane: AFCLane, set_start_time=True):
         """
@@ -204,7 +213,13 @@ class AfcToolchanger(afcUnit):
         if set_start_time:
             self.afc.afcDeltaTime.set_start_time()
 
+        current_extruder = self.function.get_current_extruder_obj()
+        if current_extruder:
+            current_extruder.status = State.TOOL_DOCK
+
         self.afc.current_state = State.TOOL_SWAP
+        lane.extruder_obj.status = State.TOOL_PICKUP
+        lane.extruder_obj.next_pickup = True
         self._increase_unselect()
         self.afc.function.log_toolhead_pos("Before toolswap: ")
         # Save the current position before switching tools and subtract offsets
@@ -220,6 +235,10 @@ class AfcToolchanger(afcUnit):
             self.afc.gcode.run_script_from_command(f"{lane.extruder_obj.custom_tool_swap}")
         else:
             self.afc.gcode.run_script_from_command('SELECT_TOOL T={}'.format(tool_index))
+        lane.extruder_obj.next_pickup = False
+
+        if current_extruder:
+            current_extruder.status = State.IDLE
 
         # Switching toolhead extruders, this is mainly for setups with multiple extruders
         lane.activate_toolhead_extruder()
@@ -231,7 +250,7 @@ class AfcToolchanger(afcUnit):
         self.afc.afcDeltaTime.log_with_time("Tool swap done", debug=False)
         if self.afc.afc_stats.average_tool_swap_time:
             self.afc.afc_stats.average_tool_swap_time.average_time(self.afc.afcDeltaTime.delta_time)
-        self.afc.current_state = State.IDLE
+        lane.extruder_obj.status = self.afc.current_state = State.IDLE
         # Update the base position and homing position after the tool swap.
         self.afc.base_position   = list(self.afc.gcode_move.base_position)
         self.afc.homing_position = list(self.afc.gcode_move.homing_position)

--- a/extras/AFC_Toolchanger.py
+++ b/extras/AFC_Toolchanger.py
@@ -143,12 +143,10 @@ class AfcToolchanger(afcUnit):
                     break
 
         if tool:
-            tool.status = State.TOOL_PICKUP
-            if hasattr(tool, 'tc_lane') and tool.tc_lane is not None:
+            if tool.tc_lane is not None:
                 self.tool_swap(tool.tc_lane)
             else:
                 self.logger.error(f"Tool '{tool_key}' does not have a valid 'tc_lane' attribute.")
-            tool.status = State.IDLE
         else:
             self.logger.error(f"Key:{tool_key} invalid for TOOL")
 

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -41,7 +41,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 try: from extras.AFC_lane import AFCLane, AFCU1Lane
 except: raise error(ERROR_STR.format(import_lib="AFC_lane", trace=traceback.format_exc()))
 
-try: from extras.AFC import AFCLaneState
+try: from extras.AFC import AFCLaneState, State
 except: raise error(ERROR_STR.format(import_lib="AFC", trace=traceback.format_exc()))
 
 try: from extras.AFC_stats import AFCStats_var
@@ -246,6 +246,8 @@ class AFCExtruder:
         self.check_transmit_status_fn   = None
         self.status_led_count:int       = 0
         self._captured_toolhead_temp: Optional[dict] = None
+        self.next_pickup: bool          = False
+        self.status: State              = State.IDLE
 
         # U1 only related variables
         self.filament_sensor_name: str  = config.get('u1_filament_sensor_name', None)
@@ -1075,6 +1077,10 @@ class AFCExtruder:
         self.response['tool_end_status'] = bool(self.tool_end_state)
         self.response['lanes'] = [lane.name for lane in self.lanes.values()]
         self.response['on_shuttle'] = self.on_shuttle()
+        self.response['is_standalone'] = self.is_standalone()
+        self.response['next_pickup'] = self.next_pickup
+        self.response['status'] = self.status
+
         return self.response
 
 def load_config_prefix(config):

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -125,7 +125,8 @@ class AFCLane:
         self.spool_id           = None
         self.color: str         = ""
         self.multi_color: list  = []
-        self.spool_vendor       = ""
+        self.spool_vendor: str  = ""
+        self.filament_name: str = ""
         self.weight: float      = 0.
         self.auto_switch_triggered = False
         self._material: str     = None
@@ -2207,7 +2208,9 @@ class AFCLane:
         response["spool_id"]= int(self.spool_id) if self.spool_id else None
         response["color"]=self.color
         if not save_to_file:
+            response["filament_name"] = self.filament_name
             response["multi_color_hexes"] = self.multi_color
+            response["initial_weight"] = self.espooler.espooler_values.full_weight
 
         response["weight"]=self.weight
         response["extruder_temp"] = self.extruder_temp

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -415,6 +415,7 @@ class AFCSpool:
         cur_lane.bed_temp = None
         cur_lane.clear_lane_data()
         cur_lane.spool_vendor = ""
+        cur_lane.filament_name = ""
 
     def set_spoolID(self, cur_lane: AFCLane, SpoolID: str, save_vars=True):
         if self.afc.spoolman is not None:
@@ -432,7 +433,9 @@ class AFCSpool:
                     cur_lane.filament_diameter  = self._get_filament_values(result['filament'], 'diameter')
                     cur_lane.empty_spool_weight = self._get_filament_values(result, 'spool_weight', default=190)
                     cur_lane.weight             = self._get_filament_values(result, 'remaining_weight')
-                    cur_lane.espooler.espooler_values.full_weight = self._get_filament_values(result, 'initial_weight', default=1000)
+                    full_weight                 = self._get_filament_values(result, 'initial_weight', default=1000)
+                    cur_lane.espooler.espooler_values.full_weight = full_weight
+                    cur_lane.filament_name      = self._get_filament_values(result['filament'], 'name')
 
                     vendor_result  = result["filament"].get("vendor", None)
                     cur_lane.spool_vendor       = ""

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -435,7 +435,7 @@ class AFCSpool:
                     cur_lane.weight             = self._get_filament_values(result, 'remaining_weight')
                     full_weight                 = self._get_filament_values(result, 'initial_weight', default=1000)
                     cur_lane.espooler.espooler_values.full_weight = full_weight
-                    cur_lane.filament_name      = self._get_filament_values(result['filament'], 'name')
+                    cur_lane.filament_name      = self._get_filament_values(result['filament'], 'name', default="")
 
                     vendor_result  = result["filament"].get("vendor", None)
                     cur_lane.spool_vendor       = ""

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -57,16 +57,32 @@ class TestStateConstants:
 
     def test_restoring_pos_value(self):
         assert State.RESTORING_POS == "Restoring"
+    
+    def test_tool_swap_value(self):
+        assert State.TOOL_SWAP == "ToolSwap"
+
+    def test_tool_dock_value(self):
+        assert State.TOOL_DOCK == "ToolDock"
+
+    def test_tool_pickup_value(self):
+        assert State.TOOL_PICKUP == "ToolPickup"
 
     def test_all_constants_are_strings(self):
-        attrs = [a for a in dir(State) if not a.startswith("_")]
-        for attr in attrs:
-            assert isinstance(getattr(State, attr), str)
+        # Iterate actual enum members rather than dir(State), which also picks up
+        # inherited str methods (capitalize, format, ...) now that State is a str/Enum mixin.
+        for member in State:
+            assert isinstance(member.value, str)
 
     def test_all_constants_unique(self):
-        attrs = [a for a in dir(State) if not a.startswith("_")]
-        values = [getattr(State, a) for a in attrs]
+        values = [member.value for member in State]
         assert len(values) == len(set(values))
+
+    def test_str_returns_plain_value_not_enum_repr(self):
+        """str()/f-string formatting must return the plain value (e.g. "Idle"),
+        not the default Enum repr ("State.IDLE"), since callers log/serialize
+        State values as plain strings."""
+        assert str(State.IDLE) == "Idle"
+        assert f"{State.TOOL_DOCK}" == "ToolDock"
 
 
 # ── AFC_VERSION ───────────────────────────────────────────────────────────────

--- a/tests/test_AFC_Toolchanger.py
+++ b/tests/test_AFC_Toolchanger.py
@@ -2,19 +2,26 @@
 
 from __future__ import annotations
 
+import sys
+import importlib.util
+import configparser
 from unittest.mock import MagicMock
+import pytest
 
 from extras.AFC_Toolchanger import AfcToolchanger
-from tests.conftest import MockLogger
+from extras.AFC import State
+from extras.AFC_lane import AFCMoveWarning
 from tests.test_AFC_extruder import _make_extruder_obj
 
-def _make_toolchanger():
-    obj = AfcToolchanger.__new__(AfcToolchanger)
-    obj.tool_swap = MagicMock()
-    obj.logger = MockLogger()
-    obj.afc = MagicMock()
-    obj.afc.tools = {}
-    return obj
+def _make_toolchanger(values=None):
+    """Build a real AfcToolchanger via its actual __init__ (mocking config/
+    printer/reactor dependencies), rather than bypassing construction with
+    __new__. self.afc ends up a real MockAFC (not a bare MagicMock), so
+    self.afc.tools/.function/.gcode/.spool/.gcode_move/.last_gcode_position
+    all come pre-wired the same way they would in production.
+    """
+    config = _make_config_for_init(values=values)
+    return AfcToolchanger(config)
 
 def _make_extruder_for_toolchanger(toolchanger, afc_name="e0", extruder_name="extruder"):
     extruder = _make_extruder_obj(afc_name)
@@ -22,6 +29,225 @@ def _make_extruder_for_toolchanger(toolchanger, afc_name="e0", extruder_name="ex
     extruder.tc_lane = MagicMock()
     toolchanger.afc.tools[extruder.th_extruder_name] = extruder
     return extruder
+
+
+# ── system_Test ──────────────────────────────────────────────────────────────
+
+def _make_lane_for_system_test(name="lane1", tcmd="T0"):
+    lane = MagicMock()
+    lane.name = name
+    lane.map = tcmd
+    lane.prep_state = False
+    lane.load_state = False
+    lane.extruder_obj.lane_loaded = None
+    lane.extruder_obj.prep_on_shuttle_check.return_value = ""
+    return lane
+
+
+class TestSystemTest:
+    def test_returns_true(self):
+        tool = _make_toolchanger()
+        lane = _make_lane_for_system_test()
+        result = tool.system_Test(lane, delay=0, assignTcmd=False, enable_movement=True)
+        assert result is True
+
+    def test_assign_tcmd_true_calls_tcmd_assign(self):
+        tool = _make_toolchanger()
+        lane = _make_lane_for_system_test()
+        tool.system_Test(lane, delay=0, assignTcmd=True, enable_movement=True)
+        tool.afc.function.TcmdAssign.assert_called_once_with(lane)
+
+    def test_assign_tcmd_false_does_not_call_tcmd_assign(self):
+        """Covers the `assignTcmd` falsy branch, proven independently of the
+        truthy case above."""
+        tool = _make_toolchanger()
+        lane = _make_lane_for_system_test()
+        tool.system_Test(lane, delay=0, assignTcmd=False, enable_movement=True)
+        tool.afc.function.TcmdAssign.assert_not_called()
+
+    def test_sends_lane_data(self):
+        tool = _make_toolchanger()
+        lane = _make_lane_for_system_test()
+        tool.system_Test(lane, delay=0, assignTcmd=False, enable_movement=True)
+        lane.send_lane_data.assert_called_once()
+
+    def test_marks_prep_done(self):
+        tool = _make_toolchanger()
+        lane = _make_lane_for_system_test()
+        tool.system_Test(lane, delay=0, assignTcmd=False, enable_movement=True)
+        lane.set_afc_prep_done.assert_called_once()
+
+    def test_loaded_message_when_prepped_loaded_and_lane_loaded_matches_name(self):
+        """All three conditions of the combined `if` true -> LOADED message,
+        including the extruder's prep_on_shuttle_check() suffix."""
+        tool = _make_toolchanger()
+        lane = _make_lane_for_system_test(name="lane1")
+        lane.prep_state = True
+        lane.load_state = True
+        lane.extruder_obj.lane_loaded = "lane1"
+        lane.extruder_obj.prep_on_shuttle_check.return_value = " [on shuttle]"
+
+        tool.system_Test(lane, delay=0, assignTcmd=False, enable_movement=True)
+
+        raw_msgs = [m for lvl, m in tool.logger.messages if lvl == "raw"]
+        assert raw_msgs == [
+            "lane1 tool cmd: T0  <span class=success--text>LOADED</span> [on shuttle]"
+        ]
+
+    def test_no_loaded_message_when_prep_state_false(self):
+        """Covers the `prep_state` half of the combined condition being falsy
+        on its own, with load_state and lane_loaded still satisfied."""
+        tool = _make_toolchanger()
+        lane = _make_lane_for_system_test(name="lane1")
+        lane.prep_state = False
+        lane.load_state = True
+        lane.extruder_obj.lane_loaded = "lane1"
+
+        tool.system_Test(lane, delay=0, assignTcmd=False, enable_movement=True)
+
+        raw_msgs = [m for lvl, m in tool.logger.messages if lvl == "raw"]
+        assert raw_msgs == ["lane1 tool cmd: T0  "]
+
+    def test_no_loaded_message_when_load_state_false(self):
+        """Covers the `load_state` half of the combined condition being falsy
+        on its own, with prep_state and lane_loaded still satisfied."""
+        tool = _make_toolchanger()
+        lane = _make_lane_for_system_test(name="lane1")
+        lane.prep_state = True
+        lane.load_state = False
+        lane.extruder_obj.lane_loaded = "lane1"
+
+        tool.system_Test(lane, delay=0, assignTcmd=False, enable_movement=True)
+
+        raw_msgs = [m for lvl, m in tool.logger.messages if lvl == "raw"]
+        assert raw_msgs == ["lane1 tool cmd: T0  "]
+
+    def test_no_loaded_message_when_lane_loaded_does_not_match_name(self):
+        """Covers the `lane_loaded == name` half of the combined condition
+        being falsy on its own, with prep_state/load_state still satisfied."""
+        tool = _make_toolchanger()
+        lane = _make_lane_for_system_test(name="lane1")
+        lane.prep_state = True
+        lane.load_state = True
+        lane.extruder_obj.lane_loaded = "some_other_lane"
+
+        tool.system_Test(lane, delay=0, assignTcmd=False, enable_movement=True)
+
+        raw_msgs = [m for lvl, m in tool.logger.messages if lvl == "raw"]
+        assert raw_msgs == ["lane1 tool cmd: T0  "]
+
+
+# ── _increase_unselect ───────────────────────────────────────────────────────
+
+class TestIncreaseUnselect:
+    def test_increases_count_when_current_extruder_present(self):
+        tool = _make_toolchanger()
+        current_extruder = _make_extruder_obj("extruder0")
+        tool.afc.function.get_current_extruder_obj.return_value = current_extruder
+
+        tool._increase_unselect()
+
+        current_extruder.estats.tool_unselected.increase_count.assert_called_once()
+
+    def test_does_not_raise_when_no_current_extruder(self):
+        """Covers the `current_extruder` falsy branch, proven independently
+        of the truthy case above."""
+        tool = _make_toolchanger()
+        tool.afc.function.get_current_extruder_obj.return_value = None
+
+        # Must not raise despite there being no current extruder.
+        tool._increase_unselect()
+
+
+# ── move_to_hub / move_to_load / load_then_home ───────────────────────────────
+# These are static overrides of AFC_unit's move interface for toolchangers,
+# which don't actually move a stepper -- the toolchanger performs moves via
+# tool_swap()/SELECT_TOOL instead. They always report success with 0 distance.
+
+class TestMoveToHub:
+    def test_returns_success_zero_distance_no_warning(self):
+        tool = _make_toolchanger()
+        lane = MagicMock()
+        result = tool.move_to_hub(lane, dist=50.0, dir=MagicMock())
+        assert result == (True, 0, AFCMoveWarning.NONE)
+
+
+class TestMoveToLoad:
+    def test_returns_success_zero_distance_no_warning(self):
+        tool = _make_toolchanger()
+        lane = MagicMock()
+        result = tool.move_to_load(lane, dist=50.0, dir=MagicMock())
+        assert result == (True, 0, AFCMoveWarning.NONE)
+
+
+class TestLoadThenHome:
+    def test_returns_success_zero_distance_no_warning(self):
+        tool = _make_toolchanger()
+        lane = MagicMock()
+        result = tool.load_then_home(lane, distance=50.0, assist_active=MagicMock(),
+                                     endstop=MagicMock())
+        assert result == (True, 0, AFCMoveWarning.NONE)
+
+
+# ── __init__ ─────────────────────────────────────────────────────────────────
+
+def _make_config_for_init(name="AFC_Toolchanger my_tc", values=None):
+    from tests.conftest import MockConfig, MockPrinter, MockAFC
+    afc = MockAFC()
+    printer = MockPrinter(afc=afc)
+    return MockConfig(name=name, printer=printer, values=values)
+
+
+class TestAfcToolchangerInit:
+    def test_type_defaults_to_toolchanger(self):
+        config = _make_config_for_init()
+        tool = AfcToolchanger(config)
+        assert tool.type == "Toolchanger"
+
+    def test_type_uses_config_value_when_provided(self):
+        config = _make_config_for_init(values={"type": "CustomToolchanger"})
+        tool = AfcToolchanger(config)
+        assert tool.type == "CustomToolchanger"
+
+    def test_registers_select_tool_command(self):
+        config = _make_config_for_init()
+        tool = AfcToolchanger(config)
+        calls = tool.functions.register_commands.call_args_list
+        names = [c.args[1] for c in calls]
+        assert "AFC_SELECT_TOOL" in names
+
+    def test_registers_unselect_tool_command(self):
+        config = _make_config_for_init()
+        tool = AfcToolchanger(config)
+        calls = tool.functions.register_commands.call_args_list
+        names = [c.args[1] for c in calls]
+        assert "AFC_UNSELECT_TOOL" in names
+
+    def test_registers_set_toolhead_led_command(self):
+        config = _make_config_for_init()
+        tool = AfcToolchanger(config)
+        calls = tool.functions.register_commands.call_args_list
+        names = [c.args[1] for c in calls]
+        assert "AFC_SET_TOOLHEAD_LED" in names
+
+
+# ── load_config_prefix / load_config ────────────────────────────────────────
+
+class TestLoadConfigPrefix:
+    def test_returns_afc_toolchanger_instance(self):
+        from extras.AFC_Toolchanger import load_config_prefix
+        config = _make_config_for_init()
+        instance = load_config_prefix(config)
+        assert isinstance(instance, AfcToolchanger)
+
+
+class TestLoadConfig:
+    def test_returns_afc_toolchanger_instance(self):
+        from extras.AFC_Toolchanger import load_config
+        config = _make_config_for_init()
+        instance = load_config(config)
+        assert isinstance(instance, AfcToolchanger)
+
 
 class TestcmdAFCSelectTool:
     def test_dict_tool_name(self):
@@ -77,7 +303,7 @@ class TestcmdAFCSelectTool:
         extruder = _make_extruder_for_toolchanger(tool)
         extruder1 = _make_extruder_for_toolchanger(tool, "e1", "extruder1")
         extruder1.tc_lane = None
-        
+
         key_tool = "e1"
         gcmd = MagicMock()
         gcmd.get.side_effect = lambda key, default=None: {
@@ -88,3 +314,572 @@ class TestcmdAFCSelectTool:
         tool.tool_swap.assert_not_called()
         error_msg = [m for lvl, m in tool.logger.messages if lvl == "error"]
         assert any(f"Tool '{key_tool}' does not have a valid 'tc_lane' attribute." in m for m in error_msg)
+
+    def test_invalid_tool_name_does_not_touch_status(self):
+        """When the TOOL key doesn't resolve to any known tool, no status
+        transition happens at all (there's no tool object to set it on)."""
+        tool = _make_toolchanger()
+        tool.tool_swap = MagicMock()
+        extruder = _make_extruder_for_toolchanger(tool)
+        sentinel = object()
+        extruder.status = sentinel
+
+        gcmd = MagicMock()
+        gcmd.get.side_effect = lambda key, default=None: {
+            "TOOL": "unknown"
+        }.get(key, default)
+
+        tool.cmd_AFC_SELECT_TOOL(gcmd)
+
+        tool.tool_swap.assert_not_called()
+        assert extruder.status is sentinel
+
+
+# ── cmd_AFC_UNSELECT_TOOL ───────────────────────────────────────────────────
+
+def _make_toolchanger_for_unselect(current_extruder=None, current_lane=None):
+    tool = _make_toolchanger()
+    tool.afc.function.get_current_extruder_obj.return_value = current_extruder
+    tool.afc.function.get_current_lane_obj.return_value = current_lane
+    return tool
+
+
+class TestCmdAFCUnselectTool:
+    def test_calls_increase_unselect(self):
+        extruder = _make_extruder_obj()
+        tool = _make_toolchanger_for_unselect(current_extruder=extruder)
+        gcmd = MagicMock()
+
+        tool.cmd_AFC_UNSELECT_TOOL(gcmd)
+
+        extruder.estats.tool_unselected.increase_count.assert_called_once()
+
+    def test_current_state_goes_tool_dock_during_unselect_then_idle(self):
+        extruder = _make_extruder_obj()
+        extruder.custom_unselect = None
+        tool = _make_toolchanger_for_unselect(current_extruder=extruder)
+        captured = {}
+
+        def _capture(*_a, **_k):
+            captured["state_during_unselect"] = tool.afc.current_state
+
+        tool.afc.gcode.run_script_from_command = MagicMock(side_effect=_capture)
+        gcmd = MagicMock()
+
+        tool.cmd_AFC_UNSELECT_TOOL(gcmd)
+
+        assert captured["state_during_unselect"] == State.TOOL_DOCK
+        assert tool.afc.current_state == State.IDLE
+
+    def test_extruder_status_goes_tool_dock_during_unselect_then_idle(self):
+        extruder = _make_extruder_obj()
+        extruder.custom_unselect = None
+        tool = _make_toolchanger_for_unselect(current_extruder=extruder)
+        captured = {}
+
+        def _capture(*_a, **_k):
+            captured["status_during_unselect"] = extruder.status
+
+        tool.afc.gcode.run_script_from_command = MagicMock(side_effect=_capture)
+        gcmd = MagicMock()
+
+        tool.cmd_AFC_UNSELECT_TOOL(gcmd)
+
+        assert captured["status_during_unselect"] == State.TOOL_DOCK
+        assert extruder.status == State.IDLE
+
+    def test_no_current_extruder_does_not_raise_and_still_idles(self):
+        """Covers the `current_extruder` falsy branch: no .status assignment
+        happens, but current_state still transitions normally."""
+        tool = _make_toolchanger_for_unselect(current_extruder=None)
+        gcmd = MagicMock()
+
+        tool.cmd_AFC_UNSELECT_TOOL(gcmd)
+
+        assert tool.afc.current_state == State.IDLE
+
+    def test_runs_custom_unselect_when_defined(self):
+        extruder = _make_extruder_obj()
+        extruder.custom_unselect = "MY_CUSTOM_UNSELECT"
+        tool = _make_toolchanger_for_unselect(current_extruder=extruder)
+        gcmd = MagicMock()
+
+        tool.cmd_AFC_UNSELECT_TOOL(gcmd)
+
+        tool.afc.gcode.run_script_from_command.assert_called_once_with("MY_CUSTOM_UNSELECT")
+        info_msgs = [m for lvl, m in tool.logger.messages if lvl == "info"]
+        assert any("MY_CUSTOM_UNSELECT" in m for m in info_msgs)
+
+    def test_runs_default_unselect_when_no_custom_unselect(self):
+        """Covers the `current_extruder.custom_unselect` falsy half of the
+        combined condition, with current_extruder itself still truthy."""
+        extruder = _make_extruder_obj()
+        extruder.custom_unselect = None
+        tool = _make_toolchanger_for_unselect(current_extruder=extruder)
+        gcmd = MagicMock()
+
+        tool.cmd_AFC_UNSELECT_TOOL(gcmd)
+
+        tool.afc.gcode.run_script_from_command.assert_called_once_with("UNSELECT_TOOL")
+
+    def test_runs_default_unselect_when_no_current_extruder(self):
+        """Covers the `current_extruder` falsy half of the combined condition."""
+        tool = _make_toolchanger_for_unselect(current_extruder=None)
+        gcmd = MagicMock()
+
+        tool.cmd_AFC_UNSELECT_TOOL(gcmd)
+
+        tool.afc.gcode.run_script_from_command.assert_called_once_with("UNSELECT_TOOL")
+
+    def test_lane_tool_loaded_idle_called_when_prepped_loaded_and_tooled(self):
+        lane_obj = MagicMock()
+        lane_obj.prep_state = True
+        lane_obj.load_state = True
+        lane_obj.tool_loaded = True
+        tool = _make_toolchanger_for_unselect(current_lane=lane_obj)
+        gcmd = MagicMock()
+
+        tool.cmd_AFC_UNSELECT_TOOL(gcmd)
+
+        lane_obj.unit_obj.lane_tool_loaded_idle.assert_called_once_with(lane_obj)
+        lane_obj.unit_obj.lane_tool_unloaded.assert_not_called()
+        lane_obj.extruder_obj.set_status_led.assert_not_called()
+
+    def test_lane_tool_unloaded_called_when_prepped_loaded_not_tooled(self):
+        lane_obj = MagicMock()
+        lane_obj.prep_state = True
+        lane_obj.load_state = True
+        lane_obj.tool_loaded = False
+        tool = _make_toolchanger_for_unselect(current_lane=lane_obj)
+        gcmd = MagicMock()
+
+        tool.cmd_AFC_UNSELECT_TOOL(gcmd)
+
+        lane_obj.unit_obj.lane_tool_unloaded.assert_called_once_with(lane_obj)
+        lane_obj.unit_obj.lane_tool_loaded_idle.assert_not_called()
+
+    def test_set_status_led_when_prep_state_false(self):
+        """Covers the `prep_state` half of `prep_state and load_state` being
+        falsy on its own, with load_state still true."""
+        lane_obj = MagicMock()
+        lane_obj.prep_state = False
+        lane_obj.load_state = True
+        tool = _make_toolchanger_for_unselect(current_lane=lane_obj)
+        gcmd = MagicMock()
+
+        tool.cmd_AFC_UNSELECT_TOOL(gcmd)
+
+        lane_obj.extruder_obj.set_status_led.assert_called_once_with(lane_obj.led_tool_unloaded)
+        lane_obj.unit_obj.lane_tool_loaded_idle.assert_not_called()
+        lane_obj.unit_obj.lane_tool_unloaded.assert_not_called()
+
+    def test_set_status_led_when_load_state_false(self):
+        """Covers the `load_state` half of `prep_state and load_state` being
+        falsy on its own, with prep_state still true."""
+        lane_obj = MagicMock()
+        lane_obj.prep_state = True
+        lane_obj.load_state = False
+        tool = _make_toolchanger_for_unselect(current_lane=lane_obj)
+        gcmd = MagicMock()
+
+        tool.cmd_AFC_UNSELECT_TOOL(gcmd)
+
+        lane_obj.extruder_obj.set_status_led.assert_called_once_with(lane_obj.led_tool_unloaded)
+
+    def test_no_lane_actions_when_no_current_lane(self):
+        tool = _make_toolchanger_for_unselect(current_lane=None)
+        gcmd = MagicMock()
+
+        # Must not raise despite no lane_obj being present.
+        tool.cmd_AFC_UNSELECT_TOOL(gcmd)
+
+    def test_sets_active_spool_empty(self):
+        tool = _make_toolchanger_for_unselect()
+        gcmd = MagicMock()
+
+        tool.cmd_AFC_UNSELECT_TOOL(gcmd)
+
+        tool.afc.spool.set_active_spool.assert_called_once_with('')
+
+
+# ── tool_swap ────────────────────────────────────────────────────────────────
+
+def _make_toolchanger_for_tool_swap():
+    # Real __init__ already wires self.function = self.afc.function (see
+    # afcUnit.__init__), so both tool_swap()'s own current-extruder lookup
+    # and _increase_unselect()'s resolve to the same mock without needing to
+    # alias them by hand. self.afc.gcode_move is a bare MagicMock though, so
+    # base_position/homing_position still need to be real (indexable) lists.
+    # afcDeltaTime/afc_stats aren't part of MockAFC's defaults, so tool_swap()
+    # needs them added explicitly.
+    tool = _make_toolchanger()
+    tool.afc.gcode_move.base_position = [0.0, 0.0, 0.0, 0.0]
+    tool.afc.gcode_move.homing_position = [0.0, 0.0, 0.0, 0.0]
+    tool.afc.afcDeltaTime = MagicMock()
+    tool.afc.afc_stats = MagicMock()
+    return tool
+
+
+def _make_lane_for_tool_swap(extruder_name="extruder1"):
+    lane = MagicMock()
+    lane.extruder_obj = _make_extruder_obj(extruder_name)
+    lane.extruder_obj.th_extruder_name = extruder_name
+    lane.extruder_obj.custom_tool_swap = None
+    return lane
+
+
+class TestToolSwap:
+    def test_lane_extruder_status_pickup_and_next_pickup_during_swap(self):
+        """lane.extruder_obj.status is TOOL_PICKUP and next_pickup is True
+        while the SELECT_TOOL command is being issued."""
+        tool = _make_toolchanger_for_tool_swap()
+        tool.function.get_current_extruder_obj.return_value = None
+        lane = _make_lane_for_tool_swap()
+        captured = {}
+
+        def _capture(*_a, **_k):
+            captured["status"] = lane.extruder_obj.status
+            captured["next_pickup"] = lane.extruder_obj.next_pickup
+
+        tool.afc.gcode.run_script_from_command = MagicMock(side_effect=_capture)
+
+        tool.tool_swap(lane)
+
+        assert captured["status"] == State.TOOL_PICKUP
+        assert captured["next_pickup"] is True
+
+    def test_lane_extruder_next_pickup_and_status_reset_after_swap(self):
+        tool = _make_toolchanger_for_tool_swap()
+        tool.function.get_current_extruder_obj.return_value = None
+        lane = _make_lane_for_tool_swap()
+
+        tool.tool_swap(lane)
+
+        assert lane.extruder_obj.next_pickup is False
+        assert lane.extruder_obj.status == State.IDLE
+        assert tool.afc.current_state == State.IDLE
+
+    def test_current_extruder_status_tool_dock_during_swap_then_idle(self):
+        """The previously-active extruder (distinct from the lane being
+        swapped to) is parked at TOOL_DOCK for the duration of the swap."""
+        tool = _make_toolchanger_for_tool_swap()
+        current_extruder = _make_extruder_obj("extruder0")
+        tool.function.get_current_extruder_obj.return_value = current_extruder
+        lane = _make_lane_for_tool_swap()
+        captured = {}
+
+        def _capture(*_a, **_k):
+            captured["status"] = current_extruder.status
+
+        tool.afc.gcode.run_script_from_command = MagicMock(side_effect=_capture)
+
+        tool.tool_swap(lane)
+
+        assert captured["status"] == State.TOOL_DOCK
+        assert current_extruder.status == State.IDLE
+
+    def test_no_current_extruder_does_not_raise(self):
+        """Covers the `current_extruder` falsy branch: no .status assignment
+        happens on a None object, and the swap still completes normally."""
+        tool = _make_toolchanger_for_tool_swap()
+        tool.function.get_current_extruder_obj.return_value = None
+        lane = _make_lane_for_tool_swap()
+
+        tool.tool_swap(lane)
+
+        assert lane.extruder_obj.status == State.IDLE
+
+    def test_increase_unselect_invoked_during_swap(self):
+        """tool_swap() calls self._increase_unselect(), which bumps the
+        previously-active extruder's tool_unselected count."""
+        tool = _make_toolchanger_for_tool_swap()
+        current_extruder = _make_extruder_obj("extruder0")
+        tool.function.get_current_extruder_obj.return_value = current_extruder
+        lane = _make_lane_for_tool_swap()
+
+        tool.tool_swap(lane)
+
+        current_extruder.estats.tool_unselected.increase_count.assert_called_once()
+
+    def test_custom_tool_swap_used_when_defined(self):
+        """Covers the `lane.extruder_obj.custom_tool_swap` truthy branch:
+        the custom macro is run instead of SELECT_TOOL, and logged."""
+        tool = _make_toolchanger_for_tool_swap()
+        tool.function.get_current_extruder_obj.return_value = None
+        lane = _make_lane_for_tool_swap()
+        lane.extruder_obj.custom_tool_swap = "MY_CUSTOM_SWAP"
+
+        tool.tool_swap(lane)
+
+        tool.afc.gcode.run_script_from_command.assert_called_once_with("MY_CUSTOM_SWAP")
+        info_msgs = [m for lvl, m in tool.logger.messages if lvl == "info"]
+        assert any("MY_CUSTOM_SWAP" in m for m in info_msgs)
+
+    def test_tool_index_zero_for_plain_extruder_name(self):
+        """Covers the "extruder" half of the tool_index ternary: the plain
+        `extruder` name maps to index 0."""
+        tool = _make_toolchanger_for_tool_swap()
+        tool.function.get_current_extruder_obj.return_value = None
+        lane = _make_lane_for_tool_swap(extruder_name="extruder")
+
+        tool.tool_swap(lane)
+
+        tool.afc.gcode.run_script_from_command.assert_called_once_with("SELECT_TOOL T=0")
+
+    def test_tool_index_parsed_from_numbered_extruder_name(self):
+        """Covers the numbered-extruder half of the tool_index ternary: the
+        trailing digits of the extruder name are parsed out as the index."""
+        tool = _make_toolchanger_for_tool_swap()
+        tool.function.get_current_extruder_obj.return_value = None
+        lane = _make_lane_for_tool_swap(extruder_name="extruder2")
+
+        tool.tool_swap(lane)
+
+        tool.afc.gcode.run_script_from_command.assert_called_once_with("SELECT_TOOL T=2")
+
+    def test_average_tool_swap_time_called_when_set(self):
+        """Covers the `self.afc.afc_stats.average_tool_swap_time` truthy branch."""
+        tool = _make_toolchanger_for_tool_swap()
+        tool.function.get_current_extruder_obj.return_value = None
+        tool.afc.afc_stats.average_tool_swap_time = MagicMock()
+        lane = _make_lane_for_tool_swap()
+
+        tool.tool_swap(lane)
+
+        tool.afc.afc_stats.average_tool_swap_time.average_time.assert_called_once_with(
+            tool.afc.afcDeltaTime.delta_time
+        )
+
+    def test_average_tool_swap_time_not_called_when_unset(self):
+        """Covers the `self.afc.afc_stats.average_tool_swap_time` falsy branch,
+        proven independently of the truthy case above."""
+        tool = _make_toolchanger_for_tool_swap()
+        tool.function.get_current_extruder_obj.return_value = None
+        tool.afc.afc_stats.average_tool_swap_time = None
+        lane = _make_lane_for_tool_swap()
+
+        # Must not raise despite average_tool_swap_time being None.
+        tool.tool_swap(lane)
+
+    def test_set_start_time_true_calls_set_start_time(self):
+        tool = _make_toolchanger_for_tool_swap()
+        tool.function.get_current_extruder_obj.return_value = None
+        lane = _make_lane_for_tool_swap()
+
+        tool.tool_swap(lane, set_start_time=True)
+
+        tool.afc.afcDeltaTime.set_start_time.assert_called_once()
+
+    def test_set_start_time_false_does_not_call_set_start_time(self):
+        """Covers the `set_start_time` falsy branch, proven independently of
+        the truthy case above."""
+        tool = _make_toolchanger_for_tool_swap()
+        tool.function.get_current_extruder_obj.return_value = None
+        lane = _make_lane_for_tool_swap()
+
+        tool.tool_swap(lane, set_start_time=False)
+
+        tool.afc.afcDeltaTime.set_start_time.assert_not_called()
+
+    def test_activates_toolhead_extruder_and_handles_activation(self):
+        tool = _make_toolchanger_for_tool_swap()
+        tool.function.get_current_extruder_obj.return_value = None
+        lane = _make_lane_for_tool_swap()
+
+        tool.tool_swap(lane)
+
+        lane.activate_toolhead_extruder.assert_called_once()
+        tool.afc.function._handle_activate_extruder.assert_called_once_with(0)
+
+    def test_waits_for_toolhead_moves(self):
+        tool = _make_toolchanger_for_tool_swap()
+        tool.function.get_current_extruder_obj.return_value = None
+        lane = _make_lane_for_tool_swap()
+
+        tool.tool_swap(lane)
+
+        tool.afc.toolhead.wait_moves.assert_called_once()
+
+    def test_logs_before_and_after_toolhead_pos_in_order(self):
+        tool = _make_toolchanger_for_tool_swap()
+        tool.function.get_current_extruder_obj.return_value = None
+        lane = _make_lane_for_tool_swap()
+
+        tool.tool_swap(lane)
+
+        calls = tool.afc.function.log_toolhead_pos.call_args_list
+        assert [c.args[0] for c in calls] == ["Before toolswap: ", "After toolswap: "]
+
+    def test_tool_selected_count_increased(self):
+        tool = _make_toolchanger_for_tool_swap()
+        tool.function.get_current_extruder_obj.return_value = None
+        lane = _make_lane_for_tool_swap()
+
+        tool.tool_swap(lane)
+
+        lane.extruder_obj.estats.tool_selected.increase_count.assert_called_once()
+
+    def test_position_bookkeeping_after_swap(self):
+        """base_position/homing_position are copied (not aliased) from
+        gcode_move, and last_gcode_position round-trips back to its original
+        values since it's offset by the same base_position before and after."""
+        tool = _make_toolchanger_for_tool_swap()
+        tool.function.get_current_extruder_obj.return_value = None
+        tool.afc.last_gcode_position = [10.0, 20.0, 5.0, 100.0]
+        tool.afc.gcode_move.base_position = [1.0, 2.0, 3.0, 4.0]
+        tool.afc.gcode_move.homing_position = [0.5, 0.5, 0.5, 0.5]
+        lane = _make_lane_for_tool_swap()
+
+        tool.tool_swap(lane)
+
+        assert tool.afc.last_gcode_position == [10.0, 20.0, 5.0, 100.0]
+        assert tool.afc.base_position == [1.0, 2.0, 3.0, 4.0]
+        assert tool.afc.homing_position == [0.5, 0.5, 0.5, 0.5]
+        assert tool.afc.base_position is not tool.afc.gcode_move.base_position
+        assert tool.afc.homing_position is not tool.afc.gcode_move.homing_position
+
+
+# ── cmd_AFC_SET_TOOLHEAD_LED ────────────────────────────────────────────────
+
+def _make_gcmd_for_set_toolhead_led(mapping="T0", turn_on=1):
+    gcmd = MagicMock()
+    gcmd.get.side_effect = lambda key, default=None: {"MAP": mapping}.get(key, default)
+    gcmd.get_int.side_effect = lambda key, default=None: {"TURN_ON": turn_on}.get(key, default)
+    gcmd.error = MagicMock(side_effect=lambda msg: Exception(msg))
+    return gcmd
+
+
+class TestCmdAFCSetToolheadLed:
+    def test_raises_and_logs_error_when_map_not_found(self):
+        """Covers the `lane_obj is None` branch: an unknown mapping logs and
+        raises gcmd.error without touching any lane's LEDs."""
+        tool = _make_toolchanger()
+        tool.afc.function.get_lane_by_map.return_value = None
+        gcmd = _make_gcmd_for_set_toolhead_led(mapping="T9")
+
+        with pytest.raises(Exception, match="T9 mapping not found when trying to set toolhead led"):
+            tool.cmd_AFC_SET_TOOLHEAD_LED(gcmd)
+
+        error_msgs = [m for lvl, m in tool.logger.messages if lvl == "error"]
+        assert error_msgs == ["T9 mapping not found when trying to set toolhead led"]
+
+    def test_sets_print_leds_on_found_lane(self):
+        tool = _make_toolchanger()
+        lane_obj = MagicMock()
+        lane_obj.extruder_obj.set_print_leds.return_value = (True, "")
+        tool.afc.function.get_lane_by_map.return_value = lane_obj
+        gcmd = _make_gcmd_for_set_toolhead_led(mapping="T2", turn_on=1)
+
+        tool.cmd_AFC_SET_TOOLHEAD_LED(gcmd)
+
+        lane_obj.extruder_obj.set_print_leds.assert_called_once_with(1)
+
+    def test_turn_on_zero_passed_through(self):
+        tool = _make_toolchanger()
+        lane_obj = MagicMock()
+        lane_obj.extruder_obj.set_print_leds.return_value = (True, "")
+        tool.afc.function.get_lane_by_map.return_value = lane_obj
+        gcmd = _make_gcmd_for_set_toolhead_led(mapping="T2", turn_on=0)
+
+        tool.cmd_AFC_SET_TOOLHEAD_LED(gcmd)
+
+        lane_obj.extruder_obj.set_print_leds.assert_called_once_with(0)
+
+    def test_success_does_not_raise(self):
+        """Covers the `not success` falsy branch, proven independently of
+        the failure case below."""
+        tool = _make_toolchanger()
+        lane_obj = MagicMock()
+        lane_obj.extruder_obj.set_print_leds.return_value = (True, "some error we ignore")
+        tool.afc.function.get_lane_by_map.return_value = lane_obj
+        gcmd = _make_gcmd_for_set_toolhead_led()
+
+        # Must not raise when set_print_leds reports success.
+        tool.cmd_AFC_SET_TOOLHEAD_LED(gcmd)
+
+    def test_raises_gcmd_error_when_set_print_leds_fails(self):
+        """Covers the `not success` truthy branch."""
+        tool = _make_toolchanger()
+        lane_obj = MagicMock()
+        lane_obj.extruder_obj.set_print_leds.return_value = (False, "led index out of range")
+        tool.afc.function.get_lane_by_map.return_value = lane_obj
+        gcmd = _make_gcmd_for_set_toolhead_led()
+
+        with pytest.raises(Exception, match="led index out of range"):
+            tool.cmd_AFC_SET_TOOLHEAD_LED(gcmd)
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# Module-level import guards
+# ═════════════════════════════════════════════════════════════════════════
+
+def _exec_afc_toolchanger_with_blocked_dependency(blocked_module_name):
+    """Execute a throw-away copy of extras/AFC_Toolchanger.py's module-level code
+    with `blocked_module_name` forced to fail import, to exercise the file's
+    top-level ``try: from X import Y / except: raise error(...)`` guards.
+
+    This never touches the real, already-imported ``extras.AFC_Toolchanger``
+    module that the rest of this test suite depends on: the copy is loaded
+    under a throwaway module name and discarded afterward, whether or not it
+    raises. Blocking an import via ``sys.modules[name] = None`` is a standard
+    Python mechanism -- it makes any ``import``/``from ... import`` of that
+    name raise ImportError immediately, without touching the module itself.
+
+    Cleanup restores the *exact same* pre-existing module object in
+    sys.modules (not just removes the block) -- simply deleting the entry
+    would let it get re-imported fresh the next time anything touches it,
+    producing new, distinct class objects that no longer match what other
+    test files already imported and bound references to.
+    """
+    import extras.AFC_Toolchanger as real_module
+    fresh_name = "extras.AFC_Toolchanger_import_guard_probe"
+    original_blocked_module = sys.modules.get(blocked_module_name)
+    sys.modules[blocked_module_name] = None
+    try:
+        spec = importlib.util.spec_from_file_location(fresh_name, real_module.__file__)
+        fresh = importlib.util.module_from_spec(spec)
+        sys.modules[fresh_name] = fresh
+        try:
+            spec.loader.exec_module(fresh)
+        finally:
+            sys.modules.pop(fresh_name, None)
+    finally:
+        if original_blocked_module is not None:
+            sys.modules[blocked_module_name] = original_blocked_module
+        else:
+            sys.modules.pop(blocked_module_name, None)
+
+
+class TestModuleImportGuard:
+    """Covers the four module-level `try/except: raise error(...)` guards in
+    AFC_Toolchanger.py, one per dependency import."""
+
+    def test_afc_utils_import_failure_raises_configparser_error(self):
+        """The very first guard imports ERROR_STR itself from AFC_utils, so
+        it can't use ERROR_STR.format(...) in its own except clause."""
+        with pytest.raises(configparser.Error) as exc_info:
+            _exec_afc_toolchanger_with_blocked_dependency("extras.AFC_utils")
+        assert str(exc_info.value).startswith(
+            "Error when trying to import AFC_utils.ERROR_STR"
+        )
+
+    def test_afc_unit_import_failure_raises_configparser_error(self):
+        with pytest.raises(configparser.Error) as exc_info:
+            _exec_afc_toolchanger_with_blocked_dependency("extras.AFC_unit")
+        assert str(exc_info.value).startswith(
+            "Error trying to import AFC_unit, please rerun install-afc.sh"
+        )
+
+    def test_afc_import_failure_raises_configparser_error(self):
+        with pytest.raises(configparser.Error) as exc_info:
+            _exec_afc_toolchanger_with_blocked_dependency("extras.AFC")
+        assert str(exc_info.value).startswith(
+            "Error trying to import AFC, please rerun install-afc.sh"
+        )
+
+    def test_afc_lane_import_failure_raises_configparser_error(self):
+        with pytest.raises(configparser.Error) as exc_info:
+            _exec_afc_toolchanger_with_blocked_dependency("extras.AFC_lane")
+        assert str(exc_info.value).startswith(
+            "Error trying to import AFC_lane, please rerun install-afc.sh"
+        )

--- a/tests/test_AFC_extruder.py
+++ b/tests/test_AFC_extruder.py
@@ -17,6 +17,7 @@ import sys
 import types
 
 from extras.AFC_extruder import AFCExtruderStats, AFCExtruder
+from extras.AFC import State
 from tests.test_AFC_lane import _make_afc_lane, AFCLaneState
 # ── Helpers ─────────────────────────────────────────────────────────
 
@@ -250,6 +251,8 @@ def _make_afc_extruder(name="extruder"):
     ext.park_detector_obj = None
     ext.tc_name = None
     ext.no_lanes = False
+    ext.next_pickup = False
+    ext.status = State.IDLE
     
     # Toolchanger stuff
     ext.tool_obj = None
@@ -754,6 +757,32 @@ class TestGetStatus:
         ext.lanes = {"lane1": lane}
         result = ext.get_status()
         assert "lane1" in result["lanes"]
+
+    def test_contains_next_pickup(self):
+        ext = _make_afc_extruder()
+        ext.next_pickup = True
+        result = ext.get_status()
+        assert result["next_pickup"] is True
+
+    def test_contains_status(self):
+        ext = _make_afc_extruder()
+        ext.status = State.TOOL_PICKUP
+        result = ext.get_status()
+        assert result["status"] == State.TOOL_PICKUP
+
+    def test_contains_is_standalone_true(self):
+        ext = _make_afc_extruder()
+        ext.no_lanes = True
+        result = ext.get_status()
+        assert result["is_standalone"] is True
+
+    def test_contains_is_standalone_false(self):
+        """Covers the other half of is_standalone(), proven independently of
+        the True case above."""
+        ext = _make_afc_extruder()
+        ext.no_lanes = False
+        result = ext.get_status()
+        assert result["is_standalone"] is False
 
 # ── on_shuttle ────────────────────────────────────────────────────────────────
 # Sentinel value that mirrors the real DETECT_PRESENT constant


### PR DESCRIPTION
## Major Changes in this PR
- Adding additional states and status so that fluidd/mainsail UI can be updated to show what tools are being dropped off/picked up when swapping toolheads for toolchangers.
- Added filament_name and initial_weight status for lanes, resolved #727
- Updated/added unit tests with help from claude

## Notes to Code Reviewers

## How the changes in this PR are tested
Changes have been made in fluidd to test this PR:
 
[Screencast_20260724_161159.webm](https://github.com/user-attachments/assets/82a5a2de-ba5a-40a3-88e1-c05c1720e3b9)


## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to software-design/software-discussions channel (as appropriate) requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved toolchanger status reporting for docking, pickup, and swapping so Fluidd/Mainsail can reflect toolhead transitions.
  * Added lane reporting for `filament_name` and initial spool weight, plus enhanced extruder status with pickup/next-pickup and standalone info.
  * Loaded filament names from spool data.

* **Bug Fixes**
  * Refined tool select/unselect and swap state transitions, including clearer idle/dock handling and safer behavior when no current lane is available.

* **Chores**
  * Updated AFC version to **1.1.37**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->