### PR TITLE
(fix): Resolving issue 804 by exposing AFC_VERSION to afc/status and AFC object endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-07-26]
+### Fixed
+- Fixed issue 804 by exposing AFC_VERSION to `afc/status` and AFC object endpoints for moonraker
+
 ## [2026-07-24]
 ### Added
 - Adding additional states and status so that fluidd/mainsail UIs can be updated to show what tools are being dropped off/picked up when swapping toolheads for toolchangers.

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -45,7 +45,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 try: from extras.AFC_stats import AFCStats
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
 
-AFC_VERSION="1.1.37"
+AFC_VERSION="1.2.0"
 
 # Class for holding different states so its clear what all valid states are
 class State(str, Enum):

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -45,7 +45,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 try: from extras.AFC_stats import AFCStats
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
 
-AFC_VERSION="1.2.0"
+AFC_VERSION="1.2.1"
 
 # Class for holding different states so its clear what all valid states are
 class State(str, Enum):

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -2533,6 +2533,7 @@ class afc:
         Displays current status of AFC for webhooks
         """
         str = {}
+        str['version']                  = AFC_VERSION
         str['current_load']             = self.current
         str['current_lane']             = self.current_loading
         str['next_lane']                = self.next_lane_load
@@ -2580,6 +2581,7 @@ class afc:
             str[unit.name]['system']['hub_loaded'] = unit.hub_obj.state if unit.hub_obj is not None else None
 
         str["system"]                           = {}
+        str["system"]['version']                = AFC_VERSION
         str["system"]['current_load']           = self.current
         str["system"]['num_units']              = len(self.units)
         str["system"]['num_lanes']              = numoflanes

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -277,6 +277,31 @@ class TestGetStatus:
         msg = obj.get_status()["message"]
         assert msg["message"] == "test msg"
 
+    def test_version_matches_afc_version(self):
+        obj = _make_afc()
+        assert obj.get_status()["version"] == AFC_VERSION
+
+
+# ── _webhooks_status ─────────────────────────────────────────────────────────
+
+class TestWebhooksStatus:
+    def test_system_version_matches_afc_version(self):
+        obj = _make_afc()
+        web_request = MagicMock()
+        obj._webhooks_status(web_request)
+        payload = web_request.send.call_args[0][0]
+        assert payload["status:"]["AFC"]["system"]["version"] == AFC_VERSION
+
+    def test_sends_expected_top_level_shape(self):
+        obj = _make_afc()
+        web_request = MagicMock()
+        obj._webhooks_status(web_request)
+        payload = web_request.send.call_args[0][0]
+        system = payload["status:"]["AFC"]["system"]
+        assert system["num_units"] == 0
+        assert system["num_lanes"] == 0
+        assert system["num_extruders"] == 0
+
 
 # ── _check_extruder_temp ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Major Changes in this PR
- Exposing AFC_VERSION to `afc/status` and AFC object endpoints for moonraker, Closes #804
- Merging in main back into DEV with this PR

## Notes to Code Reviewers

## How the changes in this PR are tested
`printer/afc/status` endpoint
```
"system": {
    "version": "1.2.1",
    "current_load": null,
    "num_units": 5,
    "num_lanes": 16,
    "num_extruders": 4,
    "spoolman": "http://spoolman.hm:7912/",
    "td1_present": false,
    "lane_data_enabled": false,
    "current_toolchange": 0,
    "number_of_toolchanges": 0,
    "extruders": {
```
`printer/objects/query?AFC` endpoint
```
"result": {
    "eventtime": 37256.727015973,
    "status": {
      "AFC": {
        "version": "1.2.1",
        "current_load": null,
        "current_lane": null,
        "next_lane": null,
```

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to pr-review channel requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AFC status and system responses now report the current AFC version.
  * Updated AFC version to 1.2.1.

* **Bug Fixes**
  * Resolved missing version information in AFC status and object endpoints.

* **Tests**
  * Added coverage validating version reporting and system status fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->