### PR TITLE
fix(AFC_unit): use getboolean for remember_spool config

### DIFF
--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -77,7 +77,7 @@ class afcUnit:
         self.extruder                    = config.get("extruder", None)                                      # Extruder name(AFC_extruder) that belongs to this unit, can be overridden in AFC_stepper section
         self.buffer_name                 = config.get('buffer', None)                                        # Buffer name(AFC_buffer) that belongs to this unit, can be overridden in AFC_stepper section
 
-        self.remember_spool              = config.get('remember_spool', False)                               # Turns on/off ability to remember last ejected spool values for all lanes in this unit, can be overridden in AFC_stepper section
+        self.remember_spool              = config.getboolean('remember_spool', False)                               # Turns on/off ability to remember last ejected spool values for all lanes in this unit, can be overridden in AFC_stepper section
         # LED SETTINGS
         # All variables use: (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in AFC.cfg file
         self.led_fault                   = config.get('led_fault', self.afc.led_fault)                       # LED color to set when faults occur in lane


### PR DESCRIPTION
## Summary

Closes #806 — Unit-level `remember_spool` is read with `config.get()` instead of `config.getboolean()`, so an explicitly-configured `False` is returned as the string `"False"` and inherited by lanes as `True` via `bool("False")`.

## Problem

In `AFC_unit.py`:
```python
self.remember_spool = config.get('remember_spool', False)  # returns string "False" when present
```

Lane-level correctly uses `config.getboolean('remember_spool', None)`, and inheritance does:
```python
if self.remember_spool is None:
    self.remember_spool = bool(self.unit_obj.remember_spool)  # bool("False") == True
```

So setting `remember_spool = False` at unit level silently enables it at lane level.

## Fix

Replace `config.get()` with `config.getboolean()` to properly parse the boolean value, matching the pattern already used in `AFC_lane.py`.

## Validation

- Verified `bool("False")` evaluates to `True` in Python (the bug)
- Verified `config.getboolean` returns actual `False` for `"False"` string values
- One-line fix, consistent with existing lane-level pattern


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AFC status and AFC webhooks now expose the AFC version to help verify the running release.
* **Bug Fixes**
  * Lane clearing now resets lane weight (along with spool ID).
  * Setting lane weight now immediately propagates updated lane data before saving.
  * Buffer configuration replacement is more precise (only replaces on exact header matches).
  * Safer copy prompts in non-interactive runs now skip cleanly instead of misbehaving.
* **Tests**
  * Added unit tests covering AFC version reporting and webhook status payload shape, plus lane weight and SET_WEIGHT behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->