### PR TITLE
(feat): Adding ability to adjust HTLF selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-08-07]
+### Added
+- Ability to adjust HTLF selector after lane selection by adding `selector_cal_distance` variable in each lane.
+
 ## [2026-08-06]
 ### Added
 - Added a `_AFC_DISPLAY_STATUS` hook, called around `TOOL_LOAD`/`TOOL_UNLOAD` with `pushing`/`retraction`

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -45,7 +45,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 try: from extras.AFC_stats import AFCStats
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
 
-AFC_VERSION="1.2.3"
+AFC_VERSION="1.2.4"
 
 # Class for holding different states so its clear what all valid states are
 class State(str, Enum):

--- a/extras/AFC_HTLF.py
+++ b/extras/AFC_HTLF.py
@@ -42,9 +42,9 @@ class AFC_HTLF(afcBoxTurtle):
 
     def __init__(self, config: ConfigWrapper) -> None:
         """
-        Parse HTLF configuration, register the home-sensor endstop/filament
-        switch (if a home_pin is configured), and register the
-        AFC_HOME_UNIT gcode command.
+        Parse HTLF configuration, register the home-sensor endstop and
+        filament switch, and register the AFC_HOME_UNIT gcode command.
+        home_pin is a required config option.
 
         :param config: Klipper config wrapper for the AFC_HTLF section
         """

--- a/extras/AFC_HTLF.py
+++ b/extras/AFC_HTLF.py
@@ -258,6 +258,9 @@ class AFC_HTLF(afcBoxTurtle):
                                                    self.selector_movement_speed,
                                                    self.selector_movement_accel,
                                                    False)
+                    # Applying selector_cal_dis move if specified in users config
+                    self._selector_cal_dis_adjust(lane)
+
                     self.logger.debug("HTLF: Selecting {}".format(lane))
                     self.current_selected_lane = lane
                     return True, self._homed_distance

--- a/extras/AFC_HTLF.py
+++ b/extras/AFC_HTLF.py
@@ -9,7 +9,7 @@ import traceback
 
 from configparser import Error as config_error
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 try: from extras.AFC_utils import ERROR_STR
 except:
@@ -28,26 +28,42 @@ except: raise config_error(ERROR_STR.format(import_lib="AFC_utils", trace=traceb
 
 if TYPE_CHECKING:
     from configfile import ConfigWrapper
+    from gcode import GCodeCommand
+    from mcu import MCU_endstop
+    from extras.AFC_stepper import AFCExtruderStepper
 
 class AFC_HTLF(afcBoxTurtle):
     VALID_CAM_ANGLES = [30,45,60]
-    def __init__(self, config: ConfigWrapper):
+
+    # Redeclaring these here so mypy does not complain about these being none since for HTLF
+    # drive stepper and selector steppers are not optional
+    drive_stepper_obj: AFCExtruderStepper
+    selector_stepper_obj: AFCExtruderStepper
+
+    def __init__(self, config: ConfigWrapper) -> None:
+        """
+        Parse HTLF configuration, register the home-sensor endstop/filament
+        switch (if a home_pin is configured), and register the
+        AFC_HOME_UNIT gcode command.
+
+        :param config: Klipper config wrapper for the AFC_HTLF section
+        """
         super().__init__(config)
         self.type: str              = config.get('type', 'HTLF')
         self.drive_stepper: str     = config.get("drive_stepper")                                                   # Name of AFC_stepper for drive motor
         self.selector_stepper: str  = config.get("selector_stepper")                                                # Name of AFC_stepper for selector motor
-        self.current_selected_lane  = None
-        self.home_state             = False
-        self.mm_move_per_rotation   = config.getint("mm_move_per_rotation", 32)                                     # How many mm moves pulley a full rotation
-        self.cam_angle              = config.getint("cam_angle")                                                    # CAM lobe angle that is currently installed. 30,45,60 (recommend using 60)
-        self.home_pin               = config.get("home_pin")                                                        # Pin for homing sensor
-        self.MAX_ANGLE_MOVEMENT     = config.getint("MAX_ANGLE_MOVEMENT", 215)                                      # Max angle to move lobes, this is when lobe 1 is fully engaged with its lane
-        self.enable_sensors_in_gui  = config.getboolean("enable_sensors_in_gui", self.afc.enable_sensors_in_gui)    # Set to True to show prep and load sensors switches as filament sensors in mainsail/fluidd gui, overrides value set in AFC.cfg
+        self.current_selected_lane: Optional[AFCLane] = None
+        self.home_state: bool       = False
+        self.mm_move_per_rotation: int = config.getint("mm_move_per_rotation", 32)                                     # How many mm moves pulley a full rotation
+        self.cam_angle: int         = config.getint("cam_angle")                                                    # CAM lobe angle that is currently installed. 30,45,60 (recommend using 60)
+        self.home_pin: str          = config.get("home_pin")                                                       # Pin for homing sensor
+        self.MAX_ANGLE_MOVEMENT:int = config.getint("MAX_ANGLE_MOVEMENT", 215)                                      # Max angle to move lobes, this is when lobe 1 is fully engaged with its lane
+        self.enable_sensors_in_gui: bool  = config.getboolean("enable_sensors_in_gui", self.afc.enable_sensors_in_gui)    # Set to True to show prep and load sensors switches as filament sensors in mainsail/fluidd gui, overrides value set in AFC.cfg
         self.selector_movement_speed: float = config.getfloat("selector_movement_speed", 50)
         self.selector_movement_accel: float = config.getfloat("selector_movement_accel", 50)
-        self.prep_homed             = False
-        self.failed_to_home         = False
-        self._homed_distance        = 0.0
+        self.prep_homed: bool       = False
+        self.failed_to_home: bool   = False
+        self._homed_distance: float = 0.0
 
 
         if self.cam_angle not in self.VALID_CAM_ANGLES:
@@ -60,22 +76,22 @@ class AFC_HTLF(afcBoxTurtle):
 
         query_endstops              = self.printer.load_object( config, "query_endstops")
         ppins                       = self.printer.lookup_object('pins')
-        self.home_endstop           = None
-        self.home_endstop_name      = None
-        if self.home_pin is not None:
-            self.home_sensor, _ = add_filament_switch(f"{self.name}_home_pin", self.home_pin,
-                                                      self.printer, self.enable_sensors_in_gui )
+        self.home_endstop: Optional[MCU_endstop] = None
+        self.home_endstop_name: str
 
-            ppins.allow_multi_use_pin(self.home_pin.strip("!^"))
-            ppins.parse_pin(self.home_pin, True, True)
-            self.home_endstop = ppins.setup_pin('endstop', self.home_pin)
-            self.home_endstop_name = f"{self.name}_home"
-            try:
-                query_endstops.register_endstop(self.home_endstop,
-                                                self.home_endstop_name)
-            except Exception as e:
-                err_msg = f"Error trying to register home endstop for {self.name}.\n Error:{e}"
-                raise config_error(err_msg)
+        self.home_sensor, _ = add_filament_switch(f"{self.name}_home_pin", self.home_pin,
+                                                    self.printer, self.enable_sensors_in_gui )
+
+        ppins.allow_multi_use_pin(self.home_pin.strip("!^"))
+        ppins.parse_pin(self.home_pin, True, True)
+        self.home_endstop = ppins.setup_pin('endstop', self.home_pin)
+        self.home_endstop_name = f"{self.name}_home"
+        try:
+            query_endstops.register_endstop(self.home_endstop,
+                                            self.home_endstop_name)
+        except Exception as e:
+            err_msg = f"Error trying to register home endstop for {self.name}.\n Error:{e}"
+            raise config_error(err_msg)
 
         self._lookup_objects(config)
 
@@ -89,7 +105,7 @@ class AFC_HTLF(afcBoxTurtle):
                                         description=self.cmd_AFC_HOME_UNIT_help,
                                         options=self.cmd_AFC_HOME_UNIT_options)
 
-    def handle_connect(self):
+    def handle_connect(self) -> None:
         """
         Handle the connection event.
         This function is called when the printer connects. It looks up AFC info
@@ -101,7 +117,19 @@ class AFC_HTLF(afcBoxTurtle):
         self.logo = '<span class=success--text>HTLF Ready\n</span>'
         self.logo_error = '<span class=error--text>HTLF Not Ready</span>\n'
 
-    def system_Test(self, cur_lane, delay, assignTcmd, enable_movement):
+    def system_Test(self, cur_lane: AFCLane|AFCExtruderStepper, delay: float,
+                    assignTcmd: bool, enable_movement: bool) -> bool:
+        """
+        Runs the standard system test, homing the selector first (if not
+        already prep-homed) and again after the test so the selector always
+        ends up back at home.
+
+        :param cur_lane: Lane to run the system test against
+        :param delay: Delay amount to wait between forward/backward movements
+        :param assignTcmd: When True assigns a tool number to cur_lane
+        :param enable_movement: When True movement is enabled during the test
+        :return: True if the selector prep-homed successfully and the test succeeded
+        """
         cur_lane.prep_state = cur_lane.load_state
         if not self.prep_homed:
             self.return_to_home( prep = True, disable_selector=False)
@@ -110,16 +138,19 @@ class AFC_HTLF(afcBoxTurtle):
 
         return self.prep_homed and status
 
-    def home_callback(self, eventtime, state):
+    def home_callback(self, eventtime: float, state: int) -> None:
         """
         Callback when home switch is triggered/untriggered
+
+        :param eventtime: Event time from the button press
+        :param state: True/1 if the home switch is triggered, False/0 otherwise
         """
-        self.home_state = state
+        self.home_state = bool(state)
 
     cmd_AFC_HOME_UNIT_help = "Command to move lane selector back to home position for specified in "\
                              "selector style units that utilizes a home sensor."
     cmd_AFC_HOME_UNIT_options = {"UNIT": {"type":"string", "default":"HTLF_1"}}
-    def cmd_AFC_HOME_UNIT(self, gcmd):
+    def cmd_AFC_HOME_UNIT(self, gcmd: GCodeCommand) -> None:
         """
         Moves units lane selector back to home position
 
@@ -135,7 +166,7 @@ class AFC_HTLF(afcBoxTurtle):
         """
         self.return_to_home()
 
-    def _move_selector_home(self, distance: float):
+    def _move_selector_home(self, distance: float) -> None:
         """
         Helper function to move stepper with correct function call depending on if homing is enabled
         or not
@@ -157,18 +188,19 @@ class AFC_HTLF(afcBoxTurtle):
                                            self.selector_movement_accel,
                                            False)
 
-    def return_to_home(self, prep=False, disable_selector=True):
+    def return_to_home(self, prep: bool=False, disable_selector: bool=True) -> bool:
         """
         Moves lobes to home position, if a current lane was selected this function moves back that amount and then performs smaller
         moves until home switch is triggered
 
         :param prep: Set to True if this function is being called within prep function, once set the fast move back if another lane
                       was selected is bypassed and only move in smaller increments
+        :param disable_selector: When True disables the selector stepper motor once homing succeeds
         :return boolean: Returns True if homing was successful
         """
-        total_moved = 0
+        total_moved: float = 0
 
-        move_distance = 200
+        move_distance: float = 200
         if self.current_selected_lane is not None and not self.home_state and not prep:
             if not self.afc.homing_enabled:
                 move_distance = self.calculate_lobe_movement(self.current_selected_lane.index)
@@ -197,7 +229,7 @@ class AFC_HTLF(afcBoxTurtle):
         self.current_selected_lane = None
         return True
 
-    def calculate_lobe_movement(self, lane_index:int ):
+    def calculate_lobe_movement(self, lane_index:int ) -> float:
         """
         Calculates movement in mm to activate lane based off passed in lane index
 
@@ -208,7 +240,7 @@ class AFC_HTLF(afcBoxTurtle):
         self.logger.debug("HTLF: Lobe Movement angle : {}".format(angle_movement))
         return (self.mm_move_per_rotation/360)*angle_movement
 
-    def select_lane( self, lane, disable_selector: bool=False ) -> tuple[bool, float|int]:
+    def select_lane( self, lane: AFCLane, disable_selector: bool=False ) -> tuple[bool, float|int]:
         """
         Moves lobe selector to specified lane based off lanes index
 
@@ -238,10 +270,11 @@ class AFC_HTLF(afcBoxTurtle):
 
         return True, 0.0
 
