### PR TITLE
(fix): Guard handle_prep_runout against cross-lane PREP concurrency (Fixing Issue #826)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-08-09]
+### Fixed
+- Fixed a "Timer too close" MCU shutdown that could occur when the PREP sensor releases while a
+  load cycle is still in progress on the same or another lane (Fixing Issue #826).
+
 ## [2026-08-07]
 ### Added
 - Ability to adjust HTLF selector after lane selection by adding `selector_cal_distance` variable in each lane.

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -108,7 +108,6 @@ class afc:
         self._last_td1_query:float    = 0
         self.lane_data_enabled  = False
         self.prep_done          = False         # Variable used to hold of save_vars function from saving too early and overriding save before prep can be ran
-        self.prep_active_count       = 0    # Lanes with an active PREP cycle right now
         self.last_prep_activity_time = 0.0  # eventtime of the last PREP edge on any lane
         self.in_print_timer     = None
         self.activate_cb_done = True

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -108,6 +108,13 @@ class afc:
         self._last_td1_query:float    = 0
         self.lane_data_enabled  = False
         self.prep_done          = False         # Variable used to hold of save_vars function from saving too early and overriding save before prep can be ran
+        # --- TTC (Timer Too Close) fix: cross-lane PREP runout guard ------------------------
+        # See handle_prep_runout() in AFC_lane.py for the full explanation. These two fields
+        # let that function detect PREP activity on ANY lane (not just its own) before acting
+        # on a runout edge, closing a race that could shut down the hub MCU with "Timer too
+        # close" (fixed 2026-08-08).
+        self.prep_active_count       = 0    # How many lanes currently have an active PREP cycle
+        self.last_prep_activity_time = 0.0  # eventtime of the last PREP edge seen on any lane
         self.in_print_timer     = None
         self.activate_cb_done = True
         self.db_backup          = False

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -108,13 +108,8 @@ class afc:
         self._last_td1_query:float    = 0
         self.lane_data_enabled  = False
         self.prep_done          = False         # Variable used to hold of save_vars function from saving too early and overriding save before prep can be ran
-        # --- TTC (Timer Too Close) fix: cross-lane PREP runout guard ------------------------
-        # See handle_prep_runout() in AFC_lane.py for the full explanation. These two fields
-        # let that function detect PREP activity on ANY lane (not just its own) before acting
-        # on a runout edge, closing a race that could shut down the hub MCU with "Timer too
-        # close" (fixed 2026-08-08).
-        self.prep_active_count       = 0    # How many lanes currently have an active PREP cycle
-        self.last_prep_activity_time = 0.0  # eventtime of the last PREP edge seen on any lane
+        self.prep_active_count       = 0    # Lanes with an active PREP cycle right now
+        self.last_prep_activity_time = 0.0  # eventtime of the last PREP edge on any lane
         self.in_print_timer     = None
         self.activate_cb_done = True
         self.db_backup          = False

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -1262,6 +1262,10 @@ class AFCLane:
                                 self.afc.error.AFC_error(f"Cannot load {self.name} spool while printer is actively moving or homing", False)
                                 return
 
+                            # Check to see if another lane already has a PREP cycle in flight
+                            if any(lane.prep_active for lane in self.afc.lanes.values() if lane is not self):
+                                return
+
                             # Calling common load function
                             self.unit_obj.prep_load(self)
 
@@ -1361,13 +1365,19 @@ class AFCLane:
         self.afc.save_vars()
 
     def _any_lane_prep_active(self) -> bool:
-        """True if any lane (this one or another) has a PREP cycle in flight right now."""
+        """
+        Check whether any lane currently has a PREP cycle in flight.
+
+        :return: True if any lane (this one or another) is mid-cycle right now
+        """
         return any(lane.prep_active for lane in self.afc.lanes.values())
 
-    def _recheck_prep_runout(self, eventtime):
+    def _recheck_prep_runout(self, eventtime: float) -> None:
         """
         Re-evaluate a PREP release that handle_prep_runout() deferred. Defers
         again if still blocked or the lane got filament back in the meantime.
+
+        :param eventtime: reactor time this recheck fired
         """
         if self.prep_state:
             self.prep_recheck_pending = False

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -1237,72 +1237,79 @@ class AFCLane:
         self.prep_active = True
         self.afc.prep_active_count += 1   # TTC fix: mirror into the shared cross-lane counter
 
-        # Checking to make sure printer is ready and making sure PREP has been called before trying to load anything
-        for i in range(1):
-            # Hacky way for do{}while(0) loop, DO NOT return from this for loop, use break instead so that self.prep_state variable gets sets correctly
-            #  before exiting function
-            with self.mutex:
-                if (self.printer.state_message == 'Printer is ready'
-                    and self._afc_prep_done
-                    and self.status != AFCLaneState.TOOL_UNLOADING):
-                    # Only try to load when load state trigger is false
-                    if (self.prep_state
-                        and not self.raw_load_state):
-                        self.logger.debug(f"Prep: callback triggered {self.name}")
-                        # Checking to make sure last time prep switch was activated was less than 1 second, returning to keep is printing message from spamming
-                        # the console since it takes klipper some time to transition to idle when idle_resume=printing
-                        if delta_time < 1.0:
-                            break
+        # TTC fix: the increment above must always be undone, even if something in this block
+        # raises (prep_load()/prep_post_load()/TOOL_LOAD()/etc. are all reachable here and none
+        # of them are guaranteed not to throw). Without this, an unhandled exception would leave
+        # prep_active_count stuck positive forever, permanently blocking handle_prep_runout's
+        # non-printing set_unloaded() path for every lane, not just this one. save_vars() stays
+        # outside the try/finally on purpose: it must still run only on normal completion
+        # (fall-through/break), not on the early-return abort below or on a raised exception.
+        try:
+            # Checking to make sure printer is ready and making sure PREP has been called before trying to load anything
+            for i in range(1):
+                # Hacky way for do{}while(0) loop, DO NOT return from this for loop, use break instead so that self.prep_state variable gets sets correctly
+                #  before exiting function
+                with self.mutex:
+                    if (self.printer.state_message == 'Printer is ready'
+                        and self._afc_prep_done
+                        and self.status != AFCLaneState.TOOL_UNLOADING):
+                        # Only try to load when load state trigger is false
+                        if (self.prep_state
+                            and not self.raw_load_state):
+                            self.logger.debug(f"Prep: callback triggered {self.name}")
+                            # Checking to make sure last time prep switch was activated was less than 1 second, returning to keep is printing message from spamming
+                            # the console since it takes klipper some time to transition to idle when idle_resume=printing
+                            if delta_time < 1.0:
+                                break
 
-                        # Check to see if the printer is printing or moving, as trying to load while printer is doing something will crash klipper
-                        if self.afc.function.is_printing(check_movement=True):
-                            self.afc.error.AFC_error(f"Cannot load {self.name} spool while printer is actively moving or homing", False)
-                            self.prep_active = False
-                            self.afc.prep_active_count -= 1   # TTC fix: mirror exit here too
-                            return
+                            # Check to see if the printer is printing or moving, as trying to load while printer is doing something will crash klipper
+                            if self.afc.function.is_printing(check_movement=True):
+                                self.afc.error.AFC_error(f"Cannot load {self.name} spool while printer is actively moving or homing", False)
+                                return
 
-                        # Calling common load function
-                        self.unit_obj.prep_load(self)
+                            # Calling common load function
+                            self.unit_obj.prep_load(self)
 
-                        self.status = AFCLaneState.NONE
-                        self.logger.debug(f"Prep: Load Done-{self.name}")
+                            self.status = AFCLaneState.NONE
+                            self.logger.debug(f"Prep: Load Done-{self.name}")
 
-                        # Verify that load state is still true as this would still trigger if prep sensor was triggered and then filament was removed
-                        #   This is only really a issue when using direct_load and still using load sensor
-                        if (self.hub == 'direct_load'
-                            and self.prep_state):
-                            self.logger.debug(f"Prep: direct load logic-{self.name}-{self.hub}")
-                            if not self.afc.TOOL_LOAD(self):
-                                self.afc.afc_stats.increase_load_error_count(self.afc)
-                            self.afc.spool._set_values(self)
-                            self.logger.debug(f"Prep: direct load logic done-{self.name}-{self.hub}")
-                            break
+                            # Verify that load state is still true as this would still trigger if prep sensor was triggered and then filament was removed
+                            #   This is only really a issue when using direct_load and still using load sensor
+                            if (self.hub == 'direct_load'
+                                and self.prep_state):
+                                self.logger.debug(f"Prep: direct load logic-{self.name}-{self.hub}")
+                                if not self.afc.TOOL_LOAD(self):
+                                    self.afc.afc_stats.increase_load_error_count(self.afc)
+                                self.afc.spool._set_values(self)
+                                self.logger.debug(f"Prep: direct load logic done-{self.name}-{self.hub}")
+                                break
 
-                        self.unit_obj.prep_post_load(self)
+                            self.unit_obj.prep_post_load(self)
 
-                        self.do_enable(False)
-                        if (self.load_state
-                            and self.prep_state):
-                            self.set_loaded()
-                            self._post_prep_user_macro()
-                            # Check if user wants to get TD-1 data when loading
-                            # TODO: When implementing multi-extruder this could still happen if a lane is loaded for a
-                            # different extruder/hub
-                            if self.td1_device_id:
-                                self._prep_capture_td1()
+                            self.do_enable(False)
+                            if (self.load_state
+                                and self.prep_state):
+                                self.set_loaded()
+                                self._post_prep_user_macro()
+                                # Check if user wants to get TD-1 data when loading
+                                # TODO: When implementing multi-extruder this could still happen if a lane is loaded for a
+                                # different extruder/hub
+                                if self.td1_device_id:
+                                    self._prep_capture_td1()
 
-                    elif(self.prep_state == True
-                        and self.raw_load_state == True
-                        and not self.afc.function.is_printing()):
-                        message = 'Cannot load {} load sensor is triggered.'.format(self.name)
-                        message += '\n    Make sure filament is not stuck in load sensor or check to make sure load sensor is not stuck triggered.'
-                        if self.unit_obj.type == "ViViD":
-                            message += f'\n    If filament is not stuck in sensor run AFC_RECOVER_LANE LANE={self.name}'
-                            message += " to reset internal AFC state."
-                        message += '\n    Once cleared try loading again'
-                        self.afc.error.AFC_error(message, pause=False)
-        self.prep_active = False
-        self.afc.prep_active_count -= 1   # TTC fix: mirror normal exit
+                        elif(self.prep_state == True
+                            and self.raw_load_state == True
+                            and not self.afc.function.is_printing()):
+                            message = 'Cannot load {} load sensor is triggered.'.format(self.name)
+                            message += '\n    Make sure filament is not stuck in load sensor or check to make sure load sensor is not stuck triggered.'
+                            if self.unit_obj.type == "ViViD":
+                                message += f'\n    If filament is not stuck in sensor run AFC_RECOVER_LANE LANE={self.name}'
+                                message += " to reset internal AFC state."
+                            message += '\n    Once cleared try loading again'
+                            self.afc.error.AFC_error(message, pause=False)
+        finally:
+            self.prep_active = False
+            self.afc.prep_active_count -= 1   # TTC fix: mirror every exit (normal, early return, or exception)
         self.afc.save_vars()
 
     def handle_prep_runout(self, eventtime, prep_state):

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -1216,8 +1216,6 @@ class AFCLane:
         :param state: 1 if the prep sensor is now triggered (filament present), 0 otherwise
         """
         self.prep_state = bool(state)
-        # Record every PREP edge (any lane) for handle_prep_runout's guard
-        self.afc.last_prep_activity_time = eventtime
 
         delta_time = eventtime - self.last_prep_time
         self.last_prep_time = eventtime
@@ -1262,6 +1260,9 @@ class AFCLane:
                                 or any(lane.prep_active for lane in self.afc.lanes.values() if lane is not self)):
                                 self.afc.error.AFC_error(f"Cannot load {self.name} spool while printer is actively moving or homing", False)
                                 return
+
+                            # Record PREP activity (any lane) for handle_prep_runout's guard
+                            self.afc.last_prep_activity_time = eventtime
 
                             # Calling common load function
                             self.unit_obj.prep_load(self)

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -1214,6 +1214,10 @@ class AFCLane:
         :param state: 1 if the prep sensor is now triggered (filament present), 0 otherwise
         """
         self.prep_state = bool(state)
+        # TTC fix: record this edge (any lane, press or release) as early as possible, so a
+        # near-simultaneous edge on another lane sees it via handle_prep_runout's time-window
+        # check below. See handle_prep_runout() for the full explanation.
+        self.afc.last_prep_activity_time = eventtime
 
         delta_time = eventtime - self.last_prep_time
         self.last_prep_time = eventtime
@@ -1231,6 +1235,7 @@ class AFCLane:
             return
 
         self.prep_active = True
+        self.afc.prep_active_count += 1   # TTC fix: mirror into the shared cross-lane counter
 
         # Checking to make sure printer is ready and making sure PREP has been called before trying to load anything
         for i in range(1):
@@ -1253,6 +1258,7 @@ class AFCLane:
                         if self.afc.function.is_printing(check_movement=True):
                             self.afc.error.AFC_error(f"Cannot load {self.name} spool while printer is actively moving or homing", False)
                             self.prep_active = False
+                            self.afc.prep_active_count -= 1   # TTC fix: mirror exit here too
                             return
 
                         # Calling common load function
@@ -1296,6 +1302,7 @@ class AFCLane:
                         message += '\n    Once cleared try loading again'
                         self.afc.error.AFC_error(message, pause=False)
         self.prep_active = False
+        self.afc.prep_active_count -= 1   # TTC fix: mirror normal exit
         self.afc.save_vars()
 
     def handle_prep_runout(self, eventtime, prep_state):
@@ -1309,11 +1316,15 @@ class AFCLane:
 
         :param eventtime: Event time from the button press
         """
-        # Call filament sensor callback so that state is registered
-        try:
-            self.prep_debounce_button._old_note_filament_present(is_filament_present=prep_state)
-        except:
-            self.prep_debounce_button._old_note_filament_present(eventtime, prep_state)
+        # Call filament sensor callback so that state is registered. Mirrors the same
+        # getattr-guarded pattern handle_load_runout uses just above — a bare try/except here
+        # only covers a call-signature mismatch, not the attribute being fully absent.
+        button = getattr(self, "prep_debounce_button", None)
+        if button:
+            try:
+                self.prep_debounce_button._old_note_filament_present(is_filament_present=prep_state)
+            except:
+                self.prep_debounce_button._old_note_filament_present(eventtime, prep_state)
 
         if (self.printer.state_message == 'Printer is ready'
             and True == self._afc_prep_done
@@ -1323,6 +1334,9 @@ class AFCLane:
                 and self.afc.function.is_printing()
                 and self.raw_load_state
                 and self.status != AFCLaneState.EJECTING):
+                # Mid-print runout/pause path — always reacts immediately, on purpose. This is
+                # a safety-relevant path and must never be delayed by the TTC guard below,
+                # which only applies to the non-printing unload branch further down.
                 # Don't run if user disabled sensor in gui
                 if not self.fila_prep.runout_helper.sensor_enabled:
                     self.logger.warning("Prep runout has been detected, but pause and runout detection has been disabled")
@@ -1332,6 +1346,34 @@ class AFCLane:
                 else:
                     self._perform_pause_runout()
             elif not prep_state:
+                # --- TTC (Timer Too Close) fix ----------------------------------------------
+                # set_unloaded() below changes lane state and updates the LED (afc_led()). If
+                # this fires while a PREP cycle is still actively driving a stepper — this
+                # lane's own (do_homing_move()/drip_move(), see AFC_stepper.py) or ANOTHER
+                # lane's — that can collide with real-time step scheduling for that motor on
+                # the hub MCU (e.g. Turtle_1) and trip Klipper's trsync watchdog, shutting the
+                # MCU down with "Timer too close". Scoped to just this branch (filament
+                # removed outside of a print) — the mid-print runout/pause branch above is
+                # never gated, so a genuine runout during a print is never delayed by this.
+                #
+                # Two complementary, cross-lane signals guard against it:
+                #  - prep_active_count: how many lanes have an active PREP cycle in flight
+                #    right now (covers overlapping/sustained activity across lanes).
+                #  - last_prep_activity_time: wall-clock time of the last PREP edge seen on
+                #    any lane (covers two edges landing close enough together that the
+                #    counter above hasn't been updated yet by the other lane — a plain
+                #    counter check can't see that).
+                #
+                # This isolates the runout event rather than fully resolving it: an edge
+                # dropped by this guard is not re-evaluated once the guard window closes.
+                # Confirmed by live reproduction testing (2026-08-08) to eliminate the
+                # fast/reliable TTC crash from normal PREP use; a much rarer failure remains
+                # only under sustained artificial host I/O stress combined with deliberately
+                # adversarial rapid multi-lane cycling, and was not reproducible in normal use.
+                PREP_GUARD_WINDOW = 2.0  # seconds
+                if (self.afc.prep_active_count > 0
+                    or (eventtime - self.afc.last_prep_activity_time) < PREP_GUARD_WINDOW):
+                    return
                 # Filament is unloaded
                 self.set_unloaded()
 

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -316,6 +316,7 @@ class AFCLane:
 
         self.connect_done = False
         self.prep_active = False
+        self.prep_recheck_pending = False
         self.last_prep_time: float = 0.
 
         self.show_macros = self.afc.show_macros
@@ -1234,9 +1235,8 @@ class AFCLane:
             return
 
         self.prep_active = True
-        self.afc.prep_active_count += 1   # mirrors self.prep_active into the shared counter
 
-        # try/finally so the counters above always get released, even on an unhandled
+        # try/finally so prep_active always gets released, even on an unhandled
         # exception from prep_load()/prep_post_load()/TOOL_LOAD(); save_vars() stays outside
         # on purpose, it must still only run on normal completion.
         try:
@@ -1304,7 +1304,6 @@ class AFCLane:
                             self.afc.error.AFC_error(message, pause=False)
         finally:
             self.prep_active = False
-            self.afc.prep_active_count -= 1
         self.afc.save_vars()
 
     def handle_prep_runout(self, eventtime, prep_state):
@@ -1347,17 +1346,23 @@ class AFCLane:
             elif not prep_state:
                 # Defer instead of acting while another lane's PREP cycle may still be
                 # driving a stepper, see _recheck_prep_runout().
-                if (self.afc.prep_active_count > 0
+                if (self._any_lane_prep_active()
                     or (eventtime - self.afc.last_prep_activity_time) < self.PREP_GUARD_WINDOW):
-                    self.reactor.register_callback(
-                        self._recheck_prep_runout,
-                        self.reactor.monotonic() + self.PREP_GUARD_WINDOW,
-                    )
+                    if not self.prep_recheck_pending:
+                        self.prep_recheck_pending = True
+                        self.reactor.register_callback(
+                            self._recheck_prep_runout,
+                            self.reactor.monotonic() + self.PREP_GUARD_WINDOW,
+                        )
                     return
                 # Filament is unloaded
                 self.set_unloaded()
 
         self.afc.save_vars()
+
+    def _any_lane_prep_active(self) -> bool:
+        """True if any lane (this one or another) has a PREP cycle in flight right now."""
+        return any(lane.prep_active for lane in self.afc.lanes.values())
 
     def _recheck_prep_runout(self, eventtime):
         """
@@ -1365,14 +1370,16 @@ class AFCLane:
         again if still blocked or the lane got filament back in the meantime.
         """
         if self.prep_state:
+            self.prep_recheck_pending = False
             return
-        if (self.afc.prep_active_count > 0
+        if (self._any_lane_prep_active()
             or (eventtime - self.afc.last_prep_activity_time) < self.PREP_GUARD_WINDOW):
             self.reactor.register_callback(
                 self._recheck_prep_runout,
                 self.reactor.monotonic() + self.PREP_GUARD_WINDOW,
             )
             return
+        self.prep_recheck_pending = False
         self.set_unloaded()
         self.afc.save_vars()
 

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -95,6 +95,7 @@ class AFCMoveWarning(Enum):
 
 class AFCLane:
     UPDATE_WEIGHT_DELAY = 10.0
+    PREP_GUARD_WINDOW = 2.0  # seconds
     def __init__(self, config: ConfigWrapper) -> None:
         self._config            = config
         self.printer            = config.get_printer()
@@ -1214,9 +1215,7 @@ class AFCLane:
         :param state: 1 if the prep sensor is now triggered (filament present), 0 otherwise
         """
         self.prep_state = bool(state)
-        # TTC fix: record this edge (any lane, press or release) as early as possible, so a
-        # near-simultaneous edge on another lane sees it via handle_prep_runout's time-window
-        # check below. See handle_prep_runout() for the full explanation.
+        # Record every PREP edge (any lane) for handle_prep_runout's guard
         self.afc.last_prep_activity_time = eventtime
 
         delta_time = eventtime - self.last_prep_time
@@ -1235,15 +1234,11 @@ class AFCLane:
             return
 
         self.prep_active = True
-        self.afc.prep_active_count += 1   # TTC fix: mirror into the shared cross-lane counter
+        self.afc.prep_active_count += 1   # mirrors self.prep_active into the shared counter
 
-        # TTC fix: the increment above must always be undone, even if something in this block
-        # raises (prep_load()/prep_post_load()/TOOL_LOAD()/etc. are all reachable here and none
-        # of them are guaranteed not to throw). Without this, an unhandled exception would leave
-        # prep_active_count stuck positive forever, permanently blocking handle_prep_runout's
-        # non-printing set_unloaded() path for every lane, not just this one. save_vars() stays
-        # outside the try/finally on purpose: it must still run only on normal completion
-        # (fall-through/break), not on the early-return abort below or on a raised exception.
+        # try/finally so the counters above always get released, even on an unhandled
+        # exception from prep_load()/prep_post_load()/TOOL_LOAD(); save_vars() stays outside
+        # on purpose, it must still only run on normal completion.
         try:
             # Checking to make sure printer is ready and making sure PREP has been called before trying to load anything
             for i in range(1):
@@ -1309,7 +1304,7 @@ class AFCLane:
                             self.afc.error.AFC_error(message, pause=False)
         finally:
             self.prep_active = False
-            self.afc.prep_active_count -= 1   # TTC fix: mirror every exit (normal, early return, or exception)
+            self.afc.prep_active_count -= 1
         self.afc.save_vars()
 
     def handle_prep_runout(self, eventtime, prep_state):
@@ -1323,9 +1318,8 @@ class AFCLane:
 
         :param eventtime: Event time from the button press
         """
-        # Call filament sensor callback so that state is registered. Mirrors the same
-        # getattr-guarded pattern handle_load_runout uses just above — a bare try/except here
-        # only covers a call-signature mismatch, not the attribute being fully absent.
+        # Call filament sensor callback so that state is registered. Mirrors the
+        # getattr-guarded pattern handle_load_runout uses just above.
         button = getattr(self, "prep_debounce_button", None)
         if button:
             try:
@@ -1341,9 +1335,7 @@ class AFCLane:
                 and self.afc.function.is_printing()
                 and self.raw_load_state
                 and self.status != AFCLaneState.EJECTING):
-                # Mid-print runout/pause path — always reacts immediately, on purpose. This is
-                # a safety-relevant path and must never be delayed by the TTC guard below,
-                # which only applies to the non-printing unload branch further down.
+                # Mid-print runout/pause: always reacts immediately, unlike the guard below.
                 # Don't run if user disabled sensor in gui
                 if not self.fila_prep.runout_helper.sensor_enabled:
                     self.logger.warning("Prep runout has been detected, but pause and runout detection has been disabled")
@@ -1353,37 +1345,35 @@ class AFCLane:
                 else:
                     self._perform_pause_runout()
             elif not prep_state:
-                # --- TTC (Timer Too Close) fix ----------------------------------------------
-                # set_unloaded() below changes lane state and updates the LED (afc_led()). If
-                # this fires while a PREP cycle is still actively driving a stepper — this
-                # lane's own (do_homing_move()/drip_move(), see AFC_stepper.py) or ANOTHER
-                # lane's — that can collide with real-time step scheduling for that motor on
-                # the hub MCU (e.g. Turtle_1) and trip Klipper's trsync watchdog, shutting the
-                # MCU down with "Timer too close". Scoped to just this branch (filament
-                # removed outside of a print) — the mid-print runout/pause branch above is
-                # never gated, so a genuine runout during a print is never delayed by this.
-                #
-                # Two complementary, cross-lane signals guard against it:
-                #  - prep_active_count: how many lanes have an active PREP cycle in flight
-                #    right now (covers overlapping/sustained activity across lanes).
-                #  - last_prep_activity_time: wall-clock time of the last PREP edge seen on
-                #    any lane (covers two edges landing close enough together that the
-                #    counter above hasn't been updated yet by the other lane — a plain
-                #    counter check can't see that).
-                #
-                # This isolates the runout event rather than fully resolving it: an edge
-                # dropped by this guard is not re-evaluated once the guard window closes.
-                # Confirmed by live reproduction testing (2026-08-08) to eliminate the
-                # fast/reliable TTC crash from normal PREP use; a much rarer failure remains
-                # only under sustained artificial host I/O stress combined with deliberately
-                # adversarial rapid multi-lane cycling, and was not reproducible in normal use.
-                PREP_GUARD_WINDOW = 2.0  # seconds
+                # Defer instead of acting while another lane's PREP cycle may still be
+                # driving a stepper, see _recheck_prep_runout().
                 if (self.afc.prep_active_count > 0
-                    or (eventtime - self.afc.last_prep_activity_time) < PREP_GUARD_WINDOW):
+                    or (eventtime - self.afc.last_prep_activity_time) < self.PREP_GUARD_WINDOW):
+                    self.reactor.register_callback(
+                        self._recheck_prep_runout,
+                        self.reactor.monotonic() + self.PREP_GUARD_WINDOW,
+                    )
                     return
                 # Filament is unloaded
                 self.set_unloaded()
 
+        self.afc.save_vars()
+
+    def _recheck_prep_runout(self, eventtime):
+        """
+        Re-evaluate a PREP release that handle_prep_runout() deferred. Defers
+        again if still blocked or the lane got filament back in the meantime.
+        """
+        if self.prep_state:
+            return
+        if (self.afc.prep_active_count > 0
+            or (eventtime - self.afc.last_prep_activity_time) < self.PREP_GUARD_WINDOW):
+            self.reactor.register_callback(
+                self._recheck_prep_runout,
+                self.reactor.monotonic() + self.PREP_GUARD_WINDOW,
+            )
+            return
+        self.set_unloaded()
         self.afc.save_vars()
 
     def _post_prep_user_macro(self):

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -1258,12 +1258,9 @@ class AFCLane:
                                 break
 
                             # Check to see if the printer is printing or moving, as trying to load while printer is doing something will crash klipper
-                            if self.afc.function.is_printing(check_movement=True):
+                            if (self.afc.function.is_printing(check_movement=True)
+                                or any(lane.prep_active for lane in self.afc.lanes.values() if lane is not self)):
                                 self.afc.error.AFC_error(f"Cannot load {self.name} spool while printer is actively moving or homing", False)
-                                return
-
-                            # Check to see if another lane already has a PREP cycle in flight
-                            if any(lane.prep_active for lane in self.afc.lanes.values() if lane is not self):
                                 return
 
                             # Calling common load function

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -857,6 +857,8 @@ class TestHandlePrepRunout:
         lane.status = "None"
         lane.name = "lane1"
         lane.prep_state = False
+        lane.prep_active = False
+        lane.prep_recheck_pending = False
         lane.afc.current = "lane2"  # not this lane, so the mid-print branch's name check fails
         lane.afc.function.is_printing = MagicMock(return_value=False)
         lane._load_state = False
@@ -865,9 +867,9 @@ class TestHandlePrepRunout:
         lane._perform_infinite_runout = MagicMock()
         lane._perform_pause_runout = MagicMock()
         lane.afc.save_vars = MagicMock()
-        # Real ints/floats, not the MagicMock defaults — the guard does numeric
-        # comparisons (>, -, <) against these.
-        lane.afc.prep_active_count = 0
+        # Real dict, not the MagicMock default — _any_lane_prep_active() iterates it.
+        # Starts with just this lane, itself not active.
+        lane.afc.lanes = {lane.name: lane}
         lane.afc.last_prep_activity_time = 0.0
         lane.fila_prep = MagicMock()
         lane.fila_prep.runout_helper.sensor_enabled = True
@@ -881,6 +883,26 @@ class TestHandlePrepRunout:
             if hasattr(lane, "prep_debounce_button"):
                 del lane.prep_debounce_button
         return lane
+
+    def _add_other_active_lane(self, lane):
+        """Add a second lane to lane.afc.lanes with prep_active=True."""
+        lane.afc.lanes["lane2"] = MagicMock(prep_active=True)
+
+    # -- _any_lane_prep_active() in isolation --
+
+    def test_any_lane_prep_active_true_when_self_active(self):
+        lane = self._make()
+        lane.prep_active = True
+        assert lane._any_lane_prep_active() is True
+
+    def test_any_lane_prep_active_true_when_other_lane_active(self):
+        lane = self._make()
+        self._add_other_active_lane(lane)
+        assert lane._any_lane_prep_active() is True
+
+    def test_any_lane_prep_active_false_when_none_active(self):
+        lane = self._make()
+        assert lane._any_lane_prep_active() is False
 
     # -- debounce button forwarding (mirrors TestHandleLoadRunout) --
 
@@ -908,11 +930,11 @@ class TestHandlePrepRunout:
         lane.handle_prep_runout(100.0, False)
         assert not hasattr(lane, "prep_debounce_button")
 
-    # -- TTC guard: prep_active_count signal --
+    # -- TTC guard: any-lane-active signal --
 
-    def test_guard_blocks_set_unloaded_when_prep_active_count_positive(self):
+    def test_guard_blocks_set_unloaded_when_another_lane_active(self):
         lane = self._make()
-        lane.afc.prep_active_count = 1
+        self._add_other_active_lane(lane)
         lane.afc.last_prep_activity_time = -100.0  # far in the past on its own
         lane.handle_prep_runout(100.0, False)
         lane.set_unloaded.assert_not_called()
@@ -922,22 +944,20 @@ class TestHandlePrepRunout:
         edge must not just vanish -- it has to be scheduled for a later
         re-evaluation, or a lane's runout can get permanently stuck stale."""
         lane = self._make()
-        lane.afc.prep_active_count = 1
+        self._add_other_active_lane(lane)
         lane.handle_prep_runout(100.0, False)
         lane.reactor.register_callback.assert_called_once_with(
             lane._recheck_prep_runout, 100.0 + lane.PREP_GUARD_WINDOW
         )
 
-    def test_guard_allows_set_unloaded_when_count_zero_and_outside_window(self):
+    def test_guard_allows_set_unloaded_when_no_lane_active_and_outside_window(self):
         lane = self._make()
-        lane.afc.prep_active_count = 0
         lane.afc.last_prep_activity_time = 0.0  # eventtime=100.0 -> delta=100s
         lane.handle_prep_runout(100.0, False)
         lane.set_unloaded.assert_called_once_with()
 
     def test_guard_allows_does_not_schedule_a_recheck(self):
         lane = self._make()
-        lane.afc.prep_active_count = 0
         lane.afc.last_prep_activity_time = 0.0
         lane.handle_prep_runout(100.0, False)
         lane.reactor.register_callback.assert_not_called()
@@ -946,21 +966,19 @@ class TestHandlePrepRunout:
 
     def test_guard_blocks_set_unloaded_within_time_window(self):
         lane = self._make()
-        lane.afc.prep_active_count = 0
         lane.afc.last_prep_activity_time = 99.5  # delta=0.5s < 2.0s window
         lane.handle_prep_runout(100.0, False)
         lane.set_unloaded.assert_not_called()
 
     def test_guard_allows_set_unloaded_at_window_boundary(self):
         lane = self._make()
-        lane.afc.prep_active_count = 0
         lane.afc.last_prep_activity_time = 98.0  # delta=2.0s, not < 2.0
         lane.handle_prep_runout(100.0, False)
         lane.set_unloaded.assert_called_once_with()
 
     def test_guard_blocks_save_vars_too(self):
         lane = self._make()
-        lane.afc.prep_active_count = 1
+        self._add_other_active_lane(lane)
         lane.handle_prep_runout(100.0, False)
         lane.afc.save_vars.assert_not_called()
 
@@ -968,7 +986,7 @@ class TestHandlePrepRunout:
 
     def test_mid_print_pause_runout_never_gated_by_ttc_guard(self):
         lane = self._make()
-        lane.afc.prep_active_count = 5       # deliberately "active", would normally gate
+        self._add_other_active_lane(lane)  # deliberately active, would normally gate
         lane.afc.last_prep_activity_time = 99.99  # deliberately inside the window too
         lane.afc.current = "lane1"
         lane.afc.function.is_printing = MagicMock(return_value=True)
@@ -981,7 +999,7 @@ class TestHandlePrepRunout:
 
     def test_mid_print_infinite_runout_never_gated_by_ttc_guard(self):
         lane = self._make()
-        lane.afc.prep_active_count = 5
+        self._add_other_active_lane(lane)
         lane.afc.last_prep_activity_time = 99.99
         lane.afc.current = "lane1"
         lane.afc.function.is_printing = MagicMock(return_value=True)
@@ -1003,9 +1021,9 @@ class TestHandlePrepRunout:
         lane.set_unloaded.assert_not_called()
         lane.reactor.register_callback.assert_not_called()
 
-    def test_recheck_defers_again_if_still_blocked_by_count(self):
+    def test_recheck_defers_again_if_still_blocked_by_another_lane(self):
         lane = self._make()
-        lane.afc.prep_active_count = 1  # e.g. a different lane started a new cycle meanwhile
+        self._add_other_active_lane(lane)  # e.g. a different lane started a new cycle meanwhile
         lane._recheck_prep_runout(200.0)
         lane.set_unloaded.assert_not_called()
         # Rescheduled relative to wall-clock now (reactor.monotonic(), fixed at 100.0 by
@@ -1024,7 +1042,6 @@ class TestHandlePrepRunout:
 
     def test_recheck_proceeds_once_clear(self):
         lane = self._make()
-        lane.afc.prep_active_count = 0
         lane.afc.last_prep_activity_time = 0.0
         lane._recheck_prep_runout(200.0)
         lane.set_unloaded.assert_called_once_with()
@@ -1036,12 +1053,12 @@ class TestHandlePrepRunout:
         one that eventually finishes the job -- not just each piece tested
         in isolation against hand-picked constants."""
         lane = self._make()
-        lane.afc.prep_active_count = 1
+        self._add_other_active_lane(lane)
         lane.handle_prep_runout(100.0, False)
         lane.set_unloaded.assert_not_called()
 
         recheck_callback, recheck_time = lane.reactor.register_callback.call_args[0]
-        lane.afc.prep_active_count = 0  # the other lane's cycle has since ended
+        lane.afc.lanes["lane2"].prep_active = False  # the other lane's cycle has since ended
         recheck_callback(recheck_time)
 
         lane.set_unloaded.assert_called_once_with()
@@ -3533,73 +3550,21 @@ class TestPrepCallback:
         assert lane.prep_active is False
         lane.afc.save_vars.assert_called_once()
 
-    # ── TTC fix: prep_active_count mirroring (self.afc.prep_active_count) ──
-    # These mirror self.prep_active 1:1 at all 3 exit points, but on the
-    # shared afc object so handle_prep_runout can see cross-lane activity.
-    # Uses a real int (not the default MagicMock) since the guard does
-    # arithmetic (+=/-=) on it — a bare MagicMock would silently swallow
-    # that without ever failing, masking a missing mirror call.
-
-    def test_prep_active_count_is_incremented_during_processing_then_decremented(self):
-        """Same shape as test_prep_active_is_true_during_processing_then_reset
-        above, but for the shared cross-lane counter: observed via a side
-        effect mid-call, proving the increment happens before prep_load runs
-        and the decrement happens after, not just "eventually both occur"."""
-        lane = _make_lane_ready_to_load()
-        lane.afc.prep_active_count = 0
-        observed = []
-        def _record(_lane):
-            observed.append(lane.afc.prep_active_count)
-        lane.unit_obj.prep_load.side_effect = _record
-        lane.prep_callback(10, True)
-        assert observed == [1]
-        assert lane.afc.prep_active_count == 0
-
-    def test_is_printing_while_moving_decrements_prep_active_count(self):
-        """Mirrors test_is_printing_while_moving_sets_prep_active_false: the
-        early-return abort path must also undo the increment, or the
-        counter would leak upward every time a load is attempted while the
-        printer is moving."""
-        lane = _make_lane_ready_to_load()
-        lane.afc.prep_active_count = 0
-        lane.afc.function.is_printing.return_value = True
-        lane.prep_callback(10, True)
-        assert lane.afc.prep_active_count == 0
-
-    def test_debounce_break_does_not_touch_prep_active_count(self):
-        """The debounce break exits before prep_active_count is ever
-        incremented (that happens further down, past this early break), so
-        it must stay at its starting value, not go negative."""
-        lane = _make_lane_ready_to_load()
-        lane.afc.prep_active_count = 0
-        lane.last_prep_time = 9.5
-        lane.prep_callback(10, True)
-        assert lane.afc.prep_active_count == 0
-
-    def test_prep_active_count_survives_concurrent_lane(self):
-        """A second lane's cycle already in flight (count starts at 1, e.g.
-        another lane's prep_callback is mid-run) must not be clobbered by
-        this lane's own increment/decrement — the counter should return to
-        the other lane's level (1), not to 0, after this lane finishes."""
-        lane = _make_lane_ready_to_load()
-        lane.afc.prep_active_count = 1  # another lane already active
-        lane.prep_callback(10, True)
-        assert lane.afc.prep_active_count == 1
+    # ── TTC fix: cross-lane interaction via afc.lanes ──
 
     def test_prep_callback_and_handle_prep_runout_real_interaction(self):
         """End-to-end, no pre-set mock guard values: prove the two methods
-        actually cooperate through the same afc.prep_active_count object,
-        not just that each behaves correctly in isolation against a
-        hand-picked constant (as the TestHandlePrepRunout tests above do).
+        actually cooperate through the shared afc.lanes dict, not just that
+        each behaves correctly in isolation against a hand-picked constant
+        (as the TestHandlePrepRunout tests above do).
 
         Sequence: lane A's prep_callback is captured mid-cycle (via
         prep_load's side effect) with a second lane (B) releasing PREP at
         that exact moment — handle_prep_runout must be blocked. Once A's
-        prep_callback finishes and the counter is back to 0, the same
-        release event must now go through.
+        prep_callback finishes and self.prep_active is back to False, the
+        same release event must now go through.
         """
         lane_a = _make_lane_ready_to_load(fullname="AFC_stepper lane1")
-        lane_a.afc.prep_active_count = 0
 
         from tests.conftest import MockReactor
         lane_b = _make_afc_lane("AFC_stepper lane2")
@@ -3609,6 +3574,8 @@ class TestPrepCallback:
         lane_b.status = "None"
         lane_b.name = "lane2"
         lane_b.prep_state = False
+        lane_b.prep_active = False
+        lane_b.prep_recheck_pending = False
         lane_b.afc.current = "lane1"  # not lane2, so mid-print branch's name check fails
         lane_b._load_state = False
         lane_b.runout_lane = None
@@ -3618,6 +3585,7 @@ class TestPrepCallback:
         lane_b.prep_debounce_button = MagicMock()
         lane_b.reactor = MockReactor()
         lane_b.reactor.register_callback = MagicMock()
+        lane_a.afc.lanes = {lane_a.name: lane_a, lane_b.name: lane_b}
 
         blocked_result = []
         def _release_lane_b_mid_cycle(_lane):
@@ -3629,26 +3597,18 @@ class TestPrepCallback:
 
         # While lane A's cycle was in flight, lane B's release was blocked.
         assert blocked_result == [False]
-        # Lane A's cycle has since ended (counter back to 0) and enough
+        # Lane A's cycle has since ended (prep_active back to False) and enough
         # wall-clock time will have passed by a later, unrelated release.
         lane_b.afc.last_prep_activity_time = -100.0
         lane_b.handle_prep_runout(10.1, False)
         lane_b.set_unloaded.assert_called_once()
 
     # ── TTC fix follow-up (CodeRabbit review on PR #827): exception-safe cleanup ──
-    # prep_active/prep_active_count are incremented before prep_load() runs and were
-    # only reset in the normal/early-return exit paths. If prep_load() (or anything
-    # else in the active-cycle block) raised, both would stay stuck permanently —
-    # for prep_active_count specifically, that means every lane's handle_prep_runout
-    # stays gated forever, not just this lane's own prep_callback re-entrancy guard.
-
-    def test_exception_in_prep_load_still_resets_prep_active_count(self):
-        lane = _make_lane_ready_to_load()
-        lane.afc.prep_active_count = 0
-        lane.unit_obj.prep_load.side_effect = RuntimeError("boom")
-        with pytest.raises(RuntimeError):
-            lane.prep_callback(10, True)
-        assert lane.afc.prep_active_count == 0
+    # prep_active is set True before prep_load() runs and was only reset in the
+    # normal/early-return exit paths. If prep_load() (or anything else in the
+    # active-cycle block) raised, it would stay stuck True permanently — meaning
+    # every lane's handle_prep_runout stays gated forever (since it's aggregated
+    # across lanes), not just this lane's own prep_callback re-entrancy guard.
 
     def test_exception_in_prep_load_still_resets_prep_active(self):
         lane = _make_lane_ready_to_load()
@@ -3676,11 +3636,10 @@ class TestPrepCallback:
 
     def test_exception_in_prep_load_does_not_block_other_lanes_afterward(self):
         """The concrete regression this whole fix is about: before it, a
-        raised exception left prep_active_count stuck positive, so a
-        completely unrelated lane's genuine PREP release would stay gated
-        forever. This proves that no longer happens."""
+        raised exception left prep_active stuck True, so a completely
+        unrelated lane's genuine PREP release would stay gated forever.
+        This proves that no longer happens."""
         lane_a = _make_lane_ready_to_load(fullname="AFC_stepper lane1")
-        lane_a.afc.prep_active_count = 0
         lane_a.unit_obj.prep_load.side_effect = RuntimeError("boom")
         with pytest.raises(RuntimeError):
             lane_a.prep_callback(10, True)
@@ -3693,6 +3652,8 @@ class TestPrepCallback:
         lane_b.status = "None"
         lane_b.name = "lane2"
         lane_b.prep_state = False
+        lane_b.prep_active = False
+        lane_b.prep_recheck_pending = False
         lane_b.afc.current = "lane1"
         lane_b._load_state = False
         lane_b.runout_lane = None
@@ -3703,6 +3664,7 @@ class TestPrepCallback:
         lane_b.reactor = MockReactor()
         lane_b.reactor.register_callback = MagicMock()
         lane_b.afc.last_prep_activity_time = -100.0
+        lane_a.afc.lanes = {lane_a.name: lane_a, lane_b.name: lane_b}
 
         lane_b.handle_prep_runout(20.0, False)
         lane_b.set_unloaded.assert_called_once()

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -837,6 +837,148 @@ class TestHandleLoadRunout:
         lane.afc.save_vars.assert_called_once_with()
 
 
+# ── handle_prep_runout — TTC (Timer Too Close) cross-lane guard ────────────────
+#
+# handle_prep_runout() reacts to the PREP switch returning to rest. Its
+# set_unloaded() call changes lane state and updates the LED, which can collide
+# with real-time step scheduling if a PREP cycle (this lane's own, or another
+# lane's) is still actively driving a stepper — tripping Klipper's trsync
+# watchdog and shutting the hub MCU down with "Timer too close". The guard
+# below is scoped to that one branch only; the mid-print runout/pause branch
+# must never be delayed by it (that's a safety-relevant path).
+
+class TestHandlePrepRunout:
+    def _make(self, prep_debounce_button=True):
+        lane = _make_afc_lane()
+        lane.printer = MagicMock()
+        lane.printer.state_message = "Printer is ready"
+        lane._afc_prep_done = True
+        lane.status = "None"
+        lane.name = "lane1"
+        lane.afc.current = "lane2"  # not this lane, so the mid-print branch's name check fails
+        lane.afc.function.is_printing = MagicMock(return_value=False)
+        lane._load_state = False
+        lane.runout_lane = None
+        lane.set_unloaded = MagicMock()
+        lane._perform_infinite_runout = MagicMock()
+        lane._perform_pause_runout = MagicMock()
+        lane.afc.save_vars = MagicMock()
+        # Real ints/floats, not the MagicMock defaults — the guard does numeric
+        # comparisons (>, -, <) against these.
+        lane.afc.prep_active_count = 0
+        lane.afc.last_prep_activity_time = 0.0
+        lane.fila_prep = MagicMock()
+        lane.fila_prep.runout_helper.sensor_enabled = True
+        if prep_debounce_button:
+            lane.prep_debounce_button = MagicMock()
+        else:
+            if hasattr(lane, "prep_debounce_button"):
+                del lane.prep_debounce_button
+        return lane
+
+    # -- debounce button forwarding (mirrors TestHandleLoadRunout) --
+
+    def test_button_present_try_path_uses_keyword_form(self):
+        lane = self._make()
+        lane.handle_prep_runout(100.0, True)
+        lane.prep_debounce_button._old_note_filament_present.assert_called_once_with(
+            is_filament_present=True
+        )
+
+    def test_button_present_except_path_uses_positional_form(self):
+        lane = self._make()
+        lane.prep_debounce_button._old_note_filament_present.side_effect = [
+            TypeError("old style"), None
+        ]
+        lane.handle_prep_runout(100.0, True)
+        assert lane.prep_debounce_button._old_note_filament_present.call_args_list == [
+            call(is_filament_present=True),
+            call(100.0, True),
+        ]
+
+    def test_button_absent_skips_forwarding_entirely(self):
+        lane = self._make(prep_debounce_button=False)
+        # Should not raise despite there being no prep_debounce_button attribute.
+        lane.handle_prep_runout(100.0, False)
+        assert not hasattr(lane, "prep_debounce_button")
+
+    # -- TTC guard: prep_active_count signal --
+
+    def test_guard_blocks_set_unloaded_when_prep_active_count_positive(self):
+        lane = self._make()
+        lane.afc.prep_active_count = 1
+        lane.afc.last_prep_activity_time = -100.0  # far in the past on its own
+        lane.handle_prep_runout(100.0, False)
+        lane.set_unloaded.assert_not_called()
+
+    def test_guard_allows_set_unloaded_when_count_zero_and_outside_window(self):
+        lane = self._make()
+        lane.afc.prep_active_count = 0
+        lane.afc.last_prep_activity_time = 0.0  # eventtime=100.0 -> delta=100s
+        lane.handle_prep_runout(100.0, False)
+        lane.set_unloaded.assert_called_once_with()
+
+    # -- TTC guard: last_prep_activity_time window signal --
+
+    def test_guard_blocks_set_unloaded_within_time_window(self):
+        lane = self._make()
+        lane.afc.prep_active_count = 0
+        lane.afc.last_prep_activity_time = 99.5  # delta=0.5s < 2.0s window
+        lane.handle_prep_runout(100.0, False)
+        lane.set_unloaded.assert_not_called()
+
+    def test_guard_allows_set_unloaded_at_window_boundary(self):
+        lane = self._make()
+        lane.afc.prep_active_count = 0
+        lane.afc.last_prep_activity_time = 98.0  # delta=2.0s, not < 2.0
+        lane.handle_prep_runout(100.0, False)
+        lane.set_unloaded.assert_called_once_with()
+
+    def test_guard_blocks_save_vars_too(self):
+        lane = self._make()
+        lane.afc.prep_active_count = 1
+        lane.handle_prep_runout(100.0, False)
+        lane.afc.save_vars.assert_not_called()
+
+    # -- TTC guard must never gate the mid-print runout/pause branch --
+
+    def test_mid_print_pause_runout_never_gated_by_ttc_guard(self):
+        lane = self._make()
+        lane.afc.prep_active_count = 5       # deliberately "active", would normally gate
+        lane.afc.last_prep_activity_time = 99.99  # deliberately inside the window too
+        lane.afc.current = "lane1"
+        lane.afc.function.is_printing = MagicMock(return_value=True)
+        lane._load_state = True
+        lane.runout_lane = None
+        lane.handle_prep_runout(100.0, False)
+        lane._perform_pause_runout.assert_called_once_with()
+        lane.set_unloaded.assert_not_called()  # took the printing branch, not the unload one
+
+    def test_mid_print_infinite_runout_never_gated_by_ttc_guard(self):
+        lane = self._make()
+        lane.afc.prep_active_count = 5
+        lane.afc.last_prep_activity_time = 99.99
+        lane.afc.current = "lane1"
+        lane.afc.function.is_printing = MagicMock(return_value=True)
+        lane._load_state = True
+        lane.runout_lane = "lane3"
+        lane.handle_prep_runout(100.0, False)
+        lane._perform_infinite_runout.assert_called_once_with()
+
+    # -- outer gate / save_vars sanity (mirrors TestHandleLoadRunout) --
+
+    def test_outer_gate_wrong_state_message_blocks_processing(self):
+        lane = self._make()
+        lane.printer.state_message = "Starting"
+        lane.handle_prep_runout(100.0, False)
+        lane.set_unloaded.assert_not_called()
+
+    def test_save_vars_called_after_normal_processing(self):
+        lane = self._make()
+        lane.handle_prep_runout(100.0, False)
+        lane.afc.save_vars.assert_called_once_with()
+
+
 # ── __str__ ───────────────────────────────────────────────────────────────────
 
 class TestAFCLaneStr:

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -3549,3 +3549,71 @@ class TestPrepCallback:
         lane_b.afc.last_prep_activity_time = -100.0
         lane_b.handle_prep_runout(10.1, False)
         lane_b.set_unloaded.assert_called_once()
+
+    # ── TTC fix follow-up (CodeRabbit review on PR #827): exception-safe cleanup ──
+    # prep_active/prep_active_count are incremented before prep_load() runs and were
+    # only reset in the normal/early-return exit paths. If prep_load() (or anything
+    # else in the active-cycle block) raised, both would stay stuck permanently —
+    # for prep_active_count specifically, that means every lane's handle_prep_runout
+    # stays gated forever, not just this lane's own prep_callback re-entrancy guard.
+
+    def test_exception_in_prep_load_still_resets_prep_active_count(self):
+        lane = _make_lane_ready_to_load()
+        lane.afc.prep_active_count = 0
+        lane.unit_obj.prep_load.side_effect = RuntimeError("boom")
+        with pytest.raises(RuntimeError):
+            lane.prep_callback(10, True)
+        assert lane.afc.prep_active_count == 0
+
+    def test_exception_in_prep_load_still_resets_prep_active(self):
+        lane = _make_lane_ready_to_load()
+        lane.unit_obj.prep_load.side_effect = RuntimeError("boom")
+        with pytest.raises(RuntimeError):
+            lane.prep_callback(10, True)
+        assert lane.prep_active is False
+
+    def test_exception_in_prep_load_still_propagates(self):
+        """The fix guarantees cleanup, not error suppression — the original
+        exception must still reach the caller unchanged."""
+        lane = _make_lane_ready_to_load()
+        lane.unit_obj.prep_load.side_effect = RuntimeError("boom")
+        with pytest.raises(RuntimeError, match="boom"):
+            lane.prep_callback(10, True)
+
+    def test_exception_in_prep_load_skips_save_vars(self):
+        """Matches the existing is_printing-abort behavior: a path that
+        never reaches normal completion must not call save_vars() either."""
+        lane = _make_lane_ready_to_load()
+        lane.unit_obj.prep_load.side_effect = RuntimeError("boom")
+        with pytest.raises(RuntimeError):
+            lane.prep_callback(10, True)
+        lane.afc.save_vars.assert_not_called()
+
+    def test_exception_in_prep_load_does_not_block_other_lanes_afterward(self):
+        """The concrete regression this whole fix is about: before it, a
+        raised exception left prep_active_count stuck positive, so a
+        completely unrelated lane's genuine PREP release would stay gated
+        forever. This proves that no longer happens."""
+        lane_a = _make_lane_ready_to_load(fullname="AFC_stepper lane1")
+        lane_a.afc.prep_active_count = 0
+        lane_a.unit_obj.prep_load.side_effect = RuntimeError("boom")
+        with pytest.raises(RuntimeError):
+            lane_a.prep_callback(10, True)
+
+        lane_b = _make_afc_lane("AFC_stepper lane2")
+        lane_b.afc = lane_a.afc
+        lane_b.printer = lane_a.printer
+        lane_b._afc_prep_done = True
+        lane_b.status = "None"
+        lane_b.name = "lane2"
+        lane_b.afc.current = "lane1"
+        lane_b._load_state = False
+        lane_b.runout_lane = None
+        lane_b.set_unloaded = MagicMock()
+        lane_b.fila_prep = MagicMock()
+        lane_b.fila_prep.runout_helper.sensor_enabled = True
+        lane_b.prep_debounce_button = MagicMock()
+        lane_b.afc.last_prep_activity_time = -100.0
+
+        lane_b.handle_prep_runout(20.0, False)
+        lane_b.set_unloaded.assert_called_once()

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -3133,6 +3133,9 @@ def _make_lane_for_prep_callback(fullname="AFC_stepper lane1"):
     lane.status = AFCLaneState.LOADED  # anything but TOOL_UNLOADING
     lane.prep_active = False
     lane.last_prep_time = 0
+    # Real dict, not the MagicMock default -- _any_lane_prep_active() iterates it.
+    # Starts with just this lane, itself not active.
+    lane.afc.lanes = {lane.name: lane}
     lane._load_state = False
     lane.hub = "PB1"
     lane.td1_device_id = None
@@ -3345,6 +3348,48 @@ class TestPrepCallback:
         lane.afc.function.is_printing.return_value = True
         lane.prep_callback(10, True)
         lane.afc.save_vars.assert_not_called()
+
+    # ── TTC guard: another lane already has a PREP cycle in flight ───────
+
+    def test_another_lane_active_blocks_prep_load(self):
+        lane = _make_lane_ready_to_load()
+        lane.afc.lanes["lane2"] = MagicMock(prep_active=True)
+        lane.prep_callback(10, True)
+        lane.unit_obj.prep_load.assert_not_called()
+
+    def test_another_lane_active_still_resets_prep_active(self):
+        lane = _make_lane_ready_to_load()
+        lane.afc.lanes["lane2"] = MagicMock(prep_active=True)
+        lane.prep_callback(10, True)
+        assert lane.prep_active is False
+
+    def test_another_lane_active_does_not_call_save_vars(self):
+        """Same shape as the is_printing guard above: this path returns
+        (not breaks), so it must skip the trailing save_vars() call."""
+        lane = _make_lane_ready_to_load()
+        lane.afc.lanes["lane2"] = MagicMock(prep_active=True)
+        lane.prep_callback(10, True)
+        lane.afc.save_vars.assert_not_called()
+
+    def test_another_lane_active_checked_after_is_printing(self):
+        """is_printing is still checked first; its own abort message must
+        fire instead of silently falling through to the new guard."""
+        lane = _make_lane_ready_to_load()
+        lane.afc.function.is_printing.return_value = True
+        lane.afc.lanes["lane2"] = MagicMock(prep_active=True)
+        lane.prep_callback(10, True)
+        lane.afc.error.AFC_error.assert_called_once_with(
+            "Cannot load lane1 spool while printer is actively moving or homing", False
+        )
+
+    def test_only_this_lane_in_afc_lanes_does_not_block_prep_load(self):
+        """Baseline: with no other lane present, _any_lane_prep_active() must
+        not block the lane's own load -- guards against a helper regression
+        that would make every prep_callback test fail closed."""
+        lane = _make_lane_ready_to_load()
+        assert list(lane.afc.lanes.keys()) == ["lane1"]
+        lane.prep_callback(10, True)
+        lane.unit_obj.prep_load.assert_called_once_with(lane)
 
     # ── successful prep_load call ─────────────────────────────────────────
 

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -849,12 +849,14 @@ class TestHandleLoadRunout:
 
 class TestHandlePrepRunout:
     def _make(self, prep_debounce_button=True):
+        from tests.conftest import MockReactor
         lane = _make_afc_lane()
         lane.printer = MagicMock()
         lane.printer.state_message = "Printer is ready"
         lane._afc_prep_done = True
         lane.status = "None"
         lane.name = "lane1"
+        lane.prep_state = False
         lane.afc.current = "lane2"  # not this lane, so the mid-print branch's name check fails
         lane.afc.function.is_printing = MagicMock(return_value=False)
         lane._load_state = False
@@ -869,6 +871,10 @@ class TestHandlePrepRunout:
         lane.afc.last_prep_activity_time = 0.0
         lane.fila_prep = MagicMock()
         lane.fila_prep.runout_helper.sensor_enabled = True
+        # Deferred-recheck fix (Jimmy's review on PR #827): a blocked edge now schedules
+        # a reactor callback instead of just returning, so tests need a reactor stand-in.
+        lane.reactor = MockReactor()
+        lane.reactor.register_callback = MagicMock()
         if prep_debounce_button:
             lane.prep_debounce_button = MagicMock()
         else:
@@ -911,12 +917,30 @@ class TestHandlePrepRunout:
         lane.handle_prep_runout(100.0, False)
         lane.set_unloaded.assert_not_called()
 
+    def test_guard_blocks_schedules_a_recheck_instead_of_dropping(self):
+        """The deferred-recheck fix (Jimmy's review on PR #827): a blocked
+        edge must not just vanish -- it has to be scheduled for a later
+        re-evaluation, or a lane's runout can get permanently stuck stale."""
+        lane = self._make()
+        lane.afc.prep_active_count = 1
+        lane.handle_prep_runout(100.0, False)
+        lane.reactor.register_callback.assert_called_once_with(
+            lane._recheck_prep_runout, 100.0 + lane.PREP_GUARD_WINDOW
+        )
+
     def test_guard_allows_set_unloaded_when_count_zero_and_outside_window(self):
         lane = self._make()
         lane.afc.prep_active_count = 0
         lane.afc.last_prep_activity_time = 0.0  # eventtime=100.0 -> delta=100s
         lane.handle_prep_runout(100.0, False)
         lane.set_unloaded.assert_called_once_with()
+
+    def test_guard_allows_does_not_schedule_a_recheck(self):
+        lane = self._make()
+        lane.afc.prep_active_count = 0
+        lane.afc.last_prep_activity_time = 0.0
+        lane.handle_prep_runout(100.0, False)
+        lane.reactor.register_callback.assert_not_called()
 
     # -- TTC guard: last_prep_activity_time window signal --
 
@@ -953,6 +977,7 @@ class TestHandlePrepRunout:
         lane.handle_prep_runout(100.0, False)
         lane._perform_pause_runout.assert_called_once_with()
         lane.set_unloaded.assert_not_called()  # took the printing branch, not the unload one
+        lane.reactor.register_callback.assert_not_called()  # never reaches the deferred-recheck logic
 
     def test_mid_print_infinite_runout_never_gated_by_ttc_guard(self):
         lane = self._make()
@@ -964,6 +989,62 @@ class TestHandlePrepRunout:
         lane.runout_lane = "lane3"
         lane.handle_prep_runout(100.0, False)
         lane._perform_infinite_runout.assert_called_once_with()
+
+    # -- deferred recheck (Jimmy's review on PR #827: an edge silently dropped by
+    # the guard could leave a lane's internal status stale forever -- e.g. eject
+    # lane A without fully pulling the filament, insert into lane B, then finish
+    # removing A's filament; B's activity kept A's release gated and it never got
+    # reprocessed). _recheck_prep_runout() is the reactor callback scheduled above. --
+
+    def test_recheck_does_nothing_if_filament_was_reinserted(self):
+        lane = self._make()
+        lane.prep_state = True  # filament is back -- the original release is moot
+        lane._recheck_prep_runout(200.0)
+        lane.set_unloaded.assert_not_called()
+        lane.reactor.register_callback.assert_not_called()
+
+    def test_recheck_defers_again_if_still_blocked_by_count(self):
+        lane = self._make()
+        lane.afc.prep_active_count = 1  # e.g. a different lane started a new cycle meanwhile
+        lane._recheck_prep_runout(200.0)
+        lane.set_unloaded.assert_not_called()
+        # Rescheduled relative to wall-clock now (reactor.monotonic(), fixed at 100.0 by
+        # MockReactor), not the eventtime argument -- matches the production code, which
+        # has no reason to anchor off a timestamp from a possibly-stale deferred call.
+        lane.reactor.register_callback.assert_called_once_with(
+            lane._recheck_prep_runout, 100.0 + lane.PREP_GUARD_WINDOW
+        )
+
+    def test_recheck_defers_again_if_still_inside_time_window(self):
+        lane = self._make()
+        lane.afc.last_prep_activity_time = 199.5  # delta=0.5s < window
+        lane._recheck_prep_runout(200.0)
+        lane.set_unloaded.assert_not_called()
+        lane.reactor.register_callback.assert_called_once()
+
+    def test_recheck_proceeds_once_clear(self):
+        lane = self._make()
+        lane.afc.prep_active_count = 0
+        lane.afc.last_prep_activity_time = 0.0
+        lane._recheck_prep_runout(200.0)
+        lane.set_unloaded.assert_called_once_with()
+        lane.afc.save_vars.assert_called_once_with()
+        lane.reactor.register_callback.assert_not_called()
+
+    def test_deferred_edge_actually_resolves_once_reactor_fires_the_recheck(self):
+        """End-to-end: the callback handle_prep_runout schedules is the same
+        one that eventually finishes the job -- not just each piece tested
+        in isolation against hand-picked constants."""
+        lane = self._make()
+        lane.afc.prep_active_count = 1
+        lane.handle_prep_runout(100.0, False)
+        lane.set_unloaded.assert_not_called()
+
+        recheck_callback, recheck_time = lane.reactor.register_callback.call_args[0]
+        lane.afc.prep_active_count = 0  # the other lane's cycle has since ended
+        recheck_callback(recheck_time)
+
+        lane.set_unloaded.assert_called_once_with()
 
     # -- outer gate / save_vars sanity (mirrors TestHandleLoadRunout) --
 
@@ -3520,12 +3601,14 @@ class TestPrepCallback:
         lane_a = _make_lane_ready_to_load(fullname="AFC_stepper lane1")
         lane_a.afc.prep_active_count = 0
 
+        from tests.conftest import MockReactor
         lane_b = _make_afc_lane("AFC_stepper lane2")
         lane_b.afc = lane_a.afc  # same shared afc object, real cross-lane setup
         lane_b.printer = lane_a.printer
         lane_b._afc_prep_done = True
         lane_b.status = "None"
         lane_b.name = "lane2"
+        lane_b.prep_state = False
         lane_b.afc.current = "lane1"  # not lane2, so mid-print branch's name check fails
         lane_b._load_state = False
         lane_b.runout_lane = None
@@ -3533,6 +3616,8 @@ class TestPrepCallback:
         lane_b.fila_prep = MagicMock()
         lane_b.fila_prep.runout_helper.sensor_enabled = True
         lane_b.prep_debounce_button = MagicMock()
+        lane_b.reactor = MockReactor()
+        lane_b.reactor.register_callback = MagicMock()
 
         blocked_result = []
         def _release_lane_b_mid_cycle(_lane):
@@ -3600,12 +3685,14 @@ class TestPrepCallback:
         with pytest.raises(RuntimeError):
             lane_a.prep_callback(10, True)
 
+        from tests.conftest import MockReactor
         lane_b = _make_afc_lane("AFC_stepper lane2")
         lane_b.afc = lane_a.afc
         lane_b.printer = lane_a.printer
         lane_b._afc_prep_done = True
         lane_b.status = "None"
         lane_b.name = "lane2"
+        lane_b.prep_state = False
         lane_b.afc.current = "lane1"
         lane_b._load_state = False
         lane_b.runout_lane = None
@@ -3613,6 +3700,8 @@ class TestPrepCallback:
         lane_b.fila_prep = MagicMock()
         lane_b.fila_prep.runout_helper.sensor_enabled = True
         lane_b.prep_debounce_button = MagicMock()
+        lane_b.reactor = MockReactor()
+        lane_b.reactor.register_callback = MagicMock()
         lane_b.afc.last_prep_activity_time = -100.0
 
         lane_b.handle_prep_runout(20.0, False)

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -3451,3 +3451,101 @@ class TestPrepCallback:
         lane.prep_callback(10, True)
         assert lane.prep_active is False
         lane.afc.save_vars.assert_called_once()
+
+    # ── TTC fix: prep_active_count mirroring (self.afc.prep_active_count) ──
+    # These mirror self.prep_active 1:1 at all 3 exit points, but on the
+    # shared afc object so handle_prep_runout can see cross-lane activity.
+    # Uses a real int (not the default MagicMock) since the guard does
+    # arithmetic (+=/-=) on it — a bare MagicMock would silently swallow
+    # that without ever failing, masking a missing mirror call.
+
+    def test_prep_active_count_is_incremented_during_processing_then_decremented(self):
+        """Same shape as test_prep_active_is_true_during_processing_then_reset
+        above, but for the shared cross-lane counter: observed via a side
+        effect mid-call, proving the increment happens before prep_load runs
+        and the decrement happens after, not just "eventually both occur"."""
+        lane = _make_lane_ready_to_load()
+        lane.afc.prep_active_count = 0
+        observed = []
+        def _record(_lane):
+            observed.append(lane.afc.prep_active_count)
+        lane.unit_obj.prep_load.side_effect = _record
+        lane.prep_callback(10, True)
+        assert observed == [1]
+        assert lane.afc.prep_active_count == 0
+
+    def test_is_printing_while_moving_decrements_prep_active_count(self):
+        """Mirrors test_is_printing_while_moving_sets_prep_active_false: the
+        early-return abort path must also undo the increment, or the
+        counter would leak upward every time a load is attempted while the
+        printer is moving."""
+        lane = _make_lane_ready_to_load()
+        lane.afc.prep_active_count = 0
+        lane.afc.function.is_printing.return_value = True
+        lane.prep_callback(10, True)
+        assert lane.afc.prep_active_count == 0
+
+    def test_debounce_break_does_not_touch_prep_active_count(self):
+        """The debounce break exits before prep_active_count is ever
+        incremented (that happens further down, past this early break), so
+        it must stay at its starting value, not go negative."""
+        lane = _make_lane_ready_to_load()
+        lane.afc.prep_active_count = 0
+        lane.last_prep_time = 9.5
+        lane.prep_callback(10, True)
+        assert lane.afc.prep_active_count == 0
+
+    def test_prep_active_count_survives_concurrent_lane(self):
+        """A second lane's cycle already in flight (count starts at 1, e.g.
+        another lane's prep_callback is mid-run) must not be clobbered by
+        this lane's own increment/decrement — the counter should return to
+        the other lane's level (1), not to 0, after this lane finishes."""
+        lane = _make_lane_ready_to_load()
+        lane.afc.prep_active_count = 1  # another lane already active
+        lane.prep_callback(10, True)
+        assert lane.afc.prep_active_count == 1
+
+    def test_prep_callback_and_handle_prep_runout_real_interaction(self):
+        """End-to-end, no pre-set mock guard values: prove the two methods
+        actually cooperate through the same afc.prep_active_count object,
+        not just that each behaves correctly in isolation against a
+        hand-picked constant (as the TestHandlePrepRunout tests above do).
+
+        Sequence: lane A's prep_callback is captured mid-cycle (via
+        prep_load's side effect) with a second lane (B) releasing PREP at
+        that exact moment — handle_prep_runout must be blocked. Once A's
+        prep_callback finishes and the counter is back to 0, the same
+        release event must now go through.
+        """
+        lane_a = _make_lane_ready_to_load(fullname="AFC_stepper lane1")
+        lane_a.afc.prep_active_count = 0
+
+        lane_b = _make_afc_lane("AFC_stepper lane2")
+        lane_b.afc = lane_a.afc  # same shared afc object, real cross-lane setup
+        lane_b.printer = lane_a.printer
+        lane_b._afc_prep_done = True
+        lane_b.status = "None"
+        lane_b.name = "lane2"
+        lane_b.afc.current = "lane1"  # not lane2, so mid-print branch's name check fails
+        lane_b._load_state = False
+        lane_b.runout_lane = None
+        lane_b.set_unloaded = MagicMock()
+        lane_b.fila_prep = MagicMock()
+        lane_b.fila_prep.runout_helper.sensor_enabled = True
+        lane_b.prep_debounce_button = MagicMock()
+
+        blocked_result = []
+        def _release_lane_b_mid_cycle(_lane):
+            lane_b.handle_prep_runout(10.05, False)
+            blocked_result.append(lane_b.set_unloaded.called)
+        lane_a.unit_obj.prep_load.side_effect = _release_lane_b_mid_cycle
+
+        lane_a.prep_callback(10.0, True)
+
+        # While lane A's cycle was in flight, lane B's release was blocked.
+        assert blocked_result == [False]
+        # Lane A's cycle has since ended (counter back to 0) and enough
+        # wall-clock time will have passed by a later, unrelated release.
+        lane_b.afc.last_prep_activity_time = -100.0
+        lane_b.handle_prep_runout(10.1, False)
+        lane_b.set_unloaded.assert_called_once()

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -3402,6 +3402,31 @@ class TestPrepCallback:
         lane.prep_callback(10, True)
         lane.unit_obj.prep_load.assert_called_once_with(lane)
 
+    # ── last_prep_activity_time: only set when a load actually starts ────
+    # Per review feedback (CodeRabbit + Jimmy): recording this on every edge,
+    # including releases, made handle_prep_runout's guard window always look
+    # "recently active" for a release triggering itself -- moved past all the
+    # guards above so only a load that's actually about to run counts.
+
+    def test_release_edge_does_not_update_last_prep_activity_time(self):
+        lane = _make_lane_ready_to_load()
+        lane.afc.last_prep_activity_time = -100.0
+        lane.prep_callback(10, False)
+        assert lane.afc.last_prep_activity_time == -100.0
+
+    def test_blocked_load_does_not_update_last_prep_activity_time(self):
+        lane = _make_lane_ready_to_load()
+        lane.afc.last_prep_activity_time = -100.0
+        lane.afc.function.is_printing.return_value = True
+        lane.prep_callback(10, True)
+        assert lane.afc.last_prep_activity_time == -100.0
+
+    def test_successful_load_updates_last_prep_activity_time(self):
+        lane = _make_lane_ready_to_load()
+        lane.afc.last_prep_activity_time = -100.0
+        lane.prep_callback(10, True)
+        assert lane.afc.last_prep_activity_time == 10
+
     # ── successful prep_load call ─────────────────────────────────────────
 
     def test_successful_load_calls_prep_load(self):

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -3371,9 +3371,20 @@ class TestPrepCallback:
         lane.prep_callback(10, True)
         lane.afc.save_vars.assert_not_called()
 
-    def test_another_lane_active_checked_after_is_printing(self):
-        """is_printing is still checked first; its own abort message must
-        fire instead of silently falling through to the new guard."""
+    def test_another_lane_active_shows_error_message(self):
+        """Per review feedback: this guard shares the same if statement (and
+        message) as the is_printing check above, instead of returning
+        silently -- the user must see why the load was refused."""
+        lane = _make_lane_ready_to_load()
+        lane.afc.lanes["lane2"] = MagicMock(prep_active=True)
+        lane.prep_callback(10, True)
+        lane.afc.error.AFC_error.assert_called_once_with(
+            "Cannot load lane1 spool while printer is actively moving or homing", False
+        )
+
+    def test_another_lane_active_checked_together_with_is_printing(self):
+        """Both conditions share one if/or now; is_printing being True is
+        enough on its own, short-circuiting before the lanes check runs."""
         lane = _make_lane_ready_to_load()
         lane.afc.function.is_printing.return_value = True
         lane.afc.lanes["lane2"] = MagicMock(prep_active=True)


### PR DESCRIPTION
## Major Changes in this PR

Releasing the PREP sensor mutates lane state and also updates the status LED on the hub MCU. When that happens while the same (or another) lane still has an active homing move in flight, the LED update competes with real-time step scheduling on that MCU, delaying the sync confirmation the Klipper `trsync` watchdog expects, which trips a "Timer too close" shutdown.

- `handle_prep_runout()` in `extras/AFC_lane.py` now checks whether any lane has an active PREP cycle in flight before acting on a runout edge (releasing the sensor), instead of acting unconditionally. Each lane already tracked its own active/inactive state; a new method,`_any_lane_prep_active()`, checks that across every lane.
- If PREP activity is in or near flight, `handle_prep_runout()` doesn't drop the release, it defers: schedules a recheck instead of acting right away. Each lane only keeps one recheck pending at a time.
- The mid-print runout/pause behavior isn't touched by this guard, it always reacts immediately, delaying it would be a real safety regression.
- No behavior change for anyone who never hits this race, same defaults, same result.

## Notes to Code Reviewers

- `PREP_GUARD_WINDOW = 2.0` (seconds) was chosen empirically from live reproduction testing, not derived analytically, open to discussion if a different value makes more sense.
- Started with a shared counter (`prep_active_count`) across all lanes. Switched to the boolean approach above per review feedback, since each lane's own active/inactive flag was already the real source of truth and a separate mirrored counter wasn't needed.
- Under conditions well beyond disk I/O saturation alone — a deliberately forced sequence of pressing/releasing PREP across all 4 lanes, repeated over several attempts, at a pace far above any normal use of the system — the crash was still reproduced once in testing. Not observed under any realistic usage pattern.

## How the changes in this PR are tested

- Live reproduction on real hardware (Voron 2.4, Box Turtle, 4 lanes, Duet 2 SAM4E8E hub MCU), with a disk I/O stress loop running in parallel to simulate host overload.
- Before the fix: under that same I/O stress, reliable crash releasing PREP mid-cycle, same lane or cross-lane.
- After the fix: repeated the same test under stress, no crash matching real usage patterns. Running in normal use since, no new "Timer too close".
- `ruff check .`: clean. `pytest tests/`: full suite passing (3268 tests). `pytest tests/klippy/`: integration suite passing (7 passed, 2 xfailed as expected).

## PR Checklist
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to pr-review channel requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

---

The investigation and this fix were done with the help of Claude, but the actual breakthrough, realizing the trigger was the sensor releasing rather than the press, came from my own testing on the printer, not something Claude suggested. Tested on real hardware and reviewed by me throughout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Reduced “Timer too close” MCU shutdowns when a PREP sensor releases during an active load cycle.
* Added a two-second safety window around recent PREP activity.
* Coordinated PREP activity across lanes to prevent overlapping operations.
* Deferred non-printing unload actions until PREP activity and recent sensor activity have cleared.
* Preserved immediate runout handling during printing and improved recovery when preparation is interrupted or debounce controls are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->