### PR TITLE
(fix): Update BT_ macros to accept lane# or just #

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-08-02]
+### Updated
+- The `BT_LANE_EJECT`, `BT_LANE_MOVE`, and `BT_CHANGE_TOOL` macros will now accept either a lane defined as `lane1` or
+  just a numeric indication of the lane such as `1`. 
 ## [2026-07-26]
 ### Fixed
 - Fixed issue 804 by exposing AFC_VERSION to `afc/status` and AFC object endpoints for moonraker

--- a/config/macros/AFC_macros.cfg
+++ b/config/macros/AFC_macros.cfg
@@ -5,31 +5,65 @@ gcode:
   TOOL_UNLOAD
 
 [gcode_macro BT_CHANGE_TOOL]
-description: Switch to a new lane by ejecting the previously loaded one and then load the lane specified by LANE parameter. Lane parameter is an integer and defaults to 1. ex. `BT_CHANGE_TOOL LANE=2` 
+description: Switch to a new lane by ejecting the previously loaded one and then load the lane specified by LANE parameter. Lane parameter is an integer and defaults to 1, but the full lane name (e.g. lane2) is also accepted. ex. `BT_CHANGE_TOOL LANE=2`
 gcode:
-  {% set lane_num = params.LANE|default(1)|int %}
   {% set stepper = printer['gcode_macro _AFC_GLOBAL_VARS'].stepper_name|string %}
-  
-  CHANGE_TOOL LANE={stepper ~ lane_num}
+  {% set lane_param = params.LANE|default('1')|string %}
+  {% set valid_chars = '0123456789' %}
+  {% set has_prefix = lane_param[:stepper|length]|lower == stepper|lower %}
+  {% set numeric_part = lane_param[stepper|length:] if has_prefix else lane_param %}
+  {% set ns = namespace(valid=numeric_part|length > 0) %}
+  {% for c in numeric_part %}
+    {% if c not in valid_chars %}
+      {% set ns.valid = false %}
+    {% endif %}
+  {% endfor %}
+
+  {% if ns.valid %}
+    CHANGE_TOOL LANE={stepper ~ numeric_part|int}
+  {% else %}
+    { action_respond_info("Error: Invalid LANE parameter: " ~ lane_param ~ ". LANE must be a number (e.g. LANE=2) or a full lane name (e.g. LANE=" ~ stepper ~ "2).") }
+  {% endif %}
 
 [gcode_macro BT_LANE_EJECT]
-description: Fully eject the filament from the lane so spool can be removed. Lane parameter is an integer and defaults to 1. ex. `BT_LANE_EJECT LANE=2`
+description: Fully eject the filament from the lane so spool can be removed. Lane parameter is an integer and defaults to 1, but the full lane name (e.g. lane2) is also accepted. ex. `BT_LANE_EJECT LANE=2`
 gcode:
-  {% set lane_num = params.LANE|default(1)|int %}
   {% set stepper = printer['gcode_macro _AFC_GLOBAL_VARS'].stepper_name|string %}
-  
-  LANE_UNLOAD LANE={stepper ~ lane_num}
+  {% set lane_param = params.LANE|default('1')|string %}
+  {% set valid_chars = '0123456789' %}
+  {% set has_prefix = lane_param[:stepper|length]|lower == stepper|lower %}
+  {% set numeric_part = lane_param[stepper|length:] if has_prefix else lane_param %}
+  {% set ns = namespace(valid=numeric_part|length > 0) %}
+  {% for c in numeric_part %}
+    {% if c not in valid_chars %}
+      {% set ns.valid = false %}
+    {% endif %}
+  {% endfor %}
+
+  {% if ns.valid %}
+    LANE_UNLOAD LANE={stepper ~ numeric_part|int}
+  {% else %}
+    { action_respond_info("Error: Invalid LANE parameter: " ~ lane_param ~ ". LANE must be a number (e.g. LANE=2) or a full lane name (e.g. LANE=" ~ stepper ~ "2).") }
+  {% endif %}
 
 [gcode_macro BT_LANE_MOVE]