-    def check_runout(self, cur_lane):
+    def check_runout(self, cur_lane: AFCLane) -> bool:
         """
         Function to check if runout logic should be triggered
 
+        :param cur_lane: Lane to check runout state for
         :return boolean: Returns true if current lane is loaded and printer is printing but lanes status is not ejecting or calibrating
         """
         return (cur_lane.name == self.afc.function.get_current_lane()
@@ -249,13 +282,29 @@ class AFC_HTLF(afcBoxTurtle):
                 and cur_lane.status != AFCLaneState.EJECTING
                 and cur_lane.status != AFCLaneState.CALIBRATING)
 
-    def prep_load(self, lane: AFCLane):
+    def prep_load(self, lane: AFCLane) -> None:
+        """
+        HTLF does not have prep switches, so there is nothing to do here.
+
+        :param lane: Lane prep loading would otherwise apply to
+        """
         # HTLF does not have prep switches returning
         return
 
-    def prep_post_load(self, lane: AFCLane):
+    def prep_post_load(self, lane: AFCLane) -> None:
+        """
+        HTLF does not have prep switches, so there is nothing to do here.
+
+        :param lane: Lane prep post-load would otherwise apply to
+        """
         # HTLF does not have prep switches returning
         return
 
-def load_config_prefix(config):
+def load_config_prefix(config: ConfigWrapper) -> AFC_HTLF:
+    """
+    Klipper config entry point for AFC_HTLF <name> sections.
+
+    :param config: Klipper config wrapper for the AFC_HTLF <name> section
+    :return type: AFC_HTLF instance to register with the printer
+    """
     return AFC_HTLF(config)

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -279,9 +279,8 @@ class AFCLane:
                                      self.load, AFCHomingPoints.LOAD)
 
         self._selector_state: Optional[bool] = None
-        self.selector_cal_dis: Optional[float] = None
+        self.selector_cal_dis: float = config.getfloat("selector_cal_distance", 0.0)
         if self.selector is not None:
-            self.selector_cal_dis = config.getfloat("selector_cal_distance", 0.0)
             show_sensor = True
             if not self.enable_sensors_in_gui or (self.sensor_to_show is not None and 'selector' not in self.sensor_to_show):
                 show_sensor = False
@@ -1761,7 +1760,9 @@ class AFCLane:
         """
         Sends lane data to moonrakers `machine/set_lane_data` endpoint
         """
-        if self.map is not None and "T" in self.map:
+        if (self.afc.moonraker
+            and self.map is not None
+            and "T" in self.map):
             scan_time = self.td1_data['scan_time'] if 'scan_time' in self.td1_data else ""
             td        = self.td1_data['td']        if 'td'        in self.td1_data else ""
 
@@ -1787,7 +1788,9 @@ class AFCLane:
         """
         Clears lane data that is currently stored at moonrakers `machine/set_lane_data` endpoint
         """
