### PR TITLE
Save weight data to lane_data

### DIFF
--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -1773,7 +1773,8 @@ class AFCLane:
                     "td"             : "",
                     "lane"           : self.lane_index,
                     "extruder_index" : self.lane_extruder_index,
-                    "spool_id"       : None
+                    "spool_id"       : None,
+                    "weight"         : 0
                 }
             }
             self.afc.moonraker.send_lane_data(lane_data)

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -255,6 +255,7 @@ class AFCSpool:
             return
         cur_lane = self.afc.lanes[lane]
         cur_lane.weight = weight
+        cur_lane.send_lane_data()
         self.afc.save_vars()
 
     cmd_SET_MATERIAL_help = "Sets filaments material for a lane"

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -1236,6 +1236,11 @@ class TestSendLaneDataExtruderIndex:
         payload = _get_sent_payload(lane)
         assert payload["namespace"] == "lane_data"
 
+    def test_weight_is_included(self):
+        lane = _make_lane_for_moonraker()
+        payload = _get_sent_payload(lane)
+        assert payload["value"]["weight"] == 750.0
+
     def test_no_send_when_map_is_none(self):
         lane = _make_lane_for_moonraker()
         lane.map = None
@@ -1270,6 +1275,11 @@ class TestClearLaneDataExtruderIndex:
         lane = _make_lane_for_moonraker()
         payload = _get_cleared_payload(lane)
         assert payload["value"]["color"] == ""
+
+    def test_weight_is_cleared(self):
+        lane = _make_lane_for_moonraker()
+        payload = _get_cleared_payload(lane)
+        assert payload["value"]["weight"] == 0
 
     def test_no_clear_when_map_is_none(self):
         lane = _make_lane_for_moonraker()

--- a/tests/test_AFC_spool.py
+++ b/tests/test_AFC_spool.py
@@ -270,6 +270,14 @@ class TestSetWeight:
         spool.cmd_SET_WEIGHT(gcmd)
         assert lane.weight == 250
 
+    def test_calls_send_lane_data(self):
+        spool = _make_spool()
+        lane = _make_lane("lane1")
+        spool.afc.lanes = {"lane1": lane}
+        gcmd = _make_gcmd(LANE="lane1", WEIGHT=250)
+        spool.cmd_SET_WEIGHT(gcmd)
+        lane.send_lane_data.assert_called()
+
     def test_set_weight_invalid_lane_logs_info(self):
         spool = _make_spool()
         spool.afc.lanes = {}


### PR DESCRIPTION
## Major Changes in this PR

Use the same thing we do in other places to make sure we save the weight to `lane_data`.

Closes #805 

## Notes to Code Reviewers

Claude wrote the tests. I broke the tests to make sure they are actually doing what we expect.

## How the changes in this PR are tested

New tests.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to pr-review channel requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clearing lane data now resets both the spool assignment and stored weight.
  * Setting a lane’s weight now immediately updates the lane data.

* **Tests**
  * Added coverage to verify weight updates are sent and fully cleared as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->