-description: Move the specified lane the specified amount. Lane parameter is an integer and defaults to 1. Distance parameter is and integer and defaults to 20. Distance over 200 uses long load speeds. ex `BT_LANE_MOVE LANE=2 DISTANCE=100`
+description: Move the specified lane the specified amount. Lane parameter is an integer and defaults to 1, but the full lane name (e.g. lane2) is also accepted. Distance parameter is and integer and defaults to 20. Distance over 200 uses long load speeds. ex `BT_LANE_MOVE LANE=2 DISTANCE=100`
 gcode:
-  {% set lane_num = params.LANE|default(1)|int %}
-  {% set dist_str = params.DISTANCE|default('20')|string %}
   {% set stepper = printer['gcode_macro _AFC_GLOBAL_VARS'].stepper_name|string %}
-
+  {% set lane_param = params.LANE|default('1')|string %}
+  {% set dist_str = params.DISTANCE|default('20')|string %}
   {% set valid_chars = '0123456789' %}
-  {% set is_valid = true %}
 
+  {% set has_prefix = lane_param[:stepper|length]|lower == stepper|lower %}
+  {% set numeric_part = lane_param[stepper|length:] if has_prefix else lane_param %}
+  {% set ns = namespace(lane_valid=numeric_part|length > 0) %}
+  {% for c in numeric_part %}
+    {% if c not in valid_chars %}
+      {% set ns.lane_valid = false %}
+    {% endif %}
+  {% endfor %}
+
+  {% set is_valid = true %}
   {% if dist_str|length > 0 %}
     {% if dist_str[-1] not in valid_chars %}
       {% set is_valid = false %}
@@ -38,9 +72,11 @@ gcode:
     {% set is_valid = false %}
   {% endif %}
 
-  {% if is_valid %}
+  {% if not ns.lane_valid %}
+    { action_respond_info("Error: Invalid LANE parameter: " ~ lane_param ~ ". LANE must be a number (e.g. LANE=2) or a full lane name (e.g. LANE=" ~ stepper ~ "2).") }
+  {% elif is_valid %}
     {% set dist = dist_str|float %}