-        if self.map is not None and "T" in self.map:
+        if (self.afc.moonraker
+            and self.map is not None
+            and "T" in self.map):
             lane_data = {
                 "namespace": "lane_data",
                 "key": self.name,

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -692,7 +692,7 @@ class AFCExtruderStepper(AFCLane):
         self.logger.debug(f"{self.name} adding endstop {key}:{name}:{pin}") # TODO:remove once fully tested on toolchanger
         self._endstops[key] = (mcu_endstop, name)
 
-    def do_homing_move(self, movepos: int, speed: int, accel: int, endstop_spec:str,
+    def do_homing_move(self, movepos: float, speed: float, accel: float, endstop_spec:str,
                        triggered=True, check_trigger=True, assist_active=True) -> tuple[bool, float]:
         """
         Perform's a homing move using the specified endstop, speed/accel and distance.

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -56,17 +56,17 @@ class afcUnit:
         self.reactor        = self.printer.get_reactor()
         self.function       = self.afc.function
         self.logger         = self.afc.logger
-        self.type           = None
+        self.type           = ""
 
         self.lanes: Dict[str, AFCLane] = {}
         self._eject_to_calibrate = False
 
         # Objects
-        self.buffer_obj: Optional[AFCBuffer|None] = None
-        self.hub_obj: Optional[afc_hub|None]       = None
-        self.extruder_obj: Optional[AFCExtruder|None] = None
-        self.drive_stepper_obj: AFCExtruderStepper = None
-        self.selector_stepper_obj: AFCExtruderStepper = None
+        self.buffer_obj: Optional[AFCBuffer] = None
+        self.hub_obj: Optional[afc_hub]       = None
+        self.extruder_obj: Optional[AFCExtruder] = None
+        self.drive_stepper_obj: Optional[AFCExtruderStepper] = None
+        self.selector_stepper_obj: Optional[AFCExtruderStepper] = None
         self.stepperless_drive: bool = False
 
         # Config get section
@@ -181,8 +181,7 @@ class afcUnit:
         error_bool   = False
         config_name = f'AFC_stepper {self.drive_stepper}'
         if section_in_config(config, config_name):
-            self.drive_stepper_obj: Optional[AFCExtruderStepper] = \
-                self.printer.load_object(config, config_name, None)
+            self.drive_stepper_obj  = self.printer.load_object(config, config_name, None)
         error, rtn_str = self._check_and_errorout(self.drive_stepper_obj, config_name,
                                                   "drive_stepper")
         error_string += rtn_str
@@ -190,8 +189,7 @@ class afcUnit:
 
         config_name = f'AFC_stepper {self.selector_stepper}'
         if section_in_config(config, config_name):
-            self.selector_stepper_obj: Optional[AFCExtruderStepper] = \
-                self.printer.load_object(config, config_name, None)
+            self.selector_stepper_obj = self.printer.load_object(config, config_name, None)
 
         error, rtn_str = self._check_and_errorout(self.selector_stepper_obj, config_name,
                                                   "selector_stepper")

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -628,6 +628,20 @@ class afcUnit:
         """
         return True, 0.0
 
+    def _selector_cal_dis_adjust(self, lane: AFCLane) -> None:
+        """
+        Helper function for moving selector selector_cal_dis amount if specified in users config.
+        Moving selector_cal_dis is a fine adjustment that can help put more pressure on the filament
+        so that filament is not slipping in the gears when moving.
+
+        :param lane: Lane to check if selector_cal_dis is specified and move selector this amount
+        """
+        if (self.selector_stepper_obj
+            and lane.selector_cal_dis is not None
+            and lane.selector_cal_dis != 0.0):
+            self.selector_stepper_obj.move(lane.selector_cal_dis, lane.short_moves_speed,
+                                           lane.short_moves_accel, False)
+
     def return_to_home(self, prep=False):
         """
         Function to home unit if unit has homing sensor

--- a/extras/AFC_vivid.py
+++ b/extras/AFC_vivid.py
@@ -189,11 +189,8 @@ class AFC_vivid(afcBoxTurtle):
                     endstop_spec=lane.selector_endstop_name,
                     assist_active=False
                 )
-
-                if (lane.selector_cal_dis is not None
-                    and lane.selector_cal_dis != 0.0):
-                    self.selector_stepper_obj.move(lane.selector_cal_dis, lane.short_moves_speed,
-                                                   lane.short_moves_accel, False)
+                # Applying selector_cal_dis move if specified in users config
+                self._selector_cal_dis_adjust(lane)
 
                 self.logger.debug(f"{self.type}: Homing done, success:{homed}, distance:{distance}")
                 return homed, round(distance, 2)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -396,6 +396,7 @@ class MockAFC:
         self.enable_sensors_in_gui = False
         self.debounce_delay = 0.1
         self.enable_hub_runout = False
+        self.load_to_hub = True
         self.enable_tool_runout = True
         self.enable_runout_in_bypass = False
         self.show_macros = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,8 +31,13 @@ def _make_configfile_mock():
     """Mock for Klipper's configfile module (not the PyPI configfile package)."""
     mod = types.ModuleType("configfile")
 
-    class KlipperError(Exception):
-        """Klipper-style configuration error."""
+    # Real Klipper's ConfigWrapper.error IS configparser.Error (klippy/
+    # configfile.py: "class ConfigWrapper: error = configparser.Error") --
+    # reuse the same class here rather than a separate fake Exception type,
+    # so code that raises configparser.Error directly (as extras modules
+    # commonly do) and code that raises via configfile.error/config.error(...)
+    # are the same, catchable exception type in tests either way.
+    KlipperError = configparser.Error
 
     class ConfigWrapper:
         def __init__(self, printer=None, fileconfig=None, access_tracking=None, section=""):
@@ -534,6 +539,18 @@ class MockPrinter:
         return self.start_args
 
 
+class _MockConfigSentinel:
+    """Distinguishes "caller passed no default" from "caller explicitly
+    passed default=None" -- mirrors configfile.sentinel in real Klipper.
+    Needed because get(option, None) is a legitimate, common call (an
+    explicit optional value) that must NOT raise, while get(option) with no
+    default at all means the option is required and missing config must
+    raise, exactly like real Klipper does."""
+
+
+_MOCK_CONFIG_SENTINEL = _MockConfigSentinel()
+
+
 class MockConfig:
     """Mock for Klipper's ConfigWrapper, used to construct extras objects."""
 
@@ -551,21 +568,33 @@ class MockConfig:
     def get_name(self):
         return self._name
 
-    def get(self, option, default=None):
-        try:
-            val = self.fileconfig.get(self.section, option)
-        except:
-            val = self._values.get(option, default)
-        return val
+    def _require(self, option, default):
+        """Raises like real Klipper's ConfigWrapper when `option` isn't set
+        anywhere and the caller didn't pass a default; otherwise returns the
+        resolved value (config value if present, else the given default)."""
+        if option in self._values:
+            return self._values[option]
+        if default is _MOCK_CONFIG_SENTINEL:
+            from configfile import error as KlipperError
+            error_str = f"Option '{option}' in section '{self.section}' must be specified"
+            raise KlipperError(error_str)
+        return default
 
-    def getfloat(self, option, default=0.0, **kwargs):
-        val = self._values.get(option, default)
+    def get(self, option, default=_MOCK_CONFIG_SENTINEL):
+        try:
+            return self.fileconfig.get(self.section, option)
+        except Exception:
+            pass
+        return self._require(option, default)
+
+    def getfloat(self, option, default=_MOCK_CONFIG_SENTINEL, **kwargs):
+        val = self._require(option, default)
         if val is None:
             return None
         return float(val)
 
-    def getboolean(self, option, default=False, **kwargs):
-        val = self._values.get(option, default)
+    def getboolean(self, option, default=_MOCK_CONFIG_SENTINEL, **kwargs):
+        val = self._require(option, default)
         if val is None:
             return None
         if isinstance(val, bool):
@@ -574,19 +603,18 @@ class MockConfig:
             return val.lower() in ("true", "1", "yes")
         return bool(val)
 
-    def getint(self, option, default=0, **kwargs):
-        val = self._values.get(option, default)
-        if val is not None:
-            return int(val)
-        else:
-            return val
+    def getint(self, option, default=_MOCK_CONFIG_SENTINEL, **kwargs):
+        val = self._require(option, default)
+        if val is None:
+            return None
+        return int(val)
 
-    def getlist(self, option, default=None, **kwargs):
-        val = self._values.get(option, default)
+    def getlist(self, option, default=_MOCK_CONFIG_SENTINEL, **kwargs):
+        val = self._require(option, default)
         return val if val is not None else []
 
-    def getlists(self, option, default=None, **kwargs):
-        val = self._values.get(option, default)
+    def getlists(self, option, default=_MOCK_CONFIG_SENTINEL, **kwargs):
+        val = self._require(option, default)
         return val if val is not None else ()
 
     def error(self, msg):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -475,7 +475,11 @@ class MockPrinter:
         self._objects: dict = {}
         self.state_message = "Printer is ready"
         self.start_args: dict = {}
-        self.objects: dict = {}
+        # Real Klipper keeps a single objects dict backing both attribute
+        # names; alias them so writes through either name (lookup_object's
+        # cache vs. code that reaches into printer.objects directly, like
+        # AFC_utils.add_filament_switch) are visible from the other.
+        self.objects: dict = self._objects
         self._event_handlers: dict = {}
     
     def lookup_object(self, name, default=None):
@@ -505,9 +509,13 @@ class MockPrinter:
             self._objects[name] = val
         return val
 
-    def load_object(self, config, name):
+    _NO_DEFAULT = object()
+
+    def load_object(self, config, name, default=_NO_DEFAULT):
         result = self.lookup_object(name)
         if result is None:
+            if default is not self._NO_DEFAULT:
+                return default
             result = self._objects[name] = MagicMock()
 
         return result

--- a/tests/klippy/afc_htlf_commands.test
+++ b/tests/klippy/afc_htlf_commands.test
@@ -1,7 +1,7 @@
 # AFC lane-specific commands integration test
 #
 # Verifies GCode commands that require at least one AFC lane to be configured.
-# Uses a minimal BoxTurtle unit (unit_1) with one lane (lane1) and one hub
+# Uses a minimal HTLF unit (unit_1) with one lane (lane1) and one hub
 # (hub_1), all wired to simulated STM32H723 pins (PC0–PC5).
 #
 # Prerequisites:

--- a/tests/klippy/afc_htlf_commands.test
+++ b/tests/klippy/afc_htlf_commands.test
@@ -1,0 +1,32 @@
+# AFC lane-specific commands integration test
+#
+# Verifies GCode commands that require at least one AFC lane to be configured.
+# Uses a minimal BoxTurtle unit (unit_1) with one lane (lane1) and one hub
+# (hub_1), all wired to simulated STM32H723 pins (PC0–PC5).
+#
+# Prerequisites:
+#   - test/dict/stm32h723.dict must exist
+#   - KLIPPER_PATH must point to a Klipper clone with chelper built
+
+DICTIONARY stm32h723.dict
+CONFIG afc_htlf_unit.cfg
+
+# --- Per-lane metadata commands ---
+# SET_COLOR / SET_MATERIAL / SET_WEIGHT: update lane state then call save_vars
+# (save_vars returns early when prep_done=False) and send_lane_data
+# (which is a no-op when lane.map is None — no moonraker call).
+SET_COLOR LANE=lane1 COLOR=FF0000
+SET_MATERIAL LANE=lane1 MATERIAL=PLA
+SET_WEIGHT LANE=lane1 WEIGHT=500
+
+# Set position extremely negative so that homing endstop in kalico does not halt the test
+AFC_STEPPER_HOME STEPPER=HTLF_Drive ENABLE=1 SPEED=100 ACCEL=100 STOP_ON_ENDSTOP=1 DIST=500 ENDSTOP=lane1_load SYNC=1
+AFC_STEPPER_HOME STEPPER=HTLF_Selector ENABLE=1 SPEED=100 ACCEL=100 STOP_ON_ENDSTOP=1 DIST=500 ENDSTOP=HTLF_1_home SYNC=1
+
+# Test non-homing move
+AFC_STEPPER_HOME STEPPER=HTLF_Drive ENABLE=1 SPEED=100 ACCEL=100 STOP_ON_ENDSTOP=0 DIST=500 ENDSTOP=load SYNC=1
+AFC_STEPPER_HOME STEPPER=HTLF_Drive ENABLE=1 SPEED=100 ACCEL=100 STOP_ON_ENDSTOP=0 DIST=500 ENDSTOP=load SYNC=0
+
+AFC_RECOVER_LANE LANE=lane1
+AFC_SELECT_LANE LANE=lane2
+AFC_HOME_UNIT UNIT=HTLF_1

--- a/tests/klippy/afc_htlf_unit.cfg
+++ b/tests/klippy/afc_htlf_unit.cfg
@@ -1,7 +1,7 @@
 
-# Minimal Klipper + AFC configuration with one BoxTurtle unit and lane.
-# Extends the base configuration by adding a simulated AFC_BoxTurtle unit,
-# one AFC_stepper lane, and one AFC_hub — all using free STM32H723 pins
+# Minimal Klipper + AFC configuration with one HTLF unit and lane.
+# Extends the base configuration by adding a simulated AFC_HTLF unit,
+# two AFC_lane lane, and one AFC_hub — all using free STM32H723 pins
 # not consumed by the base printer kinematics (PA*/PB* are already used).
 #
 # Free pin bank used here: PC0–PC5
@@ -103,7 +103,7 @@ pid_Kd: 948.182
 
 # save_variables is required by AFC to persist spool/lane state.
 [save_variables]
-filename: /tmp/afc_klippy_lane_test.cfg
+filename: /tmp/afc_klippy_HTLF_test.cfg
 
 # pause_resume is required by AFC_error
 [pause_resume]

--- a/tests/klippy/afc_htlf_unit.cfg
+++ b/tests/klippy/afc_htlf_unit.cfg
@@ -1,0 +1,263 @@
+
+# Minimal Klipper + AFC configuration with one BoxTurtle unit and lane.
+# Extends the base configuration by adding a simulated AFC_BoxTurtle unit,
+# one AFC_stepper lane, and one AFC_hub — all using free STM32H723 pins
+# not consumed by the base printer kinematics (PA*/PB* are already used).
+#
+# Free pin bank used here: PC0–PC5
+#
+# This file duplicates the base printer/AFC config so that klippy can load it
+# as a standalone config without needing an include directive.
+
+# ---------------------------------------------------------------------------
+# MCU — path is irrelevant in dict/simulation mode
+# ---------------------------------------------------------------------------
+[mcu]
+serial: /dev/null
+
+# ---------------------------------------------------------------------------
+# Printer kinematics (required by Klipper)
+# ---------------------------------------------------------------------------
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100
+
+[stepper_x]
+step_pin: PA0
+dir_pin: PA1
+enable_pin: !PA2
+microsteps: 16
+rotation_distance: 40
+endstop_pin: PA3
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_y]
+step_pin: PA4
+dir_pin: PA5
+enable_pin: !PA6
+microsteps: 16
+rotation_distance: 40
+endstop_pin: PA7
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_z]
+step_pin: PB0
+dir_pin: PB1
+enable_pin: !PB2
+microsteps: 16
+rotation_distance: 8
+endstop_pin: PB3
+position_endstop: 0
+position_max: 200
+
+[extruder]
+step_pin: PB4
+dir_pin: PB5
+enable_pin: !PB6
+microsteps: 16
+rotation_distance: 33.5
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PB7
+sensor_type: temperature_host
+min_temp: 0
+max_temp: 250
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+
+[extruder1]
+step_pin: PE2
+dir_pin: PE3
+enable_pin: !PE4
+microsteps: 16
+rotation_distance: 33.5
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PE5
+sensor_type: temperature_host
+min_temp: 0
+max_temp: 250
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+
+[heater_bed]
+heater_pin: PB8
+sensor_type: temperature_host
+min_temp: 0
+max_temp: 130
+control: pid
+pid_Kp: 54.027
+pid_Ki: 0.770
+pid_Kd: 948.182
+
+# save_variables is required by AFC to persist spool/lane state.
+[save_variables]
+filename: /tmp/afc_klippy_lane_test.cfg
+
+# pause_resume is required by AFC_error
+[pause_resume]
+
+# ---------------------------------------------------------------------------
+# AFC core
+# ---------------------------------------------------------------------------
+
+[testing]
+
+[AFC]
+VarFile: /tmp/afc_klippy_lane_test.var
+long_moves_speed: 150
+long_moves_accel: 250
+short_moves_speed: 50
+short_moves_accel: 300
+short_move_dis: 10
+enable_sensors_in_gui: False
+load_to_hub: False
+z_hop: 5
+resume_speed: 120
+resume_z_speed: 30
+error_timeout: 36000
+tool_cut: False
+park: False
+poop: False
+kick: False
+wipe: False
+form_tip: False
+
+[AFC_prep]
+enable: False
+
+[AFC_form_tip]
+cooling_tube_position: 35
+cooling_tube_length: 10
+cooling_moves: 4
+
+# ---------------------------------------------------------------------------
+# One BoxTurtle unit with a single lane — uses PC0–PC5 (all free)
+# ---------------------------------------------------------------------------
+
+# AFC extruder wrapper (required so AFC_stepper can link to an extruder object)
+[AFC_extruder extruder]
+# No tool_start / tool_end sensor pins — keep config minimal.
+
+[AFC_extruder extruder1]
+
+[AFC_HTLF HTLF_1]
+extruder: extruder
+# buffer: TN0
+drive_stepper: HTLF_Drive
+selector_stepper: HTLF_Selector
+home_pin: PE0
+cam_angle: 60
+MAX_ANGLE_MOVEMENT:220
+mm_move_per_rotation: 40        # 20T
+long_moves_speed:150
+long_moves_accel:50
+
+[AFC_stepper HTLF_Drive]
+unit: HTLF_1
+step_pin: PC0
+dir_pin: PC1
+enable_pin: PC2
+microsteps: 16
+rotation_distance: 24.0724224      #Calibrate for your setup
+gear_ratio: 80:20
+hub: direct # TODO fix this, hub not required for drive and stepper for htlf
+
+[tmc2209 AFC_stepper HTLF_Drive]
+uart_pin: PC3
+uart_address: 0
+run_current: 1.0
+sense_resistor: 0.110
+
+[AFC_stepper HTLF_Selector]
+unit: HTLF_1
+step_pin: PD0
+dir_pin: PD1
+enable_pin: PD2
+microsteps: 16
+rotation_distance: 40          # 20T
+gear_ratio: 80:20              # 20T
+hub: direct
+
+[tmc2209 AFC_stepper HTLF_Selector]
+uart_pin: PD3
+uart_address: 0
+run_current: 0.8
+hold_current: 0.4
+sense_resistor: 0.110
+
+[AFC_lane lane1]
+unit: HTLF_1:1
+dist_hub: 1560.5 
+led_index: AFC_Indicator_HTLF_1:4
+load: PC4
+map: T0
+hub: direct
+extruder: extruder
+buffer: PSF_buffer1
+debounce_delay: 2
+
+[AFC_lane lane2]
+unit: HTLF_1:4
+dist_hub: 765.0 
+led_index: AFC_Indicator_HTLF_1:1
+load: PC5
+map: T3
+hub: HTLF_1
+extruder: extruder1
+buffer: TN2
+selector_cal_distance: 2
+
+[AFC_hub HTLF_1]
+afc_bowden_length: 1095.24       # Length of the Bowden tube from the hub to the toolhead sensor in mm.
+afc_unload_bowden_length: 1095.24 
+move_dis: 60                   # Distance to move the filament within the hub in mm.
+hub_clear_move_dis: 55
+cut: False                      # Hub has Cutter
+cut_servo_name: hub_cut
+cut_confirm: True
+cut_cmd: AFC
+switch_pin: PC6
+
+[AFC_buffer TN2]
+advance_pin: PD4
+trailing_pin: PD5
+multiplier_high: 1.15
+multiplier_low: 0.90
+debug: 1
+
+[AFC_buffer PSF_buffer1]
+type: FPS_PSF
+adc_pin: PE1
+neutral_point: 0.5
+max_tension: 0.1
+max_compression: 0.9
+reversed: True
+sample_time: 0.002      # was 0.005  — MCU sample spacing
+sample_count: 4         # was 5      — samples per report (×sample_time = 8ms window)
+report_time: 0.010      # was 0.100  — host gets a fresh reading every 10ms (10x faster)
+debug: True
+integral_gain: 0.01
+filament_error_sensitivity: 7
+# integral_gain: 0.005
+enable_integral_correction: True
+
+[AFC_led AFC_Indicator_HTLF_1]
+pin: PD6
+chain_count: 4
+color_order: GRBW
+initial_RED: 0.0
+initial_GREEN: 0.0
+initial_BLUE: 0.0
+initial_WHITE: 0.0

--- a/tests/test_AFC_HTLF.py
+++ b/tests/test_AFC_HTLF.py
@@ -284,7 +284,7 @@ class TestHTLFInit:
         printer.lookup_object("pins").setup_pin = MagicMock(return_value=None)
         unit = AFC_HTLF(config)
         assert unit.home_endstop is None
-        unit.selector_stepper_obj.add_stepper.assert_not_called()
+        assert unit.selector_stepper_obj._endstops == {}
 
     # -- endstop registration failure --
 

--- a/tests/test_AFC_HTLF.py
+++ b/tests/test_AFC_HTLF.py
@@ -9,59 +9,67 @@ Covers:
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+import sys
+import importlib.util
+import configparser
+from unittest.mock import MagicMock, patch, call
 import pytest
 
 from extras.AFC_HTLF import AFC_HTLF
 from extras.AFC_BoxTurtle import afcBoxTurtle
