### PR TITLE
(fix): Fixing AFC_STATS printout, added tracking for load/unload errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2026-08-06]
 ### Added
 - Added a `_AFC_DISPLAY_STATUS` hook, called around `TOOL_LOAD`/`TOOL_UNLOAD` with `pushing`/`retraction`
   state changes. Lets any display integration (e.g. a KNOMI screen) show a live animation during those
   actions instead of a generic "printing" icon, by defining a `_AFC_DISPLAY_STATUS` gcode_macro. No-ops
   completely if that macro isn't defined.
+- Added ability to keep track when errors happen during load/unloading processes.
+### Fixed
+- Issues with lanes printing out of order when running AFC_STATS, also updated formatting to be more consistent.
 
 ## [2026-08-02]
 ### Updated

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1475,8 +1475,7 @@ class afc:
         if not self.TOOL_LOAD(cur_lane, purge_length):
             # Error happened, reset toolchanges without error count
             # and increase load error count
-            if not self.testing:
-                self.afc_stats.increase_load_error_count()
+            self.afc_stats.increase_load_error_count(self)
 
     def TOOL_LOAD(self, cur_lane: AFCLane, purge_length: Optional[float]=None, set_start_time=False):
         """
@@ -1534,6 +1533,7 @@ class afc:
                 msg = ('Failed to unload currently loaded lane {} from extruder {} before loading new lane {}.'.format(
                     lane_name, cur_extruder_obj.name, cur_lane.name))
                 self.error.fix(msg, self.lanes[lane_name])
+                self.afc_stats.increase_unload_error_count(self)
                 return False
 
         if cur_lane.name != self.current:
@@ -1883,8 +1883,7 @@ class afc:
         if not self.TOOL_UNLOAD(cur_lane):
             # Error happened, reset toolchanges without error count
             # and increase unload error count
-            if not self.testing:
-                self.afc_stats.increase_unload_error_count()
+            self.afc_stats.increase_unload_error_count(self)
 
         # User manually unloaded spool from toolhead, remove spool from active status
         self.spool.set_active_spool(None)
@@ -2479,8 +2478,7 @@ class afc:
                             self.error.fix(msg, unload_lane)  #send to error handling
                             # Error happened, reset toolchanges without error count
                             # and increase unload error count
-                            if not self.testing:
-                                self.afc_stats.increase_unload_error_count()
+                            self.afc_stats.increase_unload_error_count(self)
                             return
 
                         if (force_unload
@@ -2532,8 +2530,7 @@ class afc:
                 else:
                     # Error happened, reset toolchanges without error count
                     # and increase load error count
-                    if not self.testing:
-                        self.afc_stats.increase_load_error_count()
+                    self.afc_stats.increase_load_error_count(self)
             else:
                 # Calling handle activate extruder just to make sure lanes are synced as tool
                 # could have been changed with KTC SELECT_TOOL and lane might not be synced

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -45,7 +45,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 try: from extras.AFC_stats import AFCStats
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
 
-AFC_VERSION="1.2.1"
+AFC_VERSION="1.2.03"
 
 # Class for holding different states so its clear what all valid states are
 class State(str, Enum):

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -45,7 +45,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 try: from extras.AFC_stats import AFCStats
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
 
-AFC_VERSION="1.2.03"
+AFC_VERSION="1.2.3"
 
 # Class for holding different states so its clear what all valid states are
 class State(str, Enum):

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1472,7 +1472,11 @@ class afc:
 
         purge_length = gcmd.get('PURGE_LENGTH', None)
 
-        self.TOOL_LOAD(cur_lane, purge_length)
+        if not self.TOOL_LOAD(cur_lane, purge_length):
+            # Error happened, reset toolchanges without error count
+            # and increase load error count
+            if not self.testing:
+                self.afc_stats.increase_load_error_count()
 
     def TOOL_LOAD(self, cur_lane: AFCLane, purge_length: Optional[float]=None, set_start_time=False):
         """
@@ -1876,7 +1880,11 @@ class afc:
             self.logger.info('{} Unknown'.format(lane))
             return
         cur_lane = self.lanes[lane]
-        self.TOOL_UNLOAD(cur_lane)
+        if not self.TOOL_UNLOAD(cur_lane):
+            # Error happened, reset toolchanges without error count
+            # and increase unload error count
+            if not self.testing:
+                self.afc_stats.increase_unload_error_count()
 
         # User manually unloaded spool from toolhead, remove spool from active status
         self.spool.set_active_spool(None)
@@ -2469,6 +2477,10 @@ class afc:
                             # Abort if the unloading process fails.
                             msg = (' UNLOAD ERROR NOT CLEARED')
                             self.error.fix(msg, unload_lane)  #send to error handling
