### PR TITLE
Add generic display-status hook for load/unload (pushing/retraction)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Added a `_AFC_DISPLAY_STATUS` hook, called around `TOOL_LOAD`/`TOOL_UNLOAD` with `pushing`/`retraction`
+  state changes. Lets any display integration (e.g. a KNOMI screen) show a live animation during those
+  actions instead of a generic "printing" icon, by defining a `_AFC_DISPLAY_STATUS` gcode_macro. No-ops
+  completely if that macro isn't defined.
+
 ## [2026-08-02]
 ### Updated
 - The `BT_LANE_EJECT`, `BT_LANE_MOVE`, and `BT_CHANGE_TOOL` macros will now accept either a lane defined as `lane1` or

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -826,8 +826,11 @@ class afc:
         :param value: True/False the variable changed to
         """
         if 'gcode_macro _AFC_DISPLAY_STATUS' in self.printer.objects:
-            self.gcode.run_script_from_command(
-                f"_AFC_DISPLAY_STATUS VARIABLE={variable} VALUE={value}")
+            try:
+                self.gcode.run_script_from_command(
+                    f"_AFC_DISPLAY_STATUS VARIABLE={variable} VALUE={value}")
+            except Exception:
+                self.logger.debug("_AFC_DISPLAY_STATUS macro raised an error", exc_info=True)
 
     def _set_quiet_mode(self, val):
         """
@@ -901,7 +904,11 @@ class afc:
             if self.get_bypass_state():
                 if unload:
                     self.logger.info("Bypass detected, calling manual unload filament routine")
-                    self.gcode.run_script_from_command(self.RENAMED_UNLOAD_FILAMENT)
+                    self._set_display_status('retraction', True)
+                    try:
+                        self.gcode.run_script_from_command(self.RENAMED_UNLOAD_FILAMENT)
+                    finally:
+                        self._set_display_status('retraction', False)
                     self.logger.info("Filament unloaded")
                 else:
                     msg = "Filament loaded in bypass, not doing tool load"

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -812,6 +812,21 @@ class afc:
         except Exception:
             self.logger.debug("Unable to restore extruder temperature", exc_info=True)
 
+    def _set_knomi_status(self, variable: str, value: bool) -> None:
+        """
+        Best-effort update of the (optional) _KNOMI_STATUS gcode_macro used to drive
+        BTT KNOMI display animations during tool-change actions (e.g. pushing new
+        filament into the toolhead, retracting it back out). No-ops silently if the
+        user hasn't configured a _KNOMI_STATUS macro, since this is purely cosmetic
+        and must never affect the actual load/unload sequence.
+
+        :param variable: Name of the _KNOMI_STATUS variable to update
+        :param value: True/False to set the variable to
+        """
+        if 'gcode_macro _KNOMI_STATUS' in self.printer.objects:
+            self.gcode.run_script_from_command(
+                f"SET_GCODE_VARIABLE MACRO=_KNOMI_STATUS VARIABLE={variable} VALUE={value}")
+
     def _set_quiet_mode(self, val):
         """
         Helper function to set quiet mode to on or off
@@ -1530,7 +1545,11 @@ class afc:
                 temp_state = self.capture_toolhead_temp()
                 try:
                     # Run the load sequence, which may include custom gcode commands.
-                    success = self.load_sequence(cur_lane, cur_hub, cur_extruder)
+                    self._set_knomi_status('pushing', True)
+                    try:
+                        success = self.load_sequence(cur_lane, cur_hub, cur_extruder)
+                    finally:
+                        self._set_knomi_status('pushing', False)
                     if not success:
                         return success
 
@@ -1956,7 +1975,11 @@ class afc:
             temp_state = self.capture_toolhead_temp()
             try:
                 # Run the unload sequence, which may include custom gcode commands.
-                success = self.unload_sequence(cur_lane, cur_hub, cur_extruder)
+                self._set_knomi_status('retraction', True)
+                try:
+                    success = self.unload_sequence(cur_lane, cur_hub, cur_extruder)
+                finally:
+                    self._set_knomi_status('retraction', False)
                 if not success:
                     return success
             finally:

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -812,20 +812,22 @@ class afc:
         except Exception:
             self.logger.debug("Unable to restore extruder temperature", exc_info=True)
 
-    def _set_knomi_status(self, variable: str, value: bool) -> None:
+    def _set_display_status(self, variable: str, value: bool) -> None:
         """