+from extras.AFC_lane import AFCLaneState
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
-def _make_htlf(name="HTLF_1"):
-    """Build an AFC_HTLF bypassing the complex __init__."""
-    unit = AFC_HTLF.__new__(AFC_HTLF)
+def _make_htlf_config(name="HTLF_1", values=None, drive_stepper="drive",
+                       selector_stepper="selector", add_stepper_sections=True):
+    """Build the MockConfig/MockPrinter/MockAFC trio needed to construct an
+    AFC_HTLF via its real __init__ (chained through afcBoxTurtle.__init__
+    and afcUnit.__init__), without actually constructing it -- lets a test
+    drive AFC_HTLF(config) itself, e.g. to assert a config_error is raised.
 
-    from tests.conftest import MockAFC, MockPrinter, MockLogger, MockReactor
+    Registers [AFC_stepper <drive_stepper>]/[AFC_stepper <selector_stepper>]
+    config sections and matching MagicMock stepper objects in the printer's
+    object cache so afcUnit._lookup_objects resolves drive_stepper_obj/
+    selector_stepper_obj successfully; selector_stepper_obj._endstops is a
+    real dict since AFC_HTLF.__init__ does `selector_stepper_obj._endstops
+    [name] = ...` (item assignment, which a bare MagicMock doesn't support).
+    """
+    from tests.conftest import MockAFC, MockConfig, MockPrinter
 
     afc = MockAFC()
-    reactor = MockReactor()
-    afc.reactor = reactor
-    afc.logger = MockLogger()
     printer = MockPrinter(afc=afc)
 
-    unit.printer = printer
-    unit.afc = afc
-    unit.logger = afc.logger
-    unit.reactor = reactor
-    unit.name = name
-    unit.full_name = ["AFC_HTLF", name]
-    unit.lanes = {}
-    unit.hub_obj = None
-    unit.extruder_obj = None
-    unit.buffer_obj = None
-    unit.hub = None
-    unit.extruder = None
-    unit.buffer_name = None
-    unit.td1_defined = False
-    unit.type = "HTLF"
-    unit.gcode = afc.gcode
-    unit.drive_stepper = "drive"
-    unit.selector_stepper = "selector"
-    unit.drive_stepper_obj = MagicMock()
-    unit.selector_stepper_obj = MagicMock()
-    unit.current_selected_lane = None
-    unit.home_state = False
-    unit.mm_move_per_rotation = 32
-    unit.cam_angle = 60
-    unit.home_pin = "PA1"
-    unit.MAX_ANGLE_MOVEMENT = 215
-    unit.enable_sensors_in_gui = False
-    unit.prep_homed = False
-    unit.failed_to_home = False
-    unit.lobe_current_pos = 0
+    all_values = {
+        "drive_stepper": drive_stepper,
+        "selector_stepper": selector_stepper,
+        "cam_angle": 60,
+        "home_pin": "PA1",
+    }
+    if values:
+        all_values.update(values)
 
-    return unit
+    config = MockConfig(name=f"AFC_HTLF {name}", printer=printer, values=all_values)
+
+    if add_stepper_sections:
+        config.fileconfig.add_section(f"AFC_stepper {drive_stepper}")
+        config.fileconfig.add_section(f"AFC_stepper {selector_stepper}")
+        selector_obj = MagicMock()
+        selector_obj._endstops = {}
+        printer._objects[f"AFC_stepper {drive_stepper}"] = MagicMock()
+        printer._objects[f"AFC_stepper {selector_stepper}"] = selector_obj
+
+    return config, printer, afc
+
+
+def _make_htlf(name="HTLF_1", values=None, **kwargs):
+    """Build a real AFC_HTLF via its actual __init__. See
+    _make_htlf_config for what's pre-wired; defaults reproduce a normal,
+    fully-successful construction (cam_angle=60, home_pin="PA1", drive/
+    selector steppers resolved)."""
+    config, printer, afc = _make_htlf_config(name=name, values=values, **kwargs)
+    return AFC_HTLF(config)
 
 
 # ── Inheritance ───────────────────────────────────────────────────────────────
@@ -76,6 +84,195 @@ class TestHTLFInheritance:
 class TestHTLFConstants:
     def test_valid_cam_angles(self):
         assert AFC_HTLF.VALID_CAM_ANGLES == [30, 45, 60]
+
+    def test_home_unit_cmd_option_default(self):
+        assert AFC_HTLF.cmd_AFC_HOME_UNIT_options == {
+            "UNIT": {"type": "string", "default": "HTLF_1"}
+        }
+
+
+# ── __init__ ──────────────────────────────────────────────────────────────────
+
+class TestHTLFInit:
+    """Covers AFC_HTLF's own __init__ logic: reading its config variables,
+    the cam_angle validation, and the home-pin-dependent endstop/filament
+    switch setup. afcUnit/afcBoxTurtle's own __init__ bodies are pre-existing
+    behavior out of scope here."""
+
+    # -- config variable passthrough --
+
+    def test_defaults_when_not_set_in_config(self):
+        """Every config value AFC_HTLF.__init__ reads with a fallback default
+        (mm_move_per_rotation, MAX_ANGLE_MOVEMENT, selector_movement_speed/
+        accel, type), plus the fixed/derived attributes it always sets up
+        front (current_selected_lane, home_state, prep_homed,
+        failed_to_home, _homed_distance, lobe_current_pos) -- verified
+        together in one construction since none of them depend on each
+        other, so a single _make_htlf() call is enough to exercise all of
+        them at once."""
+        unit = _make_htlf()
+        assert unit.type == "HTLF"
+        assert unit.mm_move_per_rotation == 32
+        assert unit.MAX_ANGLE_MOVEMENT == 215
+        assert unit.selector_movement_speed == 50.0
+        assert unit.selector_movement_accel == 50.0
+        assert unit.current_selected_lane is None
+        assert unit.home_state is False
+        assert unit.prep_homed is False
+        assert unit.failed_to_home is False
+        assert unit._homed_distance == 0.0
+        assert unit.lobe_current_pos == 0
+
+    def test_reads_overridden_values_from_config(self):
+        """Mirror of test_defaults_when_not_set_in_config: the same set of
+        config-backed variables (plus drive_stepper/selector_stepper/
+        cam_angle/home_pin, which have no fallback default to compare
+        against), each given a distinct non-default value in one config and
+        verified to come back unchanged -- proving each is actually read
+        from its own config key, not several all reading the same one."""
+        unit = _make_htlf(
+            drive_stepper="drive_a",
+            selector_stepper="selector_b",
+            values={
+                "type": "CustomHTLF",
+                "mm_move_per_rotation": 40,
+                "cam_angle": 45,
+                "home_pin": "PB3",
+                "MAX_ANGLE_MOVEMENT": 180,
+                "selector_movement_speed": 75.0,
+                "selector_movement_accel": 90.0,
+                "enable_sensors_in_gui": True,
+            },
+        )
+        assert unit.type == "CustomHTLF"
+        assert unit.drive_stepper == "drive_a"
+        assert unit.selector_stepper == "selector_b"
+        assert unit.mm_move_per_rotation == 40
+        assert unit.cam_angle == 45
+        assert unit.home_pin == "PB3"
+        assert unit.MAX_ANGLE_MOVEMENT == 180
+        assert unit.selector_movement_speed == 75.0
+        assert unit.selector_movement_accel == 90.0
+        assert unit.enable_sensors_in_gui is True
+
+    def test_enable_sensors_in_gui_falls_back_to_afc_value(self):
+        """When not set in this unit's own config, enable_sensors_in_gui
+        falls back to afc.enable_sensors_in_gui rather than a fixed
+        default -- proven by setting the afc-level value and confirming it
+        propagates with no per-unit override present. Kept separate from
+        the defaults/overrides tests above since it needs its own afc
+        object rather than the config values dict."""
+        config, printer, afc = _make_htlf_config()
+        afc.enable_sensors_in_gui = True
+        unit = AFC_HTLF(config)
+        assert unit.enable_sensors_in_gui is True
+
+    # -- cam_angle validation --
+
+    @pytest.mark.parametrize("valid_angle", [30, 45, 60])
+    def test_valid_cam_angle_does_not_raise(self, valid_angle):
+        unit = _make_htlf(values={"cam_angle": valid_angle})
+        assert unit.cam_angle == valid_angle
+
+    def test_invalid_cam_angle_raises_config_error(self):
+        with pytest.raises(configparser.Error) as exc_info:
+            _make_htlf(values={"cam_angle": 90})
+        assert str(exc_info.value) == (
+            "90 is not a valid cam angle, please choose from the following [30, 45, 60]"
+        )
+
+    # -- buttons / command registration (always run, independent of home_pin) --
+
+    def test_registers_home_callback_button(self):
+        config, printer, afc = _make_htlf_config(values={"home_pin": "PA1"})
+        unit = AFC_HTLF(config)
+        buttons_mock = printer._objects["buttons"]
+        buttons_mock.register_buttons.assert_called_once_with(["PA1"], unit.home_callback)
+
+    def test_registers_afc_home_unit_command(self):
+        unit = _make_htlf()
+        unit.afc.function.register_commands.assert_called_once_with(
+            unit.afc.show_macros, "AFC_HOME_UNIT",
+            unit.cmd_AFC_HOME_UNIT,
+            description=AFC_HTLF.cmd_AFC_HOME_UNIT_help,
+            options=AFC_HTLF.cmd_AFC_HOME_UNIT_options,
+        )
+
+    # -- home_pin is None: endstop/filament-switch setup fully skipped --
+
+    def test_home_pin_none_leaves_home_endstop_none(self):
+        unit = _make_htlf(values={"home_pin": None})
+        assert unit.home_endstop is None
+        assert unit.home_endstop_name is None
+
+    def test_home_pin_none_does_not_set_home_sensor(self):
+        unit = _make_htlf(values={"home_pin": None})
+        assert not hasattr(unit, "home_sensor")
+
+    def test_home_pin_none_does_not_add_stepper_to_endstop(self):
+        unit = _make_htlf(values={"home_pin": None})
+        unit.selector_stepper_obj.add_stepper.assert_not_called()
+
+    # -- home_pin is set: endstop/filament-switch setup runs --
+
+    def test_home_pin_set_creates_home_sensor(self):
+        # enable_sensors_in_gui=True avoids add_filament_switch's
+        # show_sensor=False rename (which prefixes the cached object's key
+        # with "_"), keeping this test focused on home_sensor's identity.
+        unit = _make_htlf(values={"home_pin": "PA1", "enable_sensors_in_gui": True})
+        expected_name = f"filament_switch_sensor {unit.name}_home_pin"
+        assert unit.home_sensor is unit.printer._objects[expected_name]
+
+    def test_home_pin_set_strips_prefix_chars_for_allow_multi_use_pin(self):
+        """allow_multi_use_pin is called with the stripped pin twice: once
+        from inside add_filament_switch's own setup, once from AFC_HTLF's
+        own endstop setup right after."""
+        config, printer, afc = _make_htlf_config(values={"home_pin": "!PA1^"})
+        AFC_HTLF(config)
+        ppins = printer._objects["pins"]
+        assert ppins.allow_multi_use_pin.call_args_list == [call("PA1"), call("PA1")]
+
+    def test_home_pin_set_calls_parse_pin(self):
+        config, printer, afc = _make_htlf_config(values={"home_pin": "PA1"})
+        AFC_HTLF(config)
+        ppins = printer._objects["pins"]
+        ppins.parse_pin.assert_called_once_with("PA1", True, True)
+
+    def test_home_pin_set_sets_home_endstop_name(self):
+        unit = _make_htlf(name="HTLF_2", values={"home_pin": "PA1"})
+        assert unit.home_endstop_name == "HTLF_2_home"
+
+    def test_home_pin_set_registers_endstop_with_query_endstops(self):
+        config, printer, afc = _make_htlf_config(values={"home_pin": "PA1"})
+        unit = AFC_HTLF(config)
+        query_endstops = printer._objects["query_endstops"]
+        query_endstops.register_endstop.assert_called_once_with(
+            unit.home_endstop, unit.home_endstop_name
+        )
+
+    def test_home_pin_set_adds_stepper_to_home_endstop(self):
+        unit = _make_htlf(values={"home_pin": "PA1"})
+        unit.home_endstop.add_stepper.assert_called_once_with(
+            unit.selector_stepper_obj.extruder_stepper.stepper
+        )
+
+    def test_home_pin_set_registers_endstop_on_selector_stepper(self):
+        unit = _make_htlf(values={"home_pin": "PA1"})
+        assert unit.selector_stepper_obj._endstops[unit.home_endstop_name] == \
+            (unit.home_endstop, unit.home_endstop_name)
+
+    # -- endstop registration failure --
+
+    def test_endstop_registration_failure_raises_config_error(self):
+        config, printer, afc = _make_htlf_config(values={"home_pin": "PA1"})
+        query_endstops = MagicMock()
+        query_endstops.register_endstop.side_effect = Exception("boom")
+        printer._objects["query_endstops"] = query_endstops
+        with pytest.raises(configparser.Error) as exc_info:
+            AFC_HTLF(config)
+        assert str(exc_info.value) == (
+            "Error trying to register home endstop for HTLF_1.\n Error:boom"
+        )
 
 
 # ── home_callback ─────────────────────────────────────────────────────────────
