### PR TITLE
(fix): Report LANE_UNLOAD refusals as warnings so clients can see them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-08-13]
+### Fixed
+- `LANE_UNLOAD` now reports its refusals as warnings instead of console-only messages, so they reach
+  the message queue and show up in Mainsail/Fluidd and other clients. Previously, ejecting a lane that
+  was loaded in the toolhead logged to the console only, and a standalone extruder with no lane loaded
+  logged nothing at all - in both cases the command returned normally, so a UI could not tell a refused
+  eject from a completed one.
+
 ## [2026-08-09]
 ### Fixed
 - Fixed a "Timer too close" MCU shutdown that could occur when the PREP sensor releases while a

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1365,6 +1365,15 @@ class afc:
         self.LANE_UNLOAD( cur_lane )
 
     def LANE_UNLOAD(self, cur_lane: AFCLane):
+        """
+        Ejects a lane's filament back out of the unit, when the lane is not in use.
+
+        Refusals are logged as warnings so they reach the message queue, and from there
+        AFC.message in get_status. Clients cannot see them otherwise: this method never
+        raises, so a refused eject and a completed one look identical from the outside.
+
+        :param cur_lane: AFCLane object for the lane to eject
+        """
         # TODO: update this to unload from toolhead and move all the way back to load
         # when homing is enabled
 
@@ -1398,7 +1407,13 @@ class afc:
             cur_lane.extruder_obj.load_unload_sequence(cur_lane.extruder_obj.tool_stn_unload*-1)
 
         elif cur_lane.name == cur_lane.extruder_obj.lane_loaded:
-            self.logger.info("LANE {} is loaded in toolhead, can't unload.".format(cur_lane.name))
+            self.logger.warning(f"LANE {cur_lane.name} is loaded in toolhead, can't unload. "
+                                "Run TOOL_UNLOAD first.")
+        else:
+            # Standalone extruder with nothing loaded: no arm above applies, so the lane
+            # is left untouched. Warn rather than return silently.
+            self.logger.warning(f"LANE {cur_lane.name} not ejected: standalone extruder "
+                                "reports no lane loaded.")
 
         self.current_state = State.IDLE
 

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -4212,3 +4212,146 @@ class TestBypassUnloadDisplayStatus:
         assert result is False
         assert events == [
             ('display', 'retraction', True), 'run_script_from_command', ('display', 'retraction', False)]