-        Best-effort update of the (optional) _KNOMI_STATUS gcode_macro used to drive
-        BTT KNOMI display animations during tool-change actions (e.g. pushing new
-        filament into the toolhead, retracting it back out). No-ops silently if the
-        user hasn't configured a _KNOMI_STATUS macro, since this is purely cosmetic
-        and must never affect the actual load/unload sequence.
+        Best-effort notification of a display status change during tool-change
+        actions (e.g. pushing new filament into the toolhead, retracting it back
+        out). Calls the user-defined _AFC_DISPLAY_STATUS macro (if any) with the
+        changed variable/value as params, letting any display integration (KNOMI
+        or otherwise) decide what to do with it. No-ops silently if the user
+        hasn't defined that macro, since this is purely cosmetic and must never
+        affect the actual load/unload sequence.
 
-        :param variable: Name of the _KNOMI_STATUS variable to update
-        :param value: True/False to set the variable to
+        :param variable: Name of the status variable that changed
+        :param value: True/False the variable changed to
         """
-        if 'gcode_macro _KNOMI_STATUS' in self.printer.objects:
+        if 'gcode_macro _AFC_DISPLAY_STATUS' in self.printer.objects:
             self.gcode.run_script_from_command(
-                f"SET_GCODE_VARIABLE MACRO=_KNOMI_STATUS VARIABLE={variable} VALUE={value}")
+                f"_AFC_DISPLAY_STATUS VARIABLE={variable} VALUE={value}")
 
     def _set_quiet_mode(self, val):
         """
@@ -1545,11 +1547,11 @@ class afc:
                 temp_state = self.capture_toolhead_temp()
                 try:
                     # Run the load sequence, which may include custom gcode commands.
-                    self._set_knomi_status('pushing', True)
+                    self._set_display_status('pushing', True)
                     try:
                         success = self.load_sequence(cur_lane, cur_hub, cur_extruder)
                     finally:
-                        self._set_knomi_status('pushing', False)
+                        self._set_display_status('pushing', False)
                     if not success:
                         return success
 
@@ -1975,11 +1977,11 @@ class afc:
             temp_state = self.capture_toolhead_temp()
             try:
                 # Run the unload sequence, which may include custom gcode commands.
-                self._set_knomi_status('retraction', True)
+                self._set_display_status('retraction', True)
                 try:
                     success = self.unload_sequence(cur_lane, cur_hub, cur_extruder)
                 finally:
-                    self._set_knomi_status('retraction', False)
+                    self._set_display_status('retraction', False)
                 if not success:
                     return success
             finally:

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -3857,28 +3857,28 @@ class TestUnloadSequenceCustomCmdPostUnloadMacro:
         assert afc.gcode.run_script_from_command.call_args_list == [call("MY_CUSTOM_UNLOAD")]
         lane.set_tool_unloaded.assert_called_once_with(normal_toolchange=True)
 
-# ── _set_knomi_status ────────────────────────────────────────────────────────
+# ── _set_display_status ──────────────────────────────────────────────────────
 
-class TestSetKnomiStatus:
-    def test_noop_when_knomi_not_configured(self):
+class TestSetDisplayStatus:
+    def test_noop_when_display_hook_not_configured(self):
         afc_obj = _make_afc()
-        afc_obj._set_knomi_status('pushing', True)
+        afc_obj._set_display_status('pushing', True)
         afc_obj.gcode.run_script_from_command.assert_not_called()
 
-    def test_sends_set_gcode_variable_when_configured(self):
+    def test_calls_display_status_macro_when_configured(self):
         afc_obj = _make_afc()
-        afc_obj.printer.objects['gcode_macro _KNOMI_STATUS'] = MagicMock()
+        afc_obj.printer.objects['gcode_macro _AFC_DISPLAY_STATUS'] = MagicMock()
 