@@ -97,3 +294,657 @@ class TestHomeCallback:
         for state in [True, False, True]:
             unit.home_callback(eventtime=0.0, state=state)
             assert unit.home_state is state
+
+
+# ── handle_connect ────────────────────────────────────────────────────────────
+
+class TestHandleConnect:
+    """afcBoxTurtle.handle_connect (and afcUnit.handle_connect beneath it) is
+    real, pre-existing behavior out of scope here -- isolated via
+    patch.object so only AFC_HTLF's own override logic is exercised."""
+
+    def test_calls_super_handle_connect(self):
+        unit = _make_htlf()
+        super_mock = MagicMock()
+        with patch.object(afcBoxTurtle, "handle_connect", super_mock):
+            unit.handle_connect()
+        super_mock.assert_called_once_with()
+
+    def test_sets_htlf_specific_logo(self):
+        unit = _make_htlf()
+        with patch.object(afcBoxTurtle, "handle_connect", MagicMock()):
+            unit.handle_connect()
+        assert unit.logo == '<span class=success--text>HTLF Ready\n</span>'
+
+    def test_sets_htlf_specific_logo_error(self):
+        unit = _make_htlf()
+        with patch.object(afcBoxTurtle, "handle_connect", MagicMock()):
+            unit.handle_connect()
+        assert unit.logo_error == '<span class=error--text>HTLF Not Ready</span>\n'
+
+
+# ── system_Test ───────────────────────────────────────────────────────────────
+
+class TestSystemTest:
+    """afcBoxTurtle.system_Test is real, pre-existing behavior out of scope
+    here -- isolated via patch.object so only AFC_HTLF's own wrapper logic
+    (prep-homing, return_to_home bookkeeping, combined return value) is
+    exercised."""
+
+    def _make(self, prep_homed=False, super_return=True):
+        unit = _make_htlf()
+        unit.prep_homed = prep_homed
+        unit.return_to_home = MagicMock()
+        cur_lane = MagicMock()
+        cur_lane.load_state = True
+        cur_lane.prep_state = False
+        return unit, cur_lane, super_return
+
+    def test_sets_prep_state_from_load_state(self):
+        unit, cur_lane, _ = self._make()
+        with patch.object(afcBoxTurtle, "system_Test", MagicMock(return_value=True)):
+            unit.system_Test(cur_lane, 1.0, False, True)
+        assert cur_lane.prep_state is True
+
+    def test_calls_return_to_home_prep_first_when_not_prep_homed(self):
+        unit, cur_lane, _ = self._make(prep_homed=False)
+        with patch.object(afcBoxTurtle, "system_Test", MagicMock(return_value=True)):
+            unit.system_Test(cur_lane, 1.0, False, True)
+        assert unit.return_to_home.call_args_list[0] == \
+            call(prep=True, disable_selector=False)
+
+    def test_skips_prep_return_to_home_when_already_prep_homed(self):
+        """When prep_homed is already True, only the final unconditional
+        return_to_home() call happens -- proving the guard actually skipped
+        the prep=True call rather than it happening to look the same."""
+        unit, cur_lane, _ = self._make(prep_homed=True)
+        with patch.object(afcBoxTurtle, "system_Test", MagicMock(return_value=True)):
+            unit.system_Test(cur_lane, 1.0, False, True)
+        assert unit.return_to_home.call_args_list == [call()]
+
+    def test_always_calls_return_to_home_unconditionally_after_super(self):
+        unit, cur_lane, _ = self._make(prep_homed=False)
+        with patch.object(afcBoxTurtle, "system_Test", MagicMock(return_value=True)):
+            unit.system_Test(cur_lane, 1.0, False, True)
+        assert unit.return_to_home.call_args_list[-1] == call()
+
+    def test_calls_super_system_test_with_correct_args(self):
+        unit, cur_lane, _ = self._make(prep_homed=True)
+        super_mock = MagicMock(return_value=True)
+        with patch.object(afcBoxTurtle, "system_Test", super_mock):
+            unit.system_Test(cur_lane, 2.5, True, False)
+        super_mock.assert_called_once_with(cur_lane, 2.5, True, False)
+
+    def test_returns_true_when_prep_homed_true_and_status_true(self):
+        unit, cur_lane, _ = self._make(prep_homed=True)
+        with patch.object(afcBoxTurtle, "system_Test", MagicMock(return_value=True)):
+            result = unit.system_Test(cur_lane, 1.0, False, True)
+        assert result is True
+
+    def test_returns_false_when_prep_homed_false_even_if_status_true(self):
+        """Proves the "and" actually depends on prep_homed, not just status --
+        status alone is True here yet the result must be False."""
+        unit, cur_lane, _ = self._make(prep_homed=False)
+        # return_to_home is mocked out, so it won't flip prep_homed to True.
+        with patch.object(afcBoxTurtle, "system_Test", MagicMock(return_value=True)):
+            result = unit.system_Test(cur_lane, 1.0, False, True)
+        assert result is False
+
+    def test_returns_false_when_status_false_even_if_prep_homed_true(self):
+        """Proves the "and" actually depends on status, not just prep_homed --
+        prep_homed alone is True here yet the result must be False."""
+        unit, cur_lane, _ = self._make(prep_homed=True)
+        with patch.object(afcBoxTurtle, "system_Test", MagicMock(return_value=False)):
+            result = unit.system_Test(cur_lane, 1.0, False, True)
+        assert result is False
+
+
+# ── cmd_AFC_HOME_UNIT ─────────────────────────────────────────────────────────
+
+class TestCmdAfcHomeUnit:
+    def test_calls_return_to_home(self):
+        unit = _make_htlf()
+        unit.return_to_home = MagicMock()
+        unit.cmd_AFC_HOME_UNIT(MagicMock())
+        unit.return_to_home.assert_called_once_with()
+
+
+# ── return_to_home ───────────────────────────────────────────────────────────
+
+def _convergent_move_selector_home(unit, iterations=1, homed_distance=5.0):
+    """Side effect for a mocked _move_selector_home: sets unit.home_state to
+    True once called `iterations` times, and stashes homed_distance into
+    unit._homed_distance on every call (mirrors what the real method does
+    when homing_enabled). Used to make return_to_home's while loop converge
+    deterministically instead of spinning forever on a fully-mocked stepper."""
+    state = {"n": 0}
+    def _side_effect(distance):
+        state["n"] += 1
+        unit._homed_distance = homed_distance
+        if state["n"] >= iterations:
+            unit.home_state = True
+    return _side_effect
+
+
+class TestReturnToHome:
+    # -- fast-move block: "current_selected_lane is not None and not
+    #    home_state and not prep" (each condition tested independently) --
+
+    def test_fast_move_skipped_when_current_selected_lane_none(self):
+        unit = _make_htlf()
+        unit.current_selected_lane = None
+        unit.home_state = True  # also short-circuits the loop
+        unit._move_selector_home = MagicMock()
+        unit.return_to_home()
+        unit._move_selector_home.assert_not_called()
+
+    def test_fast_move_skipped_when_home_state_already_true(self):
+        unit = _make_htlf()
+        unit.current_selected_lane = MagicMock(index=1)
+        unit.home_state = True
+        unit._move_selector_home = MagicMock()
+        unit.return_to_home()
+        unit._move_selector_home.assert_not_called()
+
+    def test_fast_move_skipped_when_prep_true(self):
+        """Distinguished from "fast-move ran" via call count: if the fast
+        move (skipped here) had run, _move_selector_home would be called
+        twice (fast-move + one loop iteration) instead of once."""
+        unit = _make_htlf()
+        unit.current_selected_lane = MagicMock(index=2)
+        unit.home_state = False
+        unit.afc.homing_enabled = True
+        unit._move_selector_home = MagicMock(
+            side_effect=_convergent_move_selector_home(unit, iterations=1)
+        )
+        unit.return_to_home(prep=True)
+        assert unit._move_selector_home.call_count == 1
+
+    def test_fast_move_runs_with_200_when_all_conditions_true_and_homing_enabled(self):
+        unit = _make_htlf()
+        unit.current_selected_lane = MagicMock(index=2)
+        unit.home_state = False
+        unit.afc.homing_enabled = True
+        # iterations=2: the fast-move call is the 1st, so home_state only
+        # flips true on the 2nd (first loop) call -- proving both happened.
+        unit._move_selector_home = MagicMock(
+            side_effect=_convergent_move_selector_home(unit, iterations=2)
+        )
+        unit.return_to_home(prep=False)
+        assert unit._move_selector_home.call_args_list[0] == call(200)
+        assert unit._move_selector_home.call_count == 2  # fast-move + 1 loop iteration
+
+    def test_fast_move_uses_calculated_distance_when_homing_disabled(self):
+        unit = _make_htlf()
+        lane = MagicMock(index=3)
+        unit.current_selected_lane = lane
+        unit.home_state = False
+        unit.afc.homing_enabled = False
+        unit.calculate_lobe_movement = MagicMock(return_value=17.5)
+        unit._move_selector_home = MagicMock(
+            side_effect=_convergent_move_selector_home(unit, iterations=1)
+        )
+        unit.return_to_home(prep=False)
+        unit.calculate_lobe_movement.assert_called_once_with(3)
+        assert unit._move_selector_home.call_args_list[0] == call(17.5)
+
+    # -- main while loop --
+
+    def test_loop_skipped_when_home_state_already_true(self):
+        unit = _make_htlf()
+        unit.current_selected_lane = None
+        unit.home_state = True
+        unit.prep_homed = False
+        unit._move_selector_home = MagicMock()
+        result = unit.return_to_home()
+        unit._move_selector_home.assert_not_called()
+        assert result is True
+        assert unit.prep_homed is True
+
+    def test_loop_runs_until_home_state_becomes_true(self):
+        unit = _make_htlf()
+        unit.current_selected_lane = None
+        unit.home_state = False
+        unit.afc.homing_enabled = True
+        unit._move_selector_home = MagicMock(
+            side_effect=_convergent_move_selector_home(unit, iterations=3, homed_distance=2.0)
+        )
+        result = unit.return_to_home()
+        assert unit._move_selector_home.call_count == 3
+        assert result is True
+
+    def test_loop_uses_move_distance_1_when_homing_disabled(self):
+        unit = _make_htlf()
+        unit.current_selected_lane = None
+        unit.home_state = False
+        unit.afc.homing_enabled = False
+        unit._move_selector_home = MagicMock(
+            side_effect=_convergent_move_selector_home(unit, iterations=1)
+        )
+        unit.return_to_home()
+        unit._move_selector_home.assert_called_once_with(1)
+
+    def test_total_moved_accumulates_homed_distance_when_homing_enabled(self):
+        """Verified via the failed_to_home threshold: with homing_enabled
+        True, each iteration adds self._homed_distance (30, already over the
+        ~24.44 threshold for the default mm_move_per_rotation/MAX_ANGLE_
+        MOVEMENT/cam_angle) to total_moved, tripping failure on the very
+        first iteration -- proving total_moved is driven by _homed_distance,
+        not move_distance, in this branch."""
+        unit = _make_htlf()
+        unit.current_selected_lane = None
+        unit.home_state = False
+        unit.afc.homing_enabled = True
+        unit._move_selector_home = MagicMock(
+            side_effect=lambda d: setattr(unit, "_homed_distance", 30.0)
+        )
+        result = unit.return_to_home()
+        assert result is False
+        assert unit.failed_to_home is True
+        assert unit._move_selector_home.call_count == 1
+        unit.afc.error.AFC_error.assert_called_once_with(
+            f"Failed to home {unit.name}", False
+        )
+
+    def test_total_moved_accumulates_move_distance_when_homing_disabled(self):
+        """With homing_enabled False, move_distance is fixed at 1 per
+        iteration, so the ~24.44 threshold isn't crossed until the 25th
+        call -- computed independently here rather than mirroring the
+        source's own formula."""
+        unit = _make_htlf()
+        unit.current_selected_lane = None
+        unit.home_state = False
+        unit.afc.homing_enabled = False
+        unit._move_selector_home = MagicMock()  # never sets home_state
+        result = unit.return_to_home()
+        assert result is False
+        assert unit.failed_to_home is True
+        assert unit._move_selector_home.call_count == 25
+
+    def test_prep_homed_not_changed_when_failed_to_home(self):
+        """The early-return failure path exits before "self.prep_homed =
+        True", so prep_homed must remain whatever it was set to before."""
+        unit = _make_htlf()
+        unit.current_selected_lane = None
+        unit.home_state = False
+        unit.prep_homed = False
+        unit.afc.homing_enabled = True
+        unit._move_selector_home = MagicMock(
+            side_effect=lambda d: setattr(unit, "_homed_distance", 30.0)
+        )
+        unit.return_to_home()
+        assert unit.prep_homed is False
+
+    # -- success-path bookkeeping --
+
+    def test_prep_homed_set_true_on_success(self):
+        unit = _make_htlf()
+        unit.current_selected_lane = None
+        unit.home_state = True
+        unit.prep_homed = False
+        unit.return_to_home()
+        assert unit.prep_homed is True
+
+    def test_current_selected_lane_reset_to_none_on_success(self):
+        unit = _make_htlf()
+        unit.current_selected_lane = MagicMock(index=1)
+        unit.home_state = True
+        unit.return_to_home()
+        assert unit.current_selected_lane is None
+
+    def test_disable_selector_true_calls_do_enable_false_on_success(self):
+        unit = _make_htlf()
+        unit.current_selected_lane = None
+        unit.home_state = True
+        unit.return_to_home(disable_selector=True)
+        unit.selector_stepper_obj.do_enable.assert_called_once_with(False)
+
+    def test_disable_selector_false_skips_do_enable_on_success(self):
+        unit = _make_htlf()
+        unit.current_selected_lane = None
+        unit.home_state = True
+        unit.return_to_home(disable_selector=False)
+        unit.selector_stepper_obj.do_enable.assert_not_called()
+
+    def test_returns_true_on_success(self):
+        unit = _make_htlf()
+        unit.current_selected_lane = None
+        unit.home_state = True
+        assert unit.return_to_home() is True
+
+
+# ── calculate_lobe_movement ──────────────────────────────────────────────────
+
+class TestCalculateLobeMovement:
+    def test_lane_index_one_uses_full_max_angle(self):
+        unit = _make_htlf()
+        unit.MAX_ANGLE_MOVEMENT = 215
+        unit.cam_angle = 60
+        unit.mm_move_per_rotation = 32
+        # Computed independently: angle = 215 - (0 * 60) = 215;
+        # (32/360)*215 = 19.111...
+        result = unit.calculate_lobe_movement(1)
+        assert result == pytest.approx(19.111111111111114)
+
+    def test_higher_lane_index_reduces_angle_by_cam_angle_per_step(self):
+        unit = _make_htlf()
+        unit.MAX_ANGLE_MOVEMENT = 215
+        unit.cam_angle = 60
+        unit.mm_move_per_rotation = 32
+        # Computed independently: angle = 215 - (2 * 60) = 95;
+        # (32/360)*95 = 8.444...
+        result = unit.calculate_lobe_movement(3)
+        assert result == pytest.approx(8.444444444444445)
+
+    def test_logs_debug_with_angle(self):
+        unit = _make_htlf()
+        unit.MAX_ANGLE_MOVEMENT = 215
+        unit.cam_angle = 60
+        unit.calculate_lobe_movement(2)
+        # angle = 215 - (1 * 60) = 155
+        assert unit.logger.messages == [("debug", "HTLF: Lobe Movement angle : 155")]
+
+
+# ── select_lane ───────────────────────────────────────────────────────────────
+
+class TestSelectLane:
+    def test_stepper_in_fullname_returns_false_immediately(self):
+        """"stepper" in lane.fullname.lower() short-circuits before the try
+        block, so the finally's do_enable(False) must not fire either, even
+        with disable_selector=True."""
+        unit = _make_htlf()
+        lane = MagicMock()
+        lane.fullname = "AFC_stepper lane1"
+        result = unit.select_lane(lane, disable_selector=True)
+        assert result == (False, 0.0)
+        unit.selector_stepper_obj.do_enable.assert_not_called()
+
+    def test_different_lane_and_home_succeeds_moves_and_selects(self):
+        unit = _make_htlf()
+        unit.current_selected_lane = None
+        unit.return_to_home = MagicMock(return_value=True)
+        unit._homed_distance = 3.5
+        unit.calculate_lobe_movement = MagicMock(return_value=12.0)
+        lane = MagicMock()
+        lane.fullname = "AFC_HTLF lane2"
+        lane.index = 2
+        lane.name = "lane2"
+        result = unit.select_lane(lane)
+        unit.selector_stepper_obj.move.assert_called_once_with(
+            12.0, unit.selector_movement_speed, unit.selector_movement_accel, False
+        )
+        assert unit.current_selected_lane is lane
+        assert result == (True, 3.5)
+
+    def test_different_lane_and_home_fails_logs_error_and_returns_false(self):
+        unit = _make_htlf()
+        unit.current_selected_lane = None
+        unit.return_to_home = MagicMock(return_value=False)
+        lane = MagicMock()
+        lane.fullname = "AFC_HTLF lane2"
+        lane.name = "lane2"
+        result = unit.select_lane(lane)
+        assert result == (False, 0.0)
+        assert unit.current_selected_lane is None
+        assert unit.logger.messages == [
+            ("debug", "HTLF: HTLF_1 Homing to endstop."),
+            ("error", "HTLF: failed to home when selecting lane2"),
+        ]
+
+    def test_home_called_with_disable_selector_false(self):
+        """return_to_home is always called with disable_selector=False from
+        here, independent of select_lane's own disable_selector param."""
+        unit = _make_htlf()
+        unit.current_selected_lane = None
+        unit.return_to_home = MagicMock(return_value=True)
+        lane = MagicMock()
+        lane.fullname = "AFC_HTLF lane2"
+        lane.index = 1
+        unit.select_lane(lane, disable_selector=True)
+        unit.return_to_home.assert_called_once_with(disable_selector=False)
+
+    def test_already_selected_lane_skips_homing_and_returns_true(self):
+        unit = _make_htlf()
+        lane = MagicMock()
+        lane.fullname = "AFC_HTLF lane2"
+        unit.current_selected_lane = lane
+        unit.return_to_home = MagicMock()
+        result = unit.select_lane(lane)
+        unit.return_to_home.assert_not_called()
+        assert result == (True, 0.0)
+
+    def test_disable_selector_true_calls_do_enable_in_finally(self):
+        unit = _make_htlf()
+        lane = MagicMock()
+        lane.fullname = "AFC_HTLF lane2"
+        unit.current_selected_lane = lane  # already-selected path
+        unit.select_lane(lane, disable_selector=True)
+        unit.selector_stepper_obj.do_enable.assert_called_once_with(False)
+
+    def test_disable_selector_false_skips_do_enable_in_finally(self):
+        unit = _make_htlf()
+        lane = MagicMock()
+        lane.fullname = "AFC_HTLF lane2"
+        unit.current_selected_lane = lane  # already-selected path
+        unit.select_lane(lane, disable_selector=False)
+        unit.selector_stepper_obj.do_enable.assert_not_called()
+
+
+# ── check_runout ──────────────────────────────────────────────────────────────
+
+class TestCheckRunout:
+    def _make(self):
+        unit = _make_htlf()
+        cur_lane = MagicMock()
+        cur_lane.name = "lane1"
+        cur_lane.status = AFCLaneState.LOADED
+        unit.afc.function.get_current_lane.return_value = "lane1"
+        unit.afc.function.is_printing.return_value = True
+        return unit, cur_lane
+
+    def test_true_when_all_conditions_met(self):
+        unit, cur_lane = self._make()
+        assert unit.check_runout(cur_lane) is True
+
+    def test_false_when_lane_name_does_not_match_current_lane(self):
+        unit, cur_lane = self._make()
+        unit.afc.function.get_current_lane.return_value = "lane_other"
+        assert unit.check_runout(cur_lane) is False
+
+    def test_false_when_not_printing(self):
+        unit, cur_lane = self._make()
+        unit.afc.function.is_printing.return_value = False
+        assert unit.check_runout(cur_lane) is False
+
+    def test_false_when_status_is_ejecting(self):
+        unit, cur_lane = self._make()
+        cur_lane.status = AFCLaneState.EJECTING
+        assert unit.check_runout(cur_lane) is False
+
+    def test_false_when_status_is_calibrating(self):
+        unit, cur_lane = self._make()
+        cur_lane.status = AFCLaneState.CALIBRATING
+        assert unit.check_runout(cur_lane) is False
+
+
+# ── prep_load / prep_post_load ───────────────────────────────────────────────
+
+class TestPrepLoad:
+    def test_returns_none(self):
+        unit = _make_htlf()
+        assert unit.prep_load(MagicMock()) is None
+
+
+class TestPrepPostLoad:
+    def test_returns_none(self):
+        unit = _make_htlf()
+        assert unit.prep_post_load(MagicMock()) is None
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# Module-level import guards
+# ═════════════════════════════════════════════════════════════════════════
+
+def _exec_afc_htlf_with_blocked_dependency(blocked_module_name):
+    """Execute a throw-away copy of extras/AFC_HTLF.py's module-level code
+    with `blocked_module_name` forced to fail import, to exercise the file's
+    top-level ``try: from X import Y / except: raise config_error(...)``
+    guards.
+
+    Never touches the real, already-imported ``extras.AFC_HTLF`` module that
+    the rest of this test suite depends on: the copy is loaded under a
+    throwaway module name and discarded afterward, whether or not it raises.
+    Cleanup restores the exact same pre-existing module object in
+    sys.modules so other test files' references stay valid.
+    """
+    import extras.AFC_HTLF as real_module
+    fresh_name = "extras.AFC_HTLF_import_guard_probe"
+    original_blocked_module = sys.modules.get(blocked_module_name)
+    sys.modules[blocked_module_name] = None
+    try:
+        spec = importlib.util.spec_from_file_location(fresh_name, real_module.__file__)
+        fresh = importlib.util.module_from_spec(spec)
+        sys.modules[fresh_name] = fresh
+        try:
+            spec.loader.exec_module(fresh)
+        finally:
+            sys.modules.pop(fresh_name, None)
+    finally:
+        if original_blocked_module is not None:
+            sys.modules[blocked_module_name] = original_blocked_module
+        else:
+            sys.modules.pop(blocked_module_name, None)
+
+
+def _exec_afc_htlf_with_missing_attr(real_module_name, missing_attr_name):
+    """Execute a throw-away copy of extras/AFC_HTLF.py's module-level code
+    with a single attribute (`missing_attr_name`) hidden from
+    `real_module_name`, to exercise a guard whose `except:` can't be reached
+    by blocking the whole dependency module.
+
+    AFC_HTLF.py has two separate guards that both import from
+    extras.AFC_utils (ERROR_STR, then add_filament_switch); blocking that
+    module outright always trips the first of the two guards before
+    execution ever reaches the second. This swaps in a proxy that forwards
+    every attribute lookup to the real module except the one being hidden,
+    which raises AttributeError -- exactly what `from module import name`
+    converts into ImportError when the name is genuinely missing from an
+    otherwise-importable module.
+    """
+    import extras.AFC_HTLF as real_module
+    real_dep_module = sys.modules[real_module_name]
+
+    class _ProxyModule:
+        def __getattr__(self, attr_name):
+            if attr_name == missing_attr_name:
+                raise AttributeError(attr_name)
+            return getattr(real_dep_module, attr_name)
+
+    fresh_name = "extras.AFC_HTLF_import_guard_probe"
+    sys.modules[real_module_name] = _ProxyModule()
+    try:
+        spec = importlib.util.spec_from_file_location(fresh_name, real_module.__file__)
+        fresh = importlib.util.module_from_spec(spec)
+        sys.modules[fresh_name] = fresh
+        try:
+            spec.loader.exec_module(fresh)
+        finally:
+            sys.modules.pop(fresh_name, None)
+    finally:
+        sys.modules[real_module_name] = real_dep_module
+
+
+class TestModuleImportGuards:
+    """Covers the four module-level `try/except: raise config_error(...)`
+    guards in AFC_HTLF.py, one per dependency import."""
+
+    def test_afc_utils_error_str_import_failure_raises_configparser_error(self):
+        """The very first guard imports ERROR_STR itself from AFC_utils, so
+        it can't use ERROR_STR.format(...) in its own except clause."""
+        with pytest.raises(configparser.Error) as exc_info:
+            _exec_afc_htlf_with_blocked_dependency("extras.AFC_utils")
+        assert str(exc_info.value).startswith(
+            "Error when trying to import AFC_utils.ERROR_STR"
+        )
+
+    def test_afc_lane_import_failure_raises_configparser_error(self):
+        with pytest.raises(configparser.Error) as exc_info:
+            _exec_afc_htlf_with_blocked_dependency("extras.AFC_lane")
+        assert str(exc_info.value).startswith(
+            "Error trying to import AFC_lane, please rerun install-afc.sh"
+        )
+
+    def test_afc_boxturtle_import_failure_raises_configparser_error(self):
+        with pytest.raises(configparser.Error) as exc_info:
+            _exec_afc_htlf_with_blocked_dependency("extras.AFC_BoxTurtle")
+        assert str(exc_info.value).startswith(
+            "Error trying to import AFC_BoxTurtle, please rerun install-afc.sh"
+        )
+
+    def test_afc_utils_add_filament_switch_import_failure_raises_configparser_error(self):
+        """The fourth guard imports add_filament_switch from the same
+        AFC_utils module as the first guard's ERROR_STR, so it needs a
+        specific missing attribute rather than the whole module blocked."""
+        with pytest.raises(configparser.Error) as exc_info:
+            _exec_afc_htlf_with_missing_attr("extras.AFC_utils", "add_filament_switch")
+        assert str(exc_info.value).startswith(
+            "Error trying to import AFC_utils, please rerun install-afc.sh"
+        )
+
+
+# ── _move_selector_home ──────────────────────────────────────────────────────
+
+class TestMoveSelectorHome:
+    def test_homing_enabled_calls_do_homing_move_with_negative_distance(self):
+        unit = _make_htlf()
+        unit.afc.homing_enabled = True
+        unit.selector_movement_speed = 50.0
+        unit.selector_movement_accel = 75.0
+        unit.home_endstop_name = "HTLF_1_home"
+        unit.selector_stepper_obj.do_homing_move.return_value = (True, 12.5)
+        unit._move_selector_home(10.0)
+        unit.selector_stepper_obj.do_homing_move.assert_called_once_with(
+            -10.0, 50.0, 75.0, "HTLF_1_home", assist_active=False
+        )
+
+    def test_homing_enabled_stores_homed_distance(self):
+        """Verifies the class variable self._homed_distance is actually
+        updated from do_homing_move's return, not just that the method ran."""
+        unit = _make_htlf()
+        unit.afc.homing_enabled = True
+        unit.selector_stepper_obj.do_homing_move.return_value = (True, 42.5)
+        unit._move_selector_home(10.0)
+        assert unit._homed_distance == 42.5
+
+    def test_homing_enabled_logs_success_and_distance(self):
+        unit = _make_htlf()
+        unit.afc.homing_enabled = True
+        unit.selector_stepper_obj.do_homing_move.return_value = (False, 7.0)
+        unit._move_selector_home(10.0)
+        assert unit.logger.messages == [
+            ("debug", "HTLF: Homing done, success:False, distance:7.0")
+        ]
+
+    def test_homing_disabled_calls_move_with_negative_distance(self):
+        unit = _make_htlf()
+        unit.afc.homing_enabled = False
+        unit.selector_movement_speed = 50.0
+        unit.selector_movement_accel = 75.0
+        unit._move_selector_home(10.0)
+        unit.selector_stepper_obj.move.assert_called_once_with(-10.0, 50.0, 75.0, False)
+
+    def test_homing_disabled_does_not_call_do_homing_move(self):
+        unit = _make_htlf()
+        unit.afc.homing_enabled = False
+        unit._move_selector_home(10.0)
+        unit.selector_stepper_obj.do_homing_move.assert_not_called()
+
+
+# ── load_config_prefix ───────────────────────────────────────────────────────
+
+class TestLoadConfigPrefix:
+    def test_returns_afc_htlf_instance(self):
+        from extras.AFC_HTLF import load_config_prefix
+        config, printer, afc = _make_htlf_config()
+        result = load_config_prefix(config)
+        assert isinstance(result, AFC_HTLF)