-    LANE_MOVE LANE={stepper ~ lane_num} DISTANCE={dist}
+    LANE_MOVE LANE={stepper ~ numeric_part|int} DISTANCE={dist}
   {% else %}
     { action_respond_info("Error: Invalid DISTANCE parameter: " ~ dist_str) }
   {% endif %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ mypy==1.5.1
 pytest==9.0.2
 pytest-cov==7.0.0
 pytest-sugar==1.1.1
+Jinja2==3.1.6

--- a/tests/test_AFC_bt_macros.py
+++ b/tests/test_AFC_bt_macros.py
@@ -1,0 +1,173 @@
+"""
+Unit tests for the BT_ convenience macros in config/macros/AFC_macros.cfg.
+
+Regression coverage for GitHub issue #817: BT_LANE_EJECT / BT_LANE_MOVE /
+BT_CHANGE_TOOL silently coerced a non-numeric LANE value (e.g. LANE=lane1)
+to 0 via Jinja's `int` filter, producing a confusing 'lane0 is not valid'
+error instead of a clear message.
+
+These tests render the actual `gcode:` template text straight out of the
+.cfg file (via configparser, the same way Klipper's own configfile.py reads
+it) through a real jinja2.Environment configured with Klipper's macro
+delimiters ('{%' '%}' '{' '}'), so they exercise exactly what klippy would
+run -- without needing a full klippy simulation.
+
+Covers, for BT_CHANGE_TOOL / BT_LANE_EJECT / BT_LANE_MOVE:
+  - old usage:  LANE=<int>            (backwards compatible)
+  - new usage:  LANE=<full lane name> (e.g. LANE=lane2, case-insensitive)
+  - failure:    LANE=<garbage>        -> clear error, no command emitted
+"""
+
+from __future__ import annotations
+
+import configparser
+import pathlib
+import re
+from types import SimpleNamespace
+
+import jinja2
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+MACROS_CFG = REPO_ROOT / "config" / "macros" / "AFC_macros.cfg"
+
+STEPPER_NAME = "lane"
+
+
+def _load_gcode_template(macro_name: str) -> str:
+    """Pull the raw `gcode:` script for a [gcode_macro NAME] section."""
+    cp = configparser.RawConfigParser()
+    cp.read(MACROS_CFG)
+    return cp.get(f"gcode_macro {macro_name}", "gcode")
+
+
+def _render(macro_name: str, params: dict) -> tuple[str, list[str]]:
+    """Render a BT_ macro's gcode template like Klipper would.
+
+    Returns (rendered_output, responded_messages) where responded_messages
+    mirrors what action_respond_info() would have sent to the console.
+    """
+    script = _load_gcode_template(macro_name)
+    env = jinja2.Environment("{%", "%}", "{", "}")
+    template = env.from_string(script)
+
+    responded: list[str] = []
+
+    def action_respond_info(msg):
+        responded.append(msg)
+        return ""
+
+    context = {
+        "printer": {
+            "gcode_macro _AFC_GLOBAL_VARS": SimpleNamespace(
+                stepper_name=STEPPER_NAME
+            ),
+        },
+        "params": params,
+        "action_respond_info": action_respond_info,
+    }
+    output = str(template.render(context))
+    return output, responded
+
+
+def _emitted_command(output: str) -> str | None:
+    """Return the first non-blank rendered gcode line, if any."""
+    for line in output.splitlines():
+        line = line.strip()
+        if line:
+            return line
+    return None
+
+
+MACRO_CASES = [
+    # (macro_name, wrapped_command)
+    ("BT_CHANGE_TOOL", "CHANGE_TOOL"),
+    ("BT_LANE_EJECT", "LANE_UNLOAD"),
+]
+
+
+@pytest.mark.parametrize("macro_name,wrapped_command", MACRO_CASES)
+class TestChangeToolAndLaneEject:
+    def test_old_usage_default(self, macro_name, wrapped_command):
+        # No LANE given -> defaults to lane 1 (backwards compatible).
+        output, responded = _render(macro_name, {})
+        assert _emitted_command(output) == f"{wrapped_command} LANE=lane1"
+        assert responded == []
+
+    def test_old_usage_numeric(self, macro_name, wrapped_command):
+        # LANE=2 (the pre-#817 integer form) must keep working.
+        output, responded = _render(macro_name, {"LANE": "2"})
+        assert _emitted_command(output) == f"{wrapped_command} LANE=lane2"
+        assert responded == []
+
+    def test_new_usage_full_lane_name(self, macro_name, wrapped_command):
+        # LANE=lane2 (the form used by LANE_UNLOAD/CHANGE_TOOL directly).
+        output, responded = _render(macro_name, {"LANE": "lane2"})
+        assert _emitted_command(output) == f"{wrapped_command} LANE=lane2"
+        assert responded == []
+
+    def test_new_usage_full_lane_name_case_insensitive(
+        self, macro_name, wrapped_command
+    ):
+        output, responded = _render(macro_name, {"LANE": "LANE2"})
+        assert _emitted_command(output) == f"{wrapped_command} LANE=lane2"
+        assert responded == []
+
+    def test_invalid_lane_fails_clearly(self, macro_name, wrapped_command):
+        # The original bug: a garbage LANE used to silently become lane0.
+        output, responded = _render(macro_name, {"LANE": "garbage"})
+        assert _emitted_command(output) is None
+        assert wrapped_command not in output
+        assert len(responded) == 1
+        assert "Invalid LANE parameter" in responded[0]
+        assert "garbage" in responded[0]
+        # Must never silently coerce to lane0.
+        assert "lane0" not in output
+
+    def test_empty_lane_fails_clearly(self, macro_name, wrapped_command):
+        output, responded = _render(macro_name, {"LANE": ""})
+        assert _emitted_command(output) is None
+        assert wrapped_command not in output
+        assert len(responded) == 1
+        assert "Invalid LANE parameter" in responded[0]
+
+
+class TestLaneMove:
+    def test_old_usage_default(self):
+        output, responded = _render("BT_LANE_MOVE", {})
+        assert _emitted_command(output) == "LANE_MOVE LANE=lane1 DISTANCE=20.0"
+        assert responded == []
+
+    def test_old_usage_numeric_lane(self):
+        output, responded = _render(
+            "BT_LANE_MOVE", {"LANE": "2", "DISTANCE": "100"}
+        )
+        assert _emitted_command(output) == "LANE_MOVE LANE=lane2 DISTANCE=100.0"
+        assert responded == []
+
+    def test_new_usage_full_lane_name(self):
+        output, responded = _render(
+            "BT_LANE_MOVE", {"LANE": "lane2", "DISTANCE": "100"}
+        )
+        assert _emitted_command(output) == "LANE_MOVE LANE=lane2 DISTANCE=100.0"
+        assert responded == []
+
+    def test_invalid_lane_fails_clearly_even_with_valid_distance(self):
+        output, responded = _render(
+            "BT_LANE_MOVE", {"LANE": "garbage", "DISTANCE": "100"}
+        )
+        assert _emitted_command(output) is None
+        assert "LANE_MOVE" not in output
+        assert len(responded) == 1
+        assert "Invalid LANE parameter" in responded[0]
+        assert "lane0" not in output
+
+    def test_invalid_distance_still_fails_clearly(self):
+        # Pre-existing DISTANCE validation must still work once LANE is valid.
+        output, responded = _render(
+            "BT_LANE_MOVE", {"LANE": "2", "DISTANCE": "abc"}
+        )
+        assert _emitted_command(output) is None
+        assert "LANE_MOVE" not in output
+        assert len(responded) == 1
+        assert "Invalid DISTANCE parameter" in responded[0]

--- a/tests/test_AFC_bt_macros.py
+++ b/tests/test_AFC_bt_macros.py
@@ -152,6 +152,13 @@ class TestLaneMove:
         assert _emitted_command(output) == "LANE_MOVE LANE=lane2 DISTANCE=100.0"
         assert responded == []
 
+    def test_new_usage_full_lane_name_case_insensitive(self):
+        output, responded = _render(
+            "BT_LANE_MOVE", {"LANE": "LANE2", "DISTANCE": "100"}
+        )
+        assert _emitted_command(output) == "LANE_MOVE LANE=lane2 DISTANCE=100.0"
+        assert responded == []
+
     def test_invalid_lane_fails_clearly_even_with_valid_distance(self):
         output, responded = _render(
             "BT_LANE_MOVE", {"LANE": "garbage", "DISTANCE": "100"}


### PR DESCRIPTION
## Major Changes in this PR

Closes #817 

## Notes to Code Reviewers

I had some help with the jinja2 from claude on the splitting and checking if it was present or not.

## How the changes in this PR are tested

Claude added some new unit tests. I also tested this manually.

<img width="682" height="311" alt="image" src="https://github.com/user-attachments/assets/12ee3b89-8cda-4f48-ab5e-af82da5893e8" />

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to pr-review channel requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Lane-related commands now accept numeric IDs (such as `1`) or full lane names (such as `lane1`), including case-insensitive input.

- **Bug Fixes**
  - Invalid lane values now return clear errors instead of being silently converted.
  - Lane values are validated before movement and other lane operations.
  - Existing distance validation for lane movement remains effective.

- **Documentation**
  - Added changelog details describing the expanded lane input support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->