### PR TITLE
helixscreen bug fixes

### DIFF
--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -277,6 +277,12 @@ class afcBoxTurtle(afcUnit):
                 else:
                     bowden_dist = round(bow_pos - cur_lane.short_move_dis, 2)
 
+            if bowden_dist < 0:
+                self.afc.error.AFC_error(
+                    "'{}' is not a valid length. Please check your setup and re-run calibration.".format(bowden_dist),
+                    pause=False)
+                return False, "Invalid bowden length", bowden_dist
+
             unload_cal_msg = ''
             cal_msg = f'\n {variable_name}: New: {bowden_dist} Old: {bowden_length}'
             if not is_direct_dist:
@@ -285,11 +291,6 @@ class afcBoxTurtle(afcUnit):
             else:
                 cur_lane.dist_hub = bowden_dist
 
-            if bowden_dist < 0:
-                self.afc.error.AFC_error(
-                    "'{}' is not a valid length. Please check your setup and re-run calibration.".format(bowden_dist),
-                    pause=False)
-                return False, "Invalid bowden length", bowden_dist
             self.afc.function.ConfigRewrite(fullname, variable_name, bowden_dist, cal_msg)
             if not is_direct_dist:
                 self.afc.function.ConfigRewrite(fullname, "afc_unload_bowden_length", cur_lane.hub_obj.afc_unload_bowden_length, unload_cal_msg)

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -1660,6 +1660,7 @@ class afcFunction:
         if (tool_load := self.get_current_lane_obj()) is not None:
             prompt.p_end()
             self.afc.error.AFC_error("Toolhead is loaded with '{}', unload or check sensor before resetting lane".format(tool_load.name), pause=False)
+            return
 
         prompt.p_end()
 

--- a/tests/test_AFC_BoxTurtle.py
+++ b/tests/test_AFC_BoxTurtle.py
@@ -185,3 +185,56 @@ class Test_MoveLane:
             result = unit._move_lane(lane, delay=1, enable_movement=True)
         assert result is False
         pause_mock.assert_called()
+
+
+class TestCalibrateBowdenNegativeDistance:
+    """Regression coverage for AFCProject/AFC-Klipper-Add-On#800: a negative
+    bowden_dist was written into live lane/hub state before the < 0 check
+    ran, so an invalid calibration still corrupted cur_lane.dist_hub /
+    cur_lane.hub_obj.afc_bowden_length even though it returned an error."""
+
+    def _make_lane_for_calibration(self, dist_hub=900, short_move_dis=10):
+        from extras.AFC_lane import AFCMoveWarning
+
+        lane = MagicMock()
+        lane.name = "lane1"
+        lane.fullname = "AFC_stepper lane1"
+        lane.dist_hub = dist_hub
+        lane.short_move_dis = short_move_dis
+        lane.short_moves_speed = 50
+        lane.short_moves_accel = 100
+        lane.is_direct_hub.return_value = True
+        lane.is_direct_dist.return_value = True
+        lane.extruder_obj.tool_start = "toolhead"
+        # Sensor reads "not yet at toolhead" once, then "arrived" — exits
+        # the homing loop after a single short move.
+        lane.get_toolhead_pre_sensor_state.side_effect = [False, True]
+        lane.move_to.return_value = (True, 1, AFCMoveWarning.NONE)
+        lane.unit_obj.move_to_load.return_value = (True, 0, None)
+        return lane
+
+    def test_negative_bowden_dist_does_not_mutate_dist_hub(self):
+        unit = _make_box_turtle()
+        unit.afc.homing_enabled = False
+        unit.afc.error = MagicMock()
+        unit.afc.function = MagicMock()
+
+        lane = self._make_lane_for_calibration(dist_hub=900, short_move_dis=10)
+
+        # First call is the initial "retract to extruder" position (used
+        # only for bookkeeping); second call is the post-homing retract
+        # that yields the final bow_pos=3, which is less than
+        # short_move_dis=10 and drives bowden_dist negative.
+        unit.calc_position = MagicMock(side_effect=[
+            (0, "retract to extruder", True),
+            (3, "retract from toolhead sensor", True),
+        ])
+
+        success, message, bowden_dist = unit.calibrate_bowden(lane, dis=1, tol=1)
+
+        assert success is False
+        assert bowden_dist < 0
+        unit.afc.error.AFC_error.assert_called_once()
+        # The whole point of the fix: dist_hub must be left untouched.
+        assert lane.dist_hub == 900
+        unit.afc.function.ConfigRewrite.assert_not_called()