--- a/tests/test_AFC_HTLF.py
+++ b/tests/test_AFC_HTLF.py
@@ -700,6 +700,7 @@ class TestSelectLane:
         unit.return_to_home = MagicMock(return_value=True)
         unit._homed_distance = 3.5
         unit.calculate_lobe_movement = MagicMock(return_value=12.0)
+        unit._selector_cal_dis_adjust = MagicMock()
         lane = MagicMock()
         lane.fullname = "AFC_HTLF lane2"
         lane.index = 2
@@ -708,6 +709,7 @@ class TestSelectLane:
         unit.selector_stepper_obj.move.assert_called_once_with(
             12.0, unit.selector_movement_speed, unit.selector_movement_accel, False
         )
+        unit._selector_cal_dis_adjust.assert_called_once_with(lane)
         assert unit.current_selected_lane is lane
         assert result == (True, 3.5)
 

--- a/tests/test_AFC_HTLF.py
+++ b/tests/test_AFC_HTLF.py
@@ -198,22 +198,36 @@ class TestHTLFInit:
             options=AFC_HTLF.cmd_AFC_HOME_UNIT_options,
         )
 
-    # -- home_pin is None: endstop/filament-switch setup fully skipped --
+    # -- required config options have no fallback default --
 
-    def test_home_pin_none_leaves_home_endstop_none(self):
-        unit = _make_htlf(values={"home_pin": None})
-        assert unit.home_endstop is None
-        assert unit.home_endstop_name is None
+    @pytest.mark.parametrize("missing_option", [
+        "drive_stepper", "selector_stepper", "cam_angle", "home_pin",
+    ])
+    def test_required_option_missing_from_config_raises(self, missing_option):
+        """drive_stepper, selector_stepper, cam_angle and home_pin are all
+        read via config.get(...)/getint(...) with no default -- real
+        Klipper's ConfigWrapper raises immediately when an option like that
+        isn't in the user's config, rather than silently falling back to
+        None/0. Each is tested with the other three left valid, isolating
+        that this specific option is the one enforced as required."""
+        from tests.conftest import MockAFC, MockConfig, MockPrinter
 
