### PR TITLE
(fix): Adding None Checks to fix issues #771 and #782

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,9 +128,7 @@
 - **No `__new__` bypass for construction** — build test objects through the
    real `__init__` (mocking dependencies like config/printer/reactor as
    needed), rather than using `SomeClass.__new__(SomeClass)` and hand-setting
-   attributes to skip constructor logic entirely. This applies to new tests
-   even in a file where older tests already use `__new__` — don't migrate
-   the untouched older tests to match unless asked.
+   attributes to skip constructor logic entirely.
 - **Assertions must actually distinguish the branch under test** — an
    assertion has to be something that would be *false* if the code had
    taken the other branch, not just something that happens to be true

--- a/extras/AFC_hub.py
+++ b/extras/AFC_hub.py
@@ -49,7 +49,7 @@ class afc_hub:
         self.lanes: Dict[str, AFCLane] = {}
         self._state: bool = False
 
-        self.switch_pin: str = config.get('switch_pin', None)
+        self.switch_pin: Optional[str] = config.get('switch_pin', None)
         # HUB Cut variables
         # Next two variables are used in AFC
         self.hub_clear_move_dis     = config.getfloat("hub_clear_move_dis", 65)     # How far to move filament so that it's not block the hub exit
@@ -77,7 +77,8 @@ class afc_hub:
         self.enable_runout          = config.getboolean("enable_hub_runout",        self.afc.enable_hub_runout)
         self.use_dist_hub           = config.getboolean("use_dist_hub", False)      # Value to indicate that lanes dist_hub variable should be used instead of afc_bowden_length value. Set true when setting hub up as a virtual hub
 
-        if self.switch_pin.lower() != "virtual":
+        if (self.switch_pin
+            and self.switch_pin.lower() != "virtual"):
             buttons = self.printer.load_object(config, "buttons")
             self.fila, self.debounce_button = add_filament_switch(f"{self.name}_Hub", self.switch_pin,
                                                                   self.printer, self.enable_sensors_in_gui,
@@ -104,7 +105,7 @@ class afc_hub:
 
         :return boolean: Returns True when switch_pin variable equals virtual
         """
-        return self.switch_pin.lower() == "virtual"
+        return self.switch_pin.lower() == "virtual" if self.switch_pin else False
 
     def handle_runout(self, eventtime: float) -> None:
         """

--- a/extras/AFC_hub.py
+++ b/extras/AFC_hub.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import traceback
 
 from configparser import Error as config_error
-from typing import TYPE_CHECKING, Dict
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 try: from extras.AFC_utils import ERROR_STR
 except: raise config_error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".format(trace=traceback.format_exc()))
@@ -20,24 +20,36 @@ try: from extras.AFC_unit import SENSORLESS_UNITS
 except: raise config_error(ERROR_STR.format(import_lib="AFC_unit", trace=traceback.format_exc()))
 
 if TYPE_CHECKING:
+    from configfile import ConfigWrapper
+    from klippy import Printer
+    from extras.AFC import afc
     from extras.AFC_lane import AFCLane
+    from extras.AFC_unit import afcUnit
 
 class afc_hub:
-    def __init__(self, config):
-        self.printer    = config.get_printer()
+    def __init__(self, config: ConfigWrapper) -> None:
+        """
+        Parse hub configuration and register for klippy:connect/klippy:ready.
+        Registers a filament switch sensor for physical hubs; virtual hubs
+        skip that and instead derive their state from their lanes' load
+        sensors (see the state property).
+
+        :param config: Klipper config wrapper for the AFC_hub section
+        """
+        self.printer: Printer = config.get_printer()
         self.printer.register_event_handler("klippy:connect", self.handle_connect)
         self.printer.register_event_handler("klippy:ready", self.handle_ready)
-        self.afc        = self.printer.load_object(config, 'AFC')
+        self.afc: afc   = self.printer.load_object(config, 'AFC')
         self.reactor    = self.printer.get_reactor()
 
-        self.fullname   = config.get_name()
-        self.name       = self.fullname.split()[-1]
+        self.fullname: str = config.get_name()
+        self.name: str     = self.fullname.split()[-1]
 
-        self.unit = None
+        self.unit: Optional[afcUnit] = None
         self.lanes: Dict[str, AFCLane] = {}
         self._state: bool = False
 
-        self.switch_pin = config.get('switch_pin', None)
+        self.switch_pin: str = config.get('switch_pin', None)
         # HUB Cut variables
         # Next two variables are used in AFC
         self.hub_clear_move_dis     = config.getfloat("hub_clear_move_dis", 65)     # How far to move filament so that it's not block the hub exit
@@ -76,10 +88,15 @@ class afc_hub:
         # Adding self to AFC hubs
         self.afc.hubs[self.name]=self
 
-    def __str__(self):
+    def __str__(self) -> str:
+        """
+        String representation of the hub, used e.g. in error messages.
+
+        :return type: hub name
+        """
         return self.name
 
-    def is_virtual_pin(self):
+    def is_virtual_pin(self) -> bool:
         """
         Helper method that returns true when switch_pin variable is set to "virtual", meaning
         that all load switches in a unit is the hub switch. So if one load switch it triggered
@@ -89,7 +106,7 @@ class afc_hub:
         """
         return self.switch_pin.lower() == "virtual"
 
-    def handle_runout(self, eventtime):
+    def handle_runout(self, eventtime: float) -> None:
         """
         Callback function for hub runout, this is different than `switch_pin_callback` function as this function
         can be delayed and is called from filament_switch_sensor class when it detects a runout event.
@@ -107,7 +124,7 @@ class afc_hub:
             lane.handle_hub_runout(sensor=self.name)
         self.fila.runout_helper.min_event_systime = self.reactor.monotonic() + self.fila.runout_helper.event_delay
 
-    def handle_connect(self):
+    def handle_connect(self) -> None:
         """
         Handle the connection event.
         This function is called when the printer connects. It looks up AFC info
@@ -118,7 +135,7 @@ class afc_hub:
 
         self.printer.send_event("afc_hub:register_macros", self)
 
-    def handle_ready(self):
+    def handle_ready(self) -> None:
         """
         Handle the klippy:ready event. Verifies that lanes using a virtual hub sensor have a
         load sensor configured, raising a config error if any sensorless lanes are missing one.
@@ -138,7 +155,7 @@ class afc_hub:
                 raise config_error(msg)
 
     @property
-    def state(self):
+    def state(self) -> bool:
         """
         Returns current state of switch. If using virtual sensor returns True if any lanes load
         sensor is triggered.
@@ -148,10 +165,28 @@ class afc_hub:
             state = any(lane.raw_load_state for lane in self.lanes.values())
         return state
 
-    def switch_pin_callback(self, eventtime, state):
-        self._state = state
+    def switch_pin_callback(self, eventtime: float, state: int) -> None:
+        """
+        Callback for the hub's physical switch pin/button, registered via
+        buttons.register_buttons. Updates the raw sensor state; virtual hubs
+        never register this callback since they have no pin of their own.
 
-    def hub_cut(self, cur_lane):
+        :param eventtime: reactor time the sensor state changed
+        :param state: 1 if the hub switch is now triggered, 0 otherwise
+        """
+        self._state = bool(state)
+
+    def hub_cut(self, cur_lane: AFCLane) -> None:
+        """
+        Run the hub's filament-cutting sequence: feed the lane until the hub
+        sensor triggers, jog back and forth to find the trigger point
+        precisely, feed cut_dist past it, then cycle the cutting servo
+        through its prep/clip angles (and a second confirm pass if
+        cut_confirm is set) before returning to the pass-through angle and
+        retracting the lane by cut_clear.
+
+        :param cur_lane: lane object being fed into the hub for the cut
+        """
         servo_string = 'SET_SERVO SERVO={servo} ANGLE={{angle}}'.format(servo=self.cut_servo_name)
 
         # Prep the servo for cutting.
@@ -190,8 +225,15 @@ class afc_hub:
         # Retract lane by `hub_cut_clear`.
         cur_lane.move(-self.cut_clear, cur_lane.short_moves_speed, cur_lane.short_moves_accel, self.assisted_retract)
 
-    def get_status(self, eventtime=None):
-        self.response = {}
+    def get_status(self, eventtime: Optional[float]=None) -> Dict[str, Any]:
+        """
+        Build the status dict reported for this hub over Klipper's webhooks
+        API.
+
+        :param eventtime: reactor time of the status request, unused
+        :return type: hub state and its cut/bowden-length settings
+        """
+        self.response: Dict[str, Any] = {}
         self.response['state'] = bool(self.state)
         self.response['cut'] = self.cut
         self.response['cut_cmd'] = self.cut_cmd
@@ -206,5 +248,11 @@ class afc_hub:
 
         return self.response
 
-def load_config_prefix(config):
+def load_config_prefix(config: ConfigWrapper) -> afc_hub:
+    """
+    Klipper config entry point for AFC_hub <name> sections.
+
+    :param config: Klipper config wrapper for the AFC_hub <name> section
+    :return type: afc_hub instance to register with the printer
+    """
     return afc_hub(config)

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -312,7 +312,7 @@ class AFCLane:
 
         self.connect_done = False
         self.prep_active = False
-        self.last_prep_time = 0
+        self.last_prep_time: float = 0.
 
         self.show_macros = self.afc.show_macros
         self.function = self.printer.load_object(config, 'AFC_functions')
@@ -1191,8 +1191,23 @@ class AFCLane:
 
         self.afc.save_vars()
 
-    def prep_callback(self, eventtime, state):
-        self.prep_state = state
+    def prep_callback(self, eventtime: float, state: int) -> None:
+        """
+        Callback for the lane's prep (filament presence) sensor/button.
+        Decides whether to kick off a load sequence, guarded against
+        re-entrancy (prep_active) and rapid retriggering (delta_time
+        debounce).
+
+        Loads only when the prep sensor is triggered and the load sensor is
+        not (filament present but not yet at the extruder); if both are
+        triggered at once, the lane is stuck and an error is reported
+        instead. Lanes on a direct_load hub skip prep_post_load and go
+        straight to a toolhead load.
+
+        :param eventtime: reactor time the sensor state changed
+        :param state: 1 if the prep sensor is now triggered (filament present), 0 otherwise
+        """
+        self.prep_state = bool(state)
 
         delta_time = eventtime - self.last_prep_time
         self.last_prep_time = eventtime
@@ -1208,7 +1223,7 @@ class AFCLane:
             and not self.afc.auto_home
             and not self.afc.function.is_homed()):
             self.afc.error.AFC_error("Please home printer before directly loading to toolhead", False)