--- a/tests/test_AFC_functions.py
+++ b/tests/test_AFC_functions.py
@@ -1309,4 +1309,83 @@ class TestCmdAfcLaneResetUnitDelegation:
         self._run(func, gcmd)
 
         assert not hasattr(lane.unit_obj, "get_lane_reset_command")
+
+
+class TestCmdAfcLaneResetToolheadLoadedGuard:
+    """Regression coverage for AFCProject/AFC-Klipper-Add-On#803: the
+    toolhead-loaded guard logged an error but had no `return`, so the
+    reset retract ran anyway."""
+
+    def _make(self, distance=50):
+        func = _make_func()
+        afc, lane = self._make_afc_lane()
+        func.afc = afc
+        gcmd = MagicMock()
+        gcmd.get.side_effect = lambda key, default=None: {
+            "LANE": lane.name,
+            "DISTANCE": distance,
+        }.get(key, default)
+        return func, lane, gcmd
+
+    def _make_afc_lane(self):
+        afc = _make_afc()
+        afc.error = MagicMock()
+        lane = _make_afc_lane()
+        lane.hub_obj = MagicMock()
+        lane.hub_obj.state = True
+        lane.short_move_dis = 10
+        # Only expose move_to_hub, so a call to the unconditional-retract
+        # path would fail loudly rather than silently succeeding through
+        # a stray MagicMock attribute.
+        lane.unit_obj = MagicMock(spec=["move_to_hub"])
+        afc.lanes[lane.name] = lane
+        return afc, lane
+
+    def _run(self, func, gcmd):
+        with patch("extras.AFC_functions.AFCprompt") as mocked_afc_prompt:
+            func.cmd_AFC_LANE_RESET(gcmd)
+        return mocked_afc_prompt
+
+    def test_toolhead_loaded_aborts_before_retract(self):
+        func, lane, gcmd = self._make()
+        tool_lane = MagicMock()
+        tool_lane.name = "lane2"
+        func.get_current_lane_obj = MagicMock(return_value=tool_lane)
+
+        mocked_afc_prompt = self._run(func, gcmd)
+
+        func.afc.error.AFC_error.assert_called_once_with(
+            "Toolhead is loaded with 'lane2', unload or check sensor before resetting lane",
+            pause=False,
+        )
+        mocked_afc_prompt.return_value.p_end.assert_called_once()
+        lane.unit_obj.move_to_hub.assert_not_called()
+        func.afc.gcode.run_script_from_command.assert_not_called()
+        func.afc.gcode.respond_info.assert_not_called()
+
+    def test_toolhead_clear_proceeds_to_retract(self):
+        # A tiny stand-in for the hub: reports the hub as blocked on the
+        # first read (so the earlier "hub already clear" guard is passed),
+        # then reports it clear on every read after (so the move-to-hub
+        # retract while-loop exits immediately).
+        class FakeHub:
+            def __init__(self):
+                self.reads = 0
+                self.hub_clear_move_dis = 65.0
+
+            @property
+            def state(self):
+                self.reads += 1
+                return self.reads <= 1
+
+        func, lane, gcmd = self._make()
+        func.get_current_lane_obj = MagicMock(return_value=None)
+        func.afc.homing_enabled = True
+        lane.hub_obj = FakeHub()
+        lane.move = MagicMock()
+
+        self._run(func, gcmd)
+
+        func.afc.error.AFC_error.assert_not_called()
+        lane.unit_obj.move_to_hub.assert_called_once()
         func.afc.gcode.respond_info.assert_any_call("Resetting lane1 to hub")


### PR DESCRIPTION
## Major Changes in this PR

Closes #800 

Closes #803 

Two simple fixes, a missing return and moving a few lines to address downstream issues from Helixscreen.

Tests updated by claude, and regression tested manually.

## Notes to Code Reviewers

## How the changes in this PR are tested

New test cases.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to pr-review channel requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Bowden calibration handling for invalid negative distances, preventing invalid configuration updates.
  - Lane reset now stops immediately when the toolhead is loaded, avoiding unintended retract or hub-reset actions.

- **Tests**
  - Added regression coverage for invalid Bowden calibration results.
  - Added tests confirming safe lane-reset behavior for loaded and clear toolheads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->