-    def test_home_pin_none_does_not_set_home_sensor(self):
-        unit = _make_htlf(values={"home_pin": None})
-        assert not hasattr(unit, "home_sensor")
+        afc = MockAFC()
+        printer = MockPrinter(afc=afc)
+        values = {
+            "drive_stepper": "drive", "selector_stepper": "selector",
+            "cam_angle": 60, "home_pin": "PA1",
+        }
+        del values[missing_option]
+        config = MockConfig(name="AFC_HTLF HTLF_1", printer=printer, values=values)
 
-    def test_home_pin_none_does_not_add_stepper_to_endstop(self):
-        unit = _make_htlf(values={"home_pin": None})
-        unit.selector_stepper_obj.add_stepper.assert_not_called()
+        with pytest.raises(configparser.Error) as exc_info:
+            AFC_HTLF(config)
+        assert str(exc_info.value) == (
+            f"Option '{missing_option}' in section 'Test' must be specified"
+        )
 
-    # -- home_pin is set: endstop/filament-switch setup runs --
+    # -- home_pin-dependent endstop/filament-switch setup --
 
     def test_home_pin_set_creates_home_sensor(self):
         # enable_sensors_in_gui=True avoids add_filament_switch's
@@ -261,6 +275,17 @@ class TestHTLFInit:
         assert unit.selector_stepper_obj._endstops[unit.home_endstop_name] == \
             (unit.home_endstop, unit.home_endstop_name)
 
+    def test_falsy_home_endstop_skips_adding_stepper(self):
+        """If ppins.setup_pin(...) itself returns a falsy value, self.home_
+        endstop stays falsy and the add_stepper/_endstops wiring is skipped
+        entirely -- defensive code for a setup_pin failure, independent of
+        home_pin's own required-ness."""
+        config, printer, afc = _make_htlf_config(values={"home_pin": "PA1"})
+        printer.lookup_object("pins").setup_pin = MagicMock(return_value=None)
+        unit = AFC_HTLF(config)
+        assert unit.home_endstop is None
+        unit.selector_stepper_obj.add_stepper.assert_not_called()
+
     # -- endstop registration failure --
 
     def test_endstop_registration_failure_raises_config_error(self):
@@ -294,6 +319,16 @@ class TestHomeCallback:
         for state in [True, False, True]:
             unit.home_callback(eventtime=0.0, state=state)
             assert unit.home_state is state
+
+    def test_home_callback_coerces_raw_int_state_to_bool(self):
+        """Klipper's buttons.register_buttons callback contract passes raw
+        int (0/1), not bool -- matches AFC_hub.switch_pin_callback and
+        AFCLane.prep_callback, which both need the same bool() coercion."""
+        unit = _make_htlf()
+        unit.home_callback(eventtime=0.0, state=1)
+        assert unit.home_state is True
+        unit.home_callback(eventtime=0.0, state=0)
+        assert unit.home_state is False
 
 
 # ── handle_connect ────────────────────────────────────────────────────────────

--- a/tests/test_AFC_buffer.py
+++ b/tests/test_AFC_buffer.py
@@ -47,7 +47,10 @@ def _make_buffer(name="TN", error_sensitivity=0.0):
 
     afc = MockAFC()
     printer = MockPrinter(afc=afc)
-    config = MockConfig(name="AFC_buffer {}".format(name), printer=printer, values={})
+    # advance_pin/trailing_pin have no config.get(...) default; real Klipper
+    # requires them whenever type == "switched" (the default type here).
+    config = MockConfig(name="AFC_buffer {}".format(name), printer=printer,
+                        values={"advance_pin": "PA0", "trailing_pin": "PA1"})
     with patch("extras.AFC_buffer.add_filament_switch",
                return_value=(MagicMock(), MagicMock())):
         buf = AFCBuffer(config)
@@ -98,7 +101,7 @@ def _make_fps_buffer(name="FPS_buffer1", **overrides):
     printer = MockPrinter(afc=afc)
     printer.lookup_object("pins").setup_pin = MagicMock(return_value=MagicMock())
     config = MockConfig(name="AFC_FPS {}".format(name), printer=printer,
-                        values={"type": "FPS_PSF"})
+                        values={"type": "FPS_PSF", "adc_pin": "PA5"})
     buf = AFCFPSBuffer(config)
     reactor = buf.reactor  # alias -- buf.reactor is afc.reactor from real construction
 