+                            # Error happened, reset toolchanges without error count
+                            # and increase unload error count
+                            if not self.testing:
+                                self.afc_stats.increase_unload_error_count()
                             return
 
                         if (force_unload
@@ -2519,8 +2531,9 @@ class afc:
                     cur_lane.extruder_obj.estats.increase_toolcount_change()
                 else:
                     # Error happened, reset toolchanges without error count
+                    # and increase load error count
                     if not self.testing:
-                        self.afc_stats.reset_toolchange_wo_error()
+                        self.afc_stats.increase_load_error_count()
             else:
                 # Calling handle activate extruder just to make sure lanes are synced as tool
                 # could have been changed with KTC SELECT_TOOL and lane might not be synced

--- a/extras/AFC_assist.py
+++ b/extras/AFC_assist.py
@@ -753,14 +753,25 @@ class Espooler:
         if self.afc_motor_fwd is not None:
             if short:
                 ret_str += " fwd:"
-                ret_str = f"{ret_str:{' '}>32}{self.stats.n20_runtime_fwd:>8}  |\n"
+                ret_str = f"{ret_str:{' '}>32}{self.stats.n20_runtime_fwd:>8}  "
+                if self.afc_motor_rwd is not None:
+                    ret_str += "|\n"
             else:
                 ret_str += f" fwd:{self.stats.n20_runtime_fwd:>8}"
 
         if self.afc_motor_rwd is not None:
             if short:
-                ret_str += "|" + f"{'rwd:':{' '}>32}{self.stats.n20_runtime_rwd:>8}  "
+                if self.afc_motor_fwd is None:
+                    ret_str += " rwd:"
+                    ret_str = f"{ret_str:{' '}>32}{self.stats.n20_runtime_rwd:>8}  "
+                else:
+                    ret_str += "|" + f"{'rwd:':{' '}>32}{self.stats.n20_runtime_rwd:>8}  "
             else:
+                if self.afc_motor_fwd is None:
+                    # Pad out the " fwd:########" slot that's skipped here so
+                    # "rwd:" lands in the same column it would if fwd were
+                    # also present.
+                    ret_str += f"{'':{' '}>13}"
                 ret_str += f" rwd:{self.stats.n20_runtime_rwd:>8}"
 
         return ret_str

--- a/extras/AFC_assist.py
+++ b/extras/AFC_assist.py
@@ -753,13 +753,13 @@ class Espooler:
         if self.afc_motor_fwd is not None:
             if short:
                 ret_str += " fwd:"
-                ret_str = f"{ret_str:{' '}>31}{self.stats.n20_runtime_fwd:>8}   |\n"
+                ret_str = f"{ret_str:{' '}>32}{self.stats.n20_runtime_fwd:>8}  |\n"
             else:
                 ret_str += f" fwd:{self.stats.n20_runtime_fwd:>8}"
 
         if self.afc_motor_rwd is not None:
             if short:
-                ret_str += "|" + f"{'rwd:':{' '}>31}{self.stats.n20_runtime_rwd:>8}   "
+                ret_str += "|" + f"{'rwd:':{' '}>32}{self.stats.n20_runtime_rwd:>8}  "
             else:
                 ret_str += f" rwd:{self.stats.n20_runtime_rwd:>8}"
 

--- a/extras/AFC_button.py
+++ b/extras/AFC_button.py
@@ -76,6 +76,8 @@ class AFCButton:
                 self.afc.logger.info(f"Unloading {self.lane_id} before ejecting.")
                 if self.afc.TOOL_UNLOAD(self.lane_obj):
                     self.afc.LANE_UNLOAD(self.lane_obj)
+                else:
+                    self.afc.afc_stats.increase_unload_error_count(self.afc)
             else:
                 # If another lane is active, just eject this one
                 self.afc.logger.info(f"Ejecting {self.lane_id}.")
@@ -85,7 +87,8 @@ class AFCButton:
             self.afc.logger.info(f"{self.lane_id}: Short press detected.")
             if cur_lane is not None and cur_lane.name == self.lane_id:
                 self.afc.logger.info(f"Unloading tool from {self.lane_id}.")
-                self.afc.TOOL_UNLOAD(cur_lane)
+                if not self.afc.TOOL_UNLOAD(cur_lane):
+                    self.afc.afc_stats.increase_unload_error_count(self.afc)
             else:
                 self.afc.logger.info(f"Loading tool to {self.lane_id}.")
                 self.afc.CHANGE_TOOL(self.lane_obj)

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -1186,7 +1186,8 @@ class afcFunction:
 
                     self._safe_extrude(self.afc.test_extrude_amt)
                     self.logger.info("Unloading lane {}".format(lane))
-                    self.afc.TOOL_UNLOAD(lane_obj)
+                    if not self.afc.TOOL_UNLOAD(lane_obj):
+                        self.afc.afc_stats.increase_unload_error_count(self.afc)
 
                     if not self.afc.error_state:
                         self.afc.logger.info(
@@ -1218,7 +1219,8 @@ class afcFunction:
                         self.afc.logger.info(
                             "Finished testing with {} iterations for all loaded lanes".format(iterations)
                         )
-                        self.afc.TOOL_UNLOAD(lane_obj)
+                        if not self.afc.TOOL_UNLOAD(lane_obj):
+                            self.afc.afc_stats.increase_unload_error_count(self.afc)
         prompt.p_end()
 
     cmd_AFC_CALIBRATION_help = 'Open prompt to begin calibration by selecting Unit to calibrate'

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -1064,6 +1064,8 @@ class AFCLane:
             self.afc.TOOL_UNLOAD(self)
             if not self.afc.error_state:
                 self.afc.LANE_UNLOAD(self)
+            else:
+                self.afc.afc_stats.increase_unload_error_count(self.afc)
         # Pause print
         self.status = AFCLaneState.NONE
         if self.auto_switch_triggered:
@@ -1165,7 +1167,8 @@ class AFCLane:
                     if self.afc.function.is_printing(check_movement=True):
                         self.afc.error.AFC_error("Cannot load spool to toolhead while printer is actively moving or homing", False)
                     else:
-                        self.afc.TOOL_LOAD(self)
+                        if not self.afc.TOOL_LOAD(self):
+                            self.afc.afc_stats.increase_load_error_count(self.afc)
 
                 self._post_prep_user_macro()
             else:
@@ -1264,7 +1267,8 @@ class AFCLane:
                         if (self.hub == 'direct_load'
                             and self.prep_state):
                             self.logger.debug(f"Prep: direct load logic-{self.name}-{self.hub}")
-                            self.afc.TOOL_LOAD(self)
+                            if not self.afc.TOOL_LOAD(self):
+                                self.afc.afc_stats.increase_load_error_count(self.afc)
                             self.afc.spool._set_values(self)
                             self.logger.debug(f"Prep: direct load logic done-{self.name}-{self.hub}")
                             break

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -1061,8 +1061,8 @@ class AFCLane:
             self.afc.error.pause_resume.send_pause_command()
             self.afc.save_pos()
             # self.gcode.run_script_from_command('PAUSE')
-            self.afc.TOOL_UNLOAD(self)
-            if not self.afc.error_state:
+            unloaded = self.afc.TOOL_UNLOAD(self)
+            if unloaded and not self.afc.error_state:
                 self.afc.LANE_UNLOAD(self)
             else:
                 self.afc.afc_stats.increase_unload_error_count(self.afc)

--- a/extras/AFC_stats.py
+++ b/extras/AFC_stats.py
@@ -38,8 +38,22 @@ class AFCStats_var:
     moonraker : AFC_moonraker
         AFC_moonraker class to easily post values to moonraker
     """
-    def __init__(self, parent_name: str, name: str, data: dict, moonraker: AFC_moonraker,
+    def __init__(self, parent_name: str, name: str, data: Optional[dict], moonraker: AFC_moonraker,
                  new_parent_name: str='', new_average: bool=False):
+        """
+        Initialize a stat variable, loading its current value out of `data`
+        (the stats already stored in moonraker's database) if present.
+
+        :param parent_name: parent's name to store value into moonraker database
+        :param name: name to store value into moonrakers database
+        :param data: current afc_stat values stored in moonraker database, or
+                     None if moonraker has no stats stored yet
+        :param moonraker: AFC_moonraker instance used to post values to moonraker
+        :param new_parent_name: if set, migrate this stat from parent_name to
+                                 this new parent, deleting the old database entry
+        :param new_average: True to use the new sum-based average calculation
+                             instead of the old halving-average calculation
+        """
         self.parent_name = parent_name
         self.name        = name
         self.moonraker   = moonraker
@@ -66,23 +80,34 @@ class AFCStats_var:
                 multi_parent.append(name)
                 self.moonraker.remove_database_entry(self.moonraker.afc_stats_key, '.'.join(multi_parent))
 
-    def __str__(self):
+    def __str__(self) -> str:
+        """
+        :return type: string form of the current value
+        """
         return str(self._value)
 
     @property
-    def value(self):
+    def value(self) -> Any:
+        """
+        :return type: current value being tracked
+        """
         return self._value
     @value.setter
-    def value(self, value):
+    def value(self, value: Any) -> None:
+        """
+        :param value: new value to store
+        """
         self._value = value
 
-    def _get_value(self, data: dict, parent_name: list):
+    def _get_value(self, data: dict, parent_name: list) -> None:
         """
         Helper function to get correct data from dictionary based off parents name
 
+        :param data: current afc_stat values stored in moonraker database
         :param parent_name: List in correct order of parent key name in database.
                             ex. extruder.cut -> ['extruder', 'cut']
         """
+        value: Any
         if len(parent_name) == 1:
             value = check_and_return( self.name, data[parent_name[0]])
         elif len(parent_name) == 2:
@@ -102,7 +127,7 @@ class AFCStats_var:
             except:
                 self._value = value
 
-    def average_time(self, value: float):
+    def average_time(self, value: float) -> None:
         """
         Helper function for averaging time, moonrakers database is updated after
         averaging numbers. If AFC is using new average calculation, then values are just
@@ -135,14 +160,14 @@ class AFCStats_var:
         else:
             return self._value
 
-    def increase_count(self):
+    def increase_count(self) -> None:
         """
         Helper function to easily increment count and updates moonrakers database
         """
         self._value += 1
         self.update_database()
 
-    def reset_count(self):
+    def reset_count(self) -> None:
         """
         Helper function to easily reset count and updates moonrakers database
         """
@@ -150,14 +175,14 @@ class AFCStats_var:
         self.update_database()
         self.new_average = True
 
-    def update_database(self):
+    def update_database(self) -> None:
         """
         Calls AFC_moonraker update_afc_stats function with correct key, value to update
         value in moonrakers database
         """
         self.moonraker.update_afc_stats(f"{self.parent_name}.{self.name}", self._value)
 
-    def set_current_time(self):
+    def set_current_time(self) -> None:
         """
         Grabs current date/time, sets variable and updates in moonrakers database.
         Use only for variables that are dates
@@ -182,7 +207,18 @@ class AFCStats:
     logger: AFC_logger
         AFC_logger class for logging and printing to console
     """
-    def __init__(self, moonraker: AFC_moonraker, logger: AFC_logger, multiple_tools: bool=False):
+    def __init__(self, moonraker: AFC_moonraker, logger: AFC_logger,
+                 multiple_tools: bool=False) -> None:
+        """
+        Build (or load, if already present in moonraker's database) all of
+        AFC's tracked stat variables.
+
+        :param moonraker: AFC_moonraker instance, passed into each AFCStats_var
+                           for easily updating values in database
+        :param logger: AFC_logger instance for logging and printing to console
+        :param multiple_tools: True to also track tool-select/unselect stats,
+                                only meaningful for multi-toolhead setups
+        """
         self.moonraker  = moonraker
         self.logger     = logger
         self.multiple_tools = multiple_tools
@@ -221,13 +257,13 @@ class AFCStats:
             self.average_tool_swap_time     = AFCStats_var("average_time", "tool_swap",   values,
                                                            self.moonraker, new_average=self.new_average_calc.value)
 
-    def increase_toolchange_wo_error(self):
+    def increase_toolchange_wo_error(self) -> None:
         """
         Common function to increase toolchange total value when errors do not occur.
         """
         self.tc_without_error.increase_count()
 
-    def reset_toolchange_wo_error(self):
+    def reset_toolchange_wo_error(self) -> None:
         """
         Helper function for resetting number of toolchanges without errors and
         sets last error date/time as current
@@ -235,7 +271,7 @@ class AFCStats:
         self.tc_without_error.reset_count()
         self.tc_last_load_error.set_current_time()
 
-    def reset_average_times(self):
+    def reset_average_times(self) -> None:
         """
         Common function to easily reset all change times. Once resetting AFC will start
         using new calculation function when tracking and printing stats.
@@ -248,7 +284,7 @@ class AFCStats:
         self.new_average_calc.value = 1
         self.new_average_calc.update_database()
 
-    def print_stats(self, afc_obj: afc, short: bool=False):
+    def print_stats(self, afc_obj: afc, short: bool=False) -> None:
         """
         Prints all stat to console
 
@@ -264,13 +300,15 @@ class AFCStats:
         total_changes = 0
         total_unload = 0
         total_load = 0
+        print_str: str = ""
+        temp_str: str = ""
 
-        def end_string():
+        def end_string() -> None:
             nonlocal print_str, temp_str
             print_str += f"{temp_str:{' '}<{86}}|\n"
             temp_str = ""
 
-        def add_end():
+        def add_end() -> str:
             nonlocal short
             if short:
                 return END

--- a/extras/AFC_stats.py
+++ b/extras/AFC_stats.py
@@ -275,19 +275,25 @@ class AFCStats:
         self.tc_without_error.reset_count()
         self.tc_last_load_error.set_current_time()
 
-    def increase_load_error_count(self) -> None:
+    def increase_load_error_count(self, afc: afc) -> None:
         """
         Helper function for increasing load error count and resetting number of toolchanges
         without errors.
         """
+        # Testing flag is set, return early
+        if afc.testing:
+            return
         self.reset_toolchange_wo_error()
         self.total_load_errors.increase_count()
 
-    def increase_unload_error_count(self) -> None:
+    def increase_unload_error_count(self, afc: afc) -> None:
         """
         Helper function for increasing unload error count and resetting number of toolchanges
         without errors.
         """
+        # Testing flag is set, return early
+        if afc.testing:
+            return
         self.reset_toolchange_wo_error()
         self.total_unload_errors.increase_count()
 

--- a/extras/AFC_stats.py
+++ b/extras/AFC_stats.py
@@ -278,7 +278,9 @@ class AFCStats:
     def increase_load_error_count(self, afc: afc) -> None:
         """
         Helper function for increasing load error count and resetting number of toolchanges
-        without errors.
+        without errors. Error only increases and data gets reset if AFC testing variable is not True.
+
+        :param afc: AFC object that holds testing variable
         """
         # Testing flag is set, return early
         if afc.testing:
@@ -289,7 +291,9 @@ class AFCStats:
     def increase_unload_error_count(self, afc: afc) -> None:
         """
         Helper function for increasing unload error count and resetting number of toolchanges
-        without errors.
+        without errors. Error only increases and data gets reset if AFC testing variable is not True.
+
+        :param afc: AFC object that holds testing variable
         """
         # Testing flag is set, return early
         if afc.testing:
@@ -441,15 +445,24 @@ class AFCStats:
 
         print_str = overall_str + avg_str + print_str
 
+        # Fixed centering offset for the name/count portion, baked on up front
+        # so "lane :" always lines up whether the row is paired or long
+        name_count_width = max(max_lane_name_size, 9) + len(" : Lane change count: ") + 7
+        long_format_pad = " " * ((SECTIONAL_LENGTH - name_count_width) // 2)
+
         strings = []
         for unit in afc_obj.units.values():
             for lane in unit.lanes.values():
                 espooler_stats = lane.espooler.get_spooler_stats(short)
                 string = f"{lane.name:{' '}>{max(max_lane_name_size,9)}} : Lane change count: {lane.lane_load_count.value:{' '}>7}"
-                if short: string = f"|{string:{' '}^{MAX_SPAN}}|\n"
-                if len(espooler_stats) > 0:
-                    if short: string += f"|{espooler_stats:{' '}^{MAX_WIDTH-3}}|\n"
-                    else: string += f" {espooler_stats}"
+                if short:
+                    string = f"|{string:{' '}^{MAX_SPAN}}|\n"
+                    if len(espooler_stats) > 0:
+                        string += f"|{espooler_stats:{' '}^{MAX_WIDTH-3}}|\n"
+                else:
+                    string = long_format_pad + string
+                    if len(espooler_stats) > 0:
+                        string += f" {espooler_stats}"
                 strings.append(string)
 
         if short:
@@ -462,9 +475,9 @@ class AFCStats:
                 if len(s) > 60:
                     if len(temp_str) > 0: end_string()
 
-                    print_str += f"|{s:{' '}>{MAX_WIDTH-4}}  {'|'}\n"
+                    print_str += f"|{s:{' '}<{MAX_WIDTH-4}}  {'|'}\n"
                 else:
-                    temp_str += f"|{s:{' '}^{SECTIONAL_LENGTH}}"
+                    temp_str += f"|{s:{' '}<{SECTIONAL_LENGTH}}"
             if len(temp_str) > 0: end_string()
 
         print_str += f"{'':{'-'}<{MAX_WIDTH}}\n"

--- a/extras/AFC_stats.py
+++ b/extras/AFC_stats.py
@@ -228,6 +228,10 @@ class AFCStats:
                                                self.moonraker, "error_stats")
         self.tc_last_load_error = AFCStats_var("toolchange_count", "last_load_error", values,
                                                self.moonraker, "error_stats")
+        self.total_load_errors = AFCStats_var("toolchange_count", "total_load_errors", values,
+                                              self.moonraker, "error_stats")
+        self.total_unload_errors = AFCStats_var("toolchange_count", "total_unload_errors", values,
+                                                self.moonraker, "error_stats")
 
         new_average_calc = 1
         if values is not None and "average_time" in values:
@@ -270,6 +274,22 @@ class AFCStats:
         """
         self.tc_without_error.reset_count()
         self.tc_last_load_error.set_current_time()
+
+    def increase_load_error_count(self) -> None:
+        """
+        Helper function for increasing load error count and resetting number of toolchanges
+        without errors.
+        """
+        self.reset_toolchange_wo_error()
+        self.total_load_errors.increase_count()
+
+    def increase_unload_error_count(self) -> None:
+        """
+        Helper function for increasing unload error count and resetting number of toolchanges
+        without errors.
+        """
+        self.reset_toolchange_wo_error()
+        self.total_unload_errors.increase_count()
 
     def reset_average_times(self) -> None:
         """
@@ -328,6 +348,9 @@ class AFCStats:
         overall_str += f"|{'Changes without error':{' '}>22} : {self.tc_without_error.value:{' '}<17}"
         overall_str += add_end()
         overall_str += f"|{'Last error date':{' '}>22} : {self.tc_last_load_error.value:{' '}<17}|\n"
+        overall_str += f"|{'Total Load Errors':{' '}>22} : {self.total_load_errors.value:{' '}<17}"
+        overall_str += add_end()
+        overall_str += f"|{'Total Unload Errors':{' '}>22} : {self.total_unload_errors.value:{' '}<17}|\n"
 
 
         print_str = ""
@@ -413,14 +436,15 @@ class AFCStats:
         print_str = overall_str + avg_str + print_str
 
         strings = []
-        for lane in afc_obj.lanes.values():
-            espooler_stats = lane.espooler.get_spooler_stats(short)
-            string = f"{lane.name:{' '}>{max(max_lane_name_size,7)}} : Lane change count: {lane.lane_load_count.value:{' '}>7}"
-            if short: string = f"|{string:{' '}^{MAX_SPAN}}|\n"
-            if len(espooler_stats) > 0:
-                if short: string += f"|{espooler_stats:{' '}^{MAX_WIDTH-2}}|\n"
-                else: string += f"  {espooler_stats}"
-            strings.append(string)
+        for unit in afc_obj.units.values():
+            for lane in unit.lanes.values():
+                espooler_stats = lane.espooler.get_spooler_stats(short)
+                string = f"{lane.name:{' '}>{max(max_lane_name_size,9)}} : Lane change count: {lane.lane_load_count.value:{' '}>7}"
+                if short: string = f"|{string:{' '}^{MAX_SPAN}}|\n"
+                if len(espooler_stats) > 0:
+                    if short: string += f"|{espooler_stats:{' '}^{MAX_WIDTH-3}}|\n"
+                    else: string += f" {espooler_stats}"
+                strings.append(string)
 
         if short:
             print_str += "".join(strings)
@@ -432,7 +456,7 @@ class AFCStats:
                 if len(s) > 60:
                     if len(temp_str) > 0: end_string()
 
-                    print_str += f"|{s}{'|':{' '}>4}\n"
+                    print_str += f"|{s:{' '}>{MAX_WIDTH-4}}  {'|'}\n"
                 else:
                     temp_str += f"|{s:{' '}^{SECTIONAL_LENGTH}}"
             if len(temp_str) > 0: end_string()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,10 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-addopts = "-q"
+addopts = "-q -m \"not manual\""
+markers = [
+    "manual: not run as part of the normal suite; run explicitly with -m manual",
+]
 
 [tool.ruff]
 force-exclude = true  # respect exclude list even when files are passed explicitly (e.g. changed-files in CI)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -401,8 +401,10 @@ class MockAFC:
         self.error_timeout = 600
         self.td1_defined = False
         self.td1_present = False
+        self.testing = False
         self.moonraker = MockMoonraker()
         self.function = MagicMock()
+        self.afc_stats = MagicMock()
         self.error = MagicMock()
         self.spool = MagicMock()
         self.short_moves_speed = 50.0

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -896,7 +896,7 @@ def _make_afc_for_change_tool(lane_name="lane2", next_extruder_name="extruder1",
     obj.afcDeltaTime = MagicMock()
     obj.afc_stats = MagicMock()
     obj.afc_stats.average_toolchange_time = MagicMock()
-    obj.testing = True
+    obj.testing = False
     obj.save_pos = MagicMock()
     obj.restore_pos = MagicMock()
     obj.TOOL_LOAD = MagicMock(return_value=True)
@@ -1321,11 +1321,15 @@ class TestChangeTool_UnloadPath:
         assert obj.TOOL_UNLOAD.call_args.kwargs["set_start_time"] is False
 
     def test_error_fix_called_when_tool_unload_returns_false(self):
-        """When TOOL_UNLOAD returns False, error.fix is called to signal the failure."""
+        """When TOOL_UNLOAD returns False, error.fix is called to signal the
+        failure, and (outside of testing mode) increase_unload_error_count()
+        is called to record it."""
         obj, cur_lane, _ = _make_afc_for_change_tool()
         obj.TOOL_UNLOAD.return_value = False
+        obj.testing = False
         obj.CHANGE_TOOL(cur_lane)
         obj.error.fix.assert_called_once()
+        obj.afc_stats.increase_unload_error_count.assert_called_once()
 
     def test_error_fix_receives_unload_lane_object(self):
         """error.fix second arg is the pre-resolved unload_lane, not None or cur_lane."""
@@ -1347,6 +1351,22 @@ class TestChangeTool_UnloadPath:
         obj.TOOL_UNLOAD.return_value = False
         obj.CHANGE_TOOL(cur_lane)
         assert obj.next_lane_load is None
+
+    def test_increase_unload_error_count_called_on_unload_failure_not_testing(self):
+        """When TOOL_UNLOAD fails and testing=False, increase_unload_error_count() is called."""
+        obj, cur_lane, _ = _make_afc_for_change_tool()
+        obj.testing = False
+        obj.TOOL_UNLOAD.return_value = False
+        obj.CHANGE_TOOL(cur_lane)
+        obj.afc_stats.increase_unload_error_count.assert_called_once()
+
+    def test_increase_unload_error_count_skipped_on_unload_failure_when_testing(self):
+        """When TOOL_UNLOAD fails and testing=True, increase_unload_error_count() is skipped."""
+        obj, cur_lane, _ = _make_afc_for_change_tool()
+        obj.testing = True
+        obj.TOOL_UNLOAD.return_value = False
+        obj.CHANGE_TOOL(cur_lane)
+        obj.afc_stats.increase_unload_error_count.assert_not_called()
 
 
 # ── CHANGE_TOOL: load path outcomes ───────────────────────────────────────────
@@ -1414,21 +1434,21 @@ class TestChangeTool_LoadPath:
         obj.CHANGE_TOOL(cur_lane)
         obj.afc_stats.average_toolchange_time.average_time.assert_called_once_with(7.5)
 
-    def test_reset_toolchange_wo_error_called_on_load_failure_not_testing(self):
-        """When TOOL_LOAD fails and testing=False, reset_toolchange_wo_error() is called."""
+    def test_increase_load_error_count_called_on_load_failure_not_testing(self):
+        """When TOOL_LOAD fails and testing=False, increase_load_error_count() is called."""
         obj, cur_lane, _ = _make_afc_for_change_tool()
         obj.testing = False
         obj.TOOL_LOAD.return_value = False
         obj.CHANGE_TOOL(cur_lane)
-        obj.afc_stats.reset_toolchange_wo_error.assert_called_once()
+        obj.afc_stats.increase_load_error_count.assert_called_once()
 
-    def test_reset_toolchange_wo_error_skipped_on_load_failure_when_testing(self):
-        """When TOOL_LOAD fails and testing=True, reset_toolchange_wo_error() is skipped."""
+    def test_increase_load_error_count_skipped_on_load_failure_when_testing(self):
+        """When TOOL_LOAD fails and testing=True, increase_load_error_count() is skipped."""
         obj, cur_lane, _ = _make_afc_for_change_tool()
         obj.testing = True
         obj.TOOL_LOAD.return_value = False
         obj.CHANGE_TOOL(cur_lane)
-        obj.afc_stats.reset_toolchange_wo_error.assert_not_called()
+        obj.afc_stats.increase_load_error_count.assert_not_called()
 
     def test_wait_for_temp_called_with_heater_target_and_deadband(self):
         """_wait_for_temp_within_tolerance(heater, target_temp, deadband) is called.
@@ -2150,6 +2170,8 @@ class TestCmdToolLoad_LaneLoadedGuard:
         obj.TOOL_LOAD = MagicMock(return_value=True)
         obj.error = MagicMock()
         obj.function.in_print.return_value = False
+        obj.afc_stats = MagicMock()
+        obj.testing = True
 
         extruder = MagicMock()
         extruder.name = "extruder"
@@ -2185,6 +2207,34 @@ class TestCmdToolLoad_LaneLoadedGuard:
         obj.error.AFC_error.assert_not_called()
         obj.TOOL_LOAD.assert_called_once_with(lane, None)
 
+    def test_increase_load_error_count_called_on_load_failure_not_testing(self):
+        """When TOOL_LOAD fails and testing=False, increase_load_error_count() is called."""
+        obj, lane, extruder = self._make_cmd_afc()
+        extruder.lane_loaded = None
+        obj.TOOL_LOAD.return_value = False
+        obj.testing = False
+
+        gcmd = MagicMock()
+        gcmd.get = lambda key, default=None: {"LANE": "lane1", "PURGE_LENGTH": None}.get(key, default)
+
+        obj.cmd_TOOL_LOAD(gcmd)
+
+        obj.afc_stats.increase_load_error_count.assert_called_once()
+
+    def test_increase_load_error_count_skipped_on_load_failure_when_testing(self):
+        """When TOOL_LOAD fails and testing=True, increase_load_error_count() is skipped."""
+        obj, lane, extruder = self._make_cmd_afc()
+        extruder.lane_loaded = None
+        obj.TOOL_LOAD.return_value = False
+        obj.testing = True
+
+        gcmd = MagicMock()
+        gcmd.get = lambda key, default=None: {"LANE": "lane1", "PURGE_LENGTH": None}.get(key, default)
+
+        obj.cmd_TOOL_LOAD(gcmd)
+
+        obj.afc_stats.increase_load_error_count.assert_not_called()
+
     def test_passes_through_when_nothing_loaded(self):
         """Normal case: nothing loaded, cmd_TOOL_LOAD proceeds."""
         obj, lane, extruder = self._make_cmd_afc()
@@ -2197,6 +2247,135 @@ class TestCmdToolLoad_LaneLoadedGuard:
 
         obj.error.AFC_error.assert_not_called()
         obj.TOOL_LOAD.assert_called_once_with(lane, None)
+
+
+class TestCmdToolLoad_UnknownLane:
+    """Tests for the cmd_TOOL_LOAD GCode handler's unknown-lane guard."""
+
+    def test_logs_info_with_lane_name_and_returns(self):
+        """When LANE doesn't resolve to a known lane, cmd_TOOL_LOAD logs the
+        exact info message and returns without touching TOOL_LOAD."""
+        obj = _make_afc()
+        obj.TOOL_LOAD = MagicMock(return_value=True)
+        obj.error = MagicMock()
+
+        params = {"LANE": "lane_missing", "PURGE_LENGTH": None}
+        gcmd = MagicMock()
+        gcmd.get = lambda key, default=None: params.get(key, default)
+
+        obj.cmd_TOOL_LOAD(gcmd)
+
+        assert obj.logger.messages == [("info", "lane_missing Unknown")]
+        obj.TOOL_LOAD.assert_not_called()
+        obj.error.AFC_error.assert_not_called()
+
+
+# ── cmd_TOOL_UNLOAD: error counting ──────────────────────────────────────────
+
+class TestCmdToolUnload_ErrorCounting:
+    """Tests for the increase_unload_error_count() call added to
+    cmd_TOOL_UNLOAD's TOOL_UNLOAD failure path."""
+
+    def _make_cmd_afc(self):
+        from tests.test_AFC_lane import _make_afc_lane
+        obj = _make_afc()
+        obj.TOOL_UNLOAD = MagicMock(return_value=True)
+        obj._check_bypass = MagicMock(return_value=False)
+        obj.spool = MagicMock()
+        obj.afc_stats = MagicMock()
+        obj.testing = True
+
+        lane = _make_afc_lane("AFC_stepper lane1")
+        obj.lanes["lane1"] = lane
+        return obj, lane
+
+    def _make_gcmd(self):
+        gcmd = MagicMock()
+        gcmd.get = lambda key, default=None: {"LANE": "lane1"}.get(key, default)
+        return gcmd
+
+    def test_increase_unload_error_count_called_on_unload_failure_not_testing(self):
+        """When TOOL_UNLOAD fails and testing=False, increase_unload_error_count() is called."""
+        obj, _ = self._make_cmd_afc()
+        obj.TOOL_UNLOAD.return_value = False
+        obj.testing = False
+        obj.cmd_TOOL_UNLOAD(self._make_gcmd())
+        obj.afc_stats.increase_unload_error_count.assert_called_once()
+
+    def test_increase_unload_error_count_skipped_on_unload_failure_when_testing(self):
+        """When TOOL_UNLOAD fails and testing=True, increase_unload_error_count() is skipped."""
+        obj, _ = self._make_cmd_afc()
+        obj.TOOL_UNLOAD.return_value = False
+        obj.testing = True
+        obj.cmd_TOOL_UNLOAD(self._make_gcmd())
+        obj.afc_stats.increase_unload_error_count.assert_not_called()
+
+    def test_increase_unload_error_count_not_called_on_unload_success(self):
+        """Distinguishes the failure branch from the success branch: no error
+        counting happens when TOOL_UNLOAD succeeds, even with testing=False."""
+        obj, _ = self._make_cmd_afc()
+        obj.TOOL_UNLOAD.return_value = True
+        obj.testing = False
+        obj.cmd_TOOL_UNLOAD(self._make_gcmd())
+        obj.afc_stats.increase_unload_error_count.assert_not_called()
+
+
+class TestCmdToolUnload_Guards:
+    """Tests for cmd_TOOL_UNLOAD's early-exit guards: bypass detection, no
+    lane resolvable, and an unknown lane name."""
+
+    def _make_cmd_afc(self):
+        from tests.test_AFC_lane import _make_afc_lane
+        obj = _make_afc()
+        obj.TOOL_UNLOAD = MagicMock(return_value=True)
+        obj._check_bypass = MagicMock(return_value=False)
+        obj.spool = MagicMock()
+        obj.afc_stats = MagicMock()
+        obj.testing = True
+
+        lane = _make_afc_lane("AFC_stepper lane1")
+        obj.lanes["lane1"] = lane
+        return obj, lane
+
+    @staticmethod
+    def _make_gcmd(params=None):
+        params = params or {}
+        gcmd = MagicMock()
+        gcmd.get = lambda key, default=None: params.get(key, default)
+        return gcmd
+
+    def test_bypass_detected_returns_without_calling_tool_unload(self):
+        """When _check_bypass(unload=True) is truthy, cmd_TOOL_UNLOAD returns
+        immediately without resolving a lane or calling TOOL_UNLOAD."""
+        obj, _ = self._make_cmd_afc()
+        obj._check_bypass.return_value = True
+
+        obj.cmd_TOOL_UNLOAD(self._make_gcmd({"LANE": "lane1"}))
+
+        obj.TOOL_UNLOAD.assert_not_called()
+        obj.spool.set_active_spool.assert_not_called()
+
+    def test_no_lane_resolvable_returns_without_calling_tool_unload(self):
+        """When LANE isn't supplied and self.current (function.get_current_lane())
+        is None, lane resolves to None and cmd_TOOL_UNLOAD returns early."""
+        obj, _ = self._make_cmd_afc()
+        obj.function.get_current_lane.return_value = None
+
+        obj.cmd_TOOL_UNLOAD(self._make_gcmd())
+
+        obj.TOOL_UNLOAD.assert_not_called()
+        obj.spool.set_active_spool.assert_not_called()
+
+    def test_unknown_lane_logs_info_and_returns(self):
+        """When LANE resolves to a name not in self.lanes, cmd_TOOL_UNLOAD logs
+        the exact info message and returns without calling TOOL_UNLOAD."""
+        obj, _ = self._make_cmd_afc()
+
+        obj.cmd_TOOL_UNLOAD(self._make_gcmd({"LANE": "lane_missing"}))
+
+        assert obj.logger.messages == [("info", "lane_missing Unknown")]
+        obj.TOOL_UNLOAD.assert_not_called()
+        obj.spool.set_active_spool.assert_not_called()
 
 
 # ── capture_toolhead_temp ─────────────────────────────────────────────────────

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -1322,11 +1322,11 @@ class TestChangeTool_UnloadPath:
 
     def test_error_fix_called_when_tool_unload_returns_false(self):
         """When TOOL_UNLOAD returns False, error.fix is called to signal the
-        failure, and (outside of testing mode) increase_unload_error_count()
-        is called to record it."""
+        failure, and increase_unload_error_count() is called to record it
+        (whether that actually counts the error depends on afc.testing,
+        which is AFCStats's responsibility -- see tests/test_AFC_stats.py)."""
         obj, cur_lane, _ = _make_afc_for_change_tool()
         obj.TOOL_UNLOAD.return_value = False
-        obj.testing = False
         obj.CHANGE_TOOL(cur_lane)
         obj.error.fix.assert_called_once()
         obj.afc_stats.increase_unload_error_count.assert_called_once()
@@ -1352,21 +1352,15 @@ class TestChangeTool_UnloadPath:
         obj.CHANGE_TOOL(cur_lane)
         assert obj.next_lane_load is None
 
-    def test_increase_unload_error_count_called_on_unload_failure_not_testing(self):
-        """When TOOL_UNLOAD fails and testing=False, increase_unload_error_count() is called."""
+    def test_increase_unload_error_count_called_with_afc_instance(self):
+        """increase_unload_error_count() now takes the afc instance itself
+        (it, not the call site, decides whether to skip based on
+        afc.testing -- see tests/test_AFC_stats.py), so this verifies the
+        call is made with the correct argument regardless of obj.testing."""
         obj, cur_lane, _ = _make_afc_for_change_tool()
-        obj.testing = False
         obj.TOOL_UNLOAD.return_value = False
         obj.CHANGE_TOOL(cur_lane)
-        obj.afc_stats.increase_unload_error_count.assert_called_once()
-
-    def test_increase_unload_error_count_skipped_on_unload_failure_when_testing(self):
-        """When TOOL_UNLOAD fails and testing=True, increase_unload_error_count() is skipped."""
-        obj, cur_lane, _ = _make_afc_for_change_tool()
-        obj.testing = True
-        obj.TOOL_UNLOAD.return_value = False
-        obj.CHANGE_TOOL(cur_lane)
-        obj.afc_stats.increase_unload_error_count.assert_not_called()
+        obj.afc_stats.increase_unload_error_count.assert_called_once_with(obj)
 
 
 # ── CHANGE_TOOL: load path outcomes ───────────────────────────────────────────
@@ -1434,21 +1428,15 @@ class TestChangeTool_LoadPath:
         obj.CHANGE_TOOL(cur_lane)
         obj.afc_stats.average_toolchange_time.average_time.assert_called_once_with(7.5)
 
-    def test_increase_load_error_count_called_on_load_failure_not_testing(self):
-        """When TOOL_LOAD fails and testing=False, increase_load_error_count() is called."""
+    def test_increase_load_error_count_called_with_afc_instance(self):
+        """increase_load_error_count() now takes the afc instance itself (it,
+        not the call site, decides whether to skip based on afc.testing --
+        see tests/test_AFC_stats.py), so this verifies the call is made with
+        the correct argument regardless of obj.testing."""
         obj, cur_lane, _ = _make_afc_for_change_tool()
-        obj.testing = False
         obj.TOOL_LOAD.return_value = False
         obj.CHANGE_TOOL(cur_lane)
-        obj.afc_stats.increase_load_error_count.assert_called_once()
-
-    def test_increase_load_error_count_skipped_on_load_failure_when_testing(self):
-        """When TOOL_LOAD fails and testing=True, increase_load_error_count() is skipped."""
-        obj, cur_lane, _ = _make_afc_for_change_tool()
-        obj.testing = True
-        obj.TOOL_LOAD.return_value = False
-        obj.CHANGE_TOOL(cur_lane)
-        obj.afc_stats.increase_load_error_count.assert_not_called()
+        obj.afc_stats.increase_load_error_count.assert_called_once_with(obj)
 
     def test_wait_for_temp_called_with_heater_target_and_deadband(self):
         """_wait_for_temp_within_tolerance(heater, target_temp, deadband) is called.
@@ -1928,17 +1916,21 @@ class TestToolLoad_DestExtruderAlreadyLoaded:
         obj.TOOL_UNLOAD.assert_not_called()
 
     def test_unloads_when_extruder_already_has_different_lane_loaded(self):
-        """TOOL_UNLOAD is called for the already-loaded lane before proceeding."""
+        """TOOL_UNLOAD is called for the already-loaded lane before proceeding,
+        and since it succeeds, no unload error is recorded."""
         obj, target_lane, loaded_lane, dest_extruder = _make_afc_for_dest_extruder_loaded()
         obj.TOOL_LOAD(target_lane)
         obj.TOOL_UNLOAD.assert_called_once_with(loaded_lane, set_start_time=False)
+        obj.afc_stats.increase_unload_error_count.assert_not_called()
 
     def test_aborts_if_unload_fails(self):
-        """If TOOL_UNLOAD returns False, TOOL_LOAD returns False immediately."""
+        """If TOOL_UNLOAD returns False, TOOL_LOAD returns False immediately
+        and records the failure via increase_unload_error_count(self)."""
         obj, target_lane, loaded_lane, dest_extruder = _make_afc_for_dest_extruder_loaded()
         obj.TOOL_UNLOAD.return_value = False
         result = obj.TOOL_LOAD(target_lane)
         assert result is False
+        obj.afc_stats.increase_unload_error_count.assert_called_once_with(obj)
 
     def test_no_unload_when_extruder_already_has_target_lane_loaded(self):
         """If the extruder already has the target lane loaded, no unload is triggered."""
@@ -2207,33 +2199,21 @@ class TestCmdToolLoad_LaneLoadedGuard:
         obj.error.AFC_error.assert_not_called()
         obj.TOOL_LOAD.assert_called_once_with(lane, None)
 
-    def test_increase_load_error_count_called_on_load_failure_not_testing(self):
-        """When TOOL_LOAD fails and testing=False, increase_load_error_count() is called."""
+    def test_increase_load_error_count_called_with_afc_instance(self):
+        """increase_load_error_count() now takes the afc instance itself (it,
+        not the call site, decides whether to skip based on afc.testing --
+        see tests/test_AFC_stats.py), so this verifies the call is made with
+        the correct argument regardless of obj.testing."""
         obj, lane, extruder = self._make_cmd_afc()
         extruder.lane_loaded = None
         obj.TOOL_LOAD.return_value = False
-        obj.testing = False
 
         gcmd = MagicMock()
         gcmd.get = lambda key, default=None: {"LANE": "lane1", "PURGE_LENGTH": None}.get(key, default)
 
         obj.cmd_TOOL_LOAD(gcmd)
 
-        obj.afc_stats.increase_load_error_count.assert_called_once()
-
-    def test_increase_load_error_count_skipped_on_load_failure_when_testing(self):
-        """When TOOL_LOAD fails and testing=True, increase_load_error_count() is skipped."""
-        obj, lane, extruder = self._make_cmd_afc()
-        extruder.lane_loaded = None
-        obj.TOOL_LOAD.return_value = False
-        obj.testing = True
-
-        gcmd = MagicMock()
-        gcmd.get = lambda key, default=None: {"LANE": "lane1", "PURGE_LENGTH": None}.get(key, default)
-
-        obj.cmd_TOOL_LOAD(gcmd)
-
-        obj.afc_stats.increase_load_error_count.assert_not_called()
+        obj.afc_stats.increase_load_error_count.assert_called_once_with(obj)
 
     def test_passes_through_when_nothing_loaded(self):
         """Normal case: nothing loaded, cmd_TOOL_LOAD proceeds."""
@@ -2294,28 +2274,21 @@ class TestCmdToolUnload_ErrorCounting:
         gcmd.get = lambda key, default=None: {"LANE": "lane1"}.get(key, default)
         return gcmd
 
-    def test_increase_unload_error_count_called_on_unload_failure_not_testing(self):
-        """When TOOL_UNLOAD fails and testing=False, increase_unload_error_count() is called."""
+    def test_increase_unload_error_count_called_with_afc_instance(self):
+        """increase_unload_error_count() now takes the afc instance itself
+        (it, not the call site, decides whether to skip based on
+        afc.testing -- see tests/test_AFC_stats.py), so this verifies the
+        call is made with the correct argument regardless of obj.testing."""
         obj, _ = self._make_cmd_afc()
         obj.TOOL_UNLOAD.return_value = False
-        obj.testing = False
         obj.cmd_TOOL_UNLOAD(self._make_gcmd())
-        obj.afc_stats.increase_unload_error_count.assert_called_once()
-
-    def test_increase_unload_error_count_skipped_on_unload_failure_when_testing(self):
-        """When TOOL_UNLOAD fails and testing=True, increase_unload_error_count() is skipped."""
-        obj, _ = self._make_cmd_afc()
-        obj.TOOL_UNLOAD.return_value = False
-        obj.testing = True
-        obj.cmd_TOOL_UNLOAD(self._make_gcmd())
-        obj.afc_stats.increase_unload_error_count.assert_not_called()
+        obj.afc_stats.increase_unload_error_count.assert_called_once_with(obj)
 
     def test_increase_unload_error_count_not_called_on_unload_success(self):
         """Distinguishes the failure branch from the success branch: no error
-        counting happens when TOOL_UNLOAD succeeds, even with testing=False."""
+        counting happens when TOOL_UNLOAD succeeds."""
         obj, _ = self._make_cmd_afc()
         obj.TOOL_UNLOAD.return_value = True
-        obj.testing = False
         obj.cmd_TOOL_UNLOAD(self._make_gcmd())
         obj.afc_stats.increase_unload_error_count.assert_not_called()
 

--- a/tests/test_AFC_assist.py
+++ b/tests/test_AFC_assist.py
@@ -1670,13 +1670,34 @@ class TestGetSpoolerStats:
         assert result == f"N20 active time: fwd:{'12.00s':>8}"
 
     def test_rwd_only_long_format(self):
+        """With no fwd, the skipped " fwd:########" slot (13 chars) is
+        padded with spaces so "rwd:" still lands in the same column it
+        would if fwd were present -- computed independently rather than
+        mirroring the source's own format spec."""
         espooler = _make_real_espooler(has_fwd=False, has_rwd=True)
         _connect_stats(espooler)
         espooler.stats._n20_runtime_rwd.value = 8.0
 
         result = espooler.get_spooler_stats(short=False)
 
-        assert result == f"N20 active time: rwd:{'8.00s':>8}"
+        assert result == f"N20 active time:{'':>13} rwd:{'8.00s':>8}"
+
+    def test_rwd_column_aligns_whether_or_not_fwd_is_present(self):
+        """"rwd:" must start at the same character index in both the
+        both-motors and rwd-only long-format outputs."""
+        both = _make_real_espooler(has_fwd=True, has_rwd=True)
+        _connect_stats(both)
+        both.stats._n20_runtime_fwd.value = 12.0
+        both.stats._n20_runtime_rwd.value = 8.0
+
+        rwd_only = _make_real_espooler(has_fwd=False, has_rwd=True)
+        _connect_stats(rwd_only)
+        rwd_only.stats._n20_runtime_rwd.value = 8.0
+
+        both_result = both.get_spooler_stats(short=False)
+        rwd_only_result = rwd_only.get_spooler_stats(short=False)
+
+        assert both_result.index("rwd:") == rwd_only_result.index("rwd:")
 
     def test_both_motors_long_format(self):
         espooler = _make_real_espooler(has_fwd=True, has_rwd=True)
@@ -1701,6 +1722,39 @@ class TestGetSpoolerStats:
         ret_str = f"{ret_str:{' '}>32}{'12.00s':>8}  |\n"
         ret_str += "|" + f"{'rwd:':{' '}>32}{'8.00s':>8}  "
         assert result == ret_str
+
+    def test_fwd_only_short_format(self):
+        """With only fwd configured, short format has no rwd row appended
+        (no trailing "|\\n"), and the fwd row aligns the same way it does
+        when rwd is also present."""
+        espooler = _make_real_espooler(has_fwd=True, has_rwd=False)
+        _connect_stats(espooler)
+        espooler.stats._n20_runtime_fwd.value = 12.0
+
+        result = espooler.get_spooler_stats(short=True)
+
+        # Computed independently rather than mirroring the source's own
+        # format spec: "N20 active time: fwd:" is 21 chars, right-justified
+        # to 32 -- 11 leading spaces -- then the value padded to 8 and a
+        # 2-space trailer, with no closing "|\n" since there's no rwd row.
+        assert result == "           N20 active time: fwd:  12.00s  "
+
+    def test_rwd_only_short_format(self):
+        """With only rwd configured (no fwd), the rwd row must still align
+        under the exact same column "fwd:" would occupy if it were the one
+        present -- built as its own "N20 active time: rwd:" prefix
+        right-justified to the same width, not glued onto a bare "N20
+        active time:" prefix with no line break."""
+        espooler = _make_real_espooler(has_fwd=False, has_rwd=True)
+        _connect_stats(espooler)
+        espooler.stats._n20_runtime_rwd.value = 8.0
+
+        result = espooler.get_spooler_stats(short=True)
+
+        # Computed independently: "N20 active time: rwd:" is 21 chars,
+        # right-justified to 32 -- 11 leading spaces -- then the value
+        # padded to 8 and a 2-space trailer.
+        assert result == "           N20 active time: rwd:   8.00s  "
 
 
 # ── Espooler gcode macros ────────────────────────────────────────────────────

--- a/tests/test_AFC_assist.py
+++ b/tests/test_AFC_assist.py
@@ -1698,8 +1698,8 @@ class TestGetSpoolerStats:
 
         ret_str = "N20 active time:"
         ret_str += " fwd:"
-        ret_str = f"{ret_str:{' '}>31}{'12.00s':>8}   |\n"
-        ret_str += "|" + f"{'rwd:':{' '}>31}{'8.00s':>8}   "
+        ret_str = f"{ret_str:{' '}>32}{'12.00s':>8}  |\n"
+        ret_str += "|" + f"{'rwd:':{' '}>32}{'8.00s':>8}  "
         assert result == ret_str
 
 

--- a/tests/test_AFC_button.py
+++ b/tests/test_AFC_button.py
@@ -18,31 +18,28 @@ from extras.AFC_button import AFCButton
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 def _make_button(lane_id="lane1", long_press_duration=1.2):
-    """Build an AFCButton bypassing __init__."""
-    btn = AFCButton.__new__(AFCButton)
-
-    from tests.conftest import MockAFC, MockPrinter, MockReactor, MockLogger
+    """Build an AFCButton via its real __init__, then fire the klippy:ready
+    event exactly as Klipper would so lane_obj resolves the same way it does
+    at runtime (via _handle_ready, registered during __init__)."""
+    from tests.conftest import MockAFC, MockConfig, MockPrinter, MockLogger
 
     afc = MockAFC()
     afc.logger = MockLogger()
-    reactor = MockReactor()
     printer = MockPrinter(afc=afc)
-    printer._reactor = reactor
 
-    btn.printer = printer
-    btn.gcode = printer._gcode
-    btn.reactor = reactor
-    btn.afc = afc
-    btn.lane_id = lane_id
-    btn.lane_obj = None
-    btn.long_press_duration = long_press_duration
-    btn._press_time = None
-
-    # Set up a lane object
+    # Lane must already exist so _handle_ready() resolves it when
+    # klippy:ready fires below.
     lane = MagicMock()
     lane.name = lane_id
     afc.lanes = {lane_id: lane}
-    btn.lane_obj = lane
+
+    config = MockConfig(
+        name=f"AFC_button {lane_id}",
+        printer=printer,
+        values={"pin": "PA0", "long_press_duration": long_press_duration},
+    )
+    btn = AFCButton(config)
+    printer.send_event("klippy:ready")
 
     return btn
 
@@ -141,9 +138,23 @@ class TestButtonCallbackShortPress:
         cur_lane = MagicMock()
         cur_lane.name = "lane1"  # Same as this button's lane
         btn.afc.function.get_current_lane_obj.return_value = cur_lane
-        btn.afc.TOOL_UNLOAD = MagicMock()
+        btn.afc.TOOL_UNLOAD = MagicMock(return_value=True)
         btn._button_callback(100.3, False)
         btn.afc.TOOL_UNLOAD.assert_called_once_with(cur_lane)
+        btn.afc.afc_stats.increase_unload_error_count.assert_not_called()
+
+    def test_short_press_unload_failure_increases_unload_error_count(self):
+        """When TOOL_UNLOAD fails on a short-press unload, the failure is
+        recorded via increase_unload_error_count(self.afc)."""
+        btn = _make_button("lane1")
+        btn._press_time = 100.0
+        btn.afc.function.is_printing.return_value = False
+        cur_lane = MagicMock()
+        cur_lane.name = "lane1"
+        btn.afc.function.get_current_lane_obj.return_value = cur_lane
+        btn.afc.TOOL_UNLOAD = MagicMock(return_value=False)
+        btn._button_callback(100.3, False)
+        btn.afc.afc_stats.increase_unload_error_count.assert_called_once_with(btn.afc)
 
     def test_short_press_with_different_lane_active_loads_this_lane(self):
         btn = _make_button("lane1")
@@ -182,6 +193,23 @@ class TestButtonCallbackLongPress:
         btn._button_callback(101.5, False)
         btn.afc.TOOL_UNLOAD.assert_called_once()
         btn.afc.LANE_UNLOAD.assert_called_once_with(btn.lane_obj)
+        btn.afc.afc_stats.increase_unload_error_count.assert_not_called()
+
+    def test_long_press_unload_failure_increases_unload_error_count_and_skips_eject(self):
+        """When TOOL_UNLOAD fails before ejecting on a long press, the
+        failure is recorded via increase_unload_error_count(self.afc) and
+        LANE_UNLOAD (the eject) is never reached."""
+        btn = _make_button("lane1", long_press_duration=1.0)
+        btn._press_time = 100.0
+        btn.afc.function.is_printing.return_value = False
+        cur_lane = MagicMock()
+        cur_lane.name = "lane1"
+        btn.afc.function.get_current_lane_obj.return_value = cur_lane
+        btn.afc.TOOL_UNLOAD = MagicMock(return_value=False)
+        btn.afc.LANE_UNLOAD = MagicMock()
+        btn._button_callback(101.5, False)
+        btn.afc.afc_stats.increase_unload_error_count.assert_called_once_with(btn.afc)
+        btn.afc.LANE_UNLOAD.assert_not_called()
 
     def test_long_press_with_different_lane_active_ejects_only(self):
         btn = _make_button("lane1", long_press_duration=1.0)

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -1716,6 +1716,7 @@ class TestPerformPauseRunout:
         False, the lane is ejected via LANE_UNLOAD and no error is counted."""
         lane = _make_lane_for_pause_runout(unload_on_runout=True)
         lane.afc.error_state = False
+        lane.afc.TOOL_UNLOAD.return_value = True
         lane._perform_pause_runout()
         lane.afc.TOOL_UNLOAD.assert_called_once_with(lane)
         lane.afc.LANE_UNLOAD.assert_called_once_with(lane)
@@ -1727,6 +1728,7 @@ class TestPerformPauseRunout:
         increase_unload_error_count(self.afc)."""
         lane = _make_lane_for_pause_runout(unload_on_runout=True)
         lane.afc.error_state = True
+        lane.afc.TOOL_UNLOAD.return_value = False
         lane._perform_pause_runout()
         lane.afc.TOOL_UNLOAD.assert_called_once_with(lane)
         lane.afc.LANE_UNLOAD.assert_not_called()

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -658,9 +658,21 @@ class TestHandleLoadRunout:
         lane = self._make()
         lane.hub = "direct_load"
         lane.afc.function.is_printing = MagicMock(return_value=False)
+        lane.afc.TOOL_LOAD.return_value = True
         lane.handle_load_runout(100.0, True)
         lane.afc.TOOL_LOAD.assert_called_once_with(lane)
         lane.afc.error.AFC_error.assert_not_called()
+        lane.afc.afc_stats.increase_load_error_count.assert_not_called()
+
+    def test_direct_load_tool_load_failure_increases_load_error_count(self):
+        """When TOOL_LOAD fails in the direct_load branch, the failure is
+        recorded via increase_load_error_count(self.afc)."""
+        lane = self._make()
+        lane.hub = "direct_load"
+        lane.afc.function.is_printing = MagicMock(return_value=False)
+        lane.afc.TOOL_LOAD.return_value = False
+        lane.handle_load_runout(100.0, True)
+        lane.afc.afc_stats.increase_load_error_count.assert_called_once_with(lane.afc)
 
     def test_non_direct_load_hub_skips_tool_load_branch(self):
         lane = self._make()
@@ -1689,6 +1701,36 @@ class TestPerformPauseRunout:
         assert "Runout" in msg
         assert "Minimum weight" not in msg
         assert lane.name in msg
+
+    def test_unload_on_runout_false_skips_tool_unload_entirely(self):
+        """When unit_obj.unload_on_runout is False, the whole
+        TOOL_UNLOAD/LANE_UNLOAD/error-counting block is skipped."""
+        lane = _make_lane_for_pause_runout(unload_on_runout=False)
+        lane._perform_pause_runout()
+        lane.afc.TOOL_UNLOAD.assert_not_called()
+        lane.afc.LANE_UNLOAD.assert_not_called()
+        lane.afc.afc_stats.increase_unload_error_count.assert_not_called()
+
+    def test_unload_on_runout_true_and_no_error_ejects_lane(self):
+        """When unload_on_runout is True and TOOL_UNLOAD leaves error_state
+        False, the lane is ejected via LANE_UNLOAD and no error is counted."""
+        lane = _make_lane_for_pause_runout(unload_on_runout=True)
+        lane.afc.error_state = False
+        lane._perform_pause_runout()
+        lane.afc.TOOL_UNLOAD.assert_called_once_with(lane)
+        lane.afc.LANE_UNLOAD.assert_called_once_with(lane)
+        lane.afc.afc_stats.increase_unload_error_count.assert_not_called()
+
+    def test_unload_on_runout_true_and_error_state_increases_unload_error_count(self):
+        """When unload_on_runout is True and TOOL_UNLOAD leaves error_state
+        True, LANE_UNLOAD is skipped and the failure is recorded via
+        increase_unload_error_count(self.afc)."""
+        lane = _make_lane_for_pause_runout(unload_on_runout=True)
+        lane.afc.error_state = True
+        lane._perform_pause_runout()
+        lane.afc.TOOL_UNLOAD.assert_called_once_with(lane)
+        lane.afc.LANE_UNLOAD.assert_not_called()
+        lane.afc.afc_stats.increase_unload_error_count.assert_called_once_with(lane.afc)
 
 # ── cmd_SET_LANE_LOADED ───────────────────────────────────────────────────────
 #
@@ -3033,9 +3075,20 @@ class TestPrepCallback:
     def test_direct_load_hub_calls_tool_load(self):
         lane = _make_lane_ready_to_load()
         lane.hub = "direct_load"
+        lane.afc.TOOL_LOAD.return_value = True
         lane.prep_callback(10, True)
         lane.afc.TOOL_LOAD.assert_called_once_with(lane)
         lane.afc.spool._set_values.assert_called_once_with(lane)
+        lane.afc.afc_stats.increase_load_error_count.assert_not_called()
+
+    def test_direct_load_hub_tool_load_failure_increases_load_error_count(self):
+        """When TOOL_LOAD fails in the direct_load prep_callback branch, the
+        failure is recorded via increase_load_error_count(self.afc)."""
+        lane = _make_lane_ready_to_load()
+        lane.hub = "direct_load"
+        lane.afc.TOOL_LOAD.return_value = False
+        lane.prep_callback(10, True)
+        lane.afc.afc_stats.increase_load_error_count.assert_called_once_with(lane.afc)
 
     def test_direct_load_hub_breaks_before_prep_post_load(self):
         lane = _make_lane_ready_to_load()

--- a/tests/test_AFC_stats.py
+++ b/tests/test_AFC_stats.py
@@ -717,13 +717,16 @@ class TestAFCStatsPrintStats:
         # Computed by hand (not by re-deriving the source's own format
         # spec): max_lane_name_size is max(len("lane1"), 9) = 9, so the
         # name/count portion is "    lane1 : Lane change count:       1",
-        # plus the 25 "x"s appended with a 1-space indent, pushing the
-        # combined string over 60 chars and into the direct-print branch
-        # (right-justified within MAX_WIDTH-4=83, then "  |\n") instead of
-        # the temp_str accumulator.
+        # plus a fixed 2-space centering offset ((42 - 38) // 2) baked on
+        # front so this label starts at the same column a short (no-
+        # espooler) lane's would -- giving 6 leading spaces total -- then
+        # the 25 "x"s appended with a 1-space indent, pushing the combined
+        # string over 60 chars and into the direct-print branch (left-
+        # justified within MAX_WIDTH-4=83, then "  |\n") instead of the
+        # temp_str accumulator.
         assert (
-            "|                       lane1 : Lane change count:       1 "
-            + "x" * 25 + "  |\n"
+            "|      lane1 : Lane change count:       1 "
+            + "x" * 25 + " " * 17 + "  |\n"
         ) in output
 
     @staticmethod
@@ -808,29 +811,21 @@ class TestAFCStatsPrintStats:
         assert positions == sorted(positions)
 
     @staticmethod
-    def _spooler_stats_side_effect(fwd: str, rwd: str):
-        """Mirrors AFC_assist.Espooler.get_spooler_stats' actual formatting
-        exactly, including the fact that its short=True and short=False
-        outputs aren't just different widths of the same string -- short
-        mode returns a value with its own "|"/newline box formatting
-        already baked in (meant to be dropped straight into the short-mode
-        table), while long mode returns one flat line. A static
-        return_value can't represent that; print_stats calls
-        get_spooler_stats(short) with the real short flag, so the mock
-        needs a side_effect that branches on it the same way the source
-        does."""
+    def _spooler_stats_side_effect(fwd: str|None, rwd: str|None):
+        """Calls the real, unmodified Espooler.get_spooler_stats (unbound,
+        against a minimal `self` stand-in) instead of reimplementing its
+        formatting, so this can't drift out of sync with the source again.
+        fwd/rwd may each be None, mirroring a lane with only one motor pin
+        defined."""
+        from extras.AFC_assist import Espooler
+        fake_self = MagicMock()
+        fake_self.afc_motor_fwd = MagicMock() if fwd is not None else None
+        fake_self.afc_motor_rwd = MagicMock() if rwd is not None else None
+        fake_self.stats.n20_runtime_fwd = fwd
+        fake_self.stats.n20_runtime_rwd = rwd
+
         def _side_effect(short):
-            ret_str = "N20 active time:"
-            ret_str += " fwd:"
-            if short:
-                ret_str = f"{ret_str:{' '}>32}{fwd:>8}  |\n"
-            else:
-                ret_str = "N20 active time:" + f" fwd:{fwd:>8}"
-            if short:
-                ret_str += "|" + f"{'rwd:':{' '}>32}{rwd:>8}  "
-            else:
-                ret_str += f" rwd:{rwd:>8}"
-            return ret_str
+            return Espooler.get_spooler_stats(fake_self, short)
         return _side_effect
 
     def _make_preview_afc(self):
@@ -853,13 +848,24 @@ class TestAFCStatsPrintStats:
         lane3.lane_load_count.value = 5
         lane4 = self._make_lane("lane4")
         lane4.lane_load_count.value = 130
+        lane5 = self._make_lane("lane5")
+        lane5.lane_load_count.value = 130
+        lane5.espooler.get_spooler_stats.side_effect = self._spooler_stats_side_effect(
+            None, "187.32s"
+        )
+        lane6 = self._make_lane("lane6")
+        lane6.lane_load_count.value = 130
+        lane6.espooler.get_spooler_stats.side_effect = self._spooler_stats_side_effect(
+            "1123.45s", None
+        )
 
         unit1 = self._make_unit("Turtle_1")
-        unit1.lanes = {"lane1": lane1, "lane2": lane2}
+        unit1.lanes = {"lane1": lane1, "lane2": lane2, "lane3": lane3}
         unit2 = self._make_unit("Turtle_2")
-        unit2.lanes = {"lane3": lane3, "lane4": lane4}
+        unit2.lanes = {"lane4": lane4, "lane5": lane5, "lane6": lane6}
         afc_obj.units = {"Turtle_1": unit1, "Turtle_2": unit2}
-        afc_obj.lanes = {"lane1": lane1, "lane2": lane2, "lane3": lane3, "lane4": lane4}
+        afc_obj.lanes = {"lane1": lane1, "lane2": lane2, "lane3": lane3, "lane4": lane4,
+                        "lane5": lane5, "lane6": lane6}
 
         extruder = self._make_ext_mock("extruder")
         extruder.estats.tc_total.value = 214

--- a/tests/test_AFC_stats.py
+++ b/tests/test_AFC_stats.py
@@ -355,6 +355,34 @@ class TestAFCStatsInit:
         )
         assert stats.tc_last_load_error.value == "2024-01-01 10:00"
 
+    def test_creates_total_load_errors_var(self):
+        stats, _, _ = _make_afc_stats()
+        assert hasattr(stats, "total_load_errors")
+
+    def test_creates_total_unload_errors_var(self):
+        stats, _, _ = _make_afc_stats()
+        assert hasattr(stats, "total_unload_errors")
+
+    def test_total_load_errors_defaults_to_zero(self):
+        stats, _, _ = _make_afc_stats()
+        assert stats.total_load_errors.value == 0
+
+    def test_total_unload_errors_defaults_to_zero(self):
+        stats, _, _ = _make_afc_stats()
+        assert stats.total_unload_errors.value == 0
+
+    def test_total_load_errors_loads_from_existing_data(self):
+        stats, _, _ = _make_afc_stats(
+            stats_data={"error_stats": {"total_load_errors": 5}}
+        )
+        assert stats.total_load_errors.value == 5
+
+    def test_total_unload_errors_loads_from_existing_data(self):
+        stats, _, _ = _make_afc_stats(
+            stats_data={"error_stats": {"total_unload_errors": 3}}
+        )
+        assert stats.total_unload_errors.value == 3
+
 
 class TestAFCStatsIncreaseTcWoError:
     def test_increase_toolchange_wo_error_calls_increase_count(self):
@@ -377,6 +405,66 @@ class TestAFCStatsResetTcWoError:
         # Should have a date string now
         assert isinstance(stats.tc_last_load_error.value, str)
         assert len(stats.tc_last_load_error.value) > 3
+
+
+class TestAFCStatsIncreaseLoadErrorCount:
+    def test_increments_total_load_errors(self):
+        stats, _, _ = _make_afc_stats()
+        before = stats.total_load_errors.value
+        stats.increase_load_error_count()
+        assert stats.total_load_errors.value == before + 1
+
+    def test_resets_toolchange_wo_error_count(self):
+        stats, _, _ = _make_afc_stats()
+        stats.tc_without_error._value = 7
+        stats.increase_load_error_count()
+        assert stats.tc_without_error.value == 0
+
+    def test_sets_last_load_error_time(self):
+        stats, _, _ = _make_afc_stats()
+        stats.increase_load_error_count()
+        assert isinstance(stats.tc_last_load_error.value, str)
+        assert len(stats.tc_last_load_error.value) > 3
+
+    def test_does_not_increment_total_unload_errors(self):
+        """Proves increase_load_error_count only touches the load counter,
+        not the unload one -- distinguishes it from
+        increase_unload_error_count, whose implementation is otherwise
+        nearly identical."""
+        stats, _, _ = _make_afc_stats()
+        before = stats.total_unload_errors.value
+        stats.increase_load_error_count()
+        assert stats.total_unload_errors.value == before
+
+
+class TestAFCStatsIncreaseUnloadErrorCount:
+    def test_increments_total_unload_errors(self):
+        stats, _, _ = _make_afc_stats()
+        before = stats.total_unload_errors.value
+        stats.increase_unload_error_count()
+        assert stats.total_unload_errors.value == before + 1
+
+    def test_resets_toolchange_wo_error_count(self):
+        stats, _, _ = _make_afc_stats()
+        stats.tc_without_error._value = 7
+        stats.increase_unload_error_count()
+        assert stats.tc_without_error.value == 0
+
+    def test_sets_last_load_error_time(self):
+        stats, _, _ = _make_afc_stats()
+        stats.increase_unload_error_count()
+        assert isinstance(stats.tc_last_load_error.value, str)
+        assert len(stats.tc_last_load_error.value) > 3
+
+    def test_does_not_increment_total_load_errors(self):
+        """Proves increase_unload_error_count only touches the unload
+        counter, not the load one -- distinguishes it from
+        increase_load_error_count, whose implementation is otherwise
+        nearly identical."""
+        stats, _, _ = _make_afc_stats()
+        before = stats.total_load_errors.value
+        stats.increase_unload_error_count()
+        assert stats.total_load_errors.value == before
 
 
 class TestAFCStatsResetAverageTimes:
@@ -434,6 +522,21 @@ class TestAFCStatsPrintStats:
         raw_msgs = [m for lvl, m in logger.messages if lvl == "raw"]
         output = "".join(raw_msgs)
         assert "Overall Stats" in output
+
+    def test_print_stats_contains_total_load_and_unload_error_counts(self):
+        stats, _, logger = _make_afc_stats()
+        stats.total_load_errors._value = 4
+        stats.total_unload_errors._value = 2
+        afc_obj = self._make_mock_afc()
+        stats.print_stats(afc_obj)
+        raw_msgs = [m for lvl, m in logger.messages if lvl == "raw"]
+        output = "".join(raw_msgs)
+        assert "Total Load Errors" in output
+        assert "Total Unload Errors" in output
+        # Confirm the actual counter values flow through into the output,
+        # not just the static labels.
+        assert f"{'Total Load Errors':{' '}>22} : {4:{' '}<17}" in output
+        assert f"{'Total Unload Errors':{' '}>22} : {2:{' '}<17}" in output
 
     def test_print_stats_short_mode_calls_logger_raw(self):
         stats, _, logger = _make_afc_stats()
@@ -522,7 +625,10 @@ class TestAFCStatsPrintStats:
         lane.name = "lane1"
         lane.espooler.get_spooler_stats.return_value = ""  # empty espooler
         lane.lane_load_count.value = 3
+        unit = self._make_unit("Turtle_1")
+        unit.lanes = {"lane1": lane}
         afc_obj.lanes = {"lane1": lane}
+        afc_obj.units = {"Turtle_1": unit}
         stats.print_stats(afc_obj, short=False)
         raw_msgs = [m for lvl, m in logger.messages if lvl == "raw"]
         # logger.raw(print_str) is called exactly once, unconditionally, at
@@ -531,13 +637,17 @@ class TestAFCStatsPrintStats:
 
     def test_print_stats_long_format_with_lane_espooler_stats(self):
         """Non-empty espooler stats in long (non-short) format are appended
-        inline with a leading two-space indent, not boxed like short mode."""
+        inline with a leading four-space indent, not boxed like short mode."""
         stats, _, logger = _make_afc_stats()
         afc_obj = self._make_mock_afc()
+        unit = MagicMock()
+        unit.name = "Turtle_1"
         lane = MagicMock()
         lane.name = "lane1"
         lane.espooler.get_spooler_stats.return_value = "Spooler: 500g"  # non-empty
         lane.lane_load_count.value = 5
+        unit.lanes = {"lane1": lane}
+        afc_obj.units = {"Turtle_1": unit}
         afc_obj.lanes = {"lane1": lane}
         stats.print_stats(afc_obj, short=False)
         raw_msgs = [m for lvl, m in logger.messages if lvl == "raw"]
@@ -553,12 +663,17 @@ class TestAFCStatsPrintStats:
         lane.name = "lane1"
         lane.espooler.get_spooler_stats.return_value = "Spooler: 250g"  # non-empty
         lane.lane_load_count.value = 2
+        unit = self._make_unit("Turtle_1")
+        unit.lanes = {"lane1": lane}
         afc_obj.lanes = {"lane1": lane}
+        afc_obj.units = {"Turtle_1": unit}
         stats.print_stats(afc_obj, short=True)
         raw_msgs = [m for lvl, m in logger.messages if lvl == "raw"]
-        # logger.raw(print_str) is called exactly once, unconditionally, at
-        # the very end of print_stats.
-        assert len(raw_msgs) == 1
+        output = "".join(raw_msgs)
+        # short mode (MAX_WIDTH=44) boxes the non-empty espooler stats on
+        # their own line, centered within MAX_WIDTH-3=41 columns -- computed
+        # by hand rather than re-deriving the source's own format spec.
+        assert "|              Spooler: 250g              |\n" in output
 
     def test_print_stats_long_string_lane_uses_direct_print(self):
         """A lane string longer than 60 chars bypasses the temp_str
@@ -570,12 +685,24 @@ class TestAFCStatsPrintStats:
         # Long espooler stats (>21 chars) pushes string length over 60
         lane.espooler.get_spooler_stats.return_value = "x" * 25
         lane.lane_load_count.value = 1
+        unit = self._make_unit("Turtle_1")
+        unit.lanes = {"lane1": lane}
         afc_obj.lanes = {"lane1": lane}
+        afc_obj.units = {"Turtle_1": unit}
         stats.print_stats(afc_obj, short=False)
         raw_msgs = [m for lvl, m in logger.messages if lvl == "raw"]
-        # logger.raw(print_str) is called exactly once, unconditionally, at
-        # the very end of print_stats.
-        assert len(raw_msgs) == 1
+        output = "".join(raw_msgs)
+        # Computed by hand (not by re-deriving the source's own format
+        # spec): max_lane_name_size is max(len("lane1"), 9) = 9, so the
+        # name/count portion is "    lane1 : Lane change count:       1",
+        # plus the 25 "x"s appended with a 1-space indent, pushing the
+        # combined string over 60 chars and into the direct-print branch
+        # (right-justified within MAX_WIDTH-4=83, then "  |\n") instead of
+        # the temp_str accumulator.
+        assert (
+            "|                       lane1 : Lane change count:       1 "
+            + "x" * 25 + "  |\n"
+        ) in output
 
     @staticmethod
     def _make_lane(name):
@@ -623,7 +750,7 @@ class TestAFCStatsPrintStats:
         raw_msgs = [m for lvl, m in logger.messages if lvl == "raw"]
         output = "".join(raw_msgs)
 
-        positions = [output.index(name) for name in ("lane3", "lane4", "lane1", "lane2")]
+        positions = [output.index(name) for name in ("lane1", "lane2", "lane3", "lane4")]
         assert positions == sorted(positions)
 
     def test_print_stats_long_format_lanes_print_in_insertion_order(self):
@@ -638,12 +765,115 @@ class TestAFCStatsPrintStats:
             "lane1": self._make_lane("lane1"),
             "lane2": self._make_lane("lane2"),
         }
+        # Simulating where units and unit lanes will be in order and AFC lanes will not be in order
+        afc_obj.units = {
+            "Turtle_1": self._make_unit("Turtle_1"),
+            "Turtle_2": self._make_unit("Turtle_2"),
+        }
+        afc_obj.units["Turtle_1"].lanes = {
+            "lane1" : afc_obj.lanes["lane1"],
+            "lane2" : afc_obj.lanes["lane2"]
+        }
+        afc_obj.units["Turtle_2"].lanes = {
+            "lane3" : afc_obj.lanes["lane3"],
+            "lane4" : afc_obj.lanes["lane4"]
+        }
         stats.print_stats(afc_obj, short=False)
         raw_msgs = [m for lvl, m in logger.messages if lvl == "raw"]
         output = "".join(raw_msgs)
 
-        positions = [output.index(name) for name in ("lane3", "lane4", "lane1", "lane2")]
+        positions = [output.index(name) for name in ("lane1", "lane2", "lane3", "lane4")]
         assert positions == sorted(positions)
+
+    @staticmethod
+    def _spooler_stats_side_effect(fwd: str, rwd: str):
+        """Mirrors AFC_assist.Espooler.get_spooler_stats' actual formatting
+        exactly, including the fact that its short=True and short=False
+        outputs aren't just different widths of the same string -- short
+        mode returns a value with its own "|"/newline box formatting
+        already baked in (meant to be dropped straight into the short-mode
+        table), while long mode returns one flat line. A static
+        return_value can't represent that; print_stats calls
+        get_spooler_stats(short) with the real short flag, so the mock
+        needs a side_effect that branches on it the same way the source
+        does."""
+        def _side_effect(short):
+            ret_str = "N20 active time:"
+            ret_str += " fwd:"
+            if short:
+                ret_str = f"{ret_str:{' '}>32}{fwd:>8}  |\n"
+            else:
+                ret_str = "N20 active time:" + f" fwd:{fwd:>8}"
+            if short:
+                ret_str += "|" + f"{'rwd:':{' '}>32}{rwd:>8}  "
+            else:
+                ret_str += f" rwd:{rwd:>8}"
+            return ret_str
+        return _side_effect
+
+    def _make_preview_afc(self):
+        """Build a realistic-ish AFC mock: two units with two lanes each,
+        two extruders, some non-zero/non-default stat values so the printed
+        table actually has varied content to look at."""
+        afc_obj = self._make_mock_afc()
+
+        lane1 = self._make_lane("lane1")
+        lane1.lane_load_count.value = 42
+        lane1.espooler.get_spooler_stats.side_effect = self._spooler_stats_side_effect(
+            "1123.45s", "187.32s"
+        )
+        lane2 = self._make_lane("lane2")
+        lane2.lane_load_count.value = 17
+        lane2.espooler.get_spooler_stats.side_effect = self._spooler_stats_side_effect(
+            "123.45s", "87.32s"
+        )
+        lane3 = self._make_lane("lane3")
+        lane3.lane_load_count.value = 5
+        lane4 = self._make_lane("lane4")
+        lane4.lane_load_count.value = 130
+
+        unit1 = self._make_unit("Turtle_1")
+        unit1.lanes = {"lane1": lane1, "lane2": lane2}
+        unit2 = self._make_unit("Turtle_2")
+        unit2.lanes = {"lane3": lane3, "lane4": lane4}
+        afc_obj.units = {"Turtle_1": unit1, "Turtle_2": unit2}
+        afc_obj.lanes = {"lane1": lane1, "lane2": lane2, "lane3": lane3, "lane4": lane4}
+
+        extruder = self._make_ext_mock("extruder")
+        extruder.estats.tc_total.value = 214
+        extruder.estats.tc_tool_unload.value = 108
+        extruder.estats.tc_tool_load.value = 106
+        extruder.estats.cut_total.value = 89
+        extruder.estats.cut_total_since_changed.value = 12
+        extruder.estats.cut_threshold_for_warning = 50
+        extruder.estats.last_blade_changed.value = "2025-11-02 08:15"
+        extruder.estats.tool_selected.value = 60
+        extruder.estats.tool_unselected.value = 58
+        afc_obj.tools = {"extruder": extruder}
+
+        return afc_obj
+
+    def test_print_stats_visual_preview(self, capsys):
+        """Not a correctness check (the other tests in this class cover
+        that) -- prints what print_stats actually renders so you can eyeball
+        the formatting without needing a printer running. Run with:
+
+            pytest tests/test_AFC_stats.py -k print_stats_visual_preview -s
+
+        (the -s is required, otherwise pytest swallows the printed output).
+        """
+        stats, _, logger = _make_afc_stats(multiple_tools=True)
+        stats.tc_without_error._value = 358
+        stats.tc_last_load_error._value = "2025-10-15 14:32"
+
+        with capsys.disabled():
+            for label, short in (("LONG FORMAT (short=False)", False),
+                                  ("SHORT FORMAT (short=True)", True)):
+                afc_obj = self._make_preview_afc()
+                stats.print_stats(afc_obj, short=short)
+                raw_msgs = [m for lvl, m in logger.messages if lvl == "raw"]
+                print(f"\n{'=' * 20} {label} {'=' * 20}")
+                print(raw_msgs[-1])
 
 
 # ═════════════════════════════════════════════════════════════════════════

--- a/tests/test_AFC_stats.py
+++ b/tests/test_AFC_stats.py
@@ -411,18 +411,18 @@ class TestAFCStatsIncreaseLoadErrorCount:
     def test_increments_total_load_errors(self):
         stats, _, _ = _make_afc_stats()
         before = stats.total_load_errors.value
-        stats.increase_load_error_count()
+        stats.increase_load_error_count(MagicMock(testing=False))
         assert stats.total_load_errors.value == before + 1
 
     def test_resets_toolchange_wo_error_count(self):
         stats, _, _ = _make_afc_stats()
         stats.tc_without_error._value = 7
-        stats.increase_load_error_count()
+        stats.increase_load_error_count(MagicMock(testing=False))
         assert stats.tc_without_error.value == 0
 
     def test_sets_last_load_error_time(self):
         stats, _, _ = _make_afc_stats()
-        stats.increase_load_error_count()
+        stats.increase_load_error_count(MagicMock(testing=False))
         assert isinstance(stats.tc_last_load_error.value, str)
         assert len(stats.tc_last_load_error.value) > 3
 
@@ -433,26 +433,37 @@ class TestAFCStatsIncreaseLoadErrorCount:
         nearly identical."""
         stats, _, _ = _make_afc_stats()
         before = stats.total_unload_errors.value
-        stats.increase_load_error_count()
+        stats.increase_load_error_count(MagicMock(testing=False))
         assert stats.total_unload_errors.value == before
+
+    def test_skipped_when_afc_testing_true(self):
+        """When afc.testing is True, the function returns before touching
+        any counters -- neither total_load_errors nor the
+        reset_toolchange_wo_error side effects fire."""
+        stats, _, _ = _make_afc_stats()
+        stats.tc_without_error._value = 7
+        before_total = stats.total_load_errors.value
+        stats.increase_load_error_count(MagicMock(testing=True))
+        assert stats.total_load_errors.value == before_total
+        assert stats.tc_without_error.value == 7
 
 
 class TestAFCStatsIncreaseUnloadErrorCount:
     def test_increments_total_unload_errors(self):
         stats, _, _ = _make_afc_stats()
         before = stats.total_unload_errors.value
-        stats.increase_unload_error_count()
+        stats.increase_unload_error_count(MagicMock(testing=False))
         assert stats.total_unload_errors.value == before + 1
 
     def test_resets_toolchange_wo_error_count(self):
         stats, _, _ = _make_afc_stats()
         stats.tc_without_error._value = 7
-        stats.increase_unload_error_count()
+        stats.increase_unload_error_count(MagicMock(testing=False))
         assert stats.tc_without_error.value == 0
 
     def test_sets_last_load_error_time(self):
         stats, _, _ = _make_afc_stats()
-        stats.increase_unload_error_count()
+        stats.increase_unload_error_count(MagicMock(testing=False))
         assert isinstance(stats.tc_last_load_error.value, str)
         assert len(stats.tc_last_load_error.value) > 3
 
@@ -463,8 +474,19 @@ class TestAFCStatsIncreaseUnloadErrorCount:
         nearly identical."""
         stats, _, _ = _make_afc_stats()
         before = stats.total_load_errors.value
-        stats.increase_unload_error_count()
+        stats.increase_unload_error_count(MagicMock(testing=False))
         assert stats.total_load_errors.value == before
+
+    def test_skipped_when_afc_testing_true(self):
+        """When afc.testing is True, the function returns before touching
+        any counters -- neither total_unload_errors nor the
+        reset_toolchange_wo_error side effects fire."""
+        stats, _, _ = _make_afc_stats()
+        stats.tc_without_error._value = 7
+        before_total = stats.total_unload_errors.value
+        stats.increase_unload_error_count(MagicMock(testing=True))
+        assert stats.total_unload_errors.value == before_total
+        assert stats.tc_without_error.value == 7
 
 
 class TestAFCStatsResetAverageTimes:

--- a/tests/test_AFC_stats.py
+++ b/tests/test_AFC_stats.py
@@ -875,12 +875,15 @@ class TestAFCStatsPrintStats:
 
         return afc_obj
 
+    @pytest.mark.manual
     def test_print_stats_visual_preview(self, capsys):
         """Not a correctness check (the other tests in this class cover
         that) -- prints what print_stats actually renders so you can eyeball
-        the formatting without needing a printer running. Run with:
+        the formatting without needing a printer running. Marked "manual" so
+        it's excluded from the normal test run (see addopts in pyproject.toml);
+        run explicitly with:
 
-            pytest tests/test_AFC_stats.py -k print_stats_visual_preview -s
+            pytest tests/test_AFC_stats.py -k print_stats_visual_preview -s -m manual
 
         (the -s is required, otherwise pytest swallows the printed output).
         """

--- a/tests/test_AFC_stats.py
+++ b/tests/test_AFC_stats.py
@@ -8,9 +8,13 @@ Covers:
 
 from __future__ import annotations
 
+import sys
+import importlib.util
+import configparser
 from unittest.mock import MagicMock, patch
 import pytest
 
+from extras.AFC import afc
 from extras.AFC_stats import AFCStats_var, AFCStats
 
 
@@ -36,9 +40,13 @@ class TestAFCStatsVarInit:
         assert var.value == 0
 
     def test_init_data_missing_parent_defaults_to_zero(self):
+        mr = make_moonraker()
         data = {"other_parent": {"cut_total": 5}}
-        var = make_var("extruder", "cut_total", data=data)
+        var = make_var("extruder", "cut_total", data=data, moonraker=mr)
         assert var.value == 0
+        assert mr.logger.messages == [
+            ("debug", "No data in database for extruder.cut_total:True"),
+        ]
 
     def test_init_data_with_matching_parent_single_level(self):
         data = {"extruder": {"cut_total": 42}}
@@ -74,6 +82,29 @@ class TestAFCStatsVarInit:
         var = AFCStats_var("old_parent", "count", data, mr, new_parent_name="new_parent")
         assert var.parent_name == "new_parent"
         mr.update_afc_stats.assert_called()
+
+    def test_init_new_parent_already_has_data_loads_from_new_parent(self):
+        """When new_parent_name's own key already exists in data (the stat
+        was already migrated in an earlier run), the value must load from
+        the new parent's key -- checked first, before old_parent is even
+        looked at, and old_parent isn't present here at all."""
+        mr = make_moonraker()
+        data = {"new_parent": {"count": 8}}
+        var = AFCStats_var("old_parent", "count", data, mr, new_parent_name="new_parent")
+        assert var.value == 8
+
+    def test_init_new_parent_rename_skipped_when_old_parent_key_absent(self):
+        """The old-parent migration step (update_database + remove_database_
+        entry) requires BOTH data is not None AND the old parent's key
+        being present in data -- proven independently of
+        test_init_new_parent_renames_and_deletes_old, which has both true.
+        Here data is not None but old_parent's key isn't in it (only
+        new_parent's is), so the migration step must be skipped."""
+        mr = make_moonraker()
+        mr.remove_database_entry = MagicMock()
+        data = {"new_parent": {"count": 8}}
+        AFCStats_var("old_parent", "count", data, mr, new_parent_name="new_parent")
+        mr.remove_database_entry.assert_not_called()
 
     def test_str_representation(self):
         var = make_var("extruder", "cut_total", data={"extruder": {"cut_total": 10}})
@@ -215,8 +246,10 @@ class TestGetValueEdgeCases:
         mr.update_afc_stats = MagicMock()
         data = {"a": {"b": {"c": 5}}}
         var = make_var("a.b.c", "value", data=data, moonraker=mr)
-        # Value should be 0 (error path)
         assert var.value == 0
+        assert mr.logger.messages == [
+            ("error", "Cannot have more than two parent names for stats"),
+        ]
 
     def test_two_level_parent_missing_second_level_returns_zero(self):
         """Two-level parent with missing second key returns 0."""
@@ -224,6 +257,9 @@ class TestGetValueEdgeCases:
         data = {"extruder": {}}  # second level key "cut" missing
         var = make_var("extruder.cut", "cut_total", data=data, moonraker=mr)
         assert var.value == 0
+        assert mr.logger.messages == [
+            ("debug", "No data in database for extruder.cut.cut_total:True"),
+        ]
 
     def test_new_parent_with_no_data_does_not_remove(self):
         """When data=None, the old-parent delete step is skipped."""
@@ -279,17 +315,45 @@ class TestAFCStatsInit:
 
     def test_multiple_tools_logs_debug(self):
         _, _, logger = _make_afc_stats(multiple_tools=True)
-        debug_msgs = [m for lvl, m in logger.messages if lvl == "debug"]
-        assert any("multiple" in m.lower() for m in debug_msgs)
+        assert logger.messages == [("debug", "Multiple tools detected for stats")]
 
     def test_new_average_calc_set_to_one_when_no_existing_data(self):
         stats, _, _ = _make_afc_stats()
+        assert stats.new_average_calc.value == 1
+
+    def test_new_average_calc_set_to_one_when_values_present_but_no_average_time_key(self):
+        """new_average_calc defaulting to 1 requires `values is not None and
+        "average_time" in values` to be False -- proven independently of
+        the "no existing data at all" case (values is None there) by
+        supplying non-empty stats data that simply lacks an "average_time"
+        key."""
+        stats, _, _ = _make_afc_stats(stats_data={"error_stats": {"last_load_error": "N/A"}})
         assert stats.new_average_calc.value == 1
 
     def test_new_average_calc_set_to_zero_when_average_time_in_db(self):
         # When "average_time" key exists in stats data, new_average_calc stays 0
         stats, mr, _ = _make_afc_stats(stats_data={"average_time": {"new_average_calc": 0}})
         assert stats.new_average_calc.value == 0
+
+    def test_new_average_calc_not_reset_when_already_nonzero(self):
+        """When new_average_calc already resolved to a non-zero value from
+        the DB (already migrated in an earlier run), __init__ must not
+        overwrite it or push another update to the database for it."""
+        stats, mr, _ = _make_afc_stats(stats_data={"average_time": {"new_average_calc": 1}})
+        assert stats.new_average_calc.value == 1
+        matching_calls = [
+            c for c in mr.update_afc_stats.call_args_list
+            if c.args[0] == "average_time.new_average_calc"
+        ]
+        assert matching_calls == []
+
+    def test_last_load_error_not_overwritten_when_already_set(self):
+        """When error_stats.last_load_error already has a real value in the
+        DB, __init__ must not overwrite it with the "N/A" placeholder."""
+        stats, mr, _ = _make_afc_stats(
+            stats_data={"error_stats": {"last_load_error": "2024-01-01 10:00"}}
+        )
+        assert stats.tc_last_load_error.value == "2024-01-01 10:00"
 
 
 class TestAFCStatsIncreaseTcWoError:
@@ -351,6 +415,7 @@ class TestAFCStatsPrintStats:
         afc_obj = MagicMock()
         afc_obj.lanes = {}
         afc_obj.tools = {}
+        afc_obj.units = {}
         return afc_obj
 
     def test_print_stats_calls_logger_raw(self):
@@ -358,7 +423,9 @@ class TestAFCStatsPrintStats:
         afc_obj = self._make_mock_afc()
         stats.print_stats(afc_obj)
         raw_msgs = [m for lvl, m in logger.messages if lvl == "raw"]
-        assert len(raw_msgs) >= 1
+        # logger.raw(print_str) is called exactly once, unconditionally, at
+        # the very end of print_stats.
+        assert len(raw_msgs) == 1
 
     def test_print_stats_contains_overall_header(self):
         stats, _, logger = _make_afc_stats()
@@ -373,7 +440,9 @@ class TestAFCStatsPrintStats:
         afc_obj = self._make_mock_afc()
         stats.print_stats(afc_obj, short=True)
         raw_msgs = [m for lvl, m in logger.messages if lvl == "raw"]
-        assert len(raw_msgs) >= 1
+        # logger.raw(print_str) is called exactly once, unconditionally, at
+        # the very end of print_stats.
+        assert len(raw_msgs) == 1
 
     def test_print_stats_with_extruder(self):
         stats, _, logger = _make_afc_stats()
@@ -394,6 +463,8 @@ class TestAFCStatsPrintStats:
         raw_msgs = [m for lvl, m in logger.messages if lvl == "raw"]
         output = "".join(raw_msgs)
         assert "extruder" in output
+        # short=False -> extruder_lbl is just the name, no " Toolchanges" suffix
+        assert "extruder Toolchanges" not in output
 
     def test_print_stats_with_multiple_tools_and_extruder(self):
         stats, _, logger = _make_afc_stats(multiple_tools=True)
@@ -430,7 +501,8 @@ class TestAFCStatsPrintStats:
         return ext
 
     def test_print_stats_short_mode_with_multiple_tools_and_extruder(self):
-        """Covers short=True + multiple_tools branches (lines 337, 340, 343-344)."""
+        """short=True combined with multiple_tools exercises the tool
+        selected/unselected rows and the short-mode cut-string append."""
         stats, _, logger = _make_afc_stats(multiple_tools=True)
         afc_obj = self._make_mock_afc()
         afc_obj.tools = {"extruder": self._make_ext_mock()}
@@ -438,9 +510,12 @@ class TestAFCStatsPrintStats:
         raw_msgs = [m for lvl, m in logger.messages if lvl == "raw"]
         output = "".join(raw_msgs)
         assert "Overall Stats" in output
+        # short=True -> extruder_lbl gets a " Toolchanges" suffix
+        assert "extruder Toolchanges" in output
 
     def test_print_stats_long_format_with_lane(self):
-        """Covers the lane loop body and end_string() call (lines 270-271, 282, 379-381, 392-399)."""
+        """A single short lane string (<=60 chars) accumulates into temp_str
+        and flushes via end_string() at the end of the lane loop."""
         stats, _, logger = _make_afc_stats()
         afc_obj = self._make_mock_afc()
         lane = MagicMock()
@@ -450,10 +525,13 @@ class TestAFCStatsPrintStats:
         afc_obj.lanes = {"lane1": lane}
         stats.print_stats(afc_obj, short=False)
         raw_msgs = [m for lvl, m in logger.messages if lvl == "raw"]
-        assert len(raw_msgs) >= 1
+        # logger.raw(print_str) is called exactly once, unconditionally, at
+        # the very end of print_stats.
+        assert len(raw_msgs) == 1
 
     def test_print_stats_long_format_with_lane_espooler_stats(self):
-        """Covers espooler non-empty long-format branch (line 385)."""
+        """Non-empty espooler stats in long (non-short) format are appended
+        inline with a leading two-space indent, not boxed like short mode."""
         stats, _, logger = _make_afc_stats()
         afc_obj = self._make_mock_afc()
         lane = MagicMock()
@@ -467,7 +545,8 @@ class TestAFCStatsPrintStats:
         assert "lane1" in output
 
     def test_print_stats_short_format_with_lane_and_espooler(self):
-        """Covers short=True lane formatting (lines 382, 383-384)."""
+        """short=True boxes the lane string and, when espooler stats are
+        non-empty, boxes and appends those on their own line too."""
         stats, _, logger = _make_afc_stats()
         afc_obj = self._make_mock_afc()
         lane = MagicMock()
@@ -477,10 +556,13 @@ class TestAFCStatsPrintStats:
         afc_obj.lanes = {"lane1": lane}
         stats.print_stats(afc_obj, short=True)
         raw_msgs = [m for lvl, m in logger.messages if lvl == "raw"]
-        assert len(raw_msgs) >= 1
+        # logger.raw(print_str) is called exactly once, unconditionally, at
+        # the very end of print_stats.
+        assert len(raw_msgs) == 1
 
     def test_print_stats_long_string_lane_uses_direct_print(self):
-        """Covers lines 395-397: lane string > 60 chars goes directly to print_str."""
+        """A lane string longer than 60 chars bypasses the temp_str
+        accumulator and goes directly into print_str on its own line."""
         stats, _, logger = _make_afc_stats()
         afc_obj = self._make_mock_afc()
         lane = MagicMock()
@@ -491,4 +573,127 @@ class TestAFCStatsPrintStats:
         afc_obj.lanes = {"lane1": lane}
         stats.print_stats(afc_obj, short=False)
         raw_msgs = [m for lvl, m in logger.messages if lvl == "raw"]
-        assert len(raw_msgs) >= 1
+        # logger.raw(print_str) is called exactly once, unconditionally, at
+        # the very end of print_stats.
+        assert len(raw_msgs) == 1
+
+    @staticmethod
+    def _make_lane(name):
+        lane = MagicMock()
+        lane.name = name
+        lane.espooler.get_spooler_stats.return_value = ""
+        lane.lane_load_count.value = 1
+        return lane
+    
+    @staticmethod
+    def _make_unit(name):
+        unit = MagicMock()
+        unit.name = name
+        unit.lanes = {}
+        return unit
+
+    def test_print_stats_short_format_lanes_print_in_insertion_order(self):
+        """afc_obj.lanes is a plain dict; print_stats must iterate it in
+        insertion order (dict iteration order in Python 3.7+), not re-sort
+        lane names alphabetically -- lanes inserted out of numeric order
+        must come out in that same out-of-order sequence."""
+        stats, _, logger = _make_afc_stats()
+        afc_obj = self._make_mock_afc()
+        # Inserted out of numeric order on purpose.
+        afc_obj.lanes = {
+            "lane3": self._make_lane("lane3"),
+            "lane4": self._make_lane("lane4"),
+            "lane1": self._make_lane("lane1"),
+            "lane2": self._make_lane("lane2"),
+        }
+        # Simulating where units and unit lanes will be in order and AFC lanes will not be in order
+        afc_obj.units = {
+            "Turtle_1": self._make_unit("Turtle_1"),
+            "Turtle_2": self._make_unit("Turtle_2"),
+        }
+        afc_obj.units["Turtle_1"].lanes = {
+            "lane1" : afc_obj.lanes["lane1"],
+            "lane2" : afc_obj.lanes["lane2"]
+        }
+        afc_obj.units["Turtle_2"].lanes = {
+            "lane3" : afc_obj.lanes["lane3"],
+            "lane4" : afc_obj.lanes["lane4"]
+        }
+        stats.print_stats(afc_obj, short=True)
+        raw_msgs = [m for lvl, m in logger.messages if lvl == "raw"]
+        output = "".join(raw_msgs)
+
+        positions = [output.index(name) for name in ("lane3", "lane4", "lane1", "lane2")]
+        assert positions == sorted(positions)
+
+    def test_print_stats_long_format_lanes_print_in_insertion_order(self):
+        """Same as the short-format case, but through the long-format
+        temp_str accumulator/end_string() path instead of a direct join, to
+        prove that accumulation logic doesn't reorder lanes either."""
+        stats, _, logger = _make_afc_stats()
+        afc_obj = self._make_mock_afc()
+        afc_obj.lanes = {
+            "lane3": self._make_lane("lane3"),
+            "lane4": self._make_lane("lane4"),
+            "lane1": self._make_lane("lane1"),
+            "lane2": self._make_lane("lane2"),
+        }
+        stats.print_stats(afc_obj, short=False)
+        raw_msgs = [m for lvl, m in logger.messages if lvl == "raw"]
+        output = "".join(raw_msgs)
+
+        positions = [output.index(name) for name in ("lane3", "lane4", "lane1", "lane2")]
+        assert positions == sorted(positions)
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# Module-level import guard
+# ═════════════════════════════════════════════════════════════════════════
+
+def _exec_afc_stats_with_blocked_dependency(blocked_module_name):
+    """Execute a throw-away copy of extras/AFC_stats.py's module-level code
+    with `blocked_module_name` forced to fail import, to exercise the file's
+    top-level ``try: from X import Y / except: raise error(...)`` guard.
+
+    This never touches the real, already-imported ``extras.AFC_stats``
+    module that the rest of this test suite depends on: the copy is loaded
+    under a throwaway module name and discarded afterward, whether or not it
+    raises. Blocking an import via ``sys.modules[name] = None`` is a standard
+    Python mechanism -- it makes any ``import``/``from ... import`` of that
+    name raise ImportError immediately, without touching the module itself.
+
+    Cleanup restores the *exact same* pre-existing module object in
+    sys.modules (not just removes the block) -- simply deleting the entry
+    would let it get re-imported fresh the next time anything touches it,
+    producing new, distinct class objects that no longer match what other
+    test files already imported and bound references to.
+    """
+    import extras.AFC_stats as real_module
+    fresh_name = "extras.AFC_stats_import_guard_probe"
+    original_blocked_module = sys.modules.get(blocked_module_name)
+    sys.modules[blocked_module_name] = None
+    try:
+        spec = importlib.util.spec_from_file_location(fresh_name, real_module.__file__)
+        fresh = importlib.util.module_from_spec(spec)
+        sys.modules[fresh_name] = fresh
+        try:
+            spec.loader.exec_module(fresh)
+        finally:
+            sys.modules.pop(fresh_name, None)
+    finally:
+        if original_blocked_module is not None:
+            sys.modules[blocked_module_name] = original_blocked_module
+        else:
+            sys.modules.pop(blocked_module_name, None)
+
+
+class TestModuleImportGuard:
+    """Covers the single module-level `try/except: raise error(...)` guard
+    in AFC_stats.py, around its import of AFC_utils.check_and_return."""
+
+    def test_afc_utils_import_failure_raises_configparser_error(self):
+        with pytest.raises(configparser.Error) as exc_info:
+            _exec_afc_stats_with_blocked_dependency("extras.AFC_utils")
+        assert str(exc_info.value).startswith(
+            "Error when trying to import AFC_utils.check_and_return"
+        )


### PR DESCRIPTION
## Major Changes in this PR
- After fixing lane ordering to show up correctly in mainsail/fluidd, this introduced a new bug where lanes were printed out of order when running `AFC_STATS` macro. This PR fixes this so the lanes now print out in the correct order and updated some minor formatting with the long `AFC_STATS` printout. Note: load/unload error count will not increment if `testing` flag is set.
- Added tracking of load/unload errors. Closes #822 

Changes with help from claude
- Updated/added units tests
- Updating typing and method comments in AFC_stats.py

## Notes to Code Reviewers
Currently what `AFC_STATS` looks like and what this PR fixes:
<img width="980" height="1205" alt="image" src="https://github.com/user-attachments/assets/f39e57a3-07b8-45b3-a25f-afd3a71438c9" />

## How the changes in this PR are tested
Unconnected PTFE from hub and tried to load, verified load error count increases and last error date resets:

Long format with new load/unload errors at top:
<img width="962" height="1225" alt="image" src="https://github.com/user-attachments/assets/192e2581-02dc-4f8a-8d23-664e284ff52d" />

Short format with new load/unload errors at top:
<img width="501" height="1243" alt="image" src="https://github.com/user-attachments/assets/17e78e98-00ab-4ad2-b92e-4c0b11933a84" />
<img width="501" height="943" alt="image" src="https://github.com/user-attachments/assets/8757555b-8a1a-40a6-a35a-91db98f0502e" />


## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to pr-review channel requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate load and unload error totals to AFC statistics.
  * Failed tool loading and unloading is now recorded across commands, runout handling, button actions, and lane tests.
  * Improved lane ordering and statistics formatting for clearer output.

* **Bug Fixes**
  * Prevented failed unload operations from continuing with ejection or lane processing.
  * Corrected AFC statistics alignment and display-spacing issues.

* **Documentation**
  * Updated the changelog and AFC version for the August 6, 2026 release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->