-            return False
+            return
 
         self.prep_active = True
 

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -1222,8 +1222,7 @@ class AFCLane:
 
         if (self.printer.state_message == 'Printer is ready'
             and True == self._afc_prep_done
-            and self.hub is not None
-            and "direct_load" in self.hub
+            and self.hub == "direct_load"
             and not self.afc.auto_home
             and not self.afc.function.is_homed()):
             self.afc.error.AFC_error("Please home printer before directly loading to toolhead", False)

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -144,9 +144,9 @@ class AFCLane:
         self.drive_stepper: AFCExtruderStepper = None
         unit: str               = config.get('unit')                                    # Unit name(AFC_BoxTurtle/NightOwl/etc) that belongs to this stepper.
         # Overrides buffers set at the unit level
-        self.hub: str           = config.get('hub',None)                                # Hub name(AFC_hub) that belongs to this stepper, overrides hub that is set in unit(AFC_BoxTurtle/NightOwl/etc) section.
+        self.hub: Optional[str] = config.get('hub',None)                                # Hub name(AFC_hub) that belongs to this stepper, overrides hub that is set in unit(AFC_BoxTurtle/NightOwl/etc) section.
         # Overrides buffers set at the unit and extruder level
-        self.buffer_name: str   = config.get("buffer", None)                            # Buffer name(AFC_buffer) that belongs to this stepper, overrides buffer that is set in extruder(AFC_extruder) or unit(AFC_BoxTurtle/NightOwl/etc) sections.
+        self.buffer_name: Optional[str] = config.get("buffer", None)                            # Buffer name(AFC_buffer) that belongs to this stepper, overrides buffer that is set in extruder(AFC_extruder) or unit(AFC_BoxTurtle/NightOwl/etc) sections.
         self.unit               = unit.split(':')[0]
         try:
             self.index              = int(unit.split(':')[1])
@@ -1201,11 +1201,12 @@ class AFCLane:
         if self.prep_active:
             return
 
-        if (self.printer.state_message == 'Printer is ready' and
-            True == self._afc_prep_done and
-            "direct_load" in self.hub and
-            not self.afc.auto_home and
-            not self.afc.function.is_homed()):
+        if (self.printer.state_message == 'Printer is ready'
+            and True == self._afc_prep_done
+            and self.hub is not None
+            and "direct_load" in self.hub
+            and not self.afc.auto_home
+            and not self.afc.function.is_homed()):
             self.afc.error.AFC_error("Please home printer before directly loading to toolhead", False)
             return False
 
@@ -1216,9 +1217,12 @@ class AFCLane:
             # Hacky way for do{}while(0) loop, DO NOT return from this for loop, use break instead so that self.prep_state variable gets sets correctly
             #  before exiting function
             with self.mutex:
-                if self.printer.state_message == 'Printer is ready' and self._afc_prep_done and self.status != AFCLaneState.TOOL_UNLOADING:
+                if (self.printer.state_message == 'Printer is ready'
+                    and self._afc_prep_done
+                    and self.status != AFCLaneState.TOOL_UNLOADING):
                     # Only try to load when load state trigger is false
-                    if self.prep_state and not self.raw_load_state:
+                    if (self.prep_state
+                        and not self.raw_load_state):
                         self.logger.debug(f"Prep: callback triggered {self.name}")
                         # Checking to make sure last time prep switch was activated was less than 1 second, returning to keep is printing message from spamming
                         # the console since it takes klipper some time to transition to idle when idle_resume=printing
@@ -1239,7 +1243,8 @@ class AFCLane:
 
                         # Verify that load state is still true as this would still trigger if prep sensor was triggered and then filament was removed
                         #   This is only really a issue when using direct_load and still using load sensor