@@ -196,12 +199,23 @@ def _build_real_buffer(values=None):
     """Construct a real AFCBuffer via __init__ (not the attribute-bypass
     helper), for exercising __init__'s own logic. add_filament_switch does
     real Klipper config-object wiring that isn't worth reproducing under
-    test, so it's patched out."""
+    test, so it's patched out.
+
+    advance_pin/trailing_pin have no config.get(...) default, so real
+    Klipper requires them whenever type == "switched" (the default type);
+    supplied here so the default construction path succeeds the same way a
+    real, valid user config would. Callers testing a non-"switched" type can
+    still omit them via values={"type": ...}.
+    """
     from tests.conftest import MockConfig, MockPrinter, MockAFC
+
+    all_values = {"advance_pin": "PA0", "trailing_pin": "PA1"}
+    if values:
+        all_values.update(values)
 
     afc = MockAFC()
     printer = MockPrinter(afc=afc)
-    config = MockConfig(name="AFC_buffer TN", printer=printer, values=values or {})
+    config = MockConfig(name="AFC_buffer TN", printer=printer, values=all_values)
     with patch("extras.AFC_buffer.add_filament_switch",
                return_value=(MagicMock(), MagicMock())):
         buf = AFCBuffer(config)
@@ -232,7 +246,11 @@ class TestAFCBufferInit:
         assert buf.fault_timer is None
         assert buf.min_event_systime == buf.reactor.NEVER
         assert buf.led is False
-        assert buf.advance_pin is None
+        # advance_pin/trailing_pin have no config default and are required
+        # whenever type == "switched" (the default type); _build_real_buffer
+        # supplies them the same way a valid real config would.
+        assert buf.advance_pin == "PA0"
+        assert buf.trailing_pin == "PA1"
         assert buf.buffer_distance is None
 
     def test_registers_ready_event_handler(self):
@@ -280,7 +298,8 @@ class TestAFCBufferInit:
         afc = MockAFC()
         afc.function = MagicMock()
         printer = MockPrinter(afc=afc)
-        config = MockConfig(name="AFC_buffer TN", printer=printer, values={})
+        config = MockConfig(name="AFC_buffer TN", printer=printer,
+                            values={"advance_pin": "PA0", "trailing_pin": "PA1"})
         with patch("extras.AFC_buffer.add_filament_switch",
                    return_value=(MagicMock(), MagicMock())):
             buf = AFCBuffer(config)
@@ -339,7 +358,8 @@ class TestAFCBufferInit:
         afc = MockAFC()
         afc.enable_sensors_in_gui = True
         printer = MockPrinter(afc=afc)
-        config = MockConfig(name="AFC_buffer TN", printer=printer, values={})
+        config = MockConfig(name="AFC_buffer TN", printer=printer,
+                            values={"advance_pin": "PA0", "trailing_pin": "PA1"})
         with patch("extras.AFC_buffer.add_filament_switch",
                    return_value=(MagicMock(), MagicMock())):
             buf = AFCBuffer(config)
@@ -354,7 +374,8 @@ class TestAFCBufferInit:
         afc = MockAFC()
         afc.gcode.register_mux_command = MagicMock(wraps=afc.gcode.register_mux_command)
         printer = MockPrinter(afc=afc)
-        config = MockConfig(name="AFC_buffer TN", printer=printer, values={})
+        config = MockConfig(name="AFC_buffer TN", printer=printer,
+                            values={"advance_pin": "PA0", "trailing_pin": "PA1"})
         with patch("extras.AFC_buffer.add_filament_switch",
                    return_value=(MagicMock(), MagicMock())):
             AFCBuffer(config)
@@ -2986,7 +3007,7 @@ def _build_real_fps_buffer(values=None, adc=None):
     printer = MockPrinter(afc=afc)
     adc = adc if adc is not None else _FakeADC()
     printer.lookup_object("pins").setup_pin = MagicMock(return_value=adc)
-    merged = {"type": "FPS_PSF"}
+    merged = {"type": "FPS_PSF", "adc_pin": "PA5"}
     merged.update(values or {})
     config = MockConfig(name="AFC_FPS FPS1", printer=printer, values=merged)
     buf = AFCFPSBuffer(config)
@@ -3089,7 +3110,8 @@ class TestAFCFPSBufferInit:
         afc.gcode.register_mux_command = MagicMock(wraps=afc.gcode.register_mux_command)
         printer = MockPrinter(afc=afc)
         printer.lookup_object("pins").setup_pin = MagicMock(return_value=_FakeADC())
-        config = MockConfig(name="AFC_FPS FPS1", printer=printer, values={"type": "FPS_PSF"})
+        config = MockConfig(name="AFC_FPS FPS1", printer=printer,
+                            values={"type": "FPS_PSF", "adc_pin": "PA5"})
         AFCFPSBuffer(config)
         names = [c[0][0] for c in afc.gcode.register_mux_command.call_args_list]
         assert "AFC_SET_FPS_SET_POINT" in names
@@ -3934,7 +3956,8 @@ class TestLoadConfigPrefix:
         from tests.conftest import MockConfig, MockPrinter, MockAFC
         afc = MockAFC()
         printer = MockPrinter(afc=afc)
-        config = MockConfig(name="AFC_buffer TN", printer=printer, values={})
+        config = MockConfig(name="AFC_buffer TN", printer=printer,
+                            values={"advance_pin": "PA0", "trailing_pin": "PA1"})
         with patch("extras.AFC_buffer.add_filament_switch",
                    return_value=(MagicMock(), MagicMock())):
             result = load_config_prefix(config)
@@ -3946,7 +3969,8 @@ class TestLoadConfigPrefix:
         afc = MockAFC()
         printer = MockPrinter(afc=afc)
         printer.lookup_object("pins").setup_pin = MagicMock(return_value=_FakeADC())
-        config = MockConfig(name="AFC_FPS FPS1", printer=printer, values={"type": "FPS_PSF"})
+        config = MockConfig(name="AFC_FPS FPS1", printer=printer,
+                            values={"type": "FPS_PSF", "adc_pin": "PA5"})
         result = load_config_prefix(config)
         assert isinstance(result, AFCFPSBuffer)
 

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -12,7 +12,7 @@ Covers:
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock, call, patch
 import pytest
 
 from extras.AFC_lane import (
@@ -255,6 +255,46 @@ class TestAFCLaneInit:
 
     def test_update_weight_delay_class_constant(self):
         assert AFCLane.UPDATE_WEIGHT_DELAY == 10.0
+
+
+# ── selector_cal_dis (real __init__ construction) ────────────────────────────
+# The rest of this file bypasses AFCLane.__init__ via __new__, but
+# selector_cal_dis's fix (always read, not just when a selector pin is
+# configured) only shows up in __init__ itself, so this drives a real
+# construction. add_filament_switch does real Klipper config-object wiring
+# that isn't worth reproducing under test, so it's patched out; the "unit"
+# config option has no default in AFCLane.__init__ and so must be supplied.
+
+def _make_real_afc_lane(name="lane1", values=None):
+    """Construct a real AFCLane via its actual __init__."""
+    from tests.conftest import MockAFC, MockConfig, MockPrinter
+
+    afc = MockAFC()
+    printer = MockPrinter(afc=afc)
+    all_values = {"unit": "Turtle_1:1"}
+    if values:
+        all_values.update(values)
+    config = MockConfig(name=f"AFC_stepper {name}", printer=printer, values=all_values)
+    with patch("extras.AFC_lane.add_filament_switch",
+               return_value=(MagicMock(), MagicMock())):
+        return AFCLane(config)
+
+
+class TestSelectorCalDis:
+    def test_defaults_to_zero_when_selector_not_configured(self):
+        lane = _make_real_afc_lane()
+        assert lane.selector_cal_dis == 0.0
+
+    def test_reads_from_config_when_selector_not_configured(self):
+        """This exact case (selector unset, selector_cal_distance set) used
+        to leave selector_cal_dis at None, since the read was nested inside
+        "if self.selector is not None"."""
+        lane = _make_real_afc_lane(values={"selector_cal_distance": 2.5})
+        assert lane.selector_cal_dis == 2.5
+
+    def test_reads_from_config_when_selector_also_configured(self):
+        lane = _make_real_afc_lane(values={"selector": "PA5", "selector_cal_distance": 1.5})
+        assert lane.selector_cal_dis == 1.5
 
 
 # ── _get_steppers: stepperless unit early return ─────────────────────────────
@@ -1265,6 +1305,16 @@ class TestSendLaneDataExtruderIndex:
         lane.send_lane_data()
         lane.afc.moonraker.send_lane_data.assert_not_called()
 
+    def test_no_send_when_moonraker_is_falsy(self):
+        """Proven independently of map: a valid map alone isn't enough
+        without a moonraker connection."""
+        lane = _make_lane_for_moonraker()
+        lane.afc.moonraker = None
+        lane.send_lane_data()
+        # afc.moonraker is None here, so there's nothing to assert the call
+        # against -- the AttributeError that not-called would otherwise
+        # crash into is exactly what the guard is meant to prevent.
+
 
 class TestClearLaneDataExtruderIndex:
     @pytest.mark.parametrize("extruder_name,expected_index", [
@@ -1298,6 +1348,13 @@ class TestClearLaneDataExtruderIndex:
         lane.map = None
         lane.clear_lane_data()
         lane.afc.moonraker.send_lane_data.assert_not_called()
+
+    def test_no_clear_when_moonraker_is_falsy(self):
+        lane = _make_lane_for_moonraker()
+        lane.afc.moonraker = None
+        lane.clear_lane_data()
+        # afc.moonraker is None here; not raising AttributeError proves the
+        # guard short-circuited before reaching moonraker.send_lane_data(...).
 
 
 # ── _is_normal_printing_state (continued) ─────────────────────────────────────

--- a/tests/test_AFC_unit.py
+++ b/tests/test_AFC_unit.py
@@ -211,6 +211,46 @@ class TestCheckRunout:
         assert unit.check_runout("lane") is False
 
 
+# ── _selector_cal_dis_adjust ─────────────────────────────────────────────────
+
+class TestSelectorCalDisAdjust:
+    def test_moves_selector_when_configured(self):
+        unit = _make_unit()
+        unit.selector_stepper_obj = MagicMock()
+        lane = _make_lane("lane1")
+        lane.selector_cal_dis = 2.5
+        unit._selector_cal_dis_adjust(lane)
+        unit.selector_stepper_obj.move.assert_called_once_with(2.5, 50, 50, False)
+
+    def test_skipped_when_no_selector_stepper_obj(self):
+        """Proven independently of selector_cal_dis's own value: a valid,
+        non-zero selector_cal_dis alone isn't enough without a selector
+        stepper object."""
+        unit = _make_unit()
+        unit.selector_stepper_obj = None
+        lane = _make_lane("lane1")
+        lane.selector_cal_dis = 2.5
+        unit._selector_cal_dis_adjust(lane)
+        # No selector_stepper_obj to assert on; move never gets a chance to
+        # be called since the object itself is None here.
+
+    def test_skipped_when_selector_cal_dis_is_none(self):
+        unit = _make_unit()
+        unit.selector_stepper_obj = MagicMock()
+        lane = _make_lane("lane1")
+        lane.selector_cal_dis = None
+        unit._selector_cal_dis_adjust(lane)
+        unit.selector_stepper_obj.move.assert_not_called()
+
+    def test_skipped_when_selector_cal_dis_is_zero(self):
+        unit = _make_unit()
+        unit.selector_stepper_obj = MagicMock()
+        lane = _make_lane("lane1")
+        lane.selector_cal_dis = 0.0
+        unit._selector_cal_dis_adjust(lane)
+        unit.selector_stepper_obj.move.assert_not_called()
+
+
 # ── return_to_home ────────────────────────────────────────────────────────────
 
 class TestReturnToHome:

--- a/tests/test_AFC_vivid.py
+++ b/tests/test_AFC_vivid.py
@@ -374,6 +374,7 @@ class TestSelectLane:
 
     def test_calls_homing_when_not_selected(self):
         unit = _make_vivid()
+        unit._selector_cal_dis_adjust = MagicMock()
         lane = _make_lane("lane1", has_selector=True)
         lane.fila_selector.get_status.return_value = {"filament_detected": False}
         unit.printer._objects = {}  # no stepper_enable → enabled=False
@@ -383,9 +384,20 @@ class TestSelectLane:
         assert dist == 15.0
         unit.selector_stepper_obj.do_homing_move.assert_called_once()
 
+    def test_calls_selector_cal_dis_adjust_after_homing(self):
+        unit = _make_vivid()
+        unit._selector_cal_dis_adjust = MagicMock()
+        lane = _make_lane("lane1", has_selector=True)
+        lane.fila_selector.get_status.return_value = {"filament_detected": False}
+        unit.printer._objects = {}
+        unit.selector_stepper_obj.do_homing_move.return_value = (True, 15.0)
+        unit.select_lane(lane)
+        unit._selector_cal_dis_adjust.assert_called_once_with(lane)
+
     def test_calls_unselect_lane_when_disabled_but_selector_triggered(self):
         """When stepper not enabled but selector triggered, unselect_lane is called first."""
         unit = _make_vivid()
+        unit._selector_cal_dis_adjust = MagicMock()
         lane = _make_lane("lane1", has_selector=True)
         lane.fila_selector.get_status.return_value = {"filament_detected": True}
         # stepper disabled (no stepper_enable object)


### PR DESCRIPTION
## Major Changes in this PR
- Ability to adjust HTLF selector after lane selection by adding `selector_cal_distance` variable in each lane. Closes #673 
- Moved selection logic out of AFC_Vivid into a common method in AFC_unit
- Added klippy test for AFC_HTLF

Updates with help from claude:
- Finished adding unit tests for AFC_HTLF.py, now 100% coverage
- Added/updated method comments and typing.
- Updated `get` options to raise errors when default values are not supplied in unit tests as this is how klipper would normally work when variables are not supplied and are required.

## Notes to Code Reviewers
Main change happens on line 631 in AFC_unit.py and then added calling this method in HTLF and ViViD selection logic.

## How the changes in this PR are tested
Tested on my 2.4 toolchanger with HTLF attached, set variable to lane and selected. Then watched it move again after lane selection.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to pr-review channel requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added per-lane selector calibration distances for lane-specific adjustments.
  - Added HTLF configuration support and validation for homing and selector settings.

- **Bug Fixes**
  - Improved lane data handling when external connectivity is unavailable.
  - Improved selector calibration behavior when selector hardware or calibration values are missing.

- **Tests**
  - Expanded coverage for HTLF homing, lane selection, configuration, runout handling, and selector calibration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->