-        afc_obj._set_knomi_status('pushing', True)
+        afc_obj._set_display_status('pushing', True)
 
         afc_obj.gcode.run_script_from_command.assert_called_once_with(
-            "SET_GCODE_VARIABLE MACRO=_KNOMI_STATUS VARIABLE=pushing VALUE=True")
+            "_AFC_DISPLAY_STATUS VARIABLE=pushing VALUE=True")
 
     def test_sends_false_value(self):
         afc_obj = _make_afc()
-        afc_obj.printer.objects['gcode_macro _KNOMI_STATUS'] = MagicMock()
+        afc_obj.printer.objects['gcode_macro _AFC_DISPLAY_STATUS'] = MagicMock()
 
-        afc_obj._set_knomi_status('retraction', False)
+        afc_obj._set_display_status('retraction', False)
 
         afc_obj.gcode.run_script_from_command.assert_called_once_with(
-            "SET_GCODE_VARIABLE MACRO=_KNOMI_STATUS VARIABLE=retraction VALUE=False")
+            "_AFC_DISPLAY_STATUS VARIABLE=retraction VALUE=False")

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -3900,6 +3900,19 @@ class TestSetDisplayStatus:
 # exercise it through the actual TOOL_LOAD/TOOL_UNLOAD entry points, across
 # success, failure, and exception paths in the wrapped load_sequence/unload_sequence.
 
+def _recorder(events, label, return_value=None, exc=None):
+    """Returns a side_effect callable that appends `label` to the shared
+    `events` list, then returns return_value or raises exc - lets a test
+    assert the real operation actually ran *between* the display-status
+    True/False calls, not just that True preceded False."""
+    def _side_effect(*args, **kwargs):
+        events.append(label)
+        if exc is not None:
+            raise exc
+        return return_value
+    return _side_effect
+
+
 class TestToolLoadDisplayStatusLifecycle:
     def _make(self):
         afc = _make_afc()
@@ -3910,7 +3923,6 @@ class TestToolLoadDisplayStatusLifecycle:
         afc.do_poop_kick_wipe = MagicMock()
         afc.capture_toolhead_temp = MagicMock(return_value=100)
         afc.restore_toolhead_temp = MagicMock()
-        afc._set_display_status = MagicMock()
         afc.function.get_current_lane.return_value = None
         lane = _make_afc_lane()
         lane.extruder_obj.lane_loaded = lane.name
@@ -3923,35 +3935,39 @@ class TestToolLoadDisplayStatusLifecycle:
         lane._load_state = True
         lane.need_purge = False
         afc.lanes[lane.name] = lane
-        return afc, lane
+
+        events = []
+        afc._set_display_status = MagicMock(
+            side_effect=lambda var, val: events.append(('display', var, val)))
+        return afc, lane, events
 
     def test_pushing_true_then_false_around_successful_load(self):
-        afc, lane = self._make()
-        afc.load_sequence = MagicMock(return_value=True)
+        afc, lane, events = self._make()
+        afc.load_sequence = MagicMock(side_effect=_recorder(events, 'load_sequence', return_value=True))
 
         assert afc.TOOL_LOAD(lane)
 
-        assert afc._set_display_status.call_args_list == [
-            call('pushing', True), call('pushing', False)]
+        assert events == [
+            ('display', 'pushing', True), 'load_sequence', ('display', 'pushing', False)]
 
     def test_pushing_false_still_called_when_load_fails(self):
-        afc, lane = self._make()
-        afc.load_sequence = MagicMock(return_value=False)
+        afc, lane, events = self._make()
+        afc.load_sequence = MagicMock(side_effect=_recorder(events, 'load_sequence', return_value=False))
 
         assert not afc.TOOL_LOAD(lane)
 
-        assert afc._set_display_status.call_args_list == [
-            call('pushing', True), call('pushing', False)]
+        assert events == [
+            ('display', 'pushing', True), 'load_sequence', ('display', 'pushing', False)]
 
     def test_pushing_false_still_called_when_load_raises(self):