+
+
+# ── LANE_UNLOAD: eject paths and refusal reporting ────────────────────────────
+
+def _make_afc_for_lane_unload(lane_name="lane1", lane_loaded=None, standalone=False):
+    """
+    Build an afc plus a lane wired for LANE_UNLOAD.
+
+    :param lane_name: name of the lane being ejected
+    :param lane_loaded: value of extruder_obj.lane_loaded
+    :param standalone: return value of extruder_obj.is_standalone()
+    :return type: tuple of (afc, AFCLane)
+    """
+    obj = _make_afc()
+    obj.save_vars = MagicMock()
+    obj.spool = MagicMock()
+
+    cur_lane = _make_afc_lane(f"AFC_stepper {lane_name}")
+    cur_lane.extruder_obj.lane_loaded = lane_loaded
+    cur_lane.extruder_obj.is_standalone = MagicMock(return_value=standalone)
+    cur_lane.extruder_obj.tool_stn_unload = 25.0
+    cur_lane.status = AFCLaneState.LOADED
+    obj.lanes[lane_name] = cur_lane
+    return obj, cur_lane
+
+
+class TestLaneUnload:
+    # ── arm 1: lane is not in the toolhead and the extruder is not standalone ──
+
+    def test_ejects_when_lane_not_loaded_and_not_standalone(self):
+        obj, cur_lane = _make_afc_for_lane_unload(lane_loaded="lane2", standalone=False)
+        obj.LANE_UNLOAD(cur_lane)
+        cur_lane.unit_obj.eject_lane.assert_called_once_with(cur_lane)
+        assert cur_lane.status == AFCLaneState.NONE
+        assert cur_lane.loaded_to_hub is False
+
+    def test_eject_clears_spool_and_returns_home(self):
+        obj, cur_lane = _make_afc_for_lane_unload(lane_loaded="lane2", standalone=False)
+        obj.LANE_UNLOAD(cur_lane)
+        obj.spool.set_spoolID.assert_called_once_with(cur_lane, None)
+        cur_lane.unit_obj.return_to_home.assert_called_once()
+        cur_lane.unit_obj.lane_not_ready.assert_called_once_with(cur_lane)
+
+    def test_eject_logs_completion_only(self):
+        obj, cur_lane = _make_afc_for_lane_unload(lane_loaded="lane2", standalone=False)
+        obj.LANE_UNLOAD(cur_lane)
+        assert obj.logger.messages == [("info", "LANE lane1 eject done")]
+
+    # ── arm 2: standalone extruder with a lane loaded ──────────────────────────
+
+    def test_standalone_with_lane_loaded_runs_unload_sequence(self):
+        obj, cur_lane = _make_afc_for_lane_unload(lane_loaded="lane2", standalone=True)
+        obj.LANE_UNLOAD(cur_lane)
+        cur_lane.extruder_obj.load_unload_sequence.assert_called_once_with(-25.0)
+        assert cur_lane.status == AFCLaneState.EJECTING
+        cur_lane.unit_obj.eject_lane.assert_not_called()
+
+    def test_standalone_with_lane_loaded_logs_nothing(self):
+        obj, cur_lane = _make_afc_for_lane_unload(lane_loaded="lane2", standalone=True)
+        obj.LANE_UNLOAD(cur_lane)
+        assert obj.logger.messages == []
+
+    # ── arm 3: the lane is the one loaded in the toolhead ──────────────────────
+
+    def test_lane_in_toolhead_refuses_and_warns(self):
+        obj, cur_lane = _make_afc_for_lane_unload(lane_loaded="lane1", standalone=False)
+        obj.LANE_UNLOAD(cur_lane)
+        assert obj.logger.messages == [
+            ("warning", "LANE lane1 is loaded in toolhead, can't unload. Run TOOL_UNLOAD first.")]
+
+    def test_lane_in_toolhead_does_not_eject(self):
+        obj, cur_lane = _make_afc_for_lane_unload(lane_loaded="lane1", standalone=False)
+        obj.LANE_UNLOAD(cur_lane)
+        cur_lane.unit_obj.eject_lane.assert_not_called()
+        cur_lane.extruder_obj.load_unload_sequence.assert_not_called()
+        assert cur_lane.status == AFCLaneState.LOADED
+
+    # ── arm 4: standalone extruder with nothing loaded (previously silent) ─────
+
+    def test_standalone_without_lane_loaded_warns(self):
+        obj, cur_lane = _make_afc_for_lane_unload(lane_loaded=None, standalone=True)
+        obj.LANE_UNLOAD(cur_lane)
+        assert obj.logger.messages == [
+            ("warning", "LANE lane1 not ejected: standalone extruder reports no lane loaded.")]
+
+    def test_standalone_without_lane_loaded_does_not_eject(self):
+        obj, cur_lane = _make_afc_for_lane_unload(lane_loaded=None, standalone=True)
+        obj.LANE_UNLOAD(cur_lane)
+        cur_lane.unit_obj.eject_lane.assert_not_called()
+        cur_lane.extruder_obj.load_unload_sequence.assert_not_called()
+        assert cur_lane.status == AFCLaneState.LOADED
+
+    # ── first condition: each variable independently gates arm 1 ──────────────
+
+    def test_name_differs_alone_does_not_eject_when_standalone(self):
+        """name != lane_loaded is not enough: standalone must also be false."""
+        obj, cur_lane = _make_afc_for_lane_unload(lane_loaded="lane2", standalone=True)
+        obj.LANE_UNLOAD(cur_lane)
+        cur_lane.unit_obj.eject_lane.assert_not_called()
+
+    def test_not_standalone_alone_does_not_eject_when_name_matches(self):
+        """not standalone is not enough: the name must also differ from lane_loaded."""
+        obj, cur_lane = _make_afc_for_lane_unload(lane_loaded="lane1", standalone=False)
+        obj.LANE_UNLOAD(cur_lane)
+        cur_lane.unit_obj.eject_lane.assert_not_called()
+
+    # ── second condition: each variable independently gates arm 2 ─────────────
+
+    def test_standalone_alone_does_not_run_unload_sequence(self):
+        """is_standalone() is not enough: lane_loaded must also be truthy."""
+        obj, cur_lane = _make_afc_for_lane_unload(lane_loaded=None, standalone=True)
+        obj.LANE_UNLOAD(cur_lane)
+        cur_lane.extruder_obj.load_unload_sequence.assert_not_called()
+
+    def test_lane_loaded_alone_does_not_run_unload_sequence(self):
+        """A truthy lane_loaded is not enough: the extruder must also be standalone."""
+        obj, cur_lane = _make_afc_for_lane_unload(lane_loaded="lane2", standalone=False)
+        obj.LANE_UNLOAD(cur_lane)
+        cur_lane.extruder_obj.load_unload_sequence.assert_not_called()
+
+    # ── state transitions ─────────────────────────────────────────────────────
+
+    @pytest.mark.parametrize("lane_loaded,standalone", [
+        ("lane2", False),   # arm 1
+        ("lane2", True),    # arm 2
+        ("lane1", False),   # arm 3
+        (None, True),       # arm 4
+    ])
+    def test_state_returns_to_idle_on_every_arm(self, lane_loaded, standalone):
+        obj, cur_lane = _make_afc_for_lane_unload(
+            lane_loaded=lane_loaded, standalone=standalone)
+        obj.current_state = State.INIT
+        obj.LANE_UNLOAD(cur_lane)
+        assert obj.current_state == State.IDLE
+
+    def test_state_is_ejecting_while_unit_eject_runs(self):
+        """current_state is EJECTING_LANE for the duration, not just at the end."""
+        obj, cur_lane = _make_afc_for_lane_unload(lane_loaded="lane2", standalone=False)
+        seen = []
+        cur_lane.unit_obj.eject_lane = MagicMock(
+            side_effect=lambda _lane: seen.append(obj.current_state))
+        obj.LANE_UNLOAD(cur_lane)
+        assert seen == [State.EJECTING_LANE]