-                        if self.hub == 'direct_load' and self.prep_state:
+                        if (self.hub == 'direct_load'
+                            and self.prep_state):
                             self.logger.debug(f"Prep: direct load logic-{self.name}-{self.hub}")
                             self.afc.TOOL_LOAD(self)
                             self.afc.spool._set_values(self)
@@ -1259,7 +1264,7 @@ class AFCLane:
                             if self.td1_device_id:
                                 self._prep_capture_td1()
 
-                    elif (self.prep_state == True
+                    elif(self.prep_state == True
                         and self.raw_load_state == True
                         and not self.afc.function.is_printing()):
                         message = 'Cannot load {} load sensor is triggered.'.format(self.name)

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -294,11 +294,14 @@ class AFCLane:
         if (self.hub
             and "direct" not in self.hub):
             self._get_hub_object()
-            self._set_homing_endstop(query_endstops, ppins,
-                                     self.hub_obj.switch_pin, AFCHomingPoints.HUB)
+            if (self.hub_obj
+                and self.hub_obj.switch_pin):
+                self._set_homing_endstop(query_endstops, ppins,
+                                        self.hub_obj.switch_pin, AFCHomingPoints.HUB)
         if self.buffer_name:
             self._get_buffer_object()
-            if self.buffer_obj.advance_pin is not None:
+            if (self.buffer_obj 
+                and self.buffer_obj.advance_pin is not None):
                 self._set_homing_endstop(query_endstops, ppins,
                                          self.buffer_obj.advance_pin, AFCHomingPoints.BUFFER)
 
@@ -306,7 +309,8 @@ class AFCLane:
             and not self.standalone_lane): # Protects against standalone lanes
             self._get_extruder_object()
             pin = self.extruder_obj.tool_start
-            if pin and "buffer" not in pin:
+            if (pin 
+                and "buffer" not in pin):
                 self._set_homing_endstop(query_endstops, ppins,
                                          pin, AFCHomingPoints.TOOL)
 

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -300,7 +300,7 @@ class AFCLane:
                                         self.hub_obj.switch_pin, AFCHomingPoints.HUB)
         if self.buffer_name:
             self._get_buffer_object()
-            if (self.buffer_obj 
+            if (self.buffer_obj
                 and self.buffer_obj.advance_pin is not None):
                 self._set_homing_endstop(query_endstops, ppins,
                                          self.buffer_obj.advance_pin, AFCHomingPoints.BUFFER)
@@ -309,7 +309,7 @@ class AFCLane:
             and not self.standalone_lane): # Protects against standalone lanes
             self._get_extruder_object()
             pin = self.extruder_obj.tool_start