-        afc, lane = self._make()
-        afc.load_sequence = MagicMock(side_effect=Exception("boom"))
+        afc, lane, events = self._make()
+        afc.load_sequence = MagicMock(side_effect=_recorder(events, 'load_sequence', exc=Exception("boom")))
 
         with pytest.raises(Exception):
             afc.TOOL_LOAD(lane)
 
-        assert afc._set_display_status.call_args_list == [
-            call('pushing', True), call('pushing', False)]
+        assert events == [
+            ('display', 'pushing', True), 'load_sequence', ('display', 'pushing', False)]
 
 
 class TestToolUnloadDisplayStatusLifecycle:
@@ -3962,7 +3978,6 @@ class TestToolUnloadDisplayStatusLifecycle:
         afc.afc_stats = MagicMock()
         afc.capture_toolhead_temp = MagicMock(return_value=100)
         afc.restore_toolhead_temp = MagicMock()
-        afc._set_display_status = MagicMock()
         afc.gcode_move = MagicMock()
         afc.gcode_move.last_position = [0.0, 0.0, 0.0, 0.0]
         afc.z_hop = 5
@@ -3971,35 +3986,39 @@ class TestToolUnloadDisplayStatusLifecycle:
         lane.hub = "PB1"
         afc.function.get_current_lane.return_value = lane.name
         afc.lanes[lane.name] = lane
-        return afc, lane
+
+        events = []
+        afc._set_display_status = MagicMock(
+            side_effect=lambda var, val: events.append(('display', var, val)))
+        return afc, lane, events
 
     def test_retraction_true_then_false_around_successful_unload(self):
-        afc, lane = self._make()
-        afc.unload_sequence = MagicMock(return_value=True)
+        afc, lane, events = self._make()
+        afc.unload_sequence = MagicMock(side_effect=_recorder(events, 'unload_sequence', return_value=True))
 
         assert afc.TOOL_UNLOAD(lane, force_unload=True)
 
-        assert afc._set_display_status.call_args_list == [
-            call('retraction', True), call('retraction', False)]
+        assert events == [
+            ('display', 'retraction', True), 'unload_sequence', ('display', 'retraction', False)]
 
     def test_retraction_false_still_called_when_unload_fails(self):
-        afc, lane = self._make()
-        afc.unload_sequence = MagicMock(return_value=False)
+        afc, lane, events = self._make()
+        afc.unload_sequence = MagicMock(side_effect=_recorder(events, 'unload_sequence', return_value=False))
 
         assert not afc.TOOL_UNLOAD(lane, force_unload=True)
 
-        assert afc._set_display_status.call_args_list == [
-            call('retraction', True), call('retraction', False)]
+        assert events == [
+            ('display', 'retraction', True), 'unload_sequence', ('display', 'retraction', False)]
 
     def test_retraction_false_still_called_when_unload_raises(self):
-        afc, lane = self._make()
-        afc.unload_sequence = MagicMock(side_effect=Exception("boom"))
+        afc, lane, events = self._make()
+        afc.unload_sequence = MagicMock(side_effect=_recorder(events, 'unload_sequence', exc=Exception("boom")))
 
         with pytest.raises(Exception):
             afc.TOOL_UNLOAD(lane, force_unload=True)
 
-        assert afc._set_display_status.call_args_list == [
-            call('retraction', True), call('retraction', False)]
+        assert events == [
+            ('display', 'retraction', True), 'unload_sequence', ('display', 'retraction', False)]
 
 
 class TestBypassUnloadDisplayStatus:
@@ -4007,30 +4026,37 @@ class TestBypassUnloadDisplayStatus:
     TOOL_UNLOAD's normal unload_sequence wrapping, so it needs its own
     retraction True/False pair around RENAMED_UNLOAD_FILAMENT."""
 
-    def test_retraction_true_then_false_around_bypass_unload(self):
+    def _make(self):
         afc = _make_afc()
         afc.RENAMED_UNLOAD_FILAMENT = "_AFC_RENAMED_UNLOAD_FILAMENT_"
         afc.get_bypass_state = MagicMock(return_value=True)
-        afc._set_display_status = MagicMock()
+
+        events = []
+        afc._set_display_status = MagicMock(
+            side_effect=lambda var, val: events.append(('display', var, val)))
+        return afc, events
+
+    def test_retraction_true_then_false_around_bypass_unload(self):
+        afc, events = self._make()
+        afc.gcode.run_script_from_command = MagicMock(
+            side_effect=_recorder(events, 'run_script_from_command'))
 
         result = afc._check_bypass(unload=True)
 
         assert result is True
-        assert afc._set_display_status.call_args_list == [
-            call('retraction', True), call('retraction', False)]
+        assert events == [
+            ('display', 'retraction', True), 'run_script_from_command', ('display', 'retraction', False)]
         afc.gcode.run_script_from_command.assert_called_once_with(afc.RENAMED_UNLOAD_FILAMENT)
 
     def test_retraction_false_still_called_when_bypass_unload_raises(self):
         # _check_bypass has an outer bare except that swallows exceptions and
         # returns False - the inner finally must still fire before that happens.
-        afc = _make_afc()
-        afc.RENAMED_UNLOAD_FILAMENT = "_AFC_RENAMED_UNLOAD_FILAMENT_"
-        afc.get_bypass_state = MagicMock(return_value=True)
-        afc._set_display_status = MagicMock()
-        afc.gcode.run_script_from_command.side_effect = Exception("boom")
+        afc, events = self._make()
+        afc.gcode.run_script_from_command = MagicMock(
+            side_effect=_recorder(events, 'run_script_from_command', exc=Exception("boom")))
 
         result = afc._check_bypass(unload=True)
 
         assert result is False
-        assert afc._set_display_status.call_args_list == [
-            call('retraction', True), call('retraction', False)]
+        assert events == [
+            ('display', 'retraction', True), 'run_script_from_command', ('display', 'retraction', False)]

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -3882,3 +3882,155 @@ class TestSetDisplayStatus:
 
         afc_obj.gcode.run_script_from_command.assert_called_once_with(
             "_AFC_DISPLAY_STATUS VARIABLE=retraction VALUE=False")
+
+    def test_exception_from_macro_does_not_propagate(self):
+        """A broken user _AFC_DISPLAY_STATUS macro must not abort the tool change."""
+        afc_obj = _make_afc()
+        afc_obj.printer.objects['gcode_macro _AFC_DISPLAY_STATUS'] = MagicMock()
+        afc_obj.gcode.run_script_from_command.side_effect = Exception("macro exploded")
+
+        afc_obj._set_display_status('pushing', True)  # must not raise
+
+        debug_msgs = [m for lvl, m in afc_obj.logger.messages if lvl == "debug"]
+        assert any("_AFC_DISPLAY_STATUS" in m for m in debug_msgs)
+
+
+# ── TOOL_LOAD / TOOL_UNLOAD: display status lifecycle (real callers) ────────────
+# TestSetDisplayStatus above only covers _set_display_status in isolation. These
+# exercise it through the actual TOOL_LOAD/TOOL_UNLOAD entry points, across
+# success, failure, and exception paths in the wrapped load_sequence/unload_sequence.
+
+class TestToolLoadDisplayStatusLifecycle:
+    def _make(self):
+        afc = _make_afc()
+        afc.verify_macro_positions = MagicMock(return_value=False)
+        afc.save_vars = MagicMock()
+        afc.spool = MagicMock()
+        afc.afc_stats = MagicMock()
+        afc.do_poop_kick_wipe = MagicMock()
+        afc.capture_toolhead_temp = MagicMock(return_value=100)
+        afc.restore_toolhead_temp = MagicMock()
+        afc._set_display_status = MagicMock()
+        afc.function.get_current_lane.return_value = None
+        lane = _make_afc_lane()
+        lane.extruder_obj.lane_loaded = lane.name
+        lane.spool_id = None
+        lane.get_td1_data_load = MagicMock()
+        lane.lane_load_count = MagicMock()
+        lane.hub_obj = MagicMock()
+        lane.hub_obj.state = False
+        lane.hub_obj.is_virtual_pin.return_value = False
+        lane._load_state = True
+        lane.need_purge = False
+        afc.lanes[lane.name] = lane
+        return afc, lane
+
+    def test_pushing_true_then_false_around_successful_load(self):
+        afc, lane = self._make()
+        afc.load_sequence = MagicMock(return_value=True)
+
+        assert afc.TOOL_LOAD(lane)
+
+        assert afc._set_display_status.call_args_list == [
+            call('pushing', True), call('pushing', False)]
+
+    def test_pushing_false_still_called_when_load_fails(self):
+        afc, lane = self._make()
+        afc.load_sequence = MagicMock(return_value=False)
+
+        assert not afc.TOOL_LOAD(lane)
+
+        assert afc._set_display_status.call_args_list == [
+            call('pushing', True), call('pushing', False)]
+
+    def test_pushing_false_still_called_when_load_raises(self):
+        afc, lane = self._make()
+        afc.load_sequence = MagicMock(side_effect=Exception("boom"))
+
+        with pytest.raises(Exception):
+            afc.TOOL_LOAD(lane)
+
+        assert afc._set_display_status.call_args_list == [
+            call('pushing', True), call('pushing', False)]
+
+
+class TestToolUnloadDisplayStatusLifecycle:
+    def _make(self):
+        afc = _make_afc()
+        afc.verify_macro_positions = MagicMock(return_value=False)
+        afc.save_vars = MagicMock()
+        afc.afc_stats = MagicMock()
+        afc.capture_toolhead_temp = MagicMock(return_value=100)
+        afc.restore_toolhead_temp = MagicMock()
+        afc._set_display_status = MagicMock()
+        afc.gcode_move = MagicMock()
+        afc.gcode_move.last_position = [0.0, 0.0, 0.0, 0.0]
+        afc.z_hop = 5
+        afc.move_z_pos = MagicMock()
+        lane = _make_afc_lane()
+        lane.hub = "PB1"
+        afc.function.get_current_lane.return_value = lane.name
+        afc.lanes[lane.name] = lane
+        return afc, lane
+
+    def test_retraction_true_then_false_around_successful_unload(self):
+        afc, lane = self._make()
+        afc.unload_sequence = MagicMock(return_value=True)
+
+        assert afc.TOOL_UNLOAD(lane, force_unload=True)
+
+        assert afc._set_display_status.call_args_list == [
+            call('retraction', True), call('retraction', False)]
+
+    def test_retraction_false_still_called_when_unload_fails(self):
+        afc, lane = self._make()
+        afc.unload_sequence = MagicMock(return_value=False)
+
+        assert not afc.TOOL_UNLOAD(lane, force_unload=True)
+
+        assert afc._set_display_status.call_args_list == [
+            call('retraction', True), call('retraction', False)]
+
+    def test_retraction_false_still_called_when_unload_raises(self):
+        afc, lane = self._make()
+        afc.unload_sequence = MagicMock(side_effect=Exception("boom"))
+
+        with pytest.raises(Exception):
+            afc.TOOL_UNLOAD(lane, force_unload=True)
+
+        assert afc._set_display_status.call_args_list == [
+            call('retraction', True), call('retraction', False)]
+
+
+class TestBypassUnloadDisplayStatus:
+    """The manual bypass-unload path (_check_bypass) doesn't go through
+    TOOL_UNLOAD's normal unload_sequence wrapping, so it needs its own
+    retraction True/False pair around RENAMED_UNLOAD_FILAMENT."""
+
+    def test_retraction_true_then_false_around_bypass_unload(self):
+        afc = _make_afc()
+        afc.RENAMED_UNLOAD_FILAMENT = "_AFC_RENAMED_UNLOAD_FILAMENT_"
+        afc.get_bypass_state = MagicMock(return_value=True)
+        afc._set_display_status = MagicMock()
+
+        result = afc._check_bypass(unload=True)
+
+        assert result is True
+        assert afc._set_display_status.call_args_list == [
+            call('retraction', True), call('retraction', False)]
+        afc.gcode.run_script_from_command.assert_called_once_with(afc.RENAMED_UNLOAD_FILAMENT)
+
+    def test_retraction_false_still_called_when_bypass_unload_raises(self):
+        # _check_bypass has an outer bare except that swallows exceptions and
+        # returns False - the inner finally must still fire before that happens.
+        afc = _make_afc()
+        afc.RENAMED_UNLOAD_FILAMENT = "_AFC_RENAMED_UNLOAD_FILAMENT_"
+        afc.get_bypass_state = MagicMock(return_value=True)
+        afc._set_display_status = MagicMock()
+        afc.gcode.run_script_from_command.side_effect = Exception("boom")
+
+        result = afc._check_bypass(unload=True)
+
+        assert result is False
+        assert afc._set_display_status.call_args_list == [
+            call('retraction', True), call('retraction', False)]

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -3856,3 +3856,29 @@ class TestUnloadSequenceCustomCmdPostUnloadMacro:
 
         assert afc.gcode.run_script_from_command.call_args_list == [call("MY_CUSTOM_UNLOAD")]
         lane.set_tool_unloaded.assert_called_once_with(normal_toolchange=True)
+
+# ── _set_knomi_status ────────────────────────────────────────────────────────
+
+class TestSetKnomiStatus:
+    def test_noop_when_knomi_not_configured(self):
+        afc_obj = _make_afc()
+        afc_obj._set_knomi_status('pushing', True)
+        afc_obj.gcode.run_script_from_command.assert_not_called()
+
+    def test_sends_set_gcode_variable_when_configured(self):
+        afc_obj = _make_afc()
+        afc_obj.printer.objects['gcode_macro _KNOMI_STATUS'] = MagicMock()
+
+        afc_obj._set_knomi_status('pushing', True)
+
+        afc_obj.gcode.run_script_from_command.assert_called_once_with(
+            "SET_GCODE_VARIABLE MACRO=_KNOMI_STATUS VARIABLE=pushing VALUE=True")
+
+    def test_sends_false_value(self):
+        afc_obj = _make_afc()
+        afc_obj.printer.objects['gcode_macro _KNOMI_STATUS'] = MagicMock()
+
+        afc_obj._set_knomi_status('retraction', False)
+
+        afc_obj.gcode.run_script_from_command.assert_called_once_with(
+            "SET_GCODE_VARIABLE MACRO=_KNOMI_STATUS VARIABLE=retraction VALUE=False")


### PR DESCRIPTION
## Major Changes in this PR

- Adds an optional `_AFC_DISPLAY_STATUS` hook that AFC calls during `TOOL_LOAD`/`TOOL_UNLOAD`, notifying `pushing`/`retraction` — for anyone who wants to show an animation on a screen instead of the generic "printing" icon
- If nobody defines that macro, it does nothing (zero risk for anyone not using it)
- Real-world use: on a BTT KNOMI screen, relaying to its own macro (`_KNOMI_STATUS`) — no firmware recompile needed
- After CodeRabbit's review: isolated errors from the user's macro (must not break load/unload), covered the bypass path too, and strengthened the tests

## Notes to Code Reviewers

- Only 2 real spots touch `TOOL_LOAD`/`TOOL_UNLOAD` — the rest is tests
- Example GIFs and firmware source: https://github.com/rescosta/KNOMI/tree/afc-tool-change-icons

## How the changes in this PR are tested

- Unit tests + real Klipper integration tests (`tests/klippy/*`, including Kalico) — all passing, confirmed by this repo's own CI
- Tested on real hardware (my printer): all 10 states confirmed relaying correctly to the screen

## PR Checklist: (Checked-off items are either done or do not apply to this PR)

- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to pr-review channel requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

---

The initial implementation was drafted with Claude and then reviewed, tested, and edited by me.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Display integrations can show live animations while tools are pushed or retracted.
  * Status updates indicate when a tool is loading or unloading and automatically return to inactive when the action finishes.
  * Existing integrations continue to work unchanged if display-status support is not configured.

* **Documentation**
  * Added an Unreleased changelog entry describing the new display-status behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->