### PR DESCRIPTION
## Minor Change in this PR

LANE_UNLOAD refuses in two cases, but feedback isn't provided to consumers except the console:

- if lane is the one loaded in the toolhead: logger.info only, so it never reaches message_queue
- if a standalone extruder with no lane loaded: logs nothing, if/elif has no handler for this

Both situations now emit at logger.warning.  Therefore they end up in the message queue and are
retrievable from AFC.message via get_status.  That's it.

This matters because LANE_UNLOAD has no success/error feedback. Moonraker returns ok whether the
eject happened or not, so from a client's side, you can't tell if it worked or failed. The only
refusal a UI can properly observe is the is_printing one, which goes through AFC_error. This makes
(for example) a UI "Eject" button appear to do nothing at all (or at least, the client has to assume
success), which is a sub-optimal UX.

The toolhead message got modified to hint the user to "Run TOOL_UNLOAD first." If you don't like that
we can drop it but it seems it would help nudge users in the right direction.

## Notes to Code Reviewers

LANE_UNLOAD had no test class, so I added one covering all four cases rather than only the two lines
I touched. That's most of the diff.

The else case is reachable when it's a standalone extruder, the lane being ejected isn't the currently
loaded one, and lane_loaded is false. I'll have to defer to you about whether this should actually
eject the lane rather than gently fail, since nothing is loaded anywhere. Behavior is unchanged, only
the warning was added.

Obviously I did all of this to support HelixScreen UI/UX.

## How the changes in this PR are tested

18 new tests in `tests/test_AFC.py::TestLaneUnload`, covering all four arms of the if/elif chain.

- `ruff check .` clean
- full unit suite green, 3259 tests
- `--cov-branch` shows no missing or partial branches in LANE_UNLOAD
- confirmed the tests fail against the old code, not just pass against the new: reverting `warning`
  back to `info` fails `test_lane_in_toolhead_refuses_and_warns`, and deleting the `else` fails
  `test_standalone_without_lane_loaded_warns`

Klippy integration tests not run. Nothing here touches the gcode surface, and running them needs
klipper and kalico checkouts plus a firmware build on my end. Happy to if you want them.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)

- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Documentation updated in AT-Documentation repository
- [ ] Sent notification to pr-review channel requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

---

Per AI_USAGE_POLICY.md: code and tests were drafted with Claude, then reviewed, run, and edited by
me. This description is mine.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `LANE_UNLOAD` now warns when unloading is refused because the lane is loaded in the toolhead.
  * Attempts to unload when no lane is loaded on a standalone extruder now produce a clear warning.
  * Lane state and temporary ejecting conditions are handled correctly during unloading.

* **Documentation**
  * Added changelog details describing the updated warning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->