-            if (pin 
+            if (pin
                 and "buffer" not in pin):
                 self._set_homing_endstop(query_endstops, ppins,
                                          pin, AFCHomingPoints.TOOL)

--- a/mypy.ini
+++ b/mypy.ini
@@ -8,9 +8,12 @@ mypy_path=$MYPY_CONFIG_FILE_DIR/klipper/klippy
 ignore_missing_imports = True
 
 # Require full type annotations on every function/method defined in this
-# project's own extras/ modules.
+# project's own extras/ modules, and type-check the bodies of any that are
+# still missing annotations too (rather than skipping them silently) while
+# those get filled in.
 [mypy-extras.*]
 disallow_untyped_defs = True
+check_untyped_defs = True
 
 # klipper/klippy is on mypy_path above, so when a local Klipper checkout is
 # present, Klipper's own klippy/extras/ package resolves to the same

--- a/tests/test_AFC_hub.py
+++ b/tests/test_AFC_hub.py
@@ -46,7 +46,7 @@ def _make_hub(switch_pin="PA0", name="test_hub", extra_values=None):
         hub = afc_hub(config)
     printer.send_event("klippy:connect")
 
-    if switch_pin.lower() != "virtual":
+    if switch_pin and switch_pin.lower() != "virtual":
         # add_filament_switch is mocked above (it does real pin/hardware
         # setup), so the fila/runout_helper it would normally wire up need
         # their own defaults set by hand for handle_runout's tests.
@@ -81,6 +81,13 @@ class TestIsVirtualPin:
 
     def test_false_for_a_physical_pin_name(self):
         hub = _make_hub(switch_pin="PA0")
+        assert hub.is_virtual_pin() is False
+
+    def test_false_when_switch_pin_is_none(self):
+        """switch_pin is Optional[str] (unset when the config option is
+        missing); the ternary's else branch must return False rather than
+        crash on None.lower()."""
+        hub = _make_hub(switch_pin=None)
         assert hub.is_virtual_pin() is False
 
 
@@ -337,6 +344,25 @@ class TestAFCHubInit:
         with patch("extras.AFC_hub.add_filament_switch") as mock_afs:
             hub = afc_hub(config)
         mock_afs.assert_not_called()
+
+    def test_no_switch_pin_configured_does_not_crash_or_call_add_filament_switch(self):
+        """switch_pin defaults to None when the config option is missing
+        entirely (config.get('switch_pin', None)). __init__ must not crash
+        on None.lower() and must skip add_filament_switch, the same as it
+        does for an explicit "virtual" pin -- proving the `self.switch_pin`
+        truthiness check matters independently of the "virtual" comparison,
+        since None never equals "virtual" either."""
+        from tests.conftest import MockConfig, MockPrinter, MockAFC
+        afc = MockAFC()
+        printer = MockPrinter(afc=afc)
+        config = MockConfig(
+            name="AFC_hub test_hub", printer=printer,
+            values={}  # switch_pin not configured -> defaults to None
+        )
+        with patch("extras.AFC_hub.add_filament_switch") as mock_afs:
+            hub = afc_hub(config)
+        mock_afs.assert_not_called()
+        assert hub.switch_pin is None
 
     def test_virtual_hub_init_registers_hub_in_afc(self):
         from tests.conftest import MockConfig, MockPrinter, MockAFC

--- a/tests/test_AFC_hub.py
+++ b/tests/test_AFC_hub.py
@@ -11,65 +11,47 @@ Covers:
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+import sys
+import importlib.util
+import configparser
+from unittest.mock import MagicMock, patch, call
 import pytest
 
-from extras.AFC_hub import afc_hub
+from extras.AFC_hub import afc_hub, load_config_prefix
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 def _make_hub(switch_pin="PA0", name="test_hub", extra_values=None):
-    """Build an afc_hub instance by bypassing __init__ and setting attrs."""
-    hub = afc_hub.__new__(afc_hub)
+    """Build an afc_hub instance through its real __init__ and handle_connect
+    (fired via the klippy:connect event), mocking only the Klipper
+    collaborators (config/printer/AFC) and add_filament_switch, which does
+    real pin/hardware registration unrelated to afc_hub's own logic.
 
-    from tests.conftest import MockAFC, MockPrinter, MockReactor, MockLogger
+    All of __init__'s config-driven numeric/boolean attributes (bowden
+    lengths, servo angles, cut settings, etc.) fall through to their real
+    source-code defaults automatically, since MockConfig returns the
+    caller's own default whenever a value isn't present in `values` --
+    matching what this helper used to hardcode by hand.
+    """
+    from tests.conftest import MockAFC, MockPrinter, MockConfig
 
     afc = MockAFC()
-    reactor = MockReactor()
     printer = MockPrinter(afc=afc)
-    printer._reactor = reactor
+    config = MockConfig(name=f"AFC_hub {name}", printer=printer,
+                        values={"switch_pin": switch_pin})
 
-    hub.printer = printer
-    hub.afc = afc
-    hub.reactor = reactor
-    hub.gcode = afc.gcode
+    with patch("extras.AFC_hub.add_filament_switch") as mock_afs:
+        mock_afs.return_value = (MagicMock(), MagicMock())
+        hub = afc_hub(config)
+    printer.send_event("klippy:connect")
 
-    hub.fullname = f"AFC_hub {name}"
-    hub.name = name
-    hub.unit = None
-    hub.lanes = {}
-    hub._state = False
-    hub.switch_pin = switch_pin
-
-    # Default config values
-    hub.hub_clear_move_dis = 65.0
-    hub.afc_bowden_length = 900.0
-    hub.td1_bowden_length = 850.0
-    hub.afc_unload_bowden_length = 900.0
-    hub.assisted_retract = False
-    hub.move_dis = 75.0
-    hub.cut = False
-    hub.cut_cmd = None
-    hub.cut_servo_name = "cut"
-    hub.cut_dist = 50.0
-    hub.cut_clear = 120.0
-    hub.cut_min_length = 200.0
-    hub.cut_servo_pass_angle = 0.0
-    hub.cut_servo_clip_angle = 160.0
-    hub.cut_servo_prep_angle = 75.0
-    hub.cut_confirm = False
-    hub.config_bowden_length = hub.afc_bowden_length
-    hub.config_unload_bowden_length = hub.afc_unload_bowden_length
-    hub.enable_sensors_in_gui = False
-    hub.debounce_delay = 0.1
-    hub.enable_runout = False
-
-    # Filament sensor mock (used in handle_runout)
-    hub.fila = MagicMock()
-    hub.fila.runout_helper.min_event_systime = 0.0
-    hub.fila.runout_helper.event_delay = 0.5
-    hub.debounce_button = MagicMock()
+    if switch_pin.lower() != "virtual":
+        # add_filament_switch is mocked above (it does real pin/hardware
+        # setup), so the fila/runout_helper it would normally wire up need
+        # their own defaults set by hand for handle_runout's tests.
+        hub.fila.runout_helper.min_event_systime = 0.0
+        hub.fila.runout_helper.event_delay = 0.5
 
     if extra_values:
         for k, v in extra_values.items():
@@ -84,6 +66,22 @@ class TestAFCHubStr:
     def test_str_returns_name(self):
         hub = _make_hub(name="hub1")
         assert str(hub) == "hub1"
+
+
+# ── is_virtual_pin ────────────────────────────────────────────────────────────
+
+class TestIsVirtualPin:
+    def test_true_when_switch_pin_is_virtual(self):
+        hub = _make_hub(switch_pin="virtual")
+        assert hub.is_virtual_pin() is True
+
+    def test_true_is_case_insensitive(self):
+        hub = _make_hub(switch_pin="VIRTUAL")
+        assert hub.is_virtual_pin() is True
+
+    def test_false_for_a_physical_pin_name(self):
+        hub = _make_hub(switch_pin="PA0")
+        assert hub.is_virtual_pin() is False
 
 
 # ── switch_pin_callback ───────────────────────────────────────────────────────
@@ -229,13 +227,14 @@ class TestHandleRunout:
         lane.handle_hub_runout.assert_not_called()
 
     def test_runout_updates_min_event_systime(self):
+        # MockReactor's default monotonic() is 100.0; _make_hub sets
+        # event_delay to 0.5, so the expected result is 100.5 -- computed
+        # by hand here rather than re-deriving the source's own formula.
         hub = _make_hub()
         hub.lanes = {}
         hub.afc.current = None
-        initial_time = hub.fila.runout_helper.min_event_systime
         hub.handle_runout(150.0)
-        # min_event_systime should be updated to monotonic + event_delay
-        assert hub.fila.runout_helper.min_event_systime != initial_time
+        assert hub.fila.runout_helper.min_event_systime == 100.5
 
 
 # ── handle_connect ────────────────────────────────────────────────────────────
@@ -393,7 +392,7 @@ class TestAFCHubInit:
 # ── hub_cut ───────────────────────────────────────────────────────────────────
 
 class TestHubCut:
-    def test_hub_cut_no_confirm_runs_servo_commands(self):
+    def test_hub_cut_no_confirm_runs_exactly_three_servo_commands(self):
         from unittest.mock import PropertyMock
         hub = _make_hub(switch_pin="PA0")
         hub.cut_confirm = False
@@ -403,9 +402,11 @@ class TestHubCut:
         with patch.object(type(hub), "state", new_callable=PropertyMock) as mock_prop:
             mock_prop.side_effect=[False, True, True, False, False, True]
             hub.hub_cut(cur_lane)
-        # Should call run_script_from_command for prep, clip, and pass angles
-        calls = hub.gcode.run_script_from_command.call_args_list
-        assert len(calls) >= 3  # prep + clip + pass
+        # cut_confirm=False must skip the extra prep/clip pair, leaving
+        # exactly prep + clip + pass -- not just "at least" 3, since a bug
+        # that accidentally also ran the confirm branch would still pass a
+        # >= 3 check.
+        assert hub.gcode.run_script_from_command.call_count == 3
 
     def test_hub_cut_no_confirm_calls_correct_servo_angles(self):
         from unittest.mock import PropertyMock
@@ -415,12 +416,16 @@ class TestHubCut:
         with patch.object(type(hub), "state", new_callable=PropertyMock) as mock_prop:
             mock_prop.side_effect=[False, True, True, False, False, True]
             hub.hub_cut(cur_lane)
-        calls = [c[0][0] for c in hub.gcode.run_script_from_command.call_args_list]
-        assert any(str(hub.cut_servo_prep_angle) in c for c in calls)
-        assert any(str(hub.cut_servo_clip_angle) in c for c in calls)
-        assert any(str(hub.cut_servo_pass_angle) in c for c in calls)
+        # cut_servo_name="cut", prep=75.0, clip=160.0, pass=0.0 (from
+        # _make_hub's defaults) computed by hand, not via the source's own
+        # format-string construction.
+        assert hub.gcode.run_script_from_command.call_args_list == [
+            call("SET_SERVO SERVO=cut ANGLE=75.0"),
+            call("SET_SERVO SERVO=cut ANGLE=160.0"),
+            call("SET_SERVO SERVO=cut ANGLE=0.0"),
+        ]
 
-    def test_hub_cut_with_confirm_runs_extra_servo_commands(self):
+    def test_hub_cut_with_confirm_runs_exactly_five_servo_commands(self):
         from unittest.mock import PropertyMock
         hub = _make_hub(switch_pin="PA0")
         hub.cut_confirm = True
@@ -428,9 +433,15 @@ class TestHubCut:
         with patch.object(type(hub), "state", new_callable=PropertyMock) as mock_prop:
             mock_prop.side_effect=[False, True, True, False, False, True]
             hub.hub_cut(cur_lane)
-        # With confirm: prep + clip + prep + clip + pass = 5 calls
-        calls = hub.gcode.run_script_from_command.call_args_list
-        assert len(calls) >= 5
+        # cut_confirm=True adds an extra prep+clip pair before the final
+        # pass angle: prep, clip, prep, clip, pass.
+        assert hub.gcode.run_script_from_command.call_args_list == [
+            call("SET_SERVO SERVO=cut ANGLE=75.0"),
+            call("SET_SERVO SERVO=cut ANGLE=160.0"),
+            call("SET_SERVO SERVO=cut ANGLE=75.0"),
+            call("SET_SERVO SERVO=cut ANGLE=160.0"),
+            call("SET_SERVO SERVO=cut ANGLE=0.0"),
+        ]
 
     def test_hub_cut_retracts_filament_after_cut(self):
         from unittest.mock import PropertyMock
@@ -440,7 +451,142 @@ class TestHubCut:
         with patch.object(type(hub), "state", new_callable=PropertyMock) as mock_prop:
             mock_prop.side_effect=[False, True, True, False, False, True]
             hub.hub_cut(cur_lane)
-        # Last move should be negative (retract by cut_clear)
-        all_move_calls = cur_lane.move.call_args_list
-        last_call_dist = all_move_calls[-1][0][0]
-        assert last_call_dist < 0  # negative = retract
+        # Final move must retract by exactly cut_clear (120.0 from
+        # _make_hub's defaults), not merely "some negative distance".
+        last_call = cur_lane.move.call_args_list[-1]
+        assert last_call[0][0] == -120.0
+
+
+# ── load_config_prefix ──────────────────────────────────────────────────────
+
+class TestLoadConfigPrefix:
+    def test_returns_afc_hub_instance(self):
+        from tests.conftest import MockAFC, MockPrinter, MockConfig
+        afc = MockAFC()
+        printer = MockPrinter(afc=afc)
+        config = MockConfig(name="AFC_hub test_hub", printer=printer,
+                             values={"switch_pin": "virtual"})
+        result = load_config_prefix(config)
+        assert isinstance(result, afc_hub)
+
+    def test_registers_self_in_afc_hubs(self):
+        from tests.conftest import MockAFC, MockPrinter, MockConfig
+        afc = MockAFC()
+        printer = MockPrinter(afc=afc)
+        config = MockConfig(name="AFC_hub test_hub", printer=printer,
+                             values={"switch_pin": "virtual"})
+        result = load_config_prefix(config)
+        assert afc.hubs["test_hub"] is result
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# Module-level import guards
+# ═════════════════════════════════════════════════════════════════════════
+
+def _exec_afc_hub_with_blocked_dependency(blocked_module_name):
+    """Execute a throw-away copy of extras/AFC_hub.py's module-level code
+    with `blocked_module_name` forced to fail import, to exercise the file's
+    top-level ``try: from X import Y / except: raise config_error(...)``
+    guards.
+
+    This never touches the real, already-imported ``extras.AFC_hub`` module
+    that the rest of this test suite depends on: the copy is loaded under a
+    throwaway module name and discarded afterward, whether or not it raises.
+    Blocking an import via ``sys.modules[name] = None`` is a standard Python
+    mechanism -- it makes any ``import``/``from ... import`` of that name
+    raise ImportError immediately, without touching the module itself.
+
+    Cleanup restores the *exact same* pre-existing module object in
+    sys.modules (not just removes the block) -- simply deleting the entry
+    would let it get re-imported fresh the next time anything touches it,
+    producing new, distinct class objects that no longer match what other
+    test files already imported and bound references to.
+    """
+    import extras.AFC_hub as real_module
+    fresh_name = "extras.AFC_hub_import_guard_probe"
+    original_blocked_module = sys.modules.get(blocked_module_name)
+    sys.modules[blocked_module_name] = None
+    try:
+        spec = importlib.util.spec_from_file_location(fresh_name, real_module.__file__)
+        fresh = importlib.util.module_from_spec(spec)
+        sys.modules[fresh_name] = fresh
+        try:
+            spec.loader.exec_module(fresh)
+        finally:
+            sys.modules.pop(fresh_name, None)
+    finally:
+        if original_blocked_module is not None:
+            sys.modules[blocked_module_name] = original_blocked_module
+        else:
+            sys.modules.pop(blocked_module_name, None)
+
+
+def _exec_afc_hub_with_missing_attr(real_module_name, missing_attr_name):
+    """Execute a throw-away copy of extras/AFC_hub.py's module-level code
+    with a single attribute (`missing_attr_name`) hidden from
+    `real_module_name`, to exercise a guard whose `except:` can't be reached
+    by blocking the whole dependency module.
+
+    AFC_hub.py has two separate guards that both import from
+    extras.AFC_utils (ERROR_STR, then add_filament_switch); blocking that
+    module outright (via `sys.modules[name] = None`, as
+    `_exec_afc_hub_with_blocked_dependency` does) always trips the first of
+    the two guards before execution ever reaches the second, since both
+    imports run top-to-bottom against the same blocked module. This swaps in
+    a proxy that forwards every attribute lookup to the real module except
+    the one being hidden, which raises AttributeError -- exactly what
+    `from module import name` converts into ImportError when the name is
+    genuinely missing from an otherwise-importable module.
+    """
+    import extras.AFC_hub as real_module
+    real_dep_module = sys.modules[real_module_name]
+
+    class _ProxyModule:
+        def __getattr__(self, attr_name):
+            if attr_name == missing_attr_name:
+                raise AttributeError(attr_name)
+            return getattr(real_dep_module, attr_name)
+
+    fresh_name = "extras.AFC_hub_import_guard_probe"
+    sys.modules[real_module_name] = _ProxyModule()
+    try:
+        spec = importlib.util.spec_from_file_location(fresh_name, real_module.__file__)
+        fresh = importlib.util.module_from_spec(spec)
+        sys.modules[fresh_name] = fresh
+        try:
+            spec.loader.exec_module(fresh)
+        finally:
+            sys.modules.pop(fresh_name, None)
+    finally:
+        sys.modules[real_module_name] = real_dep_module
+
+
+class TestModuleImportGuards:
+    """Covers the three module-level `try/except: raise config_error(...)`
+    guards in AFC_hub.py, one per dependency import."""
+
+    def test_afc_utils_error_str_import_failure_raises_configparser_error(self):
+        """The very first guard imports ERROR_STR itself from AFC_utils, so
+        it can't use ERROR_STR.format(...) in its own except clause."""
+        with pytest.raises(configparser.Error) as exc_info:
+            _exec_afc_hub_with_blocked_dependency("extras.AFC_utils")
+        assert str(exc_info.value).startswith(
+            "Error when trying to import AFC_utils.ERROR_STR"
+        )
+
+    def test_afc_utils_add_filament_switch_import_failure_raises_configparser_error(self):
+        """The second guard imports add_filament_switch from the same
+        AFC_utils module as the first guard's ERROR_STR, so it needs a
+        specific missing attribute rather than the whole module blocked."""
+        with pytest.raises(configparser.Error) as exc_info:
+            _exec_afc_hub_with_missing_attr("extras.AFC_utils", "add_filament_switch")
+        assert str(exc_info.value).startswith(
+            "Error trying to import AFC_utils, please rerun install-afc.sh"
+        )
+
+    def test_afc_unit_import_failure_raises_configparser_error(self):
+        with pytest.raises(configparser.Error) as exc_info:
+            _exec_afc_hub_with_blocked_dependency("extras.AFC_unit")
+        assert str(exc_info.value).startswith(
+            "Error trying to import AFC_unit, please rerun install-afc.sh"
+        )

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -2772,3 +2772,409 @@ class TestAFCU1LaneEventBeforeReady:
         lane.printer.send_event("filament_feed:port", 0, False)
         assert lane.prep_state is False
         assert lane._load_state is False
+
+
+# ── prep_callback ──────────────────────────────────────────────────────────
+
+def _make_lane_for_prep_callback(fullname="AFC_stepper lane1"):
+    """Build an AFCLane wired for prep_callback tests.
+
+    Defaults every guard to its "satisfied" state (printer ready, prep done,
+    status not TOOL_UNLOADING, hub not direct_load, homed, not printing) and
+    prep_state/raw_load_state to False, so calling prep_callback with these
+    defaults is a harmless no-op unless a test flips a specific condition.
+    """
+    lane = _make_afc_lane(fullname)
+    lane.printer = MagicMock()
+    lane.printer.state_message = 'Printer is ready'
+    lane.mutex = MagicMock()
+    lane._afc_prep_done = True
+    lane.status = AFCLaneState.LOADED  # anything but TOOL_UNLOADING
+    lane.prep_active = False
+    lane.last_prep_time = 0
+    lane._load_state = False
+    lane.hub = "PB1"
+    lane.td1_device_id = None
+    lane.afc.auto_home = True
+    lane.afc.function.is_homed = MagicMock(return_value=True)
+    lane.afc.function.is_printing = MagicMock(return_value=False)
+    lane.afc.TOOL_LOAD = MagicMock()
+    lane.afc.spool._set_values = MagicMock()
+    lane.afc.error.AFC_error = MagicMock()
+    lane.afc.save_vars = MagicMock()
+    lane.unit_obj.type = "BoxTurtle"
+    lane.unit_obj.prep_load = MagicMock()
+    lane.unit_obj.prep_post_load = MagicMock()
+    lane.set_loaded = MagicMock()
+    lane.do_enable = MagicMock()
+    lane._post_prep_user_macro = MagicMock()
+    lane._prep_capture_td1 = MagicMock()
+    return lane
+
+
+def _make_lane_ready_to_load(fullname="AFC_stepper lane1"):
+    """Same as _make_lane_for_prep_callback, but pre-armed so calling
+    prep_callback(eventtime=10, state=True) takes the load branch: prep_state
+    True, raw_load_state False, delta_time >= 1.0, not printing."""
+    lane = _make_lane_for_prep_callback(fullname)
+    lane.last_prep_time = 0
+    return lane
+
+
+class TestPrepCallback:
+    """Tests for AFCLane.prep_callback."""
+
+    # ── prep_active re-entrancy guard ────────────────────────────────────
+
+    def test_prep_active_returns_early_without_processing(self):
+        lane = _make_lane_for_prep_callback()
+        lane.prep_active = True
+        lane.prep_callback(10, True)
+        lane.unit_obj.prep_load.assert_not_called()
+        lane.afc.save_vars.assert_not_called()
+
+    def test_prep_active_early_return_still_sets_prep_state(self):
+        """prep_state/last_prep_time are set before the prep_active check, so
+        they update even when the rest of the method is skipped."""
+        lane = _make_lane_for_prep_callback()
+        lane.prep_active = True
+        lane.last_prep_time = 5
+        lane.prep_callback(10, True)
+        assert lane.prep_state is True
+        assert lane.last_prep_time == 10
+
+    def test_prep_active_early_return_leaves_prep_active_true(self):
+        lane = _make_lane_for_prep_callback()
+        lane.prep_active = True
+        lane.prep_callback(10, True)
+        assert lane.prep_active is True
+
+    # ── "home printer before direct load" guard (5-way AND) ─────────────
+    # Baseline where all 5 conditions are satisfied; each independence test
+    # flips exactly one condition back to its "safe" value.
+
+    def _make_lane_at_home_guard_boundary(self):
+        lane = _make_lane_for_prep_callback()
+        lane.printer.state_message = 'Printer is ready'
+        lane._afc_prep_done = True
+        lane.hub = "direct_load"
+        lane.afc.auto_home = False
+        lane.afc.function.is_homed.return_value = False
+        return lane
+
+    def test_home_guard_fires_when_all_conditions_met(self):
+        lane = self._make_lane_at_home_guard_boundary()
+        result = lane.prep_callback(10, True)
+        assert result is False
+        lane.afc.error.AFC_error.assert_called_once_with(
+            "Please home printer before directly loading to toolhead", False
+        )
+
+    def test_home_guard_skipped_when_hub_is_none(self):
+        """hub is None must not crash on "direct_load" in self.hub, and must
+        skip the guard the same as any other unmatched hub value."""
+        lane = self._make_lane_at_home_guard_boundary()
+        lane.hub = None
+        lane.prep_callback(10, True)
+        lane.afc.error.AFC_error.assert_not_called()
+
+    def test_home_guard_fire_skips_rest_of_method(self):
+        lane = self._make_lane_at_home_guard_boundary()
+        lane.prep_callback(10, True)
+        lane.unit_obj.prep_load.assert_not_called()
+        lane.afc.save_vars.assert_not_called()
+
+    def test_home_guard_skipped_when_printer_not_ready(self):
+        lane = self._make_lane_at_home_guard_boundary()
+        lane.printer.state_message = 'not ready'
+        lane.prep_callback(10, True)
+        lane.afc.error.AFC_error.assert_not_called()
+
+    def test_home_guard_skipped_when_prep_not_done(self):
+        lane = self._make_lane_at_home_guard_boundary()
+        lane._afc_prep_done = False
+        lane.prep_callback(10, True)
+        lane.afc.error.AFC_error.assert_not_called()
+
+    def test_home_guard_skipped_when_hub_not_direct_load(self):
+        lane = self._make_lane_at_home_guard_boundary()
+        lane.hub = "PB1"
+        lane.prep_callback(10, True)
+        lane.afc.error.AFC_error.assert_not_called()
+
+    def test_home_guard_skipped_when_auto_home_enabled(self):
+        lane = self._make_lane_at_home_guard_boundary()
+        lane.afc.auto_home = True
+        lane.prep_callback(10, True)
+        lane.afc.error.AFC_error.assert_not_called()
+
+    def test_home_guard_skipped_when_already_homed(self):
+        lane = self._make_lane_at_home_guard_boundary()
+        lane.afc.function.is_homed.return_value = True
+        lane.prep_callback(10, True)
+        lane.afc.error.AFC_error.assert_not_called()
+
+    # ── outer processing guard (3-way AND): printer ready, prep done, ───
+    # ── status != TOOL_UNLOADING ─────────────────────────────────────────
+
+    def test_outer_guard_skipped_when_printer_not_ready(self):
+        lane = _make_lane_ready_to_load()
+        lane.printer.state_message = 'not ready'
+        lane.prep_callback(10, True)
+        lane.unit_obj.prep_load.assert_not_called()
+
+    def test_outer_guard_skipped_when_prep_not_done(self):
+        lane = _make_lane_ready_to_load()
+        lane._afc_prep_done = False
+        lane.prep_callback(10, True)
+        lane.unit_obj.prep_load.assert_not_called()
+
+    def test_outer_guard_skipped_when_status_tool_unloading(self):
+        lane = _make_lane_ready_to_load()
+        lane.status = AFCLaneState.TOOL_UNLOADING
+        lane.prep_callback(10, True)
+        lane.unit_obj.prep_load.assert_not_called()
+
+    # ── load-branch entry (2-way AND): prep_state, not raw_load_state ───
+
+    def test_load_branch_skipped_when_prep_state_false(self):
+        lane = _make_lane_ready_to_load()
+        lane.prep_callback(10, False)
+        lane.unit_obj.prep_load.assert_not_called()
+
+    def test_load_branch_skipped_when_raw_load_state_true(self):
+        lane = _make_lane_ready_to_load()
+        lane._load_state = True
+        lane.prep_callback(10, True)
+        lane.unit_obj.prep_load.assert_not_called()
+
+    # ── debounce: delta_time < 1.0 ───────────────────────────────────────
+
+    def test_debounce_breaks_before_is_printing_check(self):
+        lane = _make_lane_ready_to_load()
+        lane.last_prep_time = 9.5
+        lane.prep_callback(10, True)
+        lane.afc.function.is_printing.assert_not_called()
+        lane.unit_obj.prep_load.assert_not_called()
+
+    def test_debounce_break_still_resets_prep_active_and_saves_vars(self):
+        """break (not return) still falls through to the trailing
+        prep_active reset and save_vars call."""
+        lane = _make_lane_ready_to_load()
+        lane.last_prep_time = 9.5
+        lane.prep_callback(10, True)
+        assert lane.prep_active is False
+        lane.afc.save_vars.assert_called_once()
+
+    def test_no_debounce_when_delta_time_is_one_or_more(self):
+        lane = _make_lane_ready_to_load()
+        lane.last_prep_time = 0
+        lane.prep_callback(10, True)
+        lane.afc.function.is_printing.assert_called_once_with(check_movement=True)
+
+    # ── is_printing(check_movement=True) abort ───────────────────────────
+
+    def test_is_printing_while_moving_aborts_load(self):
+        lane = _make_lane_ready_to_load()
+        lane.afc.function.is_printing.return_value = True
+        lane.prep_callback(10, True)
+        lane.afc.error.AFC_error.assert_called_once_with(
+            "Cannot load lane1 spool while printer is actively moving or homing", False
+        )
+        lane.unit_obj.prep_load.assert_not_called()
+
+    def test_is_printing_while_moving_sets_prep_active_false(self):
+        lane = _make_lane_ready_to_load()
+        lane.afc.function.is_printing.return_value = True
+        lane.prep_callback(10, True)
+        assert lane.prep_active is False
+
+    def test_is_printing_while_moving_does_not_call_save_vars(self):
+        """This path returns (not breaks), so it must skip the trailing
+        save_vars() call unlike the debounce break path."""
+        lane = _make_lane_ready_to_load()
+        lane.afc.function.is_printing.return_value = True
+        lane.prep_callback(10, True)
+        lane.afc.save_vars.assert_not_called()
+
+    # ── successful prep_load call ─────────────────────────────────────────
+
+    def test_successful_load_calls_prep_load(self):
+        lane = _make_lane_ready_to_load()
+        lane.prep_callback(10, True)
+        lane.unit_obj.prep_load.assert_called_once_with(lane)
+
+    def test_successful_load_resets_status_to_none(self):
+        lane = _make_lane_ready_to_load()
+        lane.status = AFCLaneState.LOADED
+        lane.prep_callback(10, True)
+        assert lane.status == AFCLaneState.NONE
+
+    def test_successful_load_logs_debug_messages(self):
+        lane = _make_lane_ready_to_load()
+        lane.prep_callback(10, True)
+        assert lane.logger.messages == [
+            ("debug", "Prep: callback triggered lane1"),
+            ("debug", "Prep: Load Done-lane1"),
+        ]
+
+    # ── direct_load hub vs normal hub (prep_state is guaranteed True here ─
+    # ── by the enclosing load-branch guard, so only hub is independently ──
+    # ── testable for this nested condition) ────────────────────────────
+
+    def test_direct_load_hub_calls_tool_load(self):
+        lane = _make_lane_ready_to_load()
+        lane.hub = "direct_load"
+        lane.prep_callback(10, True)
+        lane.afc.TOOL_LOAD.assert_called_once_with(lane)
+        lane.afc.spool._set_values.assert_called_once_with(lane)
+
+    def test_direct_load_hub_breaks_before_prep_post_load(self):
+        lane = _make_lane_ready_to_load()
+        lane.hub = "direct_load"
+        lane.prep_callback(10, True)
+        lane.unit_obj.prep_post_load.assert_not_called()
+        lane.do_enable.assert_not_called()
+
+    def test_direct_load_hub_logs_debug_messages(self):
+        lane = _make_lane_ready_to_load()
+        lane.hub = "direct_load"
+        lane.prep_callback(10, True)
+        assert lane.logger.messages == [
+            ("debug", "Prep: callback triggered lane1"),
+            ("debug", "Prep: Load Done-lane1"),
+            ("debug", "Prep: direct load logic-lane1-direct_load"),
+            ("debug", "Prep: direct load logic done-lane1-direct_load"),
+        ]
+
+    def test_non_direct_load_hub_calls_prep_post_load_and_do_enable(self):
+        lane = _make_lane_ready_to_load()
+        lane.hub = "PB1"
+        lane.prep_callback(10, True)
+        lane.unit_obj.prep_post_load.assert_called_once_with(lane)
+        lane.do_enable.assert_called_once_with(False)
+        lane.afc.TOOL_LOAD.assert_not_called()
+
+    # ── load_state and prep_state -> set_loaded (prep_state guaranteed ───
+    # ── True here too; only load_state is independently testable) ────────
+
+    def test_load_state_true_after_prep_load_calls_set_loaded(self):
+        """Simulates prep_load() physically loading filament and the load
+        sensor triggering as a result."""
+        lane = _make_lane_ready_to_load()
+        lane.hub = "PB1"
+        lane.unit_obj.prep_load.side_effect = lambda _lane: setattr(_lane, "_load_state", True)
+        lane.prep_callback(10, True)
+        lane.set_loaded.assert_called_once()
+        lane._post_prep_user_macro.assert_called_once()
+
+    def test_load_state_false_after_prep_load_skips_set_loaded(self):
+        lane = _make_lane_ready_to_load()
+        lane.hub = "PB1"
+        lane.prep_callback(10, True)
+        lane.set_loaded.assert_not_called()
+        lane._post_prep_user_macro.assert_not_called()
+
+    # ── td1_device_id capture ─────────────────────────────────────────────
+
+    def test_td1_device_id_set_captures_td1_data(self):
+        lane = _make_lane_ready_to_load()
+        lane.hub = "PB1"
+        lane.td1_device_id = "td1-abc"
+        lane.unit_obj.prep_load.side_effect = lambda _lane: setattr(_lane, "_load_state", True)
+        lane.prep_callback(10, True)
+        lane._prep_capture_td1.assert_called_once()
+
+    def test_td1_device_id_none_skips_td1_capture(self):
+        lane = _make_lane_ready_to_load()
+        lane.hub = "PB1"
+        lane.td1_device_id = None
+        lane.unit_obj.prep_load.side_effect = lambda _lane: setattr(_lane, "_load_state", True)
+        lane.prep_callback(10, True)
+        lane._prep_capture_td1.assert_not_called()
+
+    # ── elif: sensor stuck triggered (3-way AND). Reaching this elif with ─
+    # ── any chance of firing structurally requires prep_state==True and ──
+    # ── raw_load_state==True together (otherwise the if branch above ─────
+    # ── fires instead, or prep_state==False short-circuits both) ─────────
+
+    def test_sensor_stuck_message_fires_when_all_conditions_met(self):
+        lane = _make_lane_ready_to_load()
+        lane._load_state = True
+        lane.afc.function.is_printing.return_value = False
+        lane.prep_callback(10, True)
+        lane.afc.error.AFC_error.assert_called_once_with(
+            "Cannot load lane1 load sensor is triggered."
+            "\n    Make sure filament is not stuck in load sensor or check to make sure "
+            "load sensor is not stuck triggered."
+            "\n    Once cleared try loading again",
+            pause=False,
+        )
+
+    def test_sensor_stuck_message_skipped_when_printing(self):
+        lane = _make_lane_ready_to_load()
+        lane._load_state = True
+        lane.afc.function.is_printing.return_value = True
+        lane.prep_callback(10, True)
+        lane.afc.error.AFC_error.assert_not_called()
+
+    def test_neither_branch_fires_when_prep_state_false(self):
+        lane = _make_lane_ready_to_load()
+        lane._load_state = True
+        lane.prep_callback(10, False)
+        lane.unit_obj.prep_load.assert_not_called()
+        lane.afc.error.AFC_error.assert_not_called()
+
+    def test_sensor_stuck_message_includes_vivid_recovery_hint(self):
+        lane = _make_lane_ready_to_load()
+        lane._load_state = True
+        lane.afc.function.is_printing.return_value = False
+        lane.unit_obj.type = "ViViD"
+        lane.prep_callback(10, True)
+        lane.afc.error.AFC_error.assert_called_once_with(
+            "Cannot load lane1 load sensor is triggered."
+            "\n    Make sure filament is not stuck in load sensor or check to make sure "
+            "load sensor is not stuck triggered."
+            "\n    If filament is not stuck in sensor run AFC_RECOVER_LANE LANE=lane1 "
+            "to reset internal AFC state."
+            "\n    Once cleared try loading again",
+            pause=False,
+        )
+
+    def test_sensor_stuck_message_excludes_vivid_hint_for_other_units(self):
+        lane = _make_lane_ready_to_load()
+        lane._load_state = True
+        lane.afc.function.is_printing.return_value = False
+        lane.unit_obj.type = "BoxTurtle"
+        lane.prep_callback(10, True)
+        called_msg = lane.afc.error.AFC_error.call_args[0][0]
+        assert "AFC_RECOVER_LANE" not in called_msg
+
+    # ── trailing prep_active reset / save_vars ────────────────────────────
+
+    def test_prep_active_is_true_during_processing_then_reset(self):
+        """prep_active must be True while the with-block is doing work
+        (observed via a side effect mid-call), then reset to False before
+        prep_callback returns."""
+        lane = _make_lane_ready_to_load()
+        observed = []
+        def _record(_lane):
+            observed.append(lane.prep_active)
+        lane.unit_obj.prep_load.side_effect = _record
+        lane.prep_callback(10, True)
+        assert observed == [True]
+        assert lane.prep_active is False
+
+    def test_normal_completion_saves_vars(self):
+        lane = _make_lane_ready_to_load()
+        lane.prep_callback(10, True)
+        lane.afc.save_vars.assert_called_once()
+
+    def test_outer_guard_false_still_resets_prep_active_and_saves_vars(self):
+        """Even when the outer processing guard never enters the with-block,
+        the trailing reset/save still runs (it's outside the for/with)."""
+        lane = _make_lane_ready_to_load()
+        lane.printer.state_message = 'not ready'
+        lane.prep_callback(10, True)
+        assert lane.prep_active is False
+        lane.afc.save_vars.assert_called_once()

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -2865,7 +2865,7 @@ class TestPrepCallback:
     def test_home_guard_fires_when_all_conditions_met(self):
         lane = self._make_lane_at_home_guard_boundary()
         result = lane.prep_callback(10, True)
-        assert result is False
+        assert result is None
         lane.afc.error.AFC_error.assert_called_once_with(
             "Please home printer before directly loading to toolhead", False
         )
@@ -3054,6 +3054,17 @@ class TestPrepCallback:
         lane.unit_obj.prep_post_load.assert_called_once_with(lane)
         lane.do_enable.assert_called_once_with(False)
         lane.afc.TOOL_LOAD.assert_not_called()
+
+    def test_hub_is_none_does_not_crash_and_skips_tool_load(self):
+        """hub is None must not raise on self.hub == 'direct_load', and must
+        fall through to the normal prep_post_load path exactly like any
+        other non-direct_load hub value."""
+        lane = _make_lane_ready_to_load()
+        lane.hub = None
+        lane.prep_callback(10, True)
+        lane.afc.TOOL_LOAD.assert_not_called()
+        lane.unit_obj.prep_post_load.assert_called_once_with(lane)
+        lane.do_enable.assert_called_once_with(False)
 
     # ── load_state and prep_state -> set_loaded (prep_state guaranteed ───
     # ── True here too; only load_state is independently testable) ────────

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -2848,6 +2848,14 @@ class TestPrepCallback:
         lane.prep_active = True
         lane.prep_callback(10, True)
         assert lane.prep_active is True
+    
+    def test_integer_state_is_normalized_to_bool(self):
+        lane = _make_lane_for_prep_callback()
+        lane.prep_active = True
+        lane.prep_callback(10, 1)
+        assert lane.prep_state is True
+        lane.prep_callback(11, 0)
+        assert lane.prep_state is False
 
     # ── "home printer before direct load" guard (5-way AND) ─────────────
     # Baseline where all 5 conditions are satisfied; each independence test


### PR DESCRIPTION
## Major Changes in this PR
- Added None checks to AFC_hub `switch_pin` variable, Fixes #771
- Added None checks before calling `_set_homing_endstop` in AFC_lane
- Changed the way "direct_load" check happens for hub in AFC_lane, Fixes #782
- Added unit tests to make sure AFC_hub was fully covered, converted tests to use __init__ instead of __new__
- Updated typing and method comments for AFC_hub

## Notes to Code Reviewers

## How the changes in this PR are tested
Since type casting was added to pin states, verified on my printer that prep and hub switch still triggers correctly.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to pr-review channel requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved AFC hub handling for missing or virtual switch pins.
  - Improved lane sensor processing, including state normalization, debouncing, homing checks, and direct-load detection.
  - Added safeguards for premature feeder events and sensor-related errors.
  - Preserved existing hub-cut, runout, and filament retraction behavior while strengthening validation.

- **Tests**
  - Expanded coverage for AFC hub operations, switch configurations, and lane loading scenarios.
  - Added validation for successful loading, error handling, and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->