### PR TITLE
(feat): Adding ability to map multiple T(n) macros to a single lane, add virtual tools and updating RESET_AFC_MAPPING macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2026-08-15]
+### Breaking Change
+- `RESET_AFC_MAPPING` has now been renamed to `AFC_RESET_MAPPING`
+
 ### Added
 - Ability to map multiple T(n) macros to a single lane. New `AFC_ADD_MAPPING` and
   `AFC_REMOVE_MAPPING` macros add/remove T(n) mappings on a lane, and `AFC_ENABLE_MULTIPLE_MAPPING`
@@ -14,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   uses this to move a lane's mappings to the runout lane automatically.
 
 ### Fixed
-- `RESET_AFC_MAPPING` now renumbers T(n) mappings sequentially instead of reusing old numbers, so
+- `AFC_RESET_MAPPING` now renumbers T(n) mappings sequentially instead of reusing old numbers, so
   removing a unit no longer leaves gaps or stale high-numbered mappings behind. Newly assigned
   commands are now also re-registered with Klipper.
 - `lane_data` sent to Moonraker is now keyed per T(n) mapping instead of per lane name, fixing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-08-15]
+### Added
+- Ability to map multiple T(n) macros to a single lane. New `AFC_ADD_MAPPING` and
+  `AFC_REMOVE_MAPPING` macros add/remove T(n) mappings on a lane, and `AFC_ENABLE_MULTIPLE_MAPPING`
+  turns the feature on (existing single-mapping behavior is unchanged until enabled).
+- Added `AFC_SWAP_MAPPING` macro to swap T(n) mappings between two lanes. Infinite spool runout now
+  uses this to move a lane's mappings to the runout lane automatically.
+
+### Fixed
+- `RESET_AFC_MAPPING` now renumbers T(n) mappings sequentially instead of reusing old numbers, so
+  removing a unit no longer leaves gaps or stale high-numbered mappings behind. Newly assigned
+  commands are now also re-registered with Klipper.
+- `lane_data` sent to Moonraker is now keyed per T(n) mapping instead of per lane name, fixing
+  OrcaSlicer picking up duplicate or incorrect filament data when multiple T(n) macros map to
+  one lane.
+- Fixed T(n) macro renaming so a command manually assigned in the config is still renamed
+  correctly after it's moved to a different lane via a swap or multimapping.
+
 ## [2026-08-13]
 ### Fixed
 - `LANE_UNLOAD` now reports its refusals as warnings instead of console-only messages, so they reach

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from extras.AFC_spool import AFCSpool
     from extras.AFC_error import afcError
     from extras.AFC_stepper import AFCExtruderStepper
+    from extras.AFC_unit import afcUnit
 
 ERROR_STR = "Error trying to import {import_lib}, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper\n\n{trace}"
 
@@ -79,10 +80,10 @@ class afc:
         self.printer.register_event_handler("klippy:ready", self.handle_ready)
         self.logger  = AFC_logger(self.printer, self)
 
+        self.function: afcFunction = self.printer.load_object(config, 'AFC_functions')
         self.spool: AFCSpool = self.printer.load_object(config, 'AFC_spool')
         self.error: afcError = self.printer.load_object(config, 'AFC_error')
 
-        self.function: afcFunction   = self.printer.load_object(config, 'AFC_functions')
         self.function.afc = self
         self.function.logger = self.logger
         self.gcode: GCodeDispatch = self.printer.load_object(config, 'gcode')
@@ -114,7 +115,7 @@ class afc:
         self.db_backup          = False
 
         # Objects for everything configured for AFC
-        self.units      = {}
+        self.units: Dict[str, afcUnit] = {}
         self.tools: Dict[str, AFCExtruder] = {}
         self.lanes: Dict[str, Union[AFCLane, AFCExtruderStepper]] = {}
         self.hubs       = {}
@@ -282,6 +283,7 @@ class afc:
         self.debug                  = config.getboolean('debug', False)             # Setting to True turns on more debugging to show on console
         self.log_frame_data         = config.getboolean('log_frame_data', True)
         self.testing                = config.getboolean('testing', False)           # Set to true for testing only so that failure states can be tested without stats being reset
+        self.enable_multiple_mapping = config.getboolean("enable_multiple_mapping",False)
         self.manual_home_has_probe_pos_param: bool = False
 
         # Klippy debuginput start_args can only be passed in when doing tests, this way AFC
@@ -329,6 +331,7 @@ class afc:
                                         self.cmd_UNSET_LANE_LOADED_help)
         self.function.register_commands(self.show_macros, 'AFC_RESET_STATS', self.cmd_AFC_RESET_STATS,
                                         self.cmd_AFC_RESET_STATS_help, self.cmd_AFC_RESET_STATS_options)
+        self.spool.register_commands(self)
 
     @property
     def current(self):
@@ -720,15 +723,15 @@ class afc:
             using_min_value = False
             target_temp = None
             try:
-                # cur_lane.map is expected to be the tool number as "T<n>" (e.g. "T3"),
+                # cur_lane.current_map is expected to be the tool number as "T<n>" (e.g. "T3"),
                 # used here as the index into print_tool_temperatures from the sliced
                 # file's metadata. Custom user-assigned maps may not follow this format.
-                idx = int(str(cur_lane.map).lstrip("T"))
+                idx = int(str(cur_lane.current_map).lstrip("T"))
                 if idx < 0: raise ValueError("Negative tool index")
                 target_temp = self.print_tool_temperatures[idx]
             except (ValueError, IndexError, TypeError, AttributeError) as e:
-                # Logging lane.name/e rather than cur_lane.map here: if the error came from
-                # resolving cur_lane.map itself, referencing it again would raise the same error.
+                # Logging lane.name/e rather than cur_lane.current_map here: if the error came from
+                # resolving cur_lane.current_map itself, referencing it again would raise the same error.
                 self.logger.info(
                     f"Could not resolve print_tool_temperatures index for lane {cur_lane.name}: {e}"
                 )
@@ -1616,14 +1619,16 @@ class afc:
                 if cur_hub is not None and cur_hub.state:
                     message = 'Hub not clear when trying to load.\nPlease check that hub does not contain broken filament and is clear'
                     if self.function.in_print():
-                        message += '\nOnce issue is resolved please manually load {} with {} macro and click resume to continue printing.'.format(cur_lane.name, cur_lane.map)
+                        message += f'\nOnce issue is resolved please manually load {cur_lane.name} '
+                        message += f'with {cur_lane.current_map} macro and click resume to continue printing.'
                     self.error.handle_lane_failure(cur_lane, message, pause=self.function.in_print())
                     return False
                 if not cur_lane.load_state:
                     message = 'Current lane not loaded, LOAD TRIGGER NOT TRIGGERED\n||==>--||----||-----||\nTRG   LOAD   HUB   TOOL'
                     message += '\nPlease load lane before continuing.'
                     if self.function.in_print():
-                        message += '\nOnce issue is resolved please manually load {} with {} macro and click resume to continue printing.'.format(cur_lane.name, cur_lane.map)
+                        message += f'\nOnce issue is resolved please manually load {cur_lane.name} '
+                        message += f'with {cur_lane.current_map} macro and click resume to continue printing.'
                     self.error.handle_lane_failure(cur_lane, message, pause=self.function.in_print())
                     return False
 
@@ -1631,7 +1636,7 @@ class afc:
         if cur_lane.need_purge:
             temp_state = self.capture_toolhead_temp()
             try:
-                self.logger.info(f"Flag set to purge for {cur_lane.extruder_obj.name}:{cur_lane.map}")
+                self.logger.info(f"Flag set to purge for {cur_lane.extruder_obj.name}:{cur_lane.current_map}")
                 # Make sure toolhead is up to temp before purging
                 if self._check_extruder_temp(cur_lane):
                     self.afcDeltaTime.log_with_time("Done heating toolhead")
@@ -1744,8 +1749,10 @@ class afc:
                 if hub_attempts > 20:
                     message = 'filament did not trigger hub sensor, CHECK FILAMENT PATH\n||=====||==>--||-----||\nTRG   LOAD   HUB   TOOL.'
                     if self.function.in_print():
-                        message += '\nOnce issue is resolved please manually load {} with {} macro and click resume to continue printing.'.format(cur_lane.name, cur_lane.map)
-                        message += '\nIf you have to retract filament back, use LANE_MOVE macro for {}.'.format(cur_lane.name)
+                        message += f'\nOnce issue is resolved please manually load {cur_lane.name} '
+                        message += f'with {cur_lane.current_map} macro and click resume to continue '
+                        message += 'printing. \nIf you have to retract filament back, use '
+                        message += f'LANE_MOVE macro for {cur_lane.name}.'
                     self.error.handle_lane_failure(cur_lane, message)
                     return False
 
@@ -1799,8 +1806,9 @@ class afc:
                         message += f'\nManually move filament with LANE_MOVE macro for {cur_lane.name} until filament is right before toolhead extruder gears,'
                         message += ' then load into extruder gears with extrude button in your gui of choice until the color fully changes'
                         if self.homing_enabled:
-                            message += f"\nFilament can also be reset back to hub by running AFC_RESET command then select {cur_lane.name} to reset"
-                            message += f"back to hub. Once lane is reset try reload lane with {cur_lane.map} macro."
+                            message += "\nFilament can also be reset back to hub by running AFC_RESET "
+                            message += f"command then select {cur_lane.name} to reset"
+                            message += f"back to hub. Once lane is reset try reload lane with {cur_lane.current_map} macro."
                         if self.function.in_print():
                             message += '\nOnce filament is fully loaded click resume to continue printing'
                         self.error.handle_lane_failure(cur_lane, message)
@@ -2143,7 +2151,7 @@ class afc:
                         msg += f"and select {cur_lane.name}, then AFC will slowly move lane until hub is no longer triggered.\n"
                         if self.next_lane_load is not None:
                             msg += f"\nOnce lane is behind hub and hub is no longer triggered manually load {self.next_lane_load}\n"
-                            msg += f"with {self.lanes[self.next_lane_load].map} macro.\n"
+                            msg += f"with {self.lanes[self.next_lane_load].current_map} macro.\n"
                             if self.function.in_print():
                                 msg += "Once lane is loaded click resume to continue printing"
                         self.error.handle_lane_failure(cur_lane, msg)
@@ -2186,7 +2194,8 @@ class afc:
                             message += "\nThen Manually run UNSET_LANE_LOADED to let AFC know nothing is loaded into toolhead"
                             # Check to make sure next_lane_loaded is not None before adding instructions on how to manually load next lane
                             if self.next_lane_load is not None:
-                                message += "\nThen manually load {} with {} macro".format(self.next_lane_load, self.lanes[self.next_lane_load].map)
+                                map_str = self.lanes[self.next_lane_load].current_map
+                                message += f"\nThen manually load {self.next_lane_load} with {map_str} macro"
                                 if self.function.in_print():
                                     message += "\nOnce lane is loaded click resume to continue printing"
                         self.error.handle_lane_failure(cur_lane, message)
@@ -2272,7 +2281,8 @@ class afc:
                     if self.function.in_print():
                         # Check to make sure next_lane_loaded is not None before adding instructions on how to manually load next lane
                         if self.next_lane_load is not None:
-                            message += "\nOnce hub is clear, manually load {} with {} macro".format(self.next_lane_load, self.lanes[self.next_lane_load].map)
+                            map_str = self.lanes[self.next_lane_load].current_map
+                            message += f"\nOnce hub is clear, manually load {self.next_lane_load} with {map_str} macro"
                             if self.function.in_print():
                                 message += "\nOnce lane is loaded click resume to continue printing"
 
@@ -2425,7 +2435,13 @@ class afc:
             self.error.AFC_error("I did not understand the change -- " + cmd, pause=self.function.in_print())
             return
 
-        self.CHANGE_TOOL(self.lanes[self.tool_cmds[Tcmd]], purge_length, new_extruder_temp=new_extruder_temp)
+        change_to_lane_name: str = self.tool_cmds.get(Tcmd, "")
+        change_to_lane = self.lanes.get(change_to_lane_name, None)
+        if change_to_lane:
+            change_to_lane.current_map = Tcmd
+            self.CHANGE_TOOL(change_to_lane, purge_length, new_extruder_temp=new_extruder_temp)
+        else:
+            self.error.AFC_error(f"Error trying to lookup lane for {Tcmd}")
 
     def CHANGE_TOOL(self, cur_lane: AFCLane, purge_length: Optional[float]=None, restore_pos: bool=True, new_extruder_temp: Optional[float]=None) -> None:
         try:
@@ -2620,6 +2636,8 @@ class afc:
         str["buffers"] = list(self.buffers.keys())
         str["message"] = self._get_message()
         str["led_state"] = self.led_state
+
+        str["multiple_tool_mapping"] = self.enable_multiple_mapping
         return str
 
     def _webhooks_status(self, web_request):
@@ -2764,9 +2782,9 @@ class afc:
                         lane_obj = self.lanes.get(curr_extr_lane, None)
                         if lane_obj:
                             if (lane_obj.name == curr_extruder.lane_loaded
-                                and map == lane_obj.map):
+                                and map == lane_obj.current_map):
                                 break
-                            elif (lane_obj.map == map):
+                            elif (lane_obj.current_map == map):
                                 self.logger.raw(
                                     ("<span class=warning--text>WARNING: "
                                     f"Not setting temperature for {map} since another lane is loaded for {curr_extruder.name}</span>")

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -46,7 +46,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 try: from extras.AFC_stats import AFCStats
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
 
-AFC_VERSION="1.2.4"
+AFC_VERSION="1.2.5"
 
 # Class for holding different states so its clear what all valid states are
 class State(str, Enum):

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -2782,9 +2782,9 @@ class afc:
                         lane_obj = self.lanes.get(curr_extr_lane, None)
                         if lane_obj:
                             if (lane_obj.name == curr_extruder.lane_loaded
-                                and map == lane_obj.current_map):
+                                and map in lane_obj.map):
                                 break
-                            elif (lane_obj.current_map == map):
+                            elif (map in lane_obj.map):
                                 self.logger.raw(
                                     ("<span class=warning--text>WARNING: "
                                     f"Not setting temperature for {map} since another lane is loaded for {curr_extruder.name}</span>")

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -148,7 +148,7 @@ class afcBoxTurtle(afcUnit):
         cur_lane.send_lane_data()
 
         cur_lane.do_enable(False)
-        self.logger.info( '{lane_name} tool cmd: {tcmd:3} {msg}'.format(lane_name=cur_lane.name, tcmd=cur_lane.map, msg=msg))
+        self.logger.info(f'{cur_lane.name} tool cmd: {cur_lane.map_to_string():3} {msg}')
         cur_lane.set_afc_prep_done()
 
         return succeeded

--- a/extras/AFC_OAMS.py
+++ b/extras/AFC_OAMS.py
@@ -1,6 +1,6 @@
-# AFCProject Automated Filament Changer
+# AFCProject Automated Filament Changer Software
 #
-# Copyright (C) 2024-2026 AFCProject
+# Copyright (C) 2026 AFCProject
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 

--- a/extras/AFC_OpenAMS.py
+++ b/extras/AFC_OpenAMS.py
@@ -1487,7 +1487,7 @@ class afcAMS(afcUnit):
             self.afc.function.TcmdAssign(cur_lane)
         cur_lane.do_enable(False)
         self.logger.info('{lane_name} tool cmd: {tcmd:3} {msg}'.format(
-            lane_name=cur_lane.name, tcmd=cur_lane.current_map, msg=msg))
+            lane_name=cur_lane.name, tcmd=cur_lane.map_to_string(), msg=msg))
         cur_lane.set_afc_prep_done()
         return succeeded
 

--- a/extras/AFC_OpenAMS.py
+++ b/extras/AFC_OpenAMS.py
@@ -1,6 +1,6 @@
-# AFCProject Automated Filament Changer
+# AFCProject Automated Filament Changer Software
 #
-# Copyright (C) 2024-2026 AFCProject
+# Copyright (C) 2026 AFCProject
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
@@ -1487,7 +1487,7 @@ class afcAMS(afcUnit):
             self.afc.function.TcmdAssign(cur_lane)
         cur_lane.do_enable(False)
         self.logger.info('{lane_name} tool cmd: {tcmd:3} {msg}'.format(
-            lane_name=cur_lane.name, tcmd=cur_lane.map, msg=msg))
+            lane_name=cur_lane.name, tcmd=cur_lane.map_to_string(), msg=msg))
         cur_lane.set_afc_prep_done()
         return succeeded
 

--- a/extras/AFC_OpenAMS.py
+++ b/extras/AFC_OpenAMS.py
@@ -1487,7 +1487,7 @@ class afcAMS(afcUnit):
             self.afc.function.TcmdAssign(cur_lane)
         cur_lane.do_enable(False)
         self.logger.info('{lane_name} tool cmd: {tcmd:3} {msg}'.format(
-            lane_name=cur_lane.name, tcmd=cur_lane.map_to_string(), msg=msg))
+            lane_name=cur_lane.name, tcmd=cur_lane.current_map, msg=msg))
         cur_lane.set_afc_prep_done()
         return succeeded
 

--- a/extras/AFC_OpenAMS.py
+++ b/extras/AFC_OpenAMS.py
@@ -2311,12 +2311,7 @@ class afcAMS(afcUnit):
                 f"Same-FPS reload failed for {target_name}: {e}", pause=True)
             return False
 
-        source_map = getattr(source_lane, 'map', None)
-        if source_map:
-            self.gcode.run_script_from_command(
-                f'SET_MAP LANE={target_name} MAP={source_map}')
-            self.logger.info(
-                f"Remapped {source_map} from {source_name} to {target_name}")
+        self.gcode.run_script_from_command(f'AFC_SWAP_MAPPING FROM={source_name} TO={target_name}')
 
         target_lane.set_tool_loaded()
         self.lane_tool_loaded(target_lane)

--- a/extras/AFC_Toolchanger.py
+++ b/extras/AFC_Toolchanger.py
@@ -67,7 +67,7 @@ class AfcToolchanger(afcUnit):
             msg = "<span class=success--text>LOADED</span>"
             msg += cur_lane.extruder_obj.prep_on_shuttle_check(cur_lane)
 
-        self.logger.raw( '{lane_name} tool cmd: {tcmd:3} {msg}'.format(lane_name=cur_lane.name, tcmd=cur_lane.map, msg=msg))
+        self.logger.raw(f'{cur_lane.name} tool cmd: {cur_lane.map_to_string():3} {msg}')
         cur_lane.set_afc_prep_done()
         return True
 

--- a/extras/AFC_assist.py
+++ b/extras/AFC_assist.py
@@ -453,7 +453,7 @@ class Espooler:
 
         self.past_extruder_position = -1
 
-        self.espooler_values        = Espooler_values(config)
+        self.espooler_values: Espooler_values = Espooler_values(config)
         self.stats                  = None
 
         self.function = self.printer.load_object(config, 'AFC_functions')

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -272,7 +272,7 @@ class AFCExtruder:
         self.tc_lane: Optional[AFCLane|None]            = None
         self.tool: Optional[str]        = config.get('tool', None)
         self.tool_obj                   = None
-        self.map: Optional[str]         = config.get('map', None)
+        self.map: Optional[list]        = config.getlist('map', [])
         self.no_lanes                   = False
         self.custom_tool_swap: Optional[str] = config.get("custom_tool_swap", None)
         self.custom_unselect: Optional[str] = config.get("custom_unselect", None)

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -272,7 +272,7 @@ class AFCExtruder:
         self.tc_lane: Optional[AFCLane|None]            = None
         self.tool: Optional[str]        = config.get('tool', None)
         self.tool_obj                   = None
-        self.map: Optional[list]        = config.getlist('map', [])
+        self.map: list                  = config.getlist('map', [])
         self.no_lanes                   = False
         self.custom_tool_swap: Optional[str] = config.get("custom_tool_swap", None)
         self.custom_unselect: Optional[str] = config.get("custom_unselect", None)

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -281,9 +281,6 @@ class afcFunction:
                         # status diff sees a new list and pushes the update
                         cur_lane.map = cur_lane.map + [cmd]
                         break
-                    # Set first T(n) macro to current map if its not already set
-                    if not cur_lane.current_map:
-                        cur_lane.current_map = cmd
 
         # Renaming is needed if one of this lane's current T(n) commands was manually
         # assigned to a lane in the config, even if that assignment now lives on a

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, Union, Optional, Any, List
 
 if TYPE_CHECKING:
     from extras.AFC import afc
-    from AFC_logger import AFC_logger
+    from extras.AFC_logger import AFC_logger
     from extras.AFC_lane import AFCLane
     from extras.AFC_extruder import AFCExtruder
     from extras.AFC_stepper import AFCExtruderStepper
@@ -232,7 +232,28 @@ class afcFunction:
         msg +='\n<span class=info--text>Key {} not found in section {} added to AFC_auto_vars.cfg file</span>'.format(rawkey, rawsection)
         self.logger.info(msg)
 
-    def TcmdAssign(self, cur_lane):
+    def register_tool_macro(self, lane_name: str, tool_command:str, rename_map: str="") -> None:
+        """
+        Helper method for registering T(n) macros into klipper
+
+        :param lane_name: Lane name when trying to register T(n) macro, this is only used when
+            an error has occurred and logs lane with T(n) macro
+        :param tool_command: T(n) macro to register
+        :param rename: When a non-empty string is supplied, this method calls _rename with this name
+            instead of calling gcode.register_command
+        """
+        try:
+            if rename_map:
+                self._rename(tool_command, rename_map, self.afc.cmd_CHANGE_TOOL,
+                             self.afc.cmd_CHANGE_TOOL_help)
+            else:
+                self.afc.gcode.register_command(tool_command, self.afc.cmd_CHANGE_TOOL,
+                                                desc=self.afc.cmd_CHANGE_TOOL_help)
+        except Exception:
+            self.logger.error((f"Error trying to map lane {lane_name} to {tool_command}, "
+                               f"please make sure there are no macros already setup for {tool_command}"))
+
+    def TcmdAssign(self, cur_lane: AFCLane) -> None:
         """
         Function automatically tries to generate T(n) macros for lanes. If user has already assigned mapping to `map`
         variable in their configs, this is used instead of an auto assigned command. Before assigning command, checks
@@ -243,30 +264,39 @@ class afcFunction:
 
         :param cur_lane: Lane to assign auto generated T(n) macro
         """
-        if cur_lane.map is None:
+        if not cur_lane.map:
             for x in range(99):
                 cmd = 'T{}'.format(x)
                 # Checking to see if cmd exists in lanes that have manually assigned mapping
                 # skip cmd and generate next if cmd is manually assigned by user
-                manually_assigned = any( cmd == lane._map for lane in self.afc.lanes.values() )
-                if not manually_assigned and cmd not in self.afc.tool_cmds:
+                manually_assigned = any( cmd in (lane.map or []) for lane in self.afc.lanes.values() )
+                if (not manually_assigned and
+                    cmd not in self.afc.tool_cmds):
                     # Checking if macro already exists, generate next valid cmd if current generated cmd exists
                     existing = False
                     if not self.afc.force_assign_map:
                         existing = self.afc.gcode.ready_gcode_handlers.get(cmd)
                     if not existing:
-                        cur_lane._map = cur_lane.map = cmd
+                        # Reassigning (not appending in place) so Klipper's
+                        # status diff sees a new list and pushes the update
+                        cur_lane.map = cur_lane.map + [cmd]
+                        cur_lane._map = cur_lane._map + [cmd]
                         break
-        self.afc.tool_cmds[cur_lane.map]=cur_lane.name
-        try:
-            if (cur_lane._map
-                or self.afc.force_assign_map):
-                rename_map = ("_{}".format(cur_lane.map))
-                self._rename(cur_lane.map, rename_map, self.afc.cmd_CHANGE_TOOL, self.afc.cmd_CHANGE_TOOL_help)
-            else:
-                self.afc.gcode.register_command(cur_lane.map, self.afc.cmd_CHANGE_TOOL, desc=self.afc.cmd_CHANGE_TOOL_help)
-        except:
-                self.logger.error("Error trying to map lane {lane} to {tool_macro}, please make sure there are no macros already setup for {tool_macro}".format(lane=[cur_lane.name], tool_macro=cur_lane.map), )
+                    # Set first T(n) macro to current map if its not already set
+                    if not cur_lane.current_map:
+                        cur_lane.current_map = cmd
+
+        use_rename = bool(cur_lane.map) or self.afc.force_assign_map
+        for map_str in cur_lane.map:
+            if map_str == "NONE":
+                continue
+            self.afc.tool_cmds.update({map_str: cur_lane.name})
+            # Set first T(n) macro to current map if its not already set
+            if not cur_lane.current_map:
+                cur_lane.current_map = map_str
+            rename_map = f"_{map_str}" if use_rename else ""
+            self.register_tool_macro(cur_lane.name, map_str, rename_map)
+
         self.afc.save_vars()
 
     def check_macro_present(self, macro_name):

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -269,7 +269,7 @@ class afcFunction:
                 cmd = 'T{}'.format(x)
                 # Checking to see if cmd exists in lanes that have manually assigned mapping
                 # skip cmd and generate next if cmd is manually assigned by user
-                manually_assigned = any( cmd in (lane.map or []) for lane in self.afc.lanes.values() )
+                manually_assigned = any( cmd in (lane._map or []) for lane in self.afc.lanes.values() )
                 if (not manually_assigned and
                     cmd not in self.afc.tool_cmds):
                     # Checking if macro already exists, generate next valid cmd if current generated cmd exists
@@ -280,13 +280,19 @@ class afcFunction:
                         # Reassigning (not appending in place) so Klipper's
                         # status diff sees a new list and pushes the update
                         cur_lane.map = cur_lane.map + [cmd]
-                        cur_lane._map = cur_lane._map + [cmd]
                         break
                     # Set first T(n) macro to current map if its not already set
                     if not cur_lane.current_map:
                         cur_lane.current_map = cmd
 
-        use_rename = bool(cur_lane.map) or self.afc.force_assign_map
+        # Renaming is needed if one of this lane's current T(n) commands was manually
+        # assigned to a lane in the config, even if that assignment now lives on a
+        # different lane (e.g. after a swap or multimapping reassignment).
+        # Only place this will fail is if a AFC_extruder has a mapping but is not a standalone lane,
+        # if this is the case then force_assign_map needs to be set to true in the users AFC config.
+        use_rename = (self.afc.force_assign_map
+                      or any(m in (lane._map or []) for lane in self.afc.lanes.values()
+                             for m in cur_lane.map))
         for map_str in cur_lane.map:
             if map_str == "NONE":
                 continue

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -161,7 +161,7 @@ class AFCLane:
         self.remember_spool :bool = config.getboolean('remember_spool', None)             # remember_spool that is set in AFC_Stepper section, overrides remember_spool that is set in unit(AFC_BoxTurtle/NightOwl/etc) section.
         self.map: list            = config.getlist('cmd', [])                           # Keeping this in so it does not break others config that may have used this, use map instead
         # Saving to self._map so that if a user has it defined it will be reset back to this when
-        # RESET_AFC_MAPPING macro is called.
+        # AFC_RESET_MAPPING macro is called.
         self.map = config.getlist('map', self.map)
         self._map: list           = list(self.map)
         # Holds which T(n) macro is currently mapped to this lane since map can be a list of T(n) now

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from enum import Enum
 from gcode import CommandError
 
-from typing import Optional, TYPE_CHECKING
+from typing import Optional, Union, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from configfile import ConfigWrapper
@@ -124,18 +124,18 @@ class AFCLane:
         # when lanes are unloaded
         self.tool_loaded        = False
         self.loaded_to_hub      = False
-        self.spool_id           = None
+        self.spool_id: Optional[Union[int, str]] = None
         self.color: str         = ""
         self.multi_color: list  = []
         self.spool_vendor: str  = ""
         self.filament_name: str = ""
         self.weight: float      = 0.
-        self.auto_switch_triggered = False
+        self.auto_switch_triggered: bool = False
         self._material: str     = None
-        self.extruder_temp      = None
-        self.bed_temp           = None
+        self.extruder_temp: Optional[int] = None
+        self.bed_temp: Optional[int] = None
         self.td1_data           = {}
-        self.runout_lane        = None
+        self.runout_lane: Optional[str] = None
         self.status             = AFCLaneState.NONE
         self.need_purge         = False
         self._afc_staged_spool_id: Optional[int] = None
@@ -149,7 +149,7 @@ class AFCLane:
         self.hub: Optional[str] = config.get('hub',None)                                # Hub name(AFC_hub) that belongs to this stepper, overrides hub that is set in unit(AFC_BoxTurtle/NightOwl/etc) section.
         # Overrides buffers set at the unit and extruder level
         self.buffer_name: Optional[str] = config.get("buffer", None)                            # Buffer name(AFC_buffer) that belongs to this stepper, overrides buffer that is set in extruder(AFC_extruder) or unit(AFC_BoxTurtle/NightOwl/etc) sections.
-        self.unit               = unit.split(':')[0]
+        self.unit: str           = unit.split(':')[0]
         try:
             self.index              = int(unit.split(':')[1])
         except:
@@ -170,9 +170,9 @@ class AFCLane:
 
         # LED SETTINGS
         # All variables use: (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
-        self.led_index            = config.get('led_index', None)                       # LED index of lane in chain of lane LEDs
+        self.led_index: Optional[str] = config.get('led_index', None)                       # LED index of lane in chain of lane LEDs
         self.led_fault            = config.get('led_fault',None)                        # LED color to set when faults occur in lane
-        self.led_ready            = config.get('led_ready',None)                        # LED color to set when lane is ready
+        self.led_ready: Optional[str] = config.get('led_ready',None)                        # LED color to set when lane is ready
         self.led_not_ready        = config.get('led_not_ready',None)                    # LED color to set when lane not ready
         self.led_loading          = config.get('led_loading',None)                      # LED color to set when lane is loading
         self.led_prep_loaded      = config.get('led_loading',None)                      # LED color to set when lane is loaded
@@ -240,7 +240,7 @@ class AFCLane:
 
         self.selector: str = config.get("selector", None)
 
-        self.espooler = AFC_assist.Espooler(self.name, config)
+        self.espooler: AFC_assist.Espooler = AFC_assist.Espooler(self.name, config)
         self.lane_load_count = None
 
         self.filament_diameter: float  = config.getfloat("filament_diameter", 1.75)    # Diameter of filament being used

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -167,12 +167,16 @@ class AFCLane:
         # Holds which T(n) macro is currently mapped to this lane
         # since map can be a list of T(n) now
         self.current_map: str     = ""
+        # T(n) keys this lane last pushed a lane_data record for -- lets
+        # send_lane_data() detect and clear out mappings that were removed
+        # since the last call, without every mapping macro having to do it.
+        self._sent_lane_data_keys: list = []
 
         # LED SETTINGS
         # All variables use: (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
-        self.led_index: Optional[str] = config.get('led_index', None)                       # LED index of lane in chain of lane LEDs
-        self.led_fault            = config.get('led_fault',None)                        # LED color to set when faults occur in lane
-        self.led_ready: Optional[str] = config.get('led_ready',None)                        # LED color to set when lane is ready
+        self.led_index: str       = config.get('led_index', None)                       # LED index of lane in chain of lane LEDs
+        self.led_fault: str       = config.get('led_fault',None)                        # LED color to set when faults occur in lane
+        self.led_ready: str       = config.get('led_ready',None)                        # LED color to set when lane is ready
         self.led_not_ready        = config.get('led_not_ready',None)                    # LED color to set when lane not ready
         self.led_loading          = config.get('led_loading',None)                      # LED color to set when lane is loading
         self.led_prep_loaded      = config.get('led_loading',None)                      # LED color to set when lane is loaded
@@ -1852,19 +1856,48 @@ class AFCLane:
             self.extruder_obj.tc_unit_obj.tool_swap(self, set_start_time=False)
 
 
+    def _mapped_keys(self) -> list:
+        """
+        Returns the real T(n) mappings currently assigned to this lane, with
+        the "NONE" placeholder filtered out.
+
+        :return list: T(n) command strings currently mapped to this lane
+        """
+        return [m for m in self.map if m != "NONE"]
+
     def send_lane_data(self):
         """
-        Sends lane data to moonrakers `machine/set_lane_data` endpoint
-        """
-        if (self.afc.moonraker
-            and self.current_map is not None
-            and "T" in self.current_map):
-            scan_time = self.td1_data['scan_time'] if 'scan_time' in self.td1_data else ""
-            td        = self.td1_data['td']        if 'td'        in self.td1_data else ""
+        Sends lane data to moonrakers `machine/set_lane_data` endpoint, one record
+        per T(n) currently mapped to this lane -- so a lane mapped to multiple T(n)
+        macros shows up correctly in every mapped slot, not just current_map's.
 
+        Also removes records for any T(n) this lane sent data for last time but no
+        longer maps to, skipping ones that got reassigned to a different lane --
+        that lane's own send_lane_data() call is responsible for posting its record.
+        """
+        if not self.afc.moonraker:
+            return
+
+        current_keys = self._mapped_keys()
+
+        for key in self._sent_lane_data_keys:
+            if key in current_keys:
+                continue
+            # Only remove if no lane (including this one) claims this T(n)
+            # anymore -- if it got reassigned to another lane, that lane's
+            # own map already carries it, so leave its record alone; that
+            # lane's own send_lane_data() call is responsible for it.
+            still_claimed = any(key in lane.map for lane in self.afc.lanes.values())
+            if not still_claimed:
+                self.afc.moonraker.remove_database_entry("lane_data", key)
+
+        scan_time = self.td1_data['scan_time'] if 'scan_time' in self.td1_data else ""
+        td        = self.td1_data['td']        if 'td'        in self.td1_data else ""
+
+        for key in current_keys:
             lane_data = {
                 "namespace": "lane_data",
-                "key": self.name,
+                "key": key,
                 "value": {
                     "color"          : self.color,
                     "material"       : self.material,
@@ -1872,7 +1905,7 @@ class AFCLane:
                     "nozzle_temp"    : self.extruder_temp,
                     "scan_time"      : scan_time,
                     "td"             : td,
-                    "lane"           : self.lane_index,
+                    "lane"           : key.replace("T", ""),
                     "extruder_index" : self.lane_extruder_index,
                     "spool_id"       : self.spool_id,
                     "weight"         : self.weight
@@ -1880,16 +1913,24 @@ class AFCLane:
             }
             self.afc.moonraker.send_lane_data(lane_data)
 
+        self._sent_lane_data_keys = current_keys
+
     def clear_lane_data(self):
         """
-        Clears lane data that is currently stored at moonrakers `machine/set_lane_data` endpoint
+        Clears lane data that is currently stored at moonrakers `machine/set_lane_data`
+        endpoint for every T(n) currently mapped to this lane, without touching the
+        mapping itself -- used when spool contents are cleared but the lane keeps
+        its T(n) mapping(s), e.g. on unload.
         """
-        if (self.afc.moonraker
-            and self.current_map is not None
-            and "T" in self.current_map):
+        if not self.afc.moonraker:
+            return
+
+        current_keys = self._mapped_keys()
+
+        for key in current_keys:
             lane_data = {
                 "namespace": "lane_data",
-                "key": self.name,
+                "key": key,
                 "value": {
                     "color"          : "",
                     "material"       : "",
@@ -1897,13 +1938,15 @@ class AFCLane:
                     "nozzle_temp"    : "",
                     "scan_time"      : "",
                     "td"             : "",
-                    "lane"           : self.lane_index,
+                    "lane"           : key.replace("T", ""),
                     "extruder_index" : self.lane_extruder_index,
                     "spool_id"       : None,
                     "weight"         : 0
                 }
             }
             self.afc.moonraker.send_lane_data(lane_data)
+
+        self._sent_lane_data_keys = current_keys
 
     def get_td1_data_load(self):
         """

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -2361,7 +2361,6 @@ class AFCLane:
         response['lane'] = self.index
         if not save_to_file:
             response['map'] = self.map
-            response['_map'] = self._map
         else:
             response['map'] = self.map_to_string()
         response['current_map'] = self.current_map

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -159,17 +159,16 @@ class AFCLane:
         self.afc_extruder_name    = config.get('extruder', None)                          # Extruder name(AFC_extruder) that belongs to this stepper, overrides extruder that is set in unit(AFC_BoxTurtle/NightOwl/etc) section.
         self.standalone_lane      = config.getboolean("standalone", False)
         self.remember_spool :bool = config.getboolean('remember_spool', None)             # remember_spool that is set in AFC_Stepper section, overrides remember_spool that is set in unit(AFC_BoxTurtle/NightOwl/etc) section.
-        self.map: list        = config.getlist('cmd', [])                           # Keeping this in so it does not break others config that may have used this, use map instead
+        self.map: list            = config.getlist('cmd', [])                           # Keeping this in so it does not break others config that may have used this, use map instead
         # Saving to self._map so that if a user has it defined it will be reset back to this when
         # RESET_AFC_MAPPING macro is called.
         self.map = config.getlist('map', self.map)
-        self._map: list       = list(self.map)
-        # Holds which T(n) macro is currently mapped to this lane
-        # since map can be a list of T(n) now
+        self._map: list           = list(self.map)
+        # Holds which T(n) macro is currently mapped to this lane since map can be a list of T(n) now
         self.current_map: str     = ""
-        # T(n) keys this lane last pushed a lane_data record for -- lets
-        # send_lane_data() detect and clear out mappings that were removed
-        # since the last call, without every mapping macro having to do it.
+        # Keeps track of which T(n) macros have been pushed up to moonrakers lane_data database
+        # endpoint. That way send_lane_data method and clear out mappings that were removed since
+        # last updated.
         self._sent_lane_data_keys: list = []
 
         # LED SETTINGS
@@ -2362,6 +2361,7 @@ class AFCLane:
         response['lane'] = self.index
         if not save_to_file:
             response['map'] = self.map
+            response['_map'] = self._map
         else:
             response['map'] = self.map_to_string()
         response['current_map'] = self.current_map

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -12,6 +12,7 @@ from contextlib import contextmanager
 from configfile import error
 from datetime import datetime
 from enum import Enum
+from gcode import CommandError
 
 from typing import Optional, TYPE_CHECKING
 
@@ -26,7 +27,7 @@ if TYPE_CHECKING:
     from pins import PrinterPins
     from query_endstops import QueryEndstops
 
-try: from extras.AFC_utils import ERROR_STR, add_filament_switch
+try: from extras.AFC_utils import ERROR_STR, add_filament_switch, natural_sort_key
 except: raise error("Error when trying to import AFC_utils.ERROR_STR, add_filament_switch\n{trace}".format(trace=traceback.format_exc()))
 
 try: from extras import AFC_assist
@@ -117,7 +118,7 @@ class AFCLane:
 
         #stored status variables
         self.fullname: str      = config.get_name()
-        self.name               = self.fullname.split()[-1]
+        self.name: str          = self.fullname.split()[-1]
 
         # TODO: Put these variables into a common class or something so they are easier to clear out
         # when lanes are unloaded
@@ -158,13 +159,17 @@ class AFCLane:
         self.afc_extruder_name    = config.get('extruder', None)                          # Extruder name(AFC_extruder) that belongs to this stepper, overrides extruder that is set in unit(AFC_BoxTurtle/NightOwl/etc) section.
         self.standalone_lane      = config.getboolean("standalone", False)
         self.remember_spool :bool = config.getboolean('remember_spool', None)             # remember_spool that is set in AFC_Stepper section, overrides remember_spool that is set in unit(AFC_BoxTurtle/NightOwl/etc) section.
-        self.map                = config.get('cmd', None)                               # Keeping this in so it does not break others config that may have used this, use map instead
+        self.map: list        = config.getlist('cmd', [])                           # Keeping this in so it does not break others config that may have used this, use map instead
         # Saving to self._map so that if a user has it defined it will be reset back to this when
-        # the calling RESET_AFC_MAPPING macro.
+        # RESET_AFC_MAPPING macro is called.
+        self.map = config.getlist('map', self.map)
+        self._map: list       = list(self.map)
+        # Holds which T(n) macro is currently mapped to this lane
+        # since map can be a list of T(n) now
+        self.current_map: str     = ""
 
         # LED SETTINGS
         # All variables use: (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
-        self._map = self.map      = config.get('map', self.map)
         self.led_index            = config.get('led_index', None)                       # LED index of lane in chain of lane LEDs
         self.led_fault            = config.get('led_fault',None)                        # LED color to set when faults occur in lane
         self.led_ready            = config.get('led_ready',None)                        # LED color to set when lane is ready
@@ -346,6 +351,34 @@ class AFCLane:
     def __str__(self):
         return self.name
 
+    def _format_map(self, mapping: list, empty: str) -> str:
+        """
+        Helper method to return a mapping list as a string, naturally sorted low to high
+
+        :param mapping: Mapping list to format
+        :param empty: Value to return when mapping is empty
+        :return str: Formatted mapping list
+        """
+        if not mapping:
+            return empty
+        return ", ".join(sorted(mapping, key=natural_sort_key))
+
+    def map_to_string(self) -> str:
+        """
+        Helper method to return map list as a string, naturally sorted low to high
+
+        :return str: Returns lanes map list as a string
+        """
+        return self._format_map(self.map, "NONE")
+
+    def _map_to_string(self) -> str:
+        """
+        Helper method to return _map list as a string, naturally sorted low to high
+
+        :return str: Returns lanes _map list as a string
+        """
+        return self._format_map(self._map, "NONE")
+
     @property
     def load_es(self) -> str:
         """
@@ -431,10 +464,10 @@ class AFCLane:
 
         :returns str: Returns lane mapping index as string
         """
-        if self.map is None:
+        if self.current_map is None:
             return ""
 
-        return self.map.replace("T", "")
+        return self.current_map.replace("T", "")
 
     @property
     def lane_extruder_index(self) -> int:
@@ -1022,8 +1055,17 @@ class AFCLane:
 
         # Only continue if a error did not happen
         if not self.afc.error_state:
-            # Change Mapping
-            self.gcode.run_script_from_command('SET_MAP LANE={} MAP={}'.format(change_lane.name, empty_lane.map))
+            try:
+                # Swap mapping with runout lane
+                self.gcode.run_script_from_command(
+                    f'AFC_SWAP_MAPPING FROM={empty_lane.name} TO={change_lane.name}'
+                )
+            except CommandError:
+                self.afc.error.AFC_error(
+                    f"Error when trying swap mapping from {empty_lane.name} to {change_lane.name}",
+                    pause=True
+                )
+                return
 
             # Turn off runout extruder LEDs and turn on other extruder LEDs if extruders are
             # different
@@ -1815,8 +1857,8 @@ class AFCLane:
         Sends lane data to moonrakers `machine/set_lane_data` endpoint
         """
         if (self.afc.moonraker
-            and self.map is not None
-            and "T" in self.map):
+            and self.current_map is not None
+            and "T" in self.current_map):
             scan_time = self.td1_data['scan_time'] if 'scan_time' in self.td1_data else ""
             td        = self.td1_data['td']        if 'td'        in self.td1_data else ""
 
@@ -1843,8 +1885,8 @@ class AFCLane:
         Clears lane data that is currently stored at moonrakers `machine/set_lane_data` endpoint
         """
         if (self.afc.moonraker
-            and self.map is not None
-            and "T" in self.map):
+            and self.current_map is not None
+            and "T" in self.current_map):
             lane_data = {
                 "namespace": "lane_data",
                 "key": self.name,
@@ -2275,7 +2317,11 @@ class AFCLane:
         response['buffer'] = self.buffer_name
         response['buffer_status'] = self.buffer_status()
         response['lane'] = self.index
-        response['map'] = self.map
+        if not save_to_file:
+            response['map'] = self.map
+        else:
+            response['map'] = self.map_to_string()
+        response['current_map'] = self.current_map
         response['load'] = self.load_state
         response["prep"] =bool(self.prep_state)
         if self._selector_state is not None:
@@ -2314,7 +2360,8 @@ class AFCLane:
             response['td1_color']       = self.td1_data['color'] if "color" in self.td1_data else ''
             response['td1_scan_time']   = self.td1_data['scan_time'] if "scan_time" in self.td1_data else ''
 
-        if hasattr(self, "_endstops"):
+        if (hasattr(self, "_endstops")
+            and not save_to_file):
             response["endstops"] = ",".join(self._endstops.keys())
 
         return response

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -190,11 +190,11 @@ class afcPrep:
                     if 'runout_lane' in units[cur_lane.unit][cur_lane.name]: cur_lane.runout_lane = units[cur_lane.unit][cur_lane.name]['runout_lane']
                     if cur_lane.runout_lane == '' or cur_lane.runout_lane == 'NONE': cur_lane.runout_lane = None
                     temp_map = units[cur_lane.unit][cur_lane.name].get('map', None)
-                    if (temp_map and
-                        isinstance(temp_map, str)):
-                        cur_lane.map = temp_map.replace(" ", "").split(",")
-                    else:
-                        cur_lane.map = list(temp_map or [])
+                    if temp_map:
+                        if isinstance(temp_map, str):
+                            cur_lane.map = temp_map.replace(" ", "").split(",")
+                        else:
+                            cur_lane.map = list(temp_map)
                     cur_lane.current_map = units[cur_lane.unit][cur_lane.name].get("current_map", "")
 
                     if cur_lane.map != None:

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -189,9 +189,21 @@ class afcPrep:
 
                     if 'runout_lane' in units[cur_lane.unit][cur_lane.name]: cur_lane.runout_lane = units[cur_lane.unit][cur_lane.name]['runout_lane']
                     if cur_lane.runout_lane == '' or cur_lane.runout_lane == 'NONE': cur_lane.runout_lane = None
-                    if 'map' in units[cur_lane.unit][cur_lane.name]: cur_lane.map = units[cur_lane.unit][cur_lane.name]['map']
+                    temp_map = units[cur_lane.unit][cur_lane.name].get('map', None)
+                    if (temp_map and
+                        isinstance(temp_map, str)):
+                        cur_lane.map = temp_map.replace(" ", "").split(",")
+                    else:
+                        cur_lane.map = list(temp_map or [])
+                    cur_lane.current_map = units[cur_lane.unit][cur_lane.name].get("current_map", "")
+
                     if cur_lane.map != None:
-                        self.afc.tool_cmds[cur_lane.map] = cur_lane.name
+                        for map_str in cur_lane.map:
+                            # NONE is a special placeholder so that when assigning T(n) commands
+                            # lanes with NONE will not get one assigned to keep the T(n) macros from
+                            # growing over time with the new multi mapping update
+                            if map_str != "NONE":
+                                self.afc.tool_cmds[map_str] = cur_lane.name
                     # Check first for hub_loaded as this was the old name in software with version <= 1030
                     if 'hub_loaded' in units[cur_lane.unit][cur_lane.name]: lane.loaded_to_hub = units[cur_lane.unit][cur_lane.name]['hub_loaded']
                     # Check for loaded_to_hub as this is how its being saved version > 1030

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -1,6 +1,7 @@
-# Armored Turtle Automated Filament Changer
+# AFCProject Automated Filament Changer Software
 #
 # Copyright (C) 2024-2026 Armored Turtle
+# Copyright (C) 2026 AFCProject
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 from __future__ import annotations
@@ -8,20 +9,48 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 import copy
 import traceback
+import re
+
 
 if TYPE_CHECKING:
+    from gcode import GCodeCommand
+    from configfile import ConfigWrapper
     from extras.AFC import afc
     from extras.AFC_lane import AFCLane
 
 class AFCSpool:
-    def __init__(self, config):
+    def __init__(self, config: ConfigWrapper):
         self.printer = config.get_printer()
         self.printer.register_event_handler("klippy:connect", self.handle_connect)
         self.SPOOLMAN_REMOTE_METHOD = 'spoolman_set_active_spool'
         self.print_task_config_obj = None
 
+
         # Temporary status variables
         self.next_spool_id      = None
+
+    def register_commands(self, afc: afc) -> None:
+        """
+        Method to register macros, this should be called after class has been initialized during the
+        initialization phase.
+
+        :param afc: AFC object to use
+        """
+        self.afc = afc
+        self.function = afc.function
+        self.enable_multiple_mapping = self.afc.enable_multiple_mapping
+        self.function.register_commands(self.afc.show_macros, "AFC_ADD_MAPPING",
+                                        self.cmd_AFC_ADD_MAPPING, self.cmd_AFC_ADD_MAPPING_help,
+                                        self.cmd_AFC_ADD_MAPPING_options)
+        self.function.register_commands(self.afc.show_macros, "AFC_REMOVE_MAPPING",
+                                        self.cmd_AFC_REMOVE_MAPPING, self.cmd_AFC_REMOVE_MAPPING_help,
+                                        self.cmd_AFC_REMOVE_MAPPING_options)
+        self.function.register_commands(self.afc.show_macros, "AFC_ENABLE_MULTIPLE_MAPPING",
+                                        self.cmd_AFC_ENABLE_MULTIPLE_MAPPING,
+                                        self.cmd_AFC_ENABLE_MULTIPLE_MAPPING_help,
+                                        self.cmd_AFC_ENABLE_MULTIPLE_MAPPING_options)
+        self.function.register_commands(False, "AFC_SWAP_MAPPING",
+                                        self.cmd_AFC_SWAP_MAPPING, self.cmd_AFC_SWAP_MAPPING_help)
 
     def handle_connect(self):
         """
@@ -29,7 +58,6 @@ class AFCSpool:
         This function is called when the printer connects. It looks up the AFC object
         and assigns it to the instance variable `self.AFC`.
         """
-        self.afc: afc   = self.printer.lookup_object('AFC')
         self.error      = self.afc.error
         self.reactor    = self.afc.reactor
         self.gcode      = self.afc.gcode
@@ -159,17 +187,8 @@ class AFCSpool:
         SET_MAP LANE=lane1 MAP=T1
         ```
         """
-        lane = gcmd.get('LANE', None)
-        if lane is None:
-            self.logger.info("No LANE parameter provided, please specify a valid LANE parameter.")
-            return
-
-        map_cmd = gcmd.get('MAP', None)
-
-        if map_cmd is None:
-            self.logger.info("No MAP parameter provided, please specify a valid MAP parameter.")
-            return
-
+        lane = gcmd.get('LANE')
+        map_cmd = gcmd.get('MAP')
         map_cmd = map_cmd.upper()
 
         if map_cmd not in self.afc.tool_cmds:
@@ -178,20 +197,165 @@ class AFCSpool:
 
         lane_switch = self.afc.tool_cmds[map_cmd]
         self.logger.debug("lane to switch is {}".format(lane_switch))
-        if lane not in self.afc.lanes:
+
+        cur_lane = self.afc.lanes.get(lane, None)
+        if cur_lane is None:
             self.logger.info('{} Unknown'.format(lane))
             return
-        cur_lane = self.afc.lanes[lane]
-        self.afc.tool_cmds[map_cmd]=lane
-        map_switch = cur_lane.map
-        cur_lane.map = map_cmd
+
+        sw_lane = self.afc.lanes.get(lane_switch, None)
+        if sw_lane is None:
+            self.logger.info(f"{lane_switch} is not found when swapping mapping.")
+            return
+
+        if sw_lane is cur_lane:
+            self.logger.info(f"{map_cmd} is already mapped to {lane}")
+            return
+
+        if self.enable_multiple_mapping:
+            sw_lane.map = [c for c in sw_lane.map if c != map_cmd]
+            if sw_lane.current_map == map_cmd:
+                sw_lane.current_map = ""
+            # Reassigning (not appending/removing in place) so Klipper's status
+            # diff sees a new list and pushes the update
+            cur_lane.map = cur_lane.map + [map_cmd]
+            cur_lane.map = [m for m in cur_lane.map if m != "NONE"]
+        else:
+            sw_lane.map = list(cur_lane.map)
+            sw_lane.current_map = sw_lane.map[0] if sw_lane.map else ""
+
+            cur_lane.map = [map_cmd]
+            cur_lane.current_map = map_cmd
+
+        for m in sw_lane.map:
+            if m == "NONE": continue
+            self.afc.tool_cmds[m] = sw_lane.name
+        # cur_lane.map can't contain "NONE" here: the enable_multiple_mapping
+        # branch filters it explicitly, and the else branch sets it to
+        # [map_cmd], which is always a real mapping (already validated
+        # against tool_cmds above), so no guard is needed for this loop.
+        for m in cur_lane.map:
+            self.afc.tool_cmds[m] = cur_lane.name
+        sw_lane.send_lane_data()
+
+        # TODO: need to check lane data to see how it looks
         cur_lane.send_lane_data()
 
-        sw_lane = self.afc.lanes[lane_switch]
-        self.afc.tool_cmds[map_switch] = lane_switch
-        sw_lane.map = map_switch
-        sw_lane.send_lane_data()
         self.afc.save_vars()
+
+    cmd_AFC_SWAP_MAPPING_help = "Swaps mapping between two lanes as provided with the FROM/TO variables"
+    def cmd_AFC_SWAP_MAPPING(self, gcmd: GCodeCommand) -> None:
+        lane_from = gcmd.get("FROM")
+        lane_to   = gcmd.get("TO")
+
+        lane_from_obj = self.afc.lanes.get(lane_from)
+        lane_to_obj   = self.afc.lanes.get(lane_to)
+        # TODO: verify that raised commands so not crash klipper if this is called when printing
+        if not lane_from_obj:
+            raise gcmd.error(f"Swapping from {lane_from} not found")
+        if not lane_to_obj:
+            raise gcmd.error(f"Swapping to {lane_to} not found")
+
+        lane_from_mapping = lane_from_obj.map
+        lane_to_mapping = lane_to_obj.map
+        lane_from_current = lane_from_obj.current_map
+
+        lane_from_obj.current_map = lane_to_obj.current_map
+        lane_from_obj.map = lane_to_mapping
+
+        lane_to_obj.current_map = lane_from_current
+        lane_to_obj.map = lane_from_mapping
+
+        for map_str in lane_from_obj.map:
+            if map_str == "NONE": continue
+            self.afc.tool_cmds.update({map_str: lane_from_obj.name})
+        for map_str in lane_to_obj.map:
+            if map_str == "NONE": continue
+            self.afc.tool_cmds.update({map_str: lane_to_obj.name})
+
+        lane_from_obj.send_lane_data()
+        lane_to_obj.send_lane_data()
+        self.afc.save_vars()
+
+    cmd_AFC_ADD_MAPPING_help = (
+        "Adds a new T(n) macro that currently does not exist to a lane. Mapping can be passed in "
+        "a comma separated list to add multiple to a single lane"
+    )
+    cmd_AFC_ADD_MAPPING_options = {"LANE": {"type": "string", "default": "lane1"},
+                                   "MAPPING": {"type": "string", "default": "T0"}}
+    def cmd_AFC_ADD_MAPPING(self, gcmd: GCodeCommand) -> None:
+        if not self.enable_multiple_mapping:
+            raise gcmd.error("enable multiple mapping needs to be enabled to add mappings,"
+                                " enable by running AFC_ENABLE_MULTIPLE_MAPPING ENABLE=1")
+        lane = gcmd.get("LANE")
+        mapping: str = gcmd.get("MAPPING")
+        mapping_list: list = mapping.upper().split(",")
+
+        lane_obj = self.afc.lanes.get(lane, None)
+        if not lane_obj:
+            raise gcmd.error(f"{lane} is not a valid lane")
+
+        for m in mapping_list:
+            if not re.fullmatch(r"T\d+", m):
+                self.afc.error.AFC_error(f"'{m}' is not a valid mapping, expect T(n) format.", False)
+                continue
+
+            if m in self.afc.tool_cmds:
+                self.afc.error.AFC_error(f"Cannot map {m} to {lane}, as mapping already exists.", False)
+                continue
+            self.logger.info(f"Adding {m} to {lane}")
+            self.afc.tool_cmds.update({m: lane})
+            lane_obj.map = lane_obj.map + [m]
+            self.function.register_tool_macro(lane, m)
+        lane_obj.send_lane_data()
+        self.afc.save_vars()
+
+    cmd_AFC_REMOVE_MAPPING_help = (
+        "Removes T(n) macro from specified lane, mapping can be passed in as comma separated list "
+        "to remove multiple mappings from a lane"
+    )
+    cmd_AFC_REMOVE_MAPPING_options = {"MAPPING": {"type": "string", "default": "T0"}}
+    def cmd_AFC_REMOVE_MAPPING(self, gcmd: GCodeCommand) -> None:
+        if not self.enable_multiple_mapping:
+            raise gcmd.error("enable multiple mapping needs to be enabled to remove mappings,"
+                             " enable by running AFC_ENABLE_MULTIPLE_MAPPING ENABLE=1")
+        mapping: str = gcmd.get("MAPPING")
+        mapping_list: list = mapping.upper().split(",")
+
+        for m in mapping_list:
+            if m not in self.afc.tool_cmds:
+                self.afc.error.AFC_error(f"Mapping {m} does not exist", False)
+                continue
+            lane = self.afc.tool_cmds.pop(m)
+            lane_obj = self.afc.lanes.get(lane)
+            if lane_obj:
+                self.logger.info(f"Removing {m} macro from {lane}")
+                lane_obj.map = [ c for c in lane_obj.map if c != m]
+                if lane_obj.current_map == m:
+                    lane_obj.current_map = lane_obj.map[0] if lane_obj.map else ""
+                lane_obj.send_lane_data()
+            self.gcode.register_command(m, None)
+        self.afc.save_vars()
+
+    cmd_AFC_ENABLE_MULTIPLE_MAPPING_help = (
+        "Enable ability to have multiple T(n) macros mapped to a single lane and enables use"
+        " of virtual tools"
+    )
+    cmd_AFC_ENABLE_MULTIPLE_MAPPING_options ={"ENABLE":{"type": "int", "default": 0}}
+    def cmd_AFC_ENABLE_MULTIPLE_MAPPING(self, gcmd: GCodeCommand) -> None:
+        enable = bool(gcmd.get_int("ENABLE", 0))
+        if enable:
+            self.enable_multiple_mapping = True
+            self.logger.info("Multiple T(n) mapping per lane has been enabled along with ability to "
+                             "add virtual tools with AFC_ADD_MAPPING macro")
+        else:
+            self.enable_multiple_mapping = False
+            # TODO: figure out a way to properly reset lane mappings back to a 1-1 not n-1
+            # Maybe reset everything back and then remove the remaining T(n) macros
+            self.logger.info("Multiple T(n) mapping per lane and virtual tools has been disabled")
+
+        self.afc.enable_multiple_mapping = self.enable_multiple_mapping
+        self.function.ConfigRewrite("AFC", "enable_multiple_mapping", self.enable_multiple_mapping)
 
     cmd_SET_COLOR_help = "Set filaments color for a lane"
     def cmd_SET_COLOR(self, gcmd):
@@ -528,7 +692,10 @@ class AFCSpool:
     cmd_RESET_AFC_MAPPING_help = "Resets all lane mapping in AFC"
     def cmd_RESET_AFC_MAPPING(self, gcmd):
         """
-        Resets all tool lane mapping to the order set up in the configuration.
+        Resets all tool lane mapping to the order set up in the configuration. When multiple tool
+        mapping is enabled, when reset is called and virtual tools have been added, the virtual
+        tools will be removed since reset will always revert back to a 1 to 1 mapping.
+
         Optionally resets runout lanes unless RUNOUT=no is specified.
 
         Useful to put in your PRINT_END macro to reset mapping
@@ -543,25 +710,27 @@ class AFCSpool:
         RESET_AFC_MAPPING RUNOUT=no
         ```
         """
-
+        # TODO: update this before merging into DEV
         # Gathering existing lane mapping and add to list
-        existing_cmds = [lane.map for lane in self.afc.lanes.values()]
+        existing_cmds: list[str] = [cmd for lane in self.afc.lanes.values() for cmd in lane.map if cmd != "NONE"]
         # Gather manually assigned mappings and add to list
-        manually_assigned = [ lane._map for lane in self.afc.lanes.values()]
+        manually_assigned = [ cmd for lane in self.afc.lanes.values() for cmd in lane._map]
         # Remove manually assigned mappings from auto assigned mappings
         existing_cmds = list(set(existing_cmds) - set(manually_assigned))
         # Sort list in numerical order
         existing_cmds = sorted(existing_cmds, key=lambda x: int("".join([i for i in x if i.isdigit()])))
-        for key, unit in self.afc.units.items():
+        for unit in self.afc.units.values():
             for lane in unit.lanes.values():
+                lane.map = []
                 # Reassigning manually assigned mapping to lane
-                if lane._map is not None:
-                    map_cmd = lane._map
+                if lane._map:
+                    map_cmd = lane._map[0]
                 else:
                     map_cmd = existing_cmds.pop(0)
 
                 self.afc.tool_cmds[map_cmd] = lane.name
-                self.afc.lanes[lane.name].map = map_cmd
+                lane.current_map = map_cmd
+                lane.map = [map_cmd]
 
         # Resetting runout lanes to None
         runout_opt = gcmd.get('RUNOUT', 'yes').lower()
@@ -571,6 +740,14 @@ class AFCSpool:
 
         self.afc.save_vars()
         self.logger.info("Tool mappings reset" + ("" if runout_opt == "no" else " and runout lanes reset"))
+
+        # Checking if more lanes exist, remove then since we do not know where these should be added
+        # since reset just resets back to a 1:1 mapping.
+        if len(existing_cmds) > 0:
+            self.logger.info(f"{', '.join(existing_cmds)} remain, removing these mappings")
+            for cmd in existing_cmds:
+                self.afc.tool_cmds.pop(cmd, None)
+                self.gcode.register_command(cmd, None)
 
     cmd_SET_NEXT_SPOOL_ID_help = "Set the spool id to be loaded next into AFC"
     def cmd_SET_NEXT_SPOOL_ID(self, gcmd):

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -6,7 +6,7 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 from __future__ import annotations
 
-from typing import Optional, Union, TYPE_CHECKING
+from typing import Optional, Union, Any, TYPE_CHECKING
 import copy
 import traceback
 import re
@@ -245,8 +245,25 @@ class AFCSpool:
 
     cmd_AFC_SWAP_MAPPING_help = "Swaps mapping between two lanes as provided with the FROM/TO variables"
     def cmd_AFC_SWAP_MAPPING(self, gcmd: GCodeCommand) -> None:
+        """
+        This macro allows a way to easily swap mappings between two lanes, this macro is used during
+        infinite spool runout so that a lanes current mappings correctly moves to the runout lane mapping.
+
+        Usage
+        -----
+        `AFC_SWAP_MAPPING FROM=<lane name> TO=<lane name>`
+
+        Example
+        -----
+        ```
+        AFC_SWAP_MAPPING FROM=lane1 TO=lane2
+        ```
+        """
         lane_from = gcmd.get("FROM")
         lane_to   = gcmd.get("TO")
+
+        if lane_from.lower() == lane_to.lower():
+            raise gcmd.error(f"FROM({lane_from}) TO({lane_to}) values are the same, not swapping.")
 
         lane_from_obj = self.afc.lanes.get(lane_from)
         lane_to_obj   = self.afc.lanes.get(lane_to)
@@ -284,6 +301,24 @@ class AFCSpool:
     cmd_AFC_ADD_MAPPING_options = {"LANE": {"type": "string", "default": "lane1"},
                                    "MAPPING": {"type": "string", "default": "T0"}}
     def cmd_AFC_ADD_MAPPING(self, gcmd: GCodeCommand) -> None:
+        """
+        This macro adds passed in mapping to specified lane, allows the ability to create "virtual tools". 
+        The new maps will be registered into klipper so that they can be called correctly. Mappings
+        can be passed in as a comma separated list to add multiple to a single lane.
+
+        Multiple lane mappings need to be enabled first with `AFC_ENABLE_MULTIPLE_MAPPING ENABLE=1
+        before running this command.
+
+        Usage
+        -----
+        `AFC_ADD_MAPPING MAPPING=<mappings to be add>`
+
+        Example
+        -----
+        ```
+        AFC_ADD_MAPPING LANE=lane1 MAPPING=T5,T6
+        ```
+        """
         if not self.enable_multiple_mapping:
             raise gcmd.error("enable multiple mapping needs to be enabled to add mappings,"
                                 " enable by running AFC_ENABLE_MULTIPLE_MAPPING ENABLE=1")
@@ -316,6 +351,23 @@ class AFCSpool:
     )
     cmd_AFC_REMOVE_MAPPING_options = {"MAPPING": {"type": "string", "default": "T0"}}
     def cmd_AFC_REMOVE_MAPPING(self, gcmd: GCodeCommand) -> None:
+        """
+        This macro removes specified mapping from a lanes and deregisters it in klipper so it cannot
+        be called. Comma separated list can be passed in for mappings to be removed.
+
+        Multiple lane mappings need to be enabled first with `AFC_ENABLE_MULTIPLE_MAPPING ENABLE=1
+        before running this command.
+
+        Usage
+        -----
+        `AFC_REMOVE_MAPPING MAPPING=<mappings to be removed>`
+
+        Example
+        -----
+        ```
+        AFC_REMOVE_MAPPING MAPPING=T5,T6
+        ```
+        """
         if not self.enable_multiple_mapping:
             raise gcmd.error("enable multiple mapping needs to be enabled to remove mappings,"
                              " enable by running AFC_ENABLE_MULTIPLE_MAPPING ENABLE=1")
@@ -343,6 +395,23 @@ class AFCSpool:
     )
     cmd_AFC_ENABLE_MULTIPLE_MAPPING_options ={"ENABLE":{"type": "int", "default": 0}}
     def cmd_AFC_ENABLE_MULTIPLE_MAPPING(self, gcmd: GCodeCommand) -> None:
+        """
+        This macro enables the ability to have T(n) macros mapped to multiple lanes. Enabling 
+        multiple mapping also adds the ability to add virtual tools with AFC_ADD_MAPPING and 
+        AFC_REMOVE_MAPPING macros.
+
+        When disabling multiple mapping, lanes mappings are also reset via RESET_AFC_MAPPING command.
+
+        Usage
+        -----
+        `AFC_ENABLE_MULTIPLE_MAPPING ENABLE=<0/1>`
+
+        Example
+        -----
+        ```
+        AFC_ENABLE_MULTIPLE_MAPPING ENABLE=1
+        ```
+        """
         enable = bool(gcmd.get_int("ENABLE", 0))
         if enable:
             self.enable_multiple_mapping = True
@@ -353,6 +422,7 @@ class AFCSpool:
             # TODO: figure out a way to properly reset lane mappings back to a 1-1 not n-1
             # Maybe reset everything back and then remove the remaining T(n) macros
             self.logger.info("Multiple T(n) mapping per lane and virtual tools has been disabled")
+            self._reset_mapping()
 
         self.afc.enable_multiple_mapping = self.enable_multiple_mapping
         self.function.ConfigRewrite("AFC", "enable_multiple_mapping", self.enable_multiple_mapping)
@@ -536,15 +606,15 @@ class AFCSpool:
             if cur_lane.name == self.afc.current:
                 self.set_active_spool(cur_lane.spool_id)
 
-    def _get_filament_values( self, filament, field, default=None):
-        '''
+    def _get_filament_values( self, filament: dict, field: str, default: Any=None) -> Any:
+        """
         Helper function for checking if field is set and returns value if it exists,
         otherwise returns None
 
         :param filament: Dictionary for filament values
         :param field:    Field name to check for in dictionary
         :return:         Returns value if field exists or None if field does not exist
-        '''
+        """
         value = default
         if field in filament:
             value = filament[field]
@@ -588,7 +658,8 @@ class AFCSpool:
         cur_lane.spool_vendor = ""
         cur_lane.filament_name = ""
 
-    def set_spoolID(self, cur_lane: AFCLane, SpoolID: Optional[Union[int, str]], save_vars: bool = True) -> None:
+    def set_spoolID(self, cur_lane: AFCLane, SpoolID: Optional[Union[int, str]],
+                    save_vars: bool = True) -> None:
         if (self.afc.spoolman is not None
             and self.afc.moonraker is not None):
             if (SpoolID is not None
@@ -702,7 +773,7 @@ class AFCSpool:
     cmd_RESET_AFC_MAPPING_help = "Resets all lane mapping in AFC"
     def cmd_RESET_AFC_MAPPING(self, gcmd: GCodeCommand) -> None:
         """
-        Resets all tool lane mapping to the order set up in the configuration. When multiple tool
+        Resets all tool lane mapping to the order set up in the configuration. If multiple tool
         mapping is enabled, when reset is called and virtual tools have been added, the virtual
         tools will be removed since reset will always revert back to a 1 to 1 mapping.
 
@@ -720,15 +791,27 @@ class AFCSpool:
         RESET_AFC_MAPPING RUNOUT=no
         ```
         """
-        # TODO: update this before merging into DEV
-        # Gathering existing lane mapping and add to list
-        existing_cmds: list[str] = [cmd for lane in self.afc.lanes.values() for cmd in lane.map if cmd != "NONE"]
+        # Resetting runout lanes to None
+        runout_opt = gcmd.get('RUNOUT', 'yes').lower()
+        self._reset_mapping(runout_opt)
+
+    def _reset_mapping(self, runout_opt: str = 'no') -> None:
+        """
+        Resets all lane mapping back to a 1:1 T(n) assignment, renumbering lanes
+        sequentially so adding or removing a unit doesn't leave gaps or stale
+        high numbers behind.
+
+        :param runout_opt: "no" leaves runout lanes untouched, anything else clears them
+        """
+        # Commands in use before the reset, used further down to spot leftovers
+        previously_used_cmds = {
+            cmd for lane in self.afc.lanes.values() for cmd in lane.map if cmd != "NONE"
+        }
         # Gather manually assigned mappings and add to list
-        manually_assigned = [ cmd for lane in self.afc.lanes.values() for cmd in lane._map]
-        # Remove manually assigned mappings from auto assigned mappings
-        existing_cmds = list(set(existing_cmds) - set(manually_assigned))
-        # Sort list in numerical order
-        existing_cmds = sorted(existing_cmds, key=lambda x: int("".join([i for i in x if i.isdigit()])))
+        manually_assigned = {cmd for lane in self.afc.lanes.values() for cmd in lane._map}
+        # Fresh T0..T(n-1) sequence for auto lanes, skipping manually assigned numbers
+        total_lanes = sum(len(unit.lanes) for unit in self.afc.units.values())
+        auto_cmds = [f"T{i}" for i in range(total_lanes) if f"T{i}" not in manually_assigned]
         for unit in self.afc.units.values():
             for lane in unit.lanes.values():
                 lane.map = []
@@ -736,28 +819,39 @@ class AFCSpool:
                 if lane._map:
                     map_cmd = lane._map[0]
                 else:
-                    map_cmd = existing_cmds.pop(0)
+                    map_cmd = auto_cmds.pop(0)
+
+                # New commands not already registered need to be registered in klipper
+                if map_cmd not in previously_used_cmds:
+                    self.function.register_tool_macro(lane.name, map_cmd)
 
                 self.afc.tool_cmds[map_cmd] = lane.name
                 lane.current_map = map_cmd
                 lane.map = [map_cmd]
 
-        # Resetting runout lanes to None
-        runout_opt = gcmd.get('RUNOUT', 'yes').lower()
+        # Remove commands no longer assigned to a lane (virtual-tool extras, or
+        # leftovers from a removed unit), popped before send_lane_data() below
+        # so it sees them as gone rather than still owned by this lane.
+        new_cmds = {lane.map[0] for unit in self.afc.units.values() for lane in unit.lanes.values()}
+        stale_cmds = sorted(previously_used_cmds - new_cmds,
+                            key=lambda x: int("".join([i for i in x if i.isdigit()])))
+        if stale_cmds:
+            self.logger.info(f"{', '.join(stale_cmds)} remain, removing these mappings")
+            for cmd in stale_cmds:
+                self.afc.tool_cmds.pop(cmd, None)
+                self.gcode.register_command(cmd, None)
+
+        # Run after every lane is reassigned so send_lane_data() sees the final mapping
+        for unit in self.afc.units.values():
+            for lane in unit.lanes.values():
+                lane.send_lane_data()
+
         if runout_opt != 'no':
             for lane in self.afc.lanes.values():
                 lane.runout_lane = None
 
         self.afc.save_vars()
         self.logger.info("Tool mappings reset" + ("" if runout_opt == "no" else " and runout lanes reset"))
-
-        # Checking if more lanes exist, remove then since we do not know where these should be added
-        # since reset just resets back to a 1:1 mapping.
-        if len(existing_cmds) > 0:
-            self.logger.info(f"{', '.join(existing_cmds)} remain, removing these mappings")
-            for cmd in existing_cmds:
-                self.afc.tool_cmds.pop(cmd, None)
-                self.gcode.register_command(cmd, None)
 
     cmd_SET_NEXT_SPOOL_ID_help = "Set the spool id to be loaded next into AFC"
     def cmd_SET_NEXT_SPOOL_ID(self, gcmd: GCodeCommand) -> None:

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -20,6 +20,12 @@ if TYPE_CHECKING:
 
 class AFCSpool:
     def __init__(self, config: ConfigWrapper) -> None:
+        """
+        Basic setup, actual initialization happens in handle_connect/register_commands
+        once the AFC object is available.
+
+        :param config: Klipper config wrapper for this section
+        """
         self.printer = config.get_printer()
         self.printer.register_event_handler("klippy:connect", self.handle_connect)
         self.SPOOLMAN_REMOTE_METHOD = 'spoolman_set_active_spool'
@@ -165,7 +171,7 @@ class AFCSpool:
             return
         cur_lane = self.afc.lanes.get(lane)
         if cur_lane is None:
-            self.logger.info('{} Unknown'.format(lane))
+            self.logger.info(f"{lane} Unknown")
             return
         cur_lane.bed_temp = gcmd.get_int('BED_TEMP', cur_lane.bed_temp, minval=0)
         cur_lane.extruder_temp = gcmd.get_int('EXTRUDER_TEMP', cur_lane.extruder_temp, minval=0)
@@ -192,15 +198,15 @@ class AFCSpool:
         map_cmd = map_cmd.upper()
 
         if map_cmd not in self.afc.tool_cmds:
-            self.logger.error("Invalid map command: {}".format(map_cmd))
+            self.logger.error(f"Invalid map command: {map_cmd}")
             return
 
         lane_switch = self.afc.tool_cmds[map_cmd]
-        self.logger.debug("lane to switch is {}".format(lane_switch))
+        self.logger.debug(f"lane to switch is {lane_switch}")
 
         cur_lane = self.afc.lanes.get(lane, None)
         if cur_lane is None:
-            self.logger.info('{} Unknown'.format(lane))
+            self.logger.info(f"{lane} Unknown")
             return
 
         sw_lane = self.afc.lanes.get(lane_switch, None)
@@ -302,7 +308,7 @@ class AFCSpool:
                                    "MAPPING": {"type": "string", "default": "T0"}}
     def cmd_AFC_ADD_MAPPING(self, gcmd: GCodeCommand) -> None:
         """
-        This macro adds passed in mapping to specified lane, allows the ability to create "virtual tools". 
+        This macro adds passed in mapping to specified lane, allows the ability to create "virtual tools".
         The new maps will be registered into klipper so that they can be called correctly. Mappings
         can be passed in as a comma separated list to add multiple to a single lane.
 
@@ -396,8 +402,8 @@ class AFCSpool:
     cmd_AFC_ENABLE_MULTIPLE_MAPPING_options ={"ENABLE":{"type": "int", "default": 0}}
     def cmd_AFC_ENABLE_MULTIPLE_MAPPING(self, gcmd: GCodeCommand) -> None:
         """
-        This macro enables the ability to have T(n) macros mapped to multiple lanes. Enabling 
-        multiple mapping also adds the ability to add virtual tools with AFC_ADD_MAPPING and 
+        This macro enables the ability to have T(n) macros mapped to multiple lanes. Enabling
+        multiple mapping also adds the ability to add virtual tools with AFC_ADD_MAPPING and
         AFC_REMOVE_MAPPING macros.
 
         When disabling multiple mapping, lanes mappings are also reset via RESET_AFC_MAPPING command.
@@ -419,8 +425,6 @@ class AFCSpool:
                              "add virtual tools with AFC_ADD_MAPPING macro")
         else:
             self.enable_multiple_mapping = False
-            # TODO: figure out a way to properly reset lane mappings back to a 1-1 not n-1
-            # Maybe reset everything back and then remove the remaining T(n) macros
             self.logger.info("Multiple T(n) mapping per lane and virtual tools has been disabled")
             self._reset_mapping()
 
@@ -450,10 +454,10 @@ class AFCSpool:
             return
         color = gcmd.get('COLOR', '#000000')
         if lane not in self.afc.lanes:
-            self.logger.info('{} Unknown'.format(lane))
+            self.logger.info(f"{lane} Unknown")
             return
         cur_lane = self.afc.lanes[lane]
-        cur_lane.color = '#{}'.format(color.replace('#',''))
+        cur_lane.color = f"#{color.replace('#', '')}"
         cur_lane.multi_color = []
         cur_lane.send_lane_data()
         # Refresh LED only if filament is loaded — empty lanes keep their state color
@@ -486,7 +490,7 @@ class AFCSpool:
             return
         weight = gcmd.get_float('WEIGHT', 1000.0)
         if lane not in self.afc.lanes:
-            self.logger.info('{} Unknown'.format(lane))
+            self.logger.info(f"{lane} Unknown")
             return
         cur_lane = self.afc.lanes[lane]
         cur_lane.weight = weight
@@ -525,7 +529,7 @@ class AFCSpool:
             self.logger.info("No LANE Defined")
             return
         if lane not in self.afc.lanes:
-            self.logger.info('{} Unknown'.format(lane))
+            self.logger.info(f"{lane} Unknown")
             return
         cur_lane = self.afc.lanes[lane]
         density = gcmd.get_float('DENSITY', None)
@@ -544,6 +548,11 @@ class AFCSpool:
         self.set_snapmaker_filament_params(cur_lane)
 
     def set_active_spool(self, ID: Optional[Union[int, str]]) -> None:
+        """
+        Notifies Spoolman of the spool that is now active on the toolhead.
+
+        :param ID: Spool ID to set as active, pass None to clear the active spool
+        """
         webhooks = self.printer.lookup_object('webhooks')
         if self.afc.spoolman is not None:
             if (ID
@@ -556,7 +565,7 @@ class AFCSpool:
             try:
                 webhooks.call_remote_method(self.SPOOLMAN_REMOTE_METHOD, **args)
             except self.printer.command_error as e:
-                self.logger.error("Error trying to set active spool \n{}".format(e))
+                self.logger.error(f"Error trying to set active spool \n{e}")
 
     cmd_SET_SPOOL_ID_help = "Set lanes spoolman ID"
     def cmd_SET_SPOOL_ID(self, gcmd: GCodeCommand) -> None:
@@ -582,7 +591,7 @@ class AFCSpool:
                 return
             SpoolID: Union[int, str] = gcmd.get('SPOOL_ID', '')
             if lane not in self.afc.lanes:
-                self.logger.info('{} Unknown'.format(lane))
+                self.logger.info(f"{lane} Unknown")
                 return
 
             cur_lane = self.afc.lanes[lane]
@@ -592,7 +601,7 @@ class AFCSpool:
                 try:
                     SpoolID = int(SpoolID)
                 except ValueError:
-                    self.logger.error("Invalid spool ID: {}".format(SpoolID))
+                    self.logger.error(f"Invalid spool ID: {SpoolID}")
                     return
 
                 if (cur_lane.spool_id != SpoolID
@@ -660,6 +669,16 @@ class AFCSpool:
 
     def set_spoolID(self, cur_lane: AFCLane, SpoolID: Optional[Union[int, str]],
                     save_vars: bool = True) -> None:
+        """
+        Assigns a spool from Spoolman to a lane, pulling material, color, weight,
+        and temperature values from Spoolman and updating the lane accordingly.
+        Clears the lane's values instead when SpoolID is empty/None and the lane
+        isn't set to remember its spool.
+
+        :param cur_lane:  AFC lane to assign the spool to
+        :param SpoolID:   Spoolman spool ID to assign, or None/'' to clear
+        :param save_vars: Whether to save AFC vars after assigning
+        """
         if (self.afc.spoolman is not None
             and self.afc.moonraker is not None):
             if (SpoolID is not None
@@ -688,13 +707,13 @@ class AFCSpool:
 
                     weight_check = self.disable_weight_check
 
-                    self.afc.logger.debug('Weight remaining for SpoolID {}: {}'.format(SpoolID, cur_lane.weight))
+                    self.afc.logger.debug(f"Weight remaining for SpoolID {SpoolID}: {cur_lane.weight}")
 
                     if not weight_check:
                         if (cur_lane.weight is None
                             or cur_lane.weight <= 0):
-                            error_str = ("Invalid weight for spoolID: {}. "
-                                        "Please check remaining weight before assigning.").format(SpoolID)
+                            error_str = (f"Invalid weight for spoolID: {SpoolID}. "
+                                        "Please check remaining weight before assigning.")
                             self.afc.error.AFC_error(error_str, False)
                             self.clear_values(cur_lane)
                             return
@@ -706,7 +725,7 @@ class AFCSpool:
                         cur_lane.multi_color = multi_color_hex.split(",")
                         cur_lane.color = f"#{cur_lane.multi_color[0]}"
                     else:
-                        cur_lane.color = '#{}'.format(self._get_filament_values(result['filament'], 'color_hex'))
+                        cur_lane.color = f"#{self._get_filament_values(result['filament'], 'color_hex')}"
                         cur_lane.multi_color = []
 
                     cur_lane.send_lane_data()
@@ -717,7 +736,7 @@ class AFCSpool:
                         self.afc.function.afc_led(unit._get_lane_color(cur_lane, cur_lane.led_ready), cur_lane.led_index)
 
                 except Exception as e:
-                    self.afc.error.AFC_error("Error when trying to get Spoolman data for ID:{}, Error: {}".format(SpoolID, e), False)
+                    self.afc.error.AFC_error(f"Error when trying to get Spoolman data for ID:{SpoolID}, Error: {e}", False)
             elif not cur_lane.remember_spool:
                 self.clear_values(cur_lane)
         elif not cur_lane.remember_spool:
@@ -754,16 +773,16 @@ class AFCSpool:
         is_none = runout.upper() == 'NONE'
         # Check to make sure runout does not equal lane
         if lane == runout:
-            self.logger.error("Lane({}) and runout({}) cannot be the same".format(lane, runout))
+            self.logger.error(f"Lane({lane}) and runout({runout}) cannot be the same")
             return
         # Check to make sure specified lane exists
         if lane not in self.afc.lanes:
-            self.logger.error('Unknown lane: {}'.format(lane))
+            self.logger.error(f"Unknown lane: {lane}")
             return
         # Check to make sure specified runout lane exists as long as runout is not set as 'NONE'
         if (not is_none
             and runout not in self.afc.lanes):
-            self.logger.error('Unknown runout lane: {}'.format(runout))
+            self.logger.error(f"Unknown runout lane: {runout}")
             return
 
         cur_lane = self.afc.lanes[lane]
@@ -878,7 +897,7 @@ class AFCSpool:
             try:
                 self.next_spool_id = int(SpoolID)
             except ValueError:
-                self.logger.error("Invalid spool ID: {}".format(SpoolID))
+                self.logger.error(f"Invalid spool ID: {SpoolID}")
                 self.next_spool_id = None
         else:
             self.next_spool_id = None
@@ -888,4 +907,9 @@ class AFCSpool:
             self.logger.info(f"Spool ID set for next load: '{self.next_spool_id}'")
 
 def load_config(config: ConfigWrapper) -> AFCSpool:
+    """
+    Klipper config entry point for this module.
+
+    :param config: Klipper config wrapper for this section
+    """
     return AFCSpool(config)

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -6,7 +6,7 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import Optional, Union, TYPE_CHECKING
 import copy
 import traceback
 import re
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from extras.AFC_lane import AFCLane
 
 class AFCSpool:
-    def __init__(self, config: ConfigWrapper):
+    def __init__(self, config: ConfigWrapper) -> None:
         self.printer = config.get_printer()
         self.printer.register_event_handler("klippy:connect", self.handle_connect)
         self.SPOOLMAN_REMOTE_METHOD = 'spoolman_set_active_spool'
@@ -27,7 +27,7 @@ class AFCSpool:
 
 
         # Temporary status variables
-        self.next_spool_id      = None
+        self.next_spool_id: Optional[int] = None
 
     def register_commands(self, afc: afc) -> None:
         """
@@ -52,7 +52,7 @@ class AFCSpool:
         self.function.register_commands(False, "AFC_SWAP_MAPPING",
                                         self.cmd_AFC_SWAP_MAPPING, self.cmd_AFC_SWAP_MAPPING_help)
 
-    def handle_connect(self):
+    def handle_connect(self) -> None:
         """
         Handle the connection event.
         This function is called when the printer connects. It looks up the AFC object
@@ -72,7 +72,7 @@ class AFCSpool:
         self.gcode.register_command("RESET_AFC_MAPPING", self.cmd_RESET_AFC_MAPPING, desc=self.cmd_RESET_AFC_MAPPING_help)
         self.gcode.register_command("SET_NEXT_SPOOL_ID", self.cmd_SET_NEXT_SPOOL_ID, desc=self.cmd_SET_NEXT_SPOOL_ID_help)
 
-    def register_lane_macros(self, lane_obj: AFCLane):
+    def register_lane_macros(self, lane_obj: AFCLane) -> None:
         """
         Callback function to register macros with proper lane names so that klipper errors out correctly when users supply lanes that
         are not valid
@@ -87,7 +87,7 @@ class AFCSpool:
         self.gcode.register_mux_command('SET_MAP',              "LANE", lane_obj.name, self.cmd_SET_MAP,                desc=self.cmd_SET_MAP_help)
         self.gcode.register_mux_command('AFC_SET_SPOOL_TEMP',   "LANE", lane_obj.name, self.cmd_AFC_SET_SPOOL_TEMP,     desc=self.cmd_AFC_SET_SPOOL_TEMP_help)
 
-    def set_snapmaker_filament_params(self, lane: AFCLane):
+    def set_snapmaker_filament_params(self, lane: AFCLane) -> None:
         """
         This method is only for snapmaker printers, this method updates filament color, material,
         vendor into snapmakers print_task_config object. This is needed so that the proper filament
@@ -145,7 +145,7 @@ class AFCSpool:
                 self.logger.debug(traceback.format_exc())
 
     cmd_AFC_SET_SPOOL_TEMP_help = "Set spool temperatures for a lane"
-    def cmd_AFC_SET_SPOOL_TEMP(self, gcmd):
+    def cmd_AFC_SET_SPOOL_TEMP(self, gcmd: GCodeCommand) -> None:
         """
         This function handles setting the bed and extruder temperatures for a specified lane's spool.
 
@@ -173,7 +173,7 @@ class AFCSpool:
         self.afc.save_vars()
 
     cmd_SET_MAP_help = "Changes T(n) mapping for a lane"
-    def cmd_SET_MAP(self, gcmd):
+    def cmd_SET_MAP(self, gcmd: GCodeCommand) -> None:
         """
         This function handles changing the GCODE tool change command for a Lane.
 
@@ -358,7 +358,7 @@ class AFCSpool:
         self.function.ConfigRewrite("AFC", "enable_multiple_mapping", self.enable_multiple_mapping)
 
     cmd_SET_COLOR_help = "Set filaments color for a lane"
-    def cmd_SET_COLOR(self, gcmd):
+    def cmd_SET_COLOR(self, gcmd: GCodeCommand) -> None:
         """
         This function handles changing the color of a specified lane. It retrieves the lane
         specified by the 'LANE' parameter and sets its color to the value provided by the 'COLOR' parameter.
@@ -387,14 +387,15 @@ class AFCSpool:
         cur_lane.multi_color = []
         cur_lane.send_lane_data()
         # Refresh LED only if filament is loaded — empty lanes keep their state color
-        if cur_lane.load_state and cur_lane.unit in self.afc.units:
+        if (cur_lane.load_state
+            and cur_lane.unit in self.afc.units):
             unit = cur_lane.unit_obj
             self.afc.function.afc_led(unit._get_lane_color(cur_lane, cur_lane.led_ready), cur_lane.led_index)
         self.afc.save_vars()
         self.set_snapmaker_filament_params(cur_lane)
 
     cmd_SET_WEIGHT_help = "Sets filaments weight for a lane"
-    def cmd_SET_WEIGHT(self, gcmd):
+    def cmd_SET_WEIGHT(self, gcmd: GCodeCommand) -> None:
         """
         This function handles changing the weight remaining of a spool loaded in a specified lane. It retrieves the lane
         specified by the 'LANE' parameter and sets its weight to the value provided by the 'WEIGHT' parameter.
@@ -423,7 +424,7 @@ class AFCSpool:
         self.afc.save_vars()
 
     cmd_SET_MATERIAL_help = "Sets filaments material for a lane"
-    def cmd_SET_MATERIAL(self, gcmd):
+    def cmd_SET_MATERIAL(self, gcmd: GCodeCommand) -> None:
         """
         This function handles changing the material of a specified lane. It retrieves the lane
         specified by the 'LANE' parameter and sets its material to the value provided by the 'MATERIAL' parameter.
@@ -460,8 +461,8 @@ class AFCSpool:
         density = gcmd.get_float('DENSITY', None)
 
         cur_lane.material = gcmd.get('MATERIAL')
-        cur_lane.filament_diameter = gcmd.get('DIAMETER', cur_lane.filament_diameter)
-        cur_lane.empty_spool_weight = gcmd.get('EMPTY_SPOOL_WEIGHT', cur_lane.empty_spool_weight)
+        cur_lane.filament_diameter = gcmd.get_float('DIAMETER', cur_lane.filament_diameter)
+        cur_lane.empty_spool_weight = gcmd.get_float('EMPTY_SPOOL_WEIGHT', cur_lane.empty_spool_weight)
 
         # Setting density if its not none, doing this after setting material as material setter
         # automatically sets density based on material name
@@ -472,10 +473,11 @@ class AFCSpool:
         self.afc.save_vars()
         self.set_snapmaker_filament_params(cur_lane)
 
-    def set_active_spool(self, ID):
+    def set_active_spool(self, ID: Optional[Union[int, str]]) -> None:
         webhooks = self.printer.lookup_object('webhooks')
         if self.afc.spoolman is not None:
-            if ID and ID is not None:
+            if (ID
+                and ID is not None):
                 id = int(ID)
             else:
                 id = None
@@ -487,7 +489,7 @@ class AFCSpool:
                 self.logger.error("Error trying to set active spool \n{}".format(e))
 
     cmd_SET_SPOOL_ID_help = "Set lanes spoolman ID"
-    def cmd_SET_SPOOL_ID(self, gcmd):
+    def cmd_SET_SPOOL_ID(self, gcmd: GCodeCommand) -> None:
         """
         This function handles setting the spool ID for a specified lane. It retrieves the lane
         specified by the 'LANE' parameter and updates its spool ID, material, color, and weight
@@ -508,7 +510,7 @@ class AFCSpool:
             if lane is None:
                 self.logger.info("No LANE Defined")
                 return
-            SpoolID = gcmd.get('SPOOL_ID', '')
+            SpoolID: Union[int, str] = gcmd.get('SPOOL_ID', '')
             if lane not in self.afc.lanes:
                 self.logger.info('{} Unknown'.format(lane))
                 return
@@ -523,7 +525,8 @@ class AFCSpool:
                     self.logger.error("Invalid spool ID: {}".format(SpoolID))
                     return
 
-                if cur_lane.spool_id != SpoolID and any( SpoolID == lane.spool_id for lane in self.afc.lanes.values()):
+                if (cur_lane.spool_id != SpoolID
+                    and any(SpoolID == lane.spool_id for lane in self.afc.lanes.values())):
                     self.logger.error(f"SpoolId {SpoolID} already assigned to a lane, cannot assign to {lane}.")
                     return
 
@@ -547,7 +550,7 @@ class AFCSpool:
             value = filament[field]
         return value
 
-    def _set_values(self, cur_lane):
+    def _set_values(self, cur_lane: AFCLane) -> None:
         """
         Helper function for setting lane spool values
         """
@@ -557,16 +560,19 @@ class AFCSpool:
         # assigned to this lane. If SET_SPOOL_ID or SET_COLOR was called before loading
         # (e.g. from an NFC tag scan), the spool_id and/or color will already be set with
         # real values — don't overwrite them with defaults during the load sequence.
-        if not cur_lane.remember_spool and cur_lane.spool_id is None and not cur_lane.color:
+        if (not cur_lane.remember_spool
+            and cur_lane.spool_id is None
+            and not cur_lane.color):
             cur_lane.material = self.afc.default_material_type
             cur_lane.weight = 1000 # Defaulting weight to 1000 upon load
 
-        if self.afc.spoolman is not None and self.next_spool_id is not None:
+        if (self.afc.spoolman is not None
+            and self.next_spool_id is not None):
             spool_id = self.next_spool_id
             self.next_spool_id = None
             self.set_spoolID(cur_lane, spool_id)
 
-    def clear_values(self, cur_lane: AFCLane):
+    def clear_values(self, cur_lane: AFCLane) -> None:
         """
         Helper function for clearing out lane spool values
         """
@@ -582,11 +588,13 @@ class AFCSpool:
         cur_lane.spool_vendor = ""
         cur_lane.filament_name = ""
 
-    def set_spoolID(self, cur_lane: AFCLane, SpoolID: str, save_vars=True):
-        if self.afc.spoolman is not None:
-            if SpoolID not in ('', None):
+    def set_spoolID(self, cur_lane: AFCLane, SpoolID: Optional[Union[int, str]], save_vars: bool = True) -> None:
+        if (self.afc.spoolman is not None
+            and self.afc.moonraker is not None):
+            if (SpoolID is not None
+                and SpoolID != ''):
                 try:
-                    result = self.afc.moonraker.get_spool(SpoolID)
+                    result = self.afc.moonraker.get_spool(int(SpoolID))
                     cur_lane.spool_id = SpoolID
                     cur_lane.auto_switch_triggered = False
 
@@ -609,14 +617,14 @@ class AFCSpool:
 
                     weight_check = self.disable_weight_check
 
-                    self.afc.logger.info('Weight remaining for SpoolID {}: {}'.format(SpoolID, cur_lane.weight))
+                    self.afc.logger.debug('Weight remaining for SpoolID {}: {}'.format(SpoolID, cur_lane.weight))
 
                     if not weight_check:
-                        if (
-                            cur_lane.weight is None or
-                            cur_lane.weight <= 0
-                        ):
-                            self.afc.error.AFC_error("Invalid weight for spoolID: {}. Please check remaining weight before assigning.".format(SpoolID), False)
+                        if (cur_lane.weight is None
+                            or cur_lane.weight <= 0):
+                            error_str = ("Invalid weight for spoolID: {}. "
+                                        "Please check remaining weight before assigning.").format(SpoolID)
+                            self.afc.error.AFC_error(error_str, False)
                             self.clear_values(cur_lane)
                             return
 
@@ -632,7 +640,8 @@ class AFCSpool:
 
                     cur_lane.send_lane_data()
                     # Refresh LED only if filament is loaded — empty lanes keep their state color
-                    if cur_lane.load_state and cur_lane.unit in self.afc.units:
+                    if (cur_lane.load_state
+                        and cur_lane.unit in self.afc.units):
                         unit = cur_lane.unit_obj
                         self.afc.function.afc_led(unit._get_lane_color(cur_lane, cur_lane.led_ready), cur_lane.led_index)
 
@@ -650,7 +659,7 @@ class AFCSpool:
         if save_vars: self.afc.save_vars()
 
     cmd_SET_RUNOUT_help = "Set runout lane"
-    def cmd_SET_RUNOUT(self, gcmd):
+    def cmd_SET_RUNOUT(self, gcmd: GCodeCommand) -> None:
         """
         This function handles setting the runout lane (infinite spool) for a specified lane. It retrieves the lane
         specified by the 'LANE' parameter and updates it's the lane to use if filament runs out by un-triggering prep sensor.
@@ -681,7 +690,8 @@ class AFCSpool:
             self.logger.error('Unknown lane: {}'.format(lane))
             return
         # Check to make sure specified runout lane exists as long as runout is not set as 'NONE'
-        if not is_none and runout not in self.afc.lanes:
+        if (not is_none
+            and runout not in self.afc.lanes):
             self.logger.error('Unknown runout lane: {}'.format(runout))
             return
 
@@ -690,7 +700,7 @@ class AFCSpool:
         self.afc.save_vars()
 
     cmd_RESET_AFC_MAPPING_help = "Resets all lane mapping in AFC"
-    def cmd_RESET_AFC_MAPPING(self, gcmd):
+    def cmd_RESET_AFC_MAPPING(self, gcmd: GCodeCommand) -> None:
         """
         Resets all tool lane mapping to the order set up in the configuration. When multiple tool
         mapping is enabled, when reset is called and virtual tools have been added, the virtual
@@ -750,7 +760,7 @@ class AFCSpool:
                 self.gcode.register_command(cmd, None)
 
     cmd_SET_NEXT_SPOOL_ID_help = "Set the spool id to be loaded next into AFC"
-    def cmd_SET_NEXT_SPOOL_ID(self, gcmd):
+    def cmd_SET_NEXT_SPOOL_ID(self, gcmd: GCodeCommand) -> None:
         """
         Sets the spool ID to be loaded next into the AFC.
 
@@ -783,5 +793,5 @@ class AFCSpool:
         else:
             self.logger.info(f"Spool ID set for next load: '{self.next_spool_id}'")
 
-def load_config(config):
+def load_config(config: ConfigWrapper) -> AFCSpool:
     return AFCSpool(config)

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -79,7 +79,7 @@ class AFCSpool:
         # Registering stepper callback so that mux macro can be set properly with valid lane names
         self.printer.register_event_handler("afc_stepper:register_macros",self.register_lane_macros)
 
-        self.gcode.register_command("RESET_AFC_MAPPING", self.cmd_RESET_AFC_MAPPING, desc=self.cmd_RESET_AFC_MAPPING_help)
+        self.gcode.register_command("AFC_RESET_MAPPING", self.cmd_AFC_RESET_MAPPING, desc=self.cmd_AFC_RESET_MAPPING_help)
         self.gcode.register_command("SET_NEXT_SPOOL_ID", self.cmd_SET_NEXT_SPOOL_ID, desc=self.cmd_SET_NEXT_SPOOL_ID_help)
 
     def register_lane_macros(self, lane_obj: AFCLane) -> None:
@@ -330,7 +330,7 @@ class AFCSpool:
         ```
         """
         if not self.enable_multiple_mapping:
-            raise gcmd.error("enable multiple mapping needs to be enabled to add mappings,"
+            raise gcmd.error("Enable multiple mapping needs to be enabled to add mappings,"
                                 " enable by running AFC_ENABLE_MULTIPLE_MAPPING ENABLE=1")
         lane = gcmd.get("LANE")
         mapping: str = gcmd.get("MAPPING")
@@ -379,7 +379,7 @@ class AFCSpool:
         ```
         """
         if not self.enable_multiple_mapping:
-            raise gcmd.error("enable multiple mapping needs to be enabled to remove mappings,"
+            raise gcmd.error("Enable multiple mapping needs to be enabled to remove mappings,"
                              " enable by running AFC_ENABLE_MULTIPLE_MAPPING ENABLE=1")
         mapping: str = gcmd.get("MAPPING")
         mapping_list: list = mapping.upper().split(",")
@@ -410,7 +410,7 @@ class AFCSpool:
         multiple mapping also adds the ability to add virtual tools with AFC_ADD_MAPPING and
         AFC_REMOVE_MAPPING macros.
 
-        When disabling multiple mapping, lanes mappings are also reset via RESET_AFC_MAPPING command.
+        When disabling multiple mapping, lanes mappings are also reset via AFC_RESET_MAPPING command.
 
         Usage
         -----
@@ -793,8 +793,8 @@ class AFCSpool:
         cur_lane.runout_lane = None if is_none else runout
         self.afc.save_vars()
 
-    cmd_RESET_AFC_MAPPING_help = "Resets all lane mapping in AFC"
-    def cmd_RESET_AFC_MAPPING(self, gcmd: GCodeCommand) -> None:
+    cmd_AFC_RESET_MAPPING_help = "Resets all lane mapping in AFC"
+    def cmd_AFC_RESET_MAPPING(self, gcmd: GCodeCommand) -> None:
         """
         Resets all tool lane mapping to the order set up in the configuration. If multiple tool
         mapping is enabled, when reset is called and virtual tools have been added, the virtual
@@ -806,12 +806,12 @@ class AFCSpool:
 
         Usage
         -----
-        `RESET_AFC_MAPPING [RUNOUT=yes|no]`
+        `AFC_RESET_MAPPING [RUNOUT=yes|no]`
 
         Example
         -----
         ```
-        RESET_AFC_MAPPING RUNOUT=no
+        AFC_RESET_MAPPING RUNOUT=no
         ```
         """
         # Resetting runout lanes to None

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -11,7 +11,10 @@ import copy
 import traceback
 import re
 
-from extras.AFC_utils import natural_sort_key
+from configfile import error
+
+try: from extras.AFC_utils import natural_sort_key
+except: raise error("Error when trying to import AFC_utils.natural_sort_key\n{trace}".format(trace=traceback.format_exc()))
 
 if TYPE_CHECKING:
     from gcode import GCodeCommand

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -303,6 +303,7 @@ class AFCSpool:
         lane_from_obj.send_lane_data()
         lane_to_obj.send_lane_data()
         self.afc.save_vars()
+        self.logger.info(f"Swapping mapping from({lane_from}) to({lane_to}) successful.")
 
     cmd_AFC_ADD_MAPPING_help = (
         "Adds a new T(n) macro that currently does not exist to a lane. Mapping can be passed in "

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -248,7 +248,6 @@ class AFCSpool:
             self.afc.tool_cmds[m] = cur_lane.name
         sw_lane.send_lane_data()
 
-        # TODO: need to check lane data to see how it looks
         cur_lane.send_lane_data()
 
         self.afc.save_vars()
@@ -277,7 +276,7 @@ class AFCSpool:
 
         lane_from_obj = self.afc.lanes.get(lane_from)
         lane_to_obj   = self.afc.lanes.get(lane_to)
-        # TODO: verify that raised commands so not crash klipper if this is called when printing
+
         if not lane_from_obj:
             raise gcmd.error(f"Swapping from {lane_from} not found")
         if not lane_to_obj:

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -11,6 +11,7 @@ import copy
 import traceback
 import re
 
+from extras.AFC_utils import natural_sort_key
 
 if TYPE_CHECKING:
     from gcode import GCodeCommand
@@ -830,7 +831,10 @@ class AFCSpool:
         manually_assigned = {cmd for lane in self.afc.lanes.values() for cmd in lane._map}
         # Fresh T0..T(n-1) sequence for auto lanes, skipping manually assigned numbers
         total_lanes = sum(len(unit.lanes) for unit in self.afc.units.values())
-        auto_cmds = [f"T{i}" for i in range(total_lanes) if f"T{i}" not in manually_assigned]
+        # Generate enough candidates that reserved manual numbers cannot starve
+        # the auto lanes
+        auto_cmds = [f"T{i}" for i in range(total_lanes + len(manually_assigned))
+                     if f"T{i}" not in manually_assigned][:total_lanes]
         for unit in self.afc.units.values():
             for lane in unit.lanes.values():
                 lane.map = []
@@ -852,8 +856,7 @@ class AFCSpool:
         # leftovers from a removed unit), popped before send_lane_data() below
         # so it sees them as gone rather than still owned by this lane.
         new_cmds = {lane.map[0] for unit in self.afc.units.values() for lane in unit.lanes.values()}
-        stale_cmds = sorted(previously_used_cmds - new_cmds,
-                            key=lambda x: int("".join([i for i in x if i.isdigit()])))
+        stale_cmds = sorted(previously_used_cmds - new_cmds, key=natural_sort_key)
         if stale_cmds:
             self.logger.info(f"{', '.join(stale_cmds)} remain, removing these mappings")
             for cmd in stale_cmds:

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -24,7 +24,7 @@ try: from extras.AFC_lane import AFCLane, AFCHomingPoints, VALID_DIRECT_HUB
 except: raise error(ERROR_STR.format(import_lib="AFC_lane", trace=traceback.format_exc()))
 
 if TYPE_CHECKING:
-    from toolhead import Toolhead
+    from toolhead import ToolHead
     from stepper import PrinterStepper
     from mcu import MCU_endstop
 
@@ -404,7 +404,7 @@ class AFCExtruderStepper(AFCLane):
         # Advance internal time to satisfy homing scheduler
         self.next_cmd_time += max(0., delay)
 
-    def _drip_update_time(self, toolhead: Toolhead, max_time: float, drip_completion) -> None:
+    def _drip_update_time(self, toolhead: ToolHead, max_time: float, drip_completion) -> None:
         """
         Helper function for mimicking how klipper toolhead does drip moves
 
@@ -460,7 +460,7 @@ class AFCExtruderStepper(AFCLane):
         dwell_time = self._submit_move( start_time, delta, speed, self._homing_accel)
         max_time = start_time + dwell_time
 
-        toolhead: Toolhead = self.printer.lookup_object('toolhead')
+        toolhead: ToolHead = self.printer.lookup_object('toolhead')
 
         # TODO: add a check for toolhead.drip_update_time and test with https://github.com/KalicoCrew/kalico/pull/825 PR
         if self.motion_queuing is None:

--- a/extras/AFC_utils.py
+++ b/extras/AFC_utils.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import traceback
 import json
 import inspect
+import re
 
 from datetime import datetime
 from urllib.request import (
@@ -38,6 +39,20 @@ if TYPE_CHECKING:
     from extras.pause_resume import PauseResume
 
 ERROR_STR = "Error trying to import {import_lib}, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper\n\n{trace}"
+
+_NATURAL_SORT_RE = re.compile(r'(\d+)')
+
+def natural_sort_key(value: str) -> list:
+    """
+    Splits a string into digit/non-digit chunks so lists of e.g. T(n) macros
+    sort numerically (T2 before T10) rather than lexicographically (T10
+    before T2).
+
+    :param value: String to build a sort key for, e.g. "T10"
+    :return list: Chunks with digit runs converted to int for numeric ordering
+    """
+    return [int(chunk) if chunk.isdigit() else chunk.lower()
+            for chunk in _NATURAL_SORT_RE.split(value)]
 
 def add_filament_switch(switch_name: str, switch_pin: str, printer: Printer,
                         show_sensor: bool=True, runout_callback: Callable = None,

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,11 +1,10 @@
 [mypy]
 files = extras
 
-# klipper/klippy is a local, untracked checkout of Klipper's own source
-# (not part of this repo, not present in CI). When present it lets mypy
-# check this project's types against Klipper's real classes.
-mypy_path=$MYPY_CONFIG_FILE_DIR/klipper/klippy
-ignore_missing_imports = True
+# stubs/ covers the Klipper classes/methods extras/*.py actually references
+# -- always available, unlike klipper/klippy (an optional, untracked local
+# checkout, not present in CI). Searched in order, so stubs/ takes priority.
+mypy_path=$MYPY_CONFIG_FILE_DIR/stubs:$MYPY_CONFIG_FILE_DIR/klipper/klippy
 
 # Require full type annotations on every function/method defined in this
 # project's own extras/ modules, and type-check the bodies of any that are
@@ -15,14 +14,14 @@ ignore_missing_imports = True
 disallow_untyped_defs = True
 check_untyped_defs = True
 
-# klipper/klippy is on mypy_path above, so when a local Klipper checkout is
-# present, Klipper's own klippy/extras/ package resolves to the same
-# "extras.*" prefix as this project's own extras/ package (both are
-# literally named "extras"). The wildcard above would otherwise also
-# require full annotations on Klipper source we don't maintain.
-# Exempt the specific Klipper extras modules this project's code currently
-# references under TYPE_CHECKING; if a future change adds a reference to
-# another one, running mypy locally (klipper/ checked out) will report
-# untyped-def noise for that file, and it can be added here.
-[mypy-extras.bus,extras.display,extras.display.*,extras.filament_switch_sensor,extras.force_move,extras.heaters,extras.led,extras.output_pin,extras.pause_resume]
+# Klipper's own klippy/extras/ shares the "extras.*" prefix with this
+# project's own extras/ package, and both have __init__.py, so stubbing
+# these under stubs/extras/ would shadow our own modules instead of
+# coexisting. ignore_missing_imports covers "not found" (no checkout, or a
+# fork checkout missing a fork-specific module); ignore_errors covers
+# "found but under-annotated" so [mypy-extras.*] above doesn't demand
+# annotations on Klipper source we don't maintain. Add to this list if a
+# future change references another such module.
+[mypy-extras.bus,extras.display,extras.display.*,extras.filament_switch_sensor,extras.force_move,extras.heaters,extras.led,extras.output_pin,extras.pause_resume,extras.print_task_config,extras.toolchanger]
+ignore_missing_imports = True
 ignore_errors = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 """
 Shared test fixtures and Klipper mock infrastructure for AFC unit tests.
 
-All Klipper-specific modules (configfile, queuelogger, webhooks) are mocked
+All Klipper-specific modules (configfile, queuelogger, webhooks, gcode) are mocked
 here at the module level so that all test files can import AFC extras modules
 without a running Klipper instance.
 """
@@ -118,6 +118,17 @@ def _make_webhooks_mock():
     return mod
 
 
+def _make_gcode_mock():
+    """Mock for Klipper's gcode module."""
+    mod = types.ModuleType("gcode")
+
+    class CommandError(Exception):
+        pass
+
+    mod.CommandError = CommandError
+    return mod
+
+
 def _make_led_mock():
     """Mock for extras.led (Klipper's shared LED helper module).
 
@@ -227,6 +238,7 @@ def _make_print_task_config():
 sys.modules.setdefault("configfile", _make_configfile_mock())
 sys.modules.setdefault("queuelogger", _make_queuelogger_mock())
 sys.modules.setdefault("webhooks", _make_webhooks_mock())
+sys.modules.setdefault("gcode", _make_gcode_mock())
 
 # C-extension / Klipper internals mocks
 sys.modules.setdefault("chelper", _make_chelper_mock())
@@ -468,6 +480,7 @@ class MockAFC:
         self.restore_pos = MagicMock()
 
         self.snapmaker_printer = False
+        self.enable_multiple_mapping = False
 
 
 class MockPrinter:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ import pathlib
 import queue
 import sys
 import types
+from typing import Callable
 from unittest.mock import MagicMock, patch  # noqa: F401
 
 import pytest
@@ -118,13 +119,14 @@ def _make_webhooks_mock():
     return mod
 
 
+class CommandError(Exception):
+    """Mirrors Klipper's gcode.CommandError -- raised by GCodeCommand.get()
+    (real and mocked) and by run_script_from_command failures."""
+
+
 def _make_gcode_mock():
     """Mock for Klipper's gcode module."""
     mod = types.ModuleType("gcode")
-
-    class CommandError(Exception):
-        pass
-
     mod.CommandError = CommandError
     return mod
 
@@ -338,6 +340,111 @@ class MockGcode:
 
     def create_gcode_command(self, command, commandline, params):
         return MagicMock()
+
+
+class MockGCodeCommand:
+    """Mock for Klipper's GCodeCommand, mirroring gcode.py's real .get()/
+    .get_int()/.get_float() sentinel-default semantics: a parameter with no
+    default supplied and no value in params raises .error(...), exactly like
+    real Klipper -- so code under test that assumes a parameter is present
+    can't silently receive None back in a test the way a bare
+    MagicMock()/lambda mock would let it.
+
+    Values are stored as given (not coerced to strings the way a real parsed
+    command line would be) so tests can pass native ints/floats/strings for
+    convenience; get_int()/get_float() still route through the same parser/
+    minval/maxval/above/below validation as real Klipper.
+    """
+
+    class sentinel:
+        pass
+
+    def __init__(self, params=None, commandline="", command=""):
+        self._params: dict = dict(params or {})
+        self._commandline = commandline
+        self._command = command
+        # A trackable Mock (not a bare class attribute like real Klipper's
+        # `error = CommandError`) so tests can assert on the exact call
+        # (gcmd.error.assert_called_once_with(...)). side_effect is a lambda,
+        # not the CommandError class directly -- Mock's side_effect treats an
+        # exception class specially and raises it immediately with no args,
+        # which would silently drop the message. The lambda instead just
+        # returns a real CommandError(msg) for the caller to `raise`, exactly
+        # like production's `raise gcmd.error(msg)`.
+        self.error = MagicMock(side_effect=lambda *a, **kw: CommandError(*a, **kw))
+        self.respond_info = MagicMock()
+        self.respond_raw = MagicMock()
+        # get()/get_int()/get_float() are trackable Mocks wrapping the real
+        # (renamed _get*) implementations below via side_effect, so tests can
+        # both assert on the exact call (gcmd.get_int.assert_called_once_with(...))
+        # and get real sentinel/parsing/minval/maxval behavior back -- side_effect's
+        # return value becomes the mock's return value, and a raised exception
+        # propagates the same as calling the real method directly.
+        self.get = MagicMock(side_effect=self._get)
+        self.get_int = MagicMock(side_effect=self._get_int)
+        self.get_float = MagicMock(side_effect=self._get_float)
+
+    def get_command(self):
+        return self._command
+
+    def get_commandline(self):
+        return self._commandline
+
+    def get_raw_command_parameters(self):
+        """Mirrors real Klipper's slicing logic exactly, so the defaults
+        (command="", commandline="") naturally return "" without any extra
+        setup -- override get_raw_command_parameters on the instance for a
+        test that needs a specific raw string."""
+        command = self._command
+        origline = self._commandline
+        param_start = len(command)
+        param_end = len(origline)
+        if origline[:param_start].upper() != command:
+            param_start += origline.upper().find(command)
+            end = origline.rfind('*')
+            if end >= 0 and origline[end + 1:].isdigit():
+                param_end = end
+        if origline[param_start:param_start + 1].isspace():
+            param_start += 1
+        return origline[param_start:param_end]
+
+    def get_command_parameters(self):
+        return self._params
+
+    def _get(self, name, default=sentinel, parser: Callable = str, minval=None, maxval=None,
+             above=None, below=None):
+        value = self._params.get(name)
+        if value is None:
+            if default is self.sentinel:
+                error_str = f"Error on '{self._commandline}': missing {name}"
+                raise self.error(error_str)
+            return default
+        try:
+            value = parser(value)
+        except Exception:
+            error_str = f"Error on '{self._commandline}': unable to parse {value}"
+            raise self.error(error_str)
+        if minval is not None and value < minval:
+            error_str = f"Error on '{self._commandline}': {name} must have minimum of {minval}"
+            raise self.error(error_str)
+        if maxval is not None and value > maxval:
+            error_str = f"Error on '{self._commandline}': {name} must have maximum of {maxval}"
+            raise self.error(error_str)
+        if above is not None and value <= above:
+            error_str = f"Error on '{self._commandline}': {name} must be above {above}"
+            raise self.error(error_str)
+        if below is not None and value >= below:
+            error_str = f"Error on '{self._commandline}': {name} must be below {below}"
+            raise self.error(error_str)
+        return value
+
+    def _get_int(self, name, default=sentinel, minval=None, maxval=None):
+        return self._get(name, default, parser=int, minval=minval, maxval=maxval)
+
+    def _get_float(self, name, default=sentinel, minval=None, maxval=None,
+                   above=None, below=None):
+        return self._get(name, default, parser=float, minval=minval,
+                         maxval=maxval, above=above, below=below)
 
 
 class MockLogger:

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -156,6 +156,7 @@ def _make_afc():
     obj.print_tool_temperatures = []
     obj.print_data_metadata = None
     obj.disable_print_temp_check = False
+    obj.enable_multiple_mapping = False
     return obj
 
 
@@ -240,7 +241,7 @@ class TestGetStatus:
         required = {
             "current_load", "current_state", "error_state",
             "lanes", "extruders", "hubs", "buffers", "units",
-            "message", "position_saved",
+            "message", "position_saved", "multiple_tool_mapping"
         }
         for key in required:
             assert key in status, f"Missing key: {key}"
@@ -281,6 +282,15 @@ class TestGetStatus:
         obj = _make_afc()
         assert obj.get_status()["version"] == AFC_VERSION
 
+    def test_multiple_tool_mapping_disabled(self):
+        obj = _make_afc()
+        assert obj.get_status()["multiple_tool_mapping"] == obj.enable_multiple_mapping
+    
+    def test_multiple_tool_mapping_enabled(self):
+        obj = _make_afc()
+        obj.enable_multiple_mapping = True
+        assert obj.get_status()["multiple_tool_mapping"] == obj.enable_multiple_mapping
+        
 
 # ── _webhooks_status ─────────────────────────────────────────────────────────
 
@@ -466,7 +476,7 @@ class TestCheckExtruderTemp:
         heater.can_extrude = True
         obj.function.is_printing.return_value = True
         obj.print_tool_temperatures = [230]
-        lane.map = "T0"
+        lane.current_map = "T0"
         result = obj._check_extruder_temp(lane)
         pheaters.set_temperature.assert_called_once_with(heater, 230.0)
         obj._wait_for_temp_within_tolerance.assert_called_once_with(obj.heater, 230,
@@ -481,7 +491,7 @@ class TestCheckExtruderTemp:
         )
         obj.function.is_printing.return_value = True
         obj.print_tool_temperatures = [180, 220, 260]
-        lane.map = "T1"
+        lane.current_map = "T1"
         result = obj._check_extruder_temp(lane)
         obj._get_default_material_temps.assert_not_called()
         pheaters.set_temperature.assert_called_once_with(heater, 220.0)
@@ -496,7 +506,7 @@ class TestCheckExtruderTemp:
         )
         obj.function.is_printing.return_value = True
         obj.print_tool_temperatures = [210]
-        lane.map = "T0"
+        lane.current_map = "T0"
         result = obj._check_extruder_temp(lane)
         pheaters.set_temperature.assert_called_once_with(heater, 210.0)
         obj._wait_for_temp_within_tolerance.assert_not_called()
@@ -510,7 +520,7 @@ class TestCheckExtruderTemp:
         )
         obj.function.is_printing.return_value = False
         obj.print_tool_temperatures = [999]
-        lane.map = "T0"
+        lane.current_map = "T0"
         result = obj._check_extruder_temp(lane)
         obj._get_default_material_temps.assert_called_once_with(lane)
         pheaters.set_temperature.assert_called_once_with(heater, 210.0)
@@ -525,7 +535,7 @@ class TestCheckExtruderTemp:
         )
         obj.function.is_printing.return_value = True
         obj.print_tool_temperatures = []
-        lane.map = "T0"
+        lane.current_map = "T0"
         result = obj._check_extruder_temp(lane)
         obj._get_default_material_temps.assert_called_once_with(lane)
         pheaters.set_temperature.assert_called_once_with(heater, 210.0)
@@ -550,7 +560,7 @@ class TestCheckExtruderTemp:
         heater.can_extrude = True
         obj.function.is_printing.return_value = True
         obj.print_tool_temperatures = []
-        lane.map = "T0"
+        lane.current_map = "T0"
         result = obj._check_extruder_temp(lane)
         obj._get_default_material_temps.assert_not_called()
         pheaters.set_temperature.assert_not_called()
@@ -567,7 +577,7 @@ class TestCheckExtruderTemp:
         heater.can_extrude = True
         obj.function.is_printing.return_value = True
         obj.print_tool_temperatures = []
-        lane.map = "T0"
+        lane.current_map = "T0"
         result = obj._check_extruder_temp(lane)
         obj._get_default_material_temps.assert_not_called()
         pheaters.set_temperature.assert_not_called()
@@ -584,23 +594,23 @@ class TestCheckExtruderTemp:
         heater.can_extrude = True
         obj.function.is_printing.return_value = True
         obj.print_tool_temperatures = [230]
-        lane.map = "T0"
+        lane.current_map = "T0"
         result = obj._check_extruder_temp(lane)
         obj._get_default_material_temps.assert_not_called()
         pheaters.set_temperature.assert_not_called()
         assert result is None
 
-    # ── lane.map parsing failures ─────────────────────────────────────────────
+    # ── lane.current_map parsing failures ─────────────────────────────────────
 
     def test_non_numeric_lane_map_returns_without_setting_temp(self):
-        """lane.map that doesn't parse to an int after stripping "T" (ValueError)
+        """lane.current_map that doesn't parse to an int after stripping "T" (ValueError)
         logs and returns without touching the heater."""
         obj, heater, extruder, pheaters, lane = _make_afc_for_check_extruder_temp(
             heater_target_temp=150, actual_temp=148, target_material_temp=210
         )
         obj.function.is_printing.return_value = True
         obj.print_tool_temperatures = [230]
-        lane.map = "custom_lane"
+        lane.current_map = "custom_lane"
         result = obj._check_extruder_temp(lane)
         pheaters.set_temperature.assert_not_called()
         obj._wait_for_temp_within_tolerance.assert_not_called()
@@ -610,26 +620,26 @@ class TestCheckExtruderTemp:
         assert any("custom_lane" in m for m in infos)
 
     def test_lane_map_index_out_of_range_returns_without_setting_temp(self):
-        """lane.map index beyond print_tool_temperatures' length (IndexError)
+        """lane.current_map index beyond print_tool_temperatures' length (IndexError)
         logs and returns without touching the heater."""
         obj, heater, extruder, pheaters, lane = _make_afc_for_check_extruder_temp(
             heater_target_temp=150, actual_temp=148, target_material_temp=210
         )
         obj.function.is_printing.return_value = True
         obj.print_tool_temperatures = [230]
-        lane.map = "T5"
+        lane.current_map = "T5"
         result = obj._check_extruder_temp(lane)
         pheaters.set_temperature.assert_not_called()
         obj._wait_for_temp_within_tolerance.assert_not_called()
         obj._get_default_material_temps.assert_not_called()
         assert result is None
         infos = [m for lvl, m in obj.logger.messages if lvl == "info"]
-        # Message logs lane.name + the caught exception, not cur_lane.map directly
+        # Message logs lane.name + the caught exception, not cur_lane.current_map directly
         # (see test_lane_map_attribute_error_returns_without_setting_temp for why).
         assert any(lane.name in m and "index out of range" in m for m in infos)
 
     def test_negative_lane_map_index_returns_without_setting_temp(self):
-        """lane.map that parses to a negative index (e.g. "T-1") is explicitly
+        """lane.current_map that parses to a negative index (e.g. "T-1") is explicitly
         rejected rather than silently wrapping around to the last entry in
         print_tool_temperatures via Python's negative-index semantics."""
         obj, heater, extruder, pheaters, lane = _make_afc_for_check_extruder_temp(
@@ -637,7 +647,7 @@ class TestCheckExtruderTemp:
         )
         obj.function.is_printing.return_value = True
         obj.print_tool_temperatures = [230, 999]
-        lane.map = "T-1"
+        lane.current_map = "T-1"
         result = obj._check_extruder_temp(lane)
         pheaters.set_temperature.assert_not_called()
         obj._wait_for_temp_within_tolerance.assert_not_called()
@@ -655,7 +665,7 @@ class TestCheckExtruderTemp:
         )
         obj.function.is_printing.return_value = True
         obj.print_tool_temperatures = {230}  # set: truthy but not subscriptable
-        lane.map = "T0"
+        lane.current_map = "T0"
         result = obj._check_extruder_temp(lane)
         pheaters.set_temperature.assert_not_called()
         obj._wait_for_temp_within_tolerance.assert_not_called()
@@ -665,11 +675,11 @@ class TestCheckExtruderTemp:
         assert any(lane.name in m and "not subscriptable" in m for m in infos)
 
     def test_lane_map_attribute_error_returns_without_setting_temp(self):
-        """An AttributeError raised while resolving lane.map (e.g. a custom
+        """An AttributeError raised while resolving lane.current_map (e.g. a custom
         object whose __str__ blows up) is caught and returns without touching
         the heater rather than propagating. The except handler must log via
-        lane.name/the caught exception rather than cur_lane.map -- referencing
-        cur_lane.map again here would re-raise the same AttributeError and
+        lane.name/the caught exception rather than cur_lane.current_map -- referencing
+        cur_lane.current_map again here would re-raise the same AttributeError and
         escape the try/except entirely."""
 
         class _RaisesAttributeError:
@@ -681,7 +691,7 @@ class TestCheckExtruderTemp:
         )
         obj.function.is_printing.return_value = True
         obj.print_tool_temperatures = [230]
-        lane.map = _RaisesAttributeError()
+        lane.current_map = _RaisesAttributeError()
         result = obj._check_extruder_temp(lane)
         pheaters.set_temperature.assert_not_called()
         obj._wait_for_temp_within_tolerance.assert_not_called()
@@ -700,7 +710,7 @@ class TestCheckExtruderTemp:
         )
         obj.function.is_printing.return_value = True
         obj.print_tool_temperatures = [None, 220]
-        lane.map = "T0"
+        lane.current_map = "T0"
         result = obj._check_extruder_temp(lane)
         obj._get_default_material_temps.assert_not_called()
         pheaters.set_temperature.assert_not_called()
@@ -3570,7 +3580,7 @@ class TestToolLoadNeedPurge:
         afc.gcode.run_script_from_command.assert_not_called()
 
         info_msgs = [m for lvl, m in afc.logger.messages if lvl == "info"]
-        assert any(f"Flag set to purge for {lane.extruder_obj.name}:{lane.map}" in m for m in info_msgs)
+        assert any(f"Flag set to purge for {lane.extruder_obj.name}:{lane.current_map}" in m for m in info_msgs)
 
     def test_need_purge_with_purge_length(self):
         afc, lane = self._make_afc_lane_for_need_purge()

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -31,6 +31,17 @@ from extras.AFC_lane import AFCLaneState, AFCMoveWarning
 from klippy import Printer
 
 from tests.test_AFC_lane import _make_afc_lane
+
+
+def _build_gcmd(params=None, commandline=""):
+    """Build a gcmd mock backed by MockGCodeCommand, matching real Klipper's
+    sentinel-based .get()/.get_int()/.get_float() semantics -- a parameter
+    with no value in params and no default supplied by the caller raises,
+    rather than silently returning None."""
+    from tests.conftest import MockGCodeCommand
+    return MockGCodeCommand(params=params or {}, commandline=commandline)
+
+
 # ── State constants ───────────────────────────────────────────────────────────
 
 class TestStateConstants:
@@ -1705,15 +1716,12 @@ class TestCmdChangeTool_NewExtruderTempParsing:
     """Tests for NEW_EXTRUDER_TEMP parameter parsing in cmd_CHANGE_TOOL."""
 
     def _make_gcmd(self, new_extruder_temp_str, lane="lane1", purge_length=None):
-        gcmd = MagicMock()
         # Use a T0 command line so cmd_CHANGE_TOOL takes the simple else-branch
         # (no "CHANGE" in command) and Tcmd = "T0" directly.
-        gcmd.get_commandline.return_value = "T0"
-        gcmd.get.side_effect = lambda key, default=None: {
+        return _build_gcmd({
             "PURGE_LENGTH": purge_length,
             "NEW_EXTRUDER_TEMP": new_extruder_temp_str,
-        }.get(key, default)
-        return gcmd
+        }, commandline="T0")
 
     def _make_afc_for_cmd(self):
         obj = _make_afc()
@@ -1771,12 +1779,10 @@ class TestCmdChangeTool_NewExtruderTempParsing:
     def test_invalid_purge_length_reports_error_and_does_not_call_change_tool(self):
         """A non-numeric PURGE_LENGTH triggers AFC_error and aborts without calling CHANGE_TOOL."""
         obj = self._make_afc_for_cmd()
-        gcmd = MagicMock()
-        gcmd.get_commandline.return_value = "T0"
-        gcmd.get.side_effect = lambda key, default=None: {
+        gcmd = _build_gcmd({
             "PURGE_LENGTH": "notanumber",
             "NEW_EXTRUDER_TEMP": None,
-        }.get(key, default)
+        }, commandline="T0")
         obj.cmd_CHANGE_TOOL(gcmd)
         obj.error.AFC_error.assert_called_once()
         error_msg = obj.error.AFC_error.call_args.args[0]
@@ -1785,11 +1791,9 @@ class TestCmdChangeTool_NewExtruderTempParsing:
 
 class TestCmdChange_ToolCheckBypass_CheckHomed():
     def _make_gcmd(self):
-        gcmd = MagicMock()
         # Use a T0 command line so cmd_CHANGE_TOOL takes the simple else-branch
         # (no "CHANGE" in command) and Tcmd = "T0" directly.
-        gcmd.get_commandline.return_value = "T0"
-        return gcmd
+        return _build_gcmd(commandline="T0")
 
     def test_check_bypass_True(self):
         obj, _, _ = _make_afc_for_change_tool()
@@ -1809,14 +1813,9 @@ class TestCmdChange_ToolCheckBypass_CheckHomed():
 
 class TestCmdChangeTool_SnapmakerPath:
     def _make_gcmd(self, tcmd="T0"):
-        gcmd = MagicMock()
         # Use a T0 command line so cmd_CHANGE_TOOL takes the simple else-branch
         # (no "CHANGE" in command) and Tcmd = "T0" directly.
-        gcmd.get_commandline.return_value = f"{tcmd} A0"
-        gcmd.get.side_effect = lambda key, default=None: {
-            "A": "0"
-        }.get(key, default)
-        return gcmd
+        return _build_gcmd({"A": "0"}, commandline=f"{tcmd} A0")
     def get_snapmaker_config_dir():
             pass
 
@@ -2188,8 +2187,7 @@ class TestCmdToolLoad_LaneLoadedGuard:
         obj, lane, extruder = self._make_cmd_afc()
         extruder.lane_loaded = "lane1"  # same as target
 
-        gcmd = MagicMock()
-        gcmd.get = lambda key, default=None: {"LANE": "lane1", "PURGE_LENGTH": None}.get(key, default)
+        gcmd = _build_gcmd({"LANE": "lane1", "PURGE_LENGTH": None})
 
         obj.cmd_TOOL_LOAD(gcmd)
 
@@ -2201,8 +2199,7 @@ class TestCmdToolLoad_LaneLoadedGuard:
         obj, lane, extruder = self._make_cmd_afc()
         extruder.lane_loaded = "lane2"  # different lane — stale, let TOOL_LOAD handle it
 
-        gcmd = MagicMock()
-        gcmd.get = lambda key, default=None: {"LANE": "lane1", "PURGE_LENGTH": None}.get(key, default)
+        gcmd = _build_gcmd({"LANE": "lane1", "PURGE_LENGTH": None})
 
         obj.cmd_TOOL_LOAD(gcmd)
 
@@ -2218,8 +2215,7 @@ class TestCmdToolLoad_LaneLoadedGuard:
         extruder.lane_loaded = None
         obj.TOOL_LOAD.return_value = False
 
-        gcmd = MagicMock()
-        gcmd.get = lambda key, default=None: {"LANE": "lane1", "PURGE_LENGTH": None}.get(key, default)
+        gcmd = _build_gcmd({"LANE": "lane1", "PURGE_LENGTH": None})
 
         obj.cmd_TOOL_LOAD(gcmd)
 
@@ -2230,8 +2226,7 @@ class TestCmdToolLoad_LaneLoadedGuard:
         obj, lane, extruder = self._make_cmd_afc()
         extruder.lane_loaded = None
 
-        gcmd = MagicMock()
-        gcmd.get = lambda key, default=None: {"LANE": "lane1", "PURGE_LENGTH": None}.get(key, default)
+        gcmd = _build_gcmd({"LANE": "lane1", "PURGE_LENGTH": None})
 
         obj.cmd_TOOL_LOAD(gcmd)
 
@@ -2249,9 +2244,7 @@ class TestCmdToolLoad_UnknownLane:
         obj.TOOL_LOAD = MagicMock(return_value=True)
         obj.error = MagicMock()
 
-        params = {"LANE": "lane_missing", "PURGE_LENGTH": None}
-        gcmd = MagicMock()
-        gcmd.get = lambda key, default=None: params.get(key, default)
+        gcmd = _build_gcmd({"LANE": "lane_missing", "PURGE_LENGTH": None})
 
         obj.cmd_TOOL_LOAD(gcmd)
 
@@ -2280,9 +2273,7 @@ class TestCmdToolUnload_ErrorCounting:
         return obj, lane
 
     def _make_gcmd(self):
-        gcmd = MagicMock()
-        gcmd.get = lambda key, default=None: {"LANE": "lane1"}.get(key, default)
-        return gcmd
+        return _build_gcmd({"LANE": "lane1"})
 
     def test_increase_unload_error_count_called_with_afc_instance(self):
         """increase_unload_error_count() now takes the afc instance itself
@@ -2322,10 +2313,7 @@ class TestCmdToolUnload_Guards:
 
     @staticmethod
     def _make_gcmd(params=None):
-        params = params or {}
-        gcmd = MagicMock()
-        gcmd.get = lambda key, default=None: params.get(key, default)
-        return gcmd
+        return _build_gcmd(params)
 
     def test_bypass_detected_returns_without_calling_tool_unload(self):
         """When _check_bypass(unload=True) is truthy, cmd_TOOL_UNLOAD returns
@@ -3206,11 +3194,7 @@ def _make_afc_for_lane_move(is_printing=False):
 
 
 def _make_gcmd(lane="lane1", distance=10.0, force=0):
-    gcmd = MagicMock()
-    gcmd.get.side_effect = lambda key, default=None: {"LANE": lane}.get(key, default)
-    gcmd.get_float.side_effect = lambda key, default=0: {"DISTANCE": distance}.get(key, default)
-    gcmd.get_int.side_effect = lambda key, default=0: {"FORCE": force}.get(key, default)
-    return gcmd
+    return _build_gcmd({"LANE": lane, "DISTANCE": distance, "FORCE": force})
 
 
 class TestCmdLaneMove:

--- a/tests/test_AFC_BoxTurtle.py
+++ b/tests/test_AFC_BoxTurtle.py
@@ -56,7 +56,9 @@ def _make_lane(prep_state=False, load_state=False, tool_loaded=False):
     lane.prep_state = prep_state
     lane.load_state = load_state
     lane.tool_loaded = tool_loaded
-    lane.map = "T0"
+    lane.map = ["T0"]
+    lane.current_map = "T0"
+    lane.map_to_string = MagicMock(return_value="T0")
     lane.led_ready = "0,1,0,0"
     lane.led_not_ready = "0,0,0,0.25"
     lane.led_fault = "1,0,0,0"

--- a/tests/test_AFC_OAMS.py
+++ b/tests/test_AFC_OAMS.py
@@ -109,20 +109,8 @@ def _make_oams(oams_idx=0, config_values=None):
 
 def _make_gcmd(values=None):
     """Minimal gcmd stand-in matching AFC's GCodeCommand-ish interface."""
-    values = values or {}
-    gcmd = MagicMock()
-
-    def get_float(name, default=None, **kwargs):
-        return values.get(name, default)
-
-    def get_int(name, default=None, **kwargs):
-        return values.get(name, default)
-
-    gcmd.get_float = MagicMock(side_effect=get_float)
-    gcmd.get_int = MagicMock(side_effect=get_int)
-    gcmd.error = MagicMock(side_effect=lambda msg: Exception(msg))
-    gcmd.respond_info = MagicMock()
-    return gcmd
+    from tests.conftest import MockGCodeCommand
+    return MockGCodeCommand(params=values or {})
 
 
 # ── OAMSStatus / OAMSOpCode / _oams_enum_name ────────────────────────────────

--- a/tests/test_AFC_OpenAMS.py
+++ b/tests/test_AFC_OpenAMS.py
@@ -2061,7 +2061,9 @@ def _make_lane(name, index=1, **overrides):
     lane.remember_spool = False
     lane.tool_loaded = False
     lane.load_state = False
-    lane.map = "T0"
+    lane.map = ["T0"]
+    lane.current_map = "T0"
+    lane.map_to_string = MagicMock(return_value="T0")
     lane._oams_runout_detected = False
     for k, v in overrides.items():
         setattr(lane, k, v)

--- a/tests/test_AFC_OpenAMS.py
+++ b/tests/test_AFC_OpenAMS.py
@@ -3774,20 +3774,8 @@ class TestPollOamsSensors:
 
 def _make_gcmd(values=None):
     """Minimal gcmd stand-in matching AFC's GCodeCommand-ish interface."""
-    values = values or {}
-    gcmd = MagicMock()
-
-    def get_float(name, default=None, **kwargs):
-        return values.get(name, default)
-
-    def get_int(name, default=None, **kwargs):
-        return values.get(name, default)
-
-    gcmd.get_float = MagicMock(side_effect=get_float)
-    gcmd.get_int = MagicMock(side_effect=get_int)
-    gcmd.error = MagicMock(side_effect=lambda msg: Exception(msg))
-    gcmd.respond_info = MagicMock()
-    return gcmd
+    from tests.conftest import MockGCodeCommand
+    return MockGCodeCommand(params=values or {})
 
 
 # ── Stuck spool / clog callbacks ───────────────────────────────────────────
@@ -4052,9 +4040,7 @@ class TestStuckSpoolRecoveryClearOamsState:
 
 class TestCmdStuckSpoolRecovery:
     def _gcmd(self, lane="lane1", fps="fps1"):
-        gcmd = MagicMock()
-        gcmd.get = MagicMock(side_effect=lambda k, default=None: {"LANE": lane, "FPS": fps}.get(k, default))
-        return gcmd
+        return _make_gcmd({"LANE": lane, "FPS": fps})
 
     def test_lane_not_found_falls_back(self):
         ams, afc, printer, reactor = _make_ams()

--- a/tests/test_AFC_OpenAMS.py
+++ b/tests/test_AFC_OpenAMS.py
@@ -2914,7 +2914,7 @@ class TestHandleSameFpsReload:
             "info", "Same-FPS reload complete: lane2 now active"
         ) in ams.logger.messages
 
-    def test_remaps_source_map_when_present(self):
+    def test_swaps_mapping_via_afc_swap_mapping_when_source_map_present(self):
         ams, afc, printer, reactor = _make_ams()
         ams._oams_load = MagicMock(return_value=True)
         ams.lane_not_ready = MagicMock()
@@ -2926,12 +2926,11 @@ class TestHandleSameFpsReload:
         ams.handle_same_fps_reload(source, target)
 
         ams.gcode.run_script_from_command.assert_called_once_with(
-            "SET_MAP LANE=lane2 MAP=T0")
-        assert (
-            "info", "Remapped T0 from lane1 to lane2"
-        ) in ams.logger.messages
+            "AFC_SWAP_MAPPING FROM=lane1 TO=lane2")
 
-    def test_no_source_map_skips_remap(self):
+    def test_swaps_mapping_via_afc_swap_mapping_when_no_source_map(self):
+        """AFC_SWAP_MAPPING is called unconditionally, regardless of whether
+        the source lane currently has a map assigned."""
         ams, afc, printer, reactor = _make_ams()
         ams._oams_load = MagicMock(return_value=True)
         ams.lane_not_ready = MagicMock()
@@ -2942,7 +2941,8 @@ class TestHandleSameFpsReload:
 
         ams.handle_same_fps_reload(source, target)
 
-        ams.gcode.run_script_from_command.assert_not_called()
+        ams.gcode.run_script_from_command.assert_called_once_with(
+            "AFC_SWAP_MAPPING FROM=lane1 TO=lane2")
 
     def test_hardware_load_failure_pauses_and_returns_false(self):
         ams, afc, printer, reactor = _make_ams()

--- a/tests/test_AFC_Toolchanger.py
+++ b/tests/test_AFC_Toolchanger.py
@@ -36,7 +36,9 @@ def _make_extruder_for_toolchanger(toolchanger, afc_name="e0", extruder_name="ex
 def _make_lane_for_system_test(name="lane1", tcmd="T0"):
     lane = MagicMock()
     lane.name = name
-    lane.map = tcmd
+    lane.map = [tcmd]
+    lane.current_map = tcmd
+    lane.map_to_string = MagicMock(return_value=tcmd)
     lane.prep_state = False
     lane.load_state = False
     lane.extruder_obj.lane_loaded = None

--- a/tests/test_AFC_Toolchanger.py
+++ b/tests/test_AFC_Toolchanger.py
@@ -13,6 +13,15 @@ from extras.AFC import State
 from extras.AFC_lane import AFCMoveWarning
 from tests.test_AFC_extruder import _make_extruder_obj
 
+
+def _build_gcmd(params=None, commandline=""):
+    """Build a gcmd mock backed by MockGCodeCommand, matching real Klipper's
+    sentinel-based .get() semantics (raises when a param has no value and no
+    default is supplied by the caller under test)."""
+    from tests.conftest import MockGCodeCommand
+    return MockGCodeCommand(params=params or {}, commandline=commandline)
+
+
 def _make_toolchanger(values=None):
     """Build a real AfcToolchanger via its actual __init__ (mocking config/
     printer/reactor dependencies), rather than bypassing construction with
@@ -259,10 +268,7 @@ class TestcmdAFCSelectTool:
         extruder1 = _make_extruder_for_toolchanger(tool, "e1", "extruder1")
 
         key_tool = "extruder"
-        gcmd = MagicMock()
-        gcmd.get.side_effect = lambda key, default=None: {
-            "TOOL": key_tool
-        }.get(key, default)
+        gcmd = _build_gcmd({"TOOL": key_tool})
 
         tool.cmd_AFC_SELECT_TOOL(gcmd)
         tool.tool_swap.assert_called_once_with(extruder.tc_lane)
@@ -274,10 +280,7 @@ class TestcmdAFCSelectTool:
         extruder1 = _make_extruder_for_toolchanger(tool, "e1", "extruder1")
         
         key_tool = "e1"
-        gcmd = MagicMock()
-        gcmd.get.side_effect = lambda key, default=None: {
-            "TOOL": key_tool
-        }.get(key, default)
+        gcmd = _build_gcmd({"TOOL": key_tool})
 
         tool.cmd_AFC_SELECT_TOOL(gcmd)
         tool.tool_swap.assert_called_once_with(extruder1.tc_lane)
@@ -289,10 +292,7 @@ class TestcmdAFCSelectTool:
         extruder1 = _make_extruder_for_toolchanger(tool, "e1", "extruder1")
         
         key_tool = "e2"
-        gcmd = MagicMock()
-        gcmd.get.side_effect = lambda key, default=None: {
-            "TOOL": key_tool
-        }.get(key, default)
+        gcmd = _build_gcmd({"TOOL": key_tool})
 
         tool.cmd_AFC_SELECT_TOOL(gcmd)
         tool.tool_swap.assert_not_called()
@@ -307,10 +307,7 @@ class TestcmdAFCSelectTool:
         extruder1.tc_lane = None
 
         key_tool = "e1"
-        gcmd = MagicMock()
-        gcmd.get.side_effect = lambda key, default=None: {
-            "TOOL": key_tool
-        }.get(key, default)
+        gcmd = _build_gcmd({"TOOL": key_tool})
 
         tool.cmd_AFC_SELECT_TOOL(gcmd)
         tool.tool_swap.assert_not_called()
@@ -326,10 +323,7 @@ class TestcmdAFCSelectTool:
         sentinel = object()
         extruder.status = sentinel
 
-        gcmd = MagicMock()
-        gcmd.get.side_effect = lambda key, default=None: {
-            "TOOL": "unknown"
-        }.get(key, default)
+        gcmd = _build_gcmd({"TOOL": "unknown"})
 
         tool.cmd_AFC_SELECT_TOOL(gcmd)
 
@@ -350,7 +344,7 @@ class TestCmdAFCUnselectTool:
     def test_calls_increase_unselect(self):
         extruder = _make_extruder_obj()
         tool = _make_toolchanger_for_unselect(current_extruder=extruder)
-        gcmd = MagicMock()
+        gcmd = _build_gcmd()
 
         tool.cmd_AFC_UNSELECT_TOOL(gcmd)
 
@@ -366,7 +360,7 @@ class TestCmdAFCUnselectTool:
             captured["state_during_unselect"] = tool.afc.current_state
 
         tool.afc.gcode.run_script_from_command = MagicMock(side_effect=_capture)
-        gcmd = MagicMock()
+        gcmd = _build_gcmd()
 
         tool.cmd_AFC_UNSELECT_TOOL(gcmd)
 
@@ -383,7 +377,7 @@ class TestCmdAFCUnselectTool:
             captured["status_during_unselect"] = extruder.status
 
         tool.afc.gcode.run_script_from_command = MagicMock(side_effect=_capture)
-        gcmd = MagicMock()
+        gcmd = _build_gcmd()
 
         tool.cmd_AFC_UNSELECT_TOOL(gcmd)
 
@@ -394,7 +388,7 @@ class TestCmdAFCUnselectTool:
         """Covers the `current_extruder` falsy branch: no .status assignment
         happens, but current_state still transitions normally."""
         tool = _make_toolchanger_for_unselect(current_extruder=None)
-        gcmd = MagicMock()
+        gcmd = _build_gcmd()
 
         tool.cmd_AFC_UNSELECT_TOOL(gcmd)
 
@@ -404,7 +398,7 @@ class TestCmdAFCUnselectTool:
         extruder = _make_extruder_obj()
         extruder.custom_unselect = "MY_CUSTOM_UNSELECT"
         tool = _make_toolchanger_for_unselect(current_extruder=extruder)
-        gcmd = MagicMock()
+        gcmd = _build_gcmd()
 
         tool.cmd_AFC_UNSELECT_TOOL(gcmd)
 
@@ -418,7 +412,7 @@ class TestCmdAFCUnselectTool:
         extruder = _make_extruder_obj()
         extruder.custom_unselect = None
         tool = _make_toolchanger_for_unselect(current_extruder=extruder)
-        gcmd = MagicMock()
+        gcmd = _build_gcmd()
 
         tool.cmd_AFC_UNSELECT_TOOL(gcmd)
 
@@ -427,7 +421,7 @@ class TestCmdAFCUnselectTool:
     def test_runs_default_unselect_when_no_current_extruder(self):
         """Covers the `current_extruder` falsy half of the combined condition."""
         tool = _make_toolchanger_for_unselect(current_extruder=None)
-        gcmd = MagicMock()
+        gcmd = _build_gcmd()
 
         tool.cmd_AFC_UNSELECT_TOOL(gcmd)
 
@@ -439,7 +433,7 @@ class TestCmdAFCUnselectTool:
         lane_obj.load_state = True
         lane_obj.tool_loaded = True
         tool = _make_toolchanger_for_unselect(current_lane=lane_obj)
-        gcmd = MagicMock()
+        gcmd = _build_gcmd()
 
         tool.cmd_AFC_UNSELECT_TOOL(gcmd)
 
@@ -453,7 +447,7 @@ class TestCmdAFCUnselectTool:
         lane_obj.load_state = True
         lane_obj.tool_loaded = False
         tool = _make_toolchanger_for_unselect(current_lane=lane_obj)
-        gcmd = MagicMock()
+        gcmd = _build_gcmd()
 
         tool.cmd_AFC_UNSELECT_TOOL(gcmd)
 
@@ -467,7 +461,7 @@ class TestCmdAFCUnselectTool:
         lane_obj.prep_state = False
         lane_obj.load_state = True
         tool = _make_toolchanger_for_unselect(current_lane=lane_obj)
-        gcmd = MagicMock()
+        gcmd = _build_gcmd()
 
         tool.cmd_AFC_UNSELECT_TOOL(gcmd)
 
@@ -482,7 +476,7 @@ class TestCmdAFCUnselectTool:
         lane_obj.prep_state = True
         lane_obj.load_state = False
         tool = _make_toolchanger_for_unselect(current_lane=lane_obj)
-        gcmd = MagicMock()
+        gcmd = _build_gcmd()
 
         tool.cmd_AFC_UNSELECT_TOOL(gcmd)
 
@@ -490,14 +484,14 @@ class TestCmdAFCUnselectTool:
 
     def test_no_lane_actions_when_no_current_lane(self):
         tool = _make_toolchanger_for_unselect(current_lane=None)
-        gcmd = MagicMock()
+        gcmd = _build_gcmd()
 
         # Must not raise despite no lane_obj being present.
         tool.cmd_AFC_UNSELECT_TOOL(gcmd)
 
     def test_sets_active_spool_empty(self):
         tool = _make_toolchanger_for_unselect()
-        gcmd = MagicMock()
+        gcmd = _build_gcmd()
 
         tool.cmd_AFC_UNSELECT_TOOL(gcmd)
 
@@ -744,11 +738,7 @@ class TestToolSwap:
 # ── cmd_AFC_SET_TOOLHEAD_LED ────────────────────────────────────────────────
 
 def _make_gcmd_for_set_toolhead_led(mapping="T0", turn_on=1):
-    gcmd = MagicMock()
-    gcmd.get.side_effect = lambda key, default=None: {"MAP": mapping}.get(key, default)
-    gcmd.get_int.side_effect = lambda key, default=None: {"TURN_ON": turn_on}.get(key, default)
-    gcmd.error = MagicMock(side_effect=lambda msg: Exception(msg))
-    return gcmd
+    return _build_gcmd({"MAP": mapping, "TURN_ON": turn_on})
 
 
 class TestCmdAFCSetToolheadLed:

--- a/tests/test_AFC_buffer.py
+++ b/tests/test_AFC_buffer.py
@@ -183,15 +183,13 @@ def _make_fps_buffer(name="FPS_buffer1", **overrides):
     return buf, afc, reactor, printer
 
 def _make_gcmd(values=None, floats=None):
-    """General-purpose gcmd mock: gcmd.get(key) / gcmd.get_float(key) pull
-    from the given dicts, falling back to the provided default arg."""
-    values = values or {}
-    floats = floats or {}
-    gcmd = MagicMock()
-    gcmd.get = MagicMock(side_effect=lambda k, default=None: values.get(k, default))
-    gcmd.get_float = MagicMock(side_effect=lambda k, default=None, **kw: floats.get(k, default))
-    gcmd.error = MagicMock(side_effect=lambda msg: Exception(msg))
-    return gcmd
+    """General-purpose gcmd mock backed by MockGCodeCommand: values/floats
+    are merged into one params dict, mirroring real Klipper's single
+    underlying params dict (get()/get_float() differ only in how they parse
+    the same stored value, not in where it comes from)."""
+    from tests.conftest import MockGCodeCommand
+    params = {**(values or {}), **(floats or {})}
+    return MockGCodeCommand(params=params)
 
 # ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -1649,8 +1647,7 @@ class TestCmdEnableBuffer:
         """cmd_ENABLE_BUFFER should call enable_buffer() exactly once."""
         buf = _make_buffer()
         lane = _make_lane(buf)
-        gcmd = MagicMock()
-        gcmd.get.return_value = "lane1"
+        gcmd = _make_gcmd({"LANE": "lane1"})
         buf.enable_buffer = MagicMock()
         buf.cmd_ENABLE_BUFFER(gcmd)
         buf.enable_buffer.assert_called_once()
@@ -1660,17 +1657,14 @@ class TestCmdEnableBuffer:
         buf = _make_buffer()
         lane = _make_lane(buf)
         buf.set_multiplier = MagicMock()
-        gcmd = MagicMock()
-        gcmd.get.return_value = "lane1"
+        gcmd = _make_gcmd({"LANE": "lane1"})
         buf.cmd_ENABLE_BUFFER(gcmd)
         assert buf.enable is True
         assert buf.current_lane == lane
 
     def test_unassigned_lane_raises_gcmd_error(self):
         buf = _make_buffer()
-        gcmd = MagicMock()
-        gcmd.get.return_value = "not_a_real_lane"
-        gcmd.error = MagicMock(side_effect=lambda msg: Exception(msg))
+        gcmd = _make_gcmd({"LANE": "not_a_real_lane"})
         with pytest.raises(Exception, match="not_a_real_lane not assigned"):
             buf.cmd_ENABLE_BUFFER(gcmd)
 
@@ -1701,10 +1695,9 @@ class TestCmdDisableBuffer:
 # ── cmd_AFC_SET_ERROR_SENSITIVITY ─────────────────────────────────────────────
 
 def _gcmd(sensitivity):
-    """Return a mock gcmd whose get_float returns the given sensitivity."""
-    gcmd = MagicMock()
-    gcmd.get_float.return_value = sensitivity
-    return gcmd
+    """Return a mock gcmd whose get_float('SENSITIVITY', ...) returns the
+    given sensitivity."""
+    return _make_gcmd(floats={"SENSITIVITY": sensitivity})
 
 
 class TestCmdSetErrorSensitivity:

--- a/tests/test_AFC_error.py
+++ b/tests/test_AFC_error.py
@@ -882,8 +882,8 @@ class TestCmdAfcResume:
         afc.gcode_move.last_position = [0.0, 0.0, 0.0]
         afc.move_z_pos = MagicMock()
         afc.restore_pos = MagicMock()
-        gcmd = MagicMock()
-        gcmd.get_raw_command_parameters.return_value = ""
+        from tests.conftest import MockGCodeCommand
+        gcmd = MockGCodeCommand()
         err.set_error_state = MagicMock()
         err.cmd_AFC_RESUME(gcmd)
         afc.gcode.run_script_from_command.assert_called_once()
@@ -898,8 +898,8 @@ class TestCmdAfcResume:
         afc.gcode_move.last_position = [0.0, 0.0, 0.0]  # z=0 ≤ 0+0.5
         afc.move_z_pos = MagicMock()
         afc.restore_pos = MagicMock()
-        gcmd = MagicMock()
-        gcmd.get_raw_command_parameters.return_value = ""
+        from tests.conftest import MockGCodeCommand
+        gcmd = MockGCodeCommand()
         err.set_error_state = MagicMock()
         err.cmd_AFC_RESUME(gcmd)
         afc.move_z_pos.assert_called_once()
@@ -912,8 +912,8 @@ class TestCmdAfcResume:
         afc.gcode_move.last_position = [0.0, 0.0, 10.0]  # z=10 > 0+0.5
         afc.move_z_pos = MagicMock()
         afc.restore_pos = MagicMock()
-        gcmd = MagicMock()
-        gcmd.get_raw_command_parameters.return_value = ""
+        from tests.conftest import MockGCodeCommand
+        gcmd = MockGCodeCommand()
         err.set_error_state = MagicMock()
         err.cmd_AFC_RESUME(gcmd)
         afc.move_z_pos.assert_not_called()
@@ -938,8 +938,8 @@ class TestCmdAfcResume:
         afc.gcode_move.last_position = [0.0, 0.0, 0.0]
         afc.move_z_pos = MagicMock()
         afc.restore_pos = MagicMock()
-        gcmd = MagicMock()
-        gcmd.get_raw_command_parameters.return_value = ""
+        from tests.conftest import MockGCodeCommand
+        gcmd = MockGCodeCommand()
         err.set_error_state = MagicMock()
         err.pause = True
         err.cmd_AFC_RESUME(gcmd)
@@ -957,8 +957,8 @@ class TestCmdAfcResume:
         afc.gcode_move.last_position = [0.0, 0.0, 0.0]
         afc.move_z_pos = MagicMock()
         afc.restore_pos = MagicMock()
-        gcmd = MagicMock()
-        gcmd.get_raw_command_parameters.return_value = ""
+        from tests.conftest import MockGCodeCommand
+        gcmd = MockGCodeCommand()
         err.set_error_state = MagicMock()
         err.pause = True
         err.cmd_AFC_RESUME(gcmd)
@@ -978,8 +978,8 @@ class TestCmdAfcResume:
         afc.gcode_move.last_position = [0.0, 0.0, 0.0]
         afc.move_z_pos = MagicMock()
         afc.restore_pos = MagicMock()
-        gcmd = MagicMock()
-        gcmd.get_raw_command_parameters.return_value = ""
+        from tests.conftest import MockGCodeCommand
+        gcmd = MockGCodeCommand()
         err.set_error_state = MagicMock()
         err.pause = True
         err.cmd_AFC_RESUME(gcmd)
@@ -1001,8 +1001,8 @@ class TestCmdAfcResume:
         afc.gcode_move.last_position = [0.0, 0.0, 0.0]
         afc.move_z_pos = MagicMock()
         afc.restore_pos = MagicMock()
-        gcmd = MagicMock()
-        gcmd.get_raw_command_parameters.return_value = ""
+        from tests.conftest import MockGCodeCommand
+        gcmd = MockGCodeCommand()
         err.set_error_state = MagicMock()
         err.pause = True
         err.cmd_AFC_RESUME(gcmd)
@@ -1041,8 +1041,8 @@ class TestCmdAfcPause:
         afc.move_z_pos = MagicMock()
         afc.last_gcode_position = [0.0, 0.0, 0.0, 0.0]
         afc.gcode_move.last_position = [0.0, 0.0, 0.0]
-        gcmd = MagicMock()
-        gcmd.get_raw_command_parameters.return_value = ""
+        from tests.conftest import MockGCodeCommand
+        gcmd = MockGCodeCommand()
         err.cmd_AFC_PAUSE(gcmd)
         # run_script_from_command called at least twice: PAUSE macro + SET_IDLE_TIMEOUT
         assert afc.gcode.run_script_from_command.call_count >= 1
@@ -1085,8 +1085,8 @@ class TestCmdAfcPause:
         afc.z_hop = 0.5  # target = 0 + 0.5 = 0.5
         afc.gcode_move.last_position = [0.0, 0.0, 1.0]  # current z = 1.0 > 0.5
         afc.move_z_pos = MagicMock()
-        gcmd = MagicMock()
-        gcmd.get_raw_command_parameters.return_value = ""
+        from tests.conftest import MockGCodeCommand
+        gcmd = MockGCodeCommand()
         err.cmd_AFC_PAUSE(gcmd)
         afc.move_z_pos.assert_not_called()
         assert err.logger.messages == [

--- a/tests/test_AFC_extruder.py
+++ b/tests/test_AFC_extruder.py
@@ -646,13 +646,19 @@ class TestUpdateToolAfterExtr:
 class TestCmdUpdateToolheadSensors:
     def _make_gcmd(self, tool_stn=None, tool_stn_unload=None, tool_after=None,
                    ext=None):
-        gcmd = MagicMock()
-        gcmd.get_float.side_effect = lambda key, default: {
-            "TOOL_STN": tool_stn if tool_stn is not None else (ext.tool_stn if ext else default),
-            "TOOL_STN_UNLOAD": tool_stn_unload if tool_stn_unload is not None else (ext.tool_stn_unload if ext else default),
-            "TOOL_AFTER_EXTRUDER": tool_after if tool_after is not None else (ext.tool_sensor_after_extruder if ext else default),
-        }[key]
-        return gcmd
+        """Values left as None fall through to cmd_UPDATE_TOOLHEAD_SENSORS's
+        own default (gcmd.get_float(..., self.tool_stn) etc.), so there's no
+        need to duplicate that fallback here -- ext is unused now but kept
+        as a parameter so existing call sites don't need to change."""
+        from tests.conftest import MockGCodeCommand
+        params = {}
+        if tool_stn is not None:
+            params["TOOL_STN"] = tool_stn
+        if tool_stn_unload is not None:
+            params["TOOL_STN_UNLOAD"] = tool_stn_unload
+        if tool_after is not None:
+            params["TOOL_AFTER_EXTRUDER"] = tool_after
+        return MockGCodeCommand(params=params)
 
     def test_changed_tool_stn_calls_update(self):
         ext = _make_afc_extruder()

--- a/tests/test_AFC_form_tip.py
+++ b/tests/test_AFC_form_tip.py
@@ -60,11 +60,8 @@ def _make_tip_form(values=None):
 
 
 def _make_gcmd(**kwargs):
-    gcmd = MagicMock()
-    gcmd.get_float = lambda key, default: kwargs.get(key, default)
-    gcmd.get_int = lambda key, default: int(kwargs.get(key, default))
-    gcmd.get = lambda key, default: str(kwargs.get(key, default))
-    return gcmd
+    from tests.conftest import MockGCodeCommand
+    return MockGCodeCommand(params=kwargs)
 
 
 # ── Attribute initialization ──────────────────────────────────────────────────

--- a/tests/test_AFC_functions.py
+++ b/tests/test_AFC_functions.py
@@ -805,8 +805,8 @@ class TestTcmdAssign:
 
     def test_auto_assign_skips_command_with_existing_gcode_macro(self):
         """When a candidate T(n) already has a registered gcode handler and
-        force_assign_map is off, TcmdAssign moves on without claiming it,
-        but still records it as the lane's current_map."""
+        force_assign_map is off, TcmdAssign moves on without claiming it, and
+        current_map ends up as the command the lane actually owns."""
         func = _make_func()
         cur_lane = _make_afc_lane("AFC_stepper lane1")
         cur_lane.map = []
@@ -821,7 +821,7 @@ class TestTcmdAssign:
         func.TcmdAssign(cur_lane)
 
         assert cur_lane.map == ["T1"]
-        assert cur_lane.current_map == "T0"
+        assert cur_lane.current_map == "T1"
 
     def test_auto_assign_force_assign_map_ignores_existing_gcode_macro(self):
         """force_assign_map short-circuits the existing-macro check, so the
@@ -840,9 +840,10 @@ class TestTcmdAssign:
 
         assert cur_lane.map == ["T0"]
 
-    def test_auto_assign_second_existing_macro_hit_does_not_overwrite_current_map(self):
-        """Covers the loop continuing past a second already-claimed candidate
-        without re-setting current_map, since it was set on the first hit."""
+    def test_auto_assign_second_existing_macro_hit_keeps_current_map_unset(self):
+        """Covers the loop continuing past two already-claimed candidates
+        without setting current_map to either, since neither is owned by
+        this lane; current_map ends up as the real assignment, T2."""
         func = _make_func()
         cur_lane = _make_afc_lane("AFC_stepper lane1")
         cur_lane.map = []
@@ -857,7 +858,7 @@ class TestTcmdAssign:
         func.TcmdAssign(cur_lane)
 
         assert cur_lane.map == ["T2"]
-        assert cur_lane.current_map == "T0"
+        assert cur_lane.current_map == "T2"
 
     def test_auto_assign_exhausts_range_without_finding_command(self):
         """Covers the range(99) loop finishing without a break when every

--- a/tests/test_AFC_functions.py
+++ b/tests/test_AFC_functions.py
@@ -654,19 +654,15 @@ class TestCalibrateAFC:
 
     def _make_gcmd_for_calibration(self, distance=25, tolerance=5, bowden=None, lane=None,
                                    unit=None, TD1=None):
-        gcmd = MagicMock()
-        gcmd.get.side_effect = lambda key, default=None: {
+        from tests.conftest import MockGCodeCommand
+        return MockGCodeCommand(params={
             "BOWDEN": bowden,
             "LANE": lane,
             "UNIT": unit,
-            "TD1": TD1
-        }.get(key, default)
-
-        gcmd.get_float.side_effect = lambda key, default=None: {
+            "TD1": TD1,
             "DISTANCE": distance,
             "TOLERANCE": tolerance,
-        }.get(key, default)
-        return gcmd
+        })
 
     def _setup_calibration(self, standalone=False, td1_present=False, moonraker=None):
         """Builds func/afc/lane with the defaults nearly every test relies on."""
@@ -1239,11 +1235,8 @@ class TestCmdAfcLaneResetUnitDelegation:
         afc, lane = self._make_afc_lane()
         func.afc = afc
         func.get_current_lane_obj = MagicMock(return_value=None)
-        gcmd = MagicMock()
-        gcmd.get.side_effect = lambda key, default=None: {
-            "LANE": lane.name,
-            "DISTANCE": distance,
-        }.get(key, default)
+        from tests.conftest import MockGCodeCommand
+        gcmd = MockGCodeCommand(params={"LANE": lane.name, "DISTANCE": distance})
         return func, lane, gcmd
 
     def _make_afc_lane(self):
@@ -1320,11 +1313,8 @@ class TestCmdAfcLaneResetToolheadLoadedGuard:
         func = _make_func()
         afc, lane = self._make_afc_lane()
         func.afc = afc
-        gcmd = MagicMock()
-        gcmd.get.side_effect = lambda key, default=None: {
-            "LANE": lane.name,
-            "DISTANCE": distance,
-        }.get(key, default)
+        from tests.conftest import MockGCodeCommand
+        gcmd = MockGCodeCommand(params={"LANE": lane.name, "DISTANCE": distance})
         return func, lane, gcmd
 
     def _make_afc_lane(self):

--- a/tests/test_AFC_functions.py
+++ b/tests/test_AFC_functions.py
@@ -632,6 +632,272 @@ class TestGetExtruderPos_ReturnValue:
         assert isinstance(result, float)
 # ── end get_extruder_pos ──────────────────────────────────────────────────────
 
+# ── register_tool_macro ─────────────────────────────────────────────────────────
+
+def _wire_change_tool(func):
+    """Set the cmd_CHANGE_TOOL attributes register_tool_macro forwards along."""
+    func.afc.cmd_CHANGE_TOOL = MagicMock()
+    func.afc.cmd_CHANGE_TOOL_help = "help text"
+
+
+class TestRegisterToolMacro:
+    def test_no_rename_registers_command_directly(self):
+        func = _make_func()
+        _wire_change_tool(func)
+        func.afc.gcode.register_command = MagicMock()
+
+        func.register_tool_macro("lane1", "T0", "")
+
+        func.afc.gcode.register_command.assert_called_once_with(
+            "T0", func.afc.cmd_CHANGE_TOOL, desc=func.afc.cmd_CHANGE_TOOL_help
+        )
+
+    def test_rename_delegates_to_rename_method(self):
+        func = _make_func()
+        _wire_change_tool(func)
+        func._rename = MagicMock()
+
+        func.register_tool_macro("lane1", "T0", "_T0")
+
+        func._rename.assert_called_once_with(
+            "T0", "_T0", func.afc.cmd_CHANGE_TOOL, func.afc.cmd_CHANGE_TOOL_help
+        )
+        assert "T0" not in func.afc.gcode._commands
+
+    def test_exception_when_registering_directly_logs_error(self):
+        func = _make_func()
+        _wire_change_tool(func)
+        func.afc.gcode.register_command = MagicMock(side_effect=Exception("boom"))
+
+        func.register_tool_macro("lane1", "T0", "")
+
+        assert func.logger.messages == [
+            ("error", "Error trying to map lane lane1 to T0, please make sure there "
+                      "are no macros already setup for T0")
+        ]
+
+    def test_exception_when_renaming_logs_error(self):
+        func = _make_func()
+        _wire_change_tool(func)
+        func._rename = MagicMock(side_effect=Exception("boom"))
+
+        func.register_tool_macro("lane1", "T0", "_T0")
+
+        assert func.logger.messages == [
+            ("error", "Error trying to map lane lane1 to T0, please make sure there "
+                      "are no macros already setup for T0")
+        ]
+
+# ── end register_tool_macro ───────────────────────────────────────────────────
+
+# ── TcmdAssign ───────────────────────────────────────────────────────────────
+
+class TestTcmdAssign:
+    def test_use_rename_true_when_own_map_manually_assigned(self):
+        func = _make_func()
+        cur_lane = _make_afc_lane("AFC_stepper lane1")
+        cur_lane.map = ["T0"]
+        cur_lane._map = ["T0"]
+        func.afc.lanes = {"lane1": cur_lane}
+        func.afc.force_assign_map = False
+        func.register_tool_macro = MagicMock()
+
+        func.TcmdAssign(cur_lane)
+
+        func.register_tool_macro.assert_called_once_with("lane1", "T0", "_T0")
+
+    def test_use_rename_true_when_force_assign_map(self):
+        func = _make_func()
+        cur_lane = _make_afc_lane("AFC_stepper lane1")
+        cur_lane.map = ["T3"]
+        cur_lane._map = []
+        func.afc.lanes = {"lane1": cur_lane}
+        func.afc.force_assign_map = True
+        func.register_tool_macro = MagicMock()
+
+        func.TcmdAssign(cur_lane)
+
+        func.register_tool_macro.assert_called_once_with("lane1", "T3", "_T3")
+
+    def test_use_rename_true_when_map_manually_assigned_on_other_lane(self):
+        """cur_lane's own _map is empty, but the T(n) command it currently
+        holds was manually assigned to a different lane in the config."""
+        func = _make_func()
+        cur_lane = _make_afc_lane("AFC_stepper lane1")
+        cur_lane.map = ["T5"]
+        cur_lane._map = []
+        other_lane = _make_afc_lane("AFC_stepper lane2")
+        other_lane.map = ["T1"]
+        other_lane._map = ["T5"]
+        func.afc.lanes = {"lane1": cur_lane, "lane2": other_lane}
+        func.afc.force_assign_map = False
+        func.register_tool_macro = MagicMock()
+
+        func.TcmdAssign(cur_lane)
+
+        func.register_tool_macro.assert_called_once_with("lane1", "T5", "_T5")
+
+    def test_use_rename_false_when_no_manual_mapping_anywhere(self):
+        func = _make_func()
+        cur_lane = _make_afc_lane("AFC_stepper lane1")
+        cur_lane.map = ["T3"]
+        cur_lane._map = []
+        other_lane = _make_afc_lane("AFC_stepper lane2")
+        other_lane.map = ["T1"]
+        other_lane._map = []
+        func.afc.lanes = {"lane1": cur_lane, "lane2": other_lane}
+        func.afc.force_assign_map = False
+        func.register_tool_macro = MagicMock()
+
+        func.TcmdAssign(cur_lane)
+
+        func.register_tool_macro.assert_called_once_with("lane1", "T3", "")
+
+    def test_auto_assigns_first_available_command(self):
+        func = _make_func()
+        cur_lane = _make_afc_lane("AFC_stepper lane1")
+        cur_lane.map = []
+        cur_lane._map = []
+        cur_lane.current_map = ""
+        func.afc.lanes = {"lane1": cur_lane}
+        func.afc.tool_cmds = {}
+        func.afc.force_assign_map = False
+        func.afc.gcode.ready_gcode_handlers = {}
+        func.register_tool_macro = MagicMock()
+
+        func.TcmdAssign(cur_lane)
+
+        assert cur_lane.map == ["T0"]
+        assert cur_lane.current_map == "T0"
+
+    def test_auto_assign_skips_command_manually_assigned_to_another_lane(self):
+        func = _make_func()
+        cur_lane = _make_afc_lane("AFC_stepper lane1")
+        cur_lane.map = []
+        cur_lane._map = []
+        other_lane = _make_afc_lane("AFC_stepper lane2")
+        other_lane.map = ["T0"]
+        other_lane._map = ["T0"]
+        func.afc.lanes = {"lane1": cur_lane, "lane2": other_lane}
+        func.afc.tool_cmds = {}
+        func.afc.force_assign_map = False
+        func.afc.gcode.ready_gcode_handlers = {}
+        func.register_tool_macro = MagicMock()
+
+        func.TcmdAssign(cur_lane)
+
+        assert cur_lane.map == ["T1"]
+
+    def test_auto_assign_skips_command_already_in_tool_cmds(self):
+        func = _make_func()
+        cur_lane = _make_afc_lane("AFC_stepper lane1")
+        cur_lane.map = []
+        cur_lane._map = []
+        func.afc.lanes = {"lane1": cur_lane}
+        func.afc.tool_cmds = {"T0": "lane2"}
+        func.afc.force_assign_map = False
+        func.afc.gcode.ready_gcode_handlers = {}
+        func.register_tool_macro = MagicMock()
+
+        func.TcmdAssign(cur_lane)
+
+        assert cur_lane.map == ["T1"]
+
+    def test_auto_assign_skips_command_with_existing_gcode_macro(self):
+        """When a candidate T(n) already has a registered gcode handler and
+        force_assign_map is off, TcmdAssign moves on without claiming it,
+        but still records it as the lane's current_map."""
+        func = _make_func()
+        cur_lane = _make_afc_lane("AFC_stepper lane1")
+        cur_lane.map = []
+        cur_lane._map = []
+        cur_lane.current_map = ""
+        func.afc.lanes = {"lane1": cur_lane}
+        func.afc.tool_cmds = {}
+        func.afc.force_assign_map = False
+        func.afc.gcode.ready_gcode_handlers = {"T0": MagicMock()}
+        func.register_tool_macro = MagicMock()
+
+        func.TcmdAssign(cur_lane)
+
+        assert cur_lane.map == ["T1"]
+        assert cur_lane.current_map == "T0"
+
+    def test_auto_assign_force_assign_map_ignores_existing_gcode_macro(self):
+        """force_assign_map short-circuits the existing-macro check, so the
+        first candidate is claimed even though a handler is already registered."""
+        func = _make_func()
+        cur_lane = _make_afc_lane("AFC_stepper lane1")
+        cur_lane.map = []
+        cur_lane._map = []
+        func.afc.lanes = {"lane1": cur_lane}
+        func.afc.tool_cmds = {}
+        func.afc.force_assign_map = True
+        func.afc.gcode.ready_gcode_handlers = {"T0": MagicMock()}
+        func.register_tool_macro = MagicMock()
+
+        func.TcmdAssign(cur_lane)
+
+        assert cur_lane.map == ["T0"]
+
+    def test_auto_assign_second_existing_macro_hit_does_not_overwrite_current_map(self):
+        """Covers the loop continuing past a second already-claimed candidate
+        without re-setting current_map, since it was set on the first hit."""
+        func = _make_func()
+        cur_lane = _make_afc_lane("AFC_stepper lane1")
+        cur_lane.map = []
+        cur_lane._map = []
+        cur_lane.current_map = ""
+        func.afc.lanes = {"lane1": cur_lane}
+        func.afc.tool_cmds = {}
+        func.afc.force_assign_map = False
+        func.afc.gcode.ready_gcode_handlers = {"T0": MagicMock(), "T1": MagicMock()}
+        func.register_tool_macro = MagicMock()
+
+        func.TcmdAssign(cur_lane)
+
+        assert cur_lane.map == ["T2"]
+        assert cur_lane.current_map == "T0"
+
+    def test_auto_assign_exhausts_range_without_finding_command(self):
+        """Covers the range(99) loop finishing without a break when every
+        candidate command is already claimed in tool_cmds."""
+        func = _make_func()
+        cur_lane = _make_afc_lane("AFC_stepper lane1")
+        cur_lane.map = []
+        cur_lane._map = []
+        func.afc.lanes = {"lane1": cur_lane}
+        func.afc.tool_cmds = {f"T{i}": "otherlane" for i in range(99)}
+        func.afc.force_assign_map = False
+        func.afc.gcode.ready_gcode_handlers = {}
+        func.register_tool_macro = MagicMock()
+
+        func.TcmdAssign(cur_lane)
+
+        assert cur_lane.map == []
+        func.register_tool_macro.assert_not_called()
+
+    def test_skips_none_placeholder_already_in_map(self):
+        """cur_lane.map already holding a "NONE" placeholder alongside a real
+        mapping should skip NONE and only register the real command."""
+        func = _make_func()
+        cur_lane = _make_afc_lane("AFC_stepper lane1")
+        cur_lane.map = ["NONE", "T1"]
+        cur_lane._map = []
+        cur_lane.current_map = ""
+        func.afc.lanes = {"lane1": cur_lane}
+        func.afc.tool_cmds = {}
+        func.afc.force_assign_map = False
+        func.register_tool_macro = MagicMock()
+
+        func.TcmdAssign(cur_lane)
+
+        assert "NONE" not in func.afc.tool_cmds
+        assert func.afc.tool_cmds == {"T1": "lane1"}
+        func.register_tool_macro.assert_called_once_with("lane1", "T1", "")
+
+# ── end TcmdAssign ─────────────────────────────────────────────────────────────
+
 class TestCalibrateAFC:
     # ------------------------------------------------------------------
     # Fixtures / builders

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -1218,12 +1218,10 @@ class Test_MapToString:
         lane._map = ["T10", "T2", "T0"]
         assert lane._map_to_string() == "T0, T2, T10"
 
-    def test_empty_list_returns_empty_string(self):
-        """Unlike map_to_string(), _map_to_string() has no empty-list guard
-        -- an empty list joins to "" rather than "NONE"."""
+    def test_empty_list_returns_none_placeholder(self):
         lane = _make_afc_lane()
         lane._map = []
-        assert lane._map_to_string() == ""
+        assert lane._map_to_string() == "NONE"
 
 
 # ── get_status: map sorting ───────────────────────────────────────────────────
@@ -1262,17 +1260,14 @@ def _make_lane_for_get_status(map_value):
 
 
 class TestGetStatusMapSorting:
-    def test_map_is_naturally_sorted_low_to_high(self):
+    def test_map_returns_raw_unsorted_list(self):
+        """Unlike map_to_string(), the live (not save_to_file) branch returns
+        self.map as-is -- other code relies on map[0] being the first
+        assigned mapping, not the naturally-lowest one, so insertion order
+        must be preserved here."""
         lane = _make_lane_for_get_status(["T10", "T2", "T0"])
         response = lane.get_status()
-        assert response["map"] == ["T0", "T2", "T10"]
-
-    def test_does_not_mutate_self_map_order(self):
-        """response['map'] is a sorted copy -- self.map itself must keep its
-        original order, since other code relies on map[0] being the first
-        assigned mapping, not the lowest one."""
-        lane = _make_lane_for_get_status(["T10", "T2", "T0"])
-        lane.get_status()
+        assert response["map"] == ["T10", "T2", "T0"]
         assert lane.map == ["T10", "T2", "T0"]
 
     def test_save_to_file_uses_map_to_string_instead_of_raw_list(self):

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -225,6 +225,7 @@ def _make_afc_lane(fullname="AFC_stepper lane1"):
     lane.map = ["T0"]
     lane._map = ["T0"]
     lane.current_map = "T0"
+    lane._sent_lane_data_keys = []
     lane.gcode = MagicMock()
     lane.need_purge = False
     return lane
@@ -1566,7 +1567,9 @@ class TestIsNormalPrintingState:
 def _make_lane_for_moonraker(extruder_name="extruder", map_value="T0"):
     """Build a minimal AFCLane wired up for send/clear lane data tests."""
     lane = _make_afc_lane("AFC_stepper lane1")
-    lane.current_map = map_value
+    lane.map = [map_value] if map_value is not None else []
+    lane._sent_lane_data_keys = []
+    lane.afc.tool_cmds = {}
     lane.extruder_obj = MagicMock()
     lane.extruder_obj.th_extruder_name = lane.extruder_obj.name = extruder_name
     lane.color = "#FF0000"
@@ -1580,14 +1583,14 @@ def _make_lane_for_moonraker(extruder_name="extruder", map_value="T0"):
 
 
 def _get_sent_payload(lane):
-    """Call send_lane_data and return the payload passed to moonraker."""
+    """Call send_lane_data and return the single payload passed to moonraker."""
     lane.send_lane_data()
     lane.afc.moonraker.send_lane_data.assert_called_once()
     return lane.afc.moonraker.send_lane_data.call_args[0][0]
 
 
 def _get_cleared_payload(lane):
-    """Call clear_lane_data and return the payload passed to moonraker."""
+    """Call clear_lane_data and return the single payload passed to moonraker."""
     lane.clear_lane_data()
     lane.afc.moonraker.send_lane_data.assert_called_once()
     return lane.afc.moonraker.send_lane_data.call_args[0][0]
@@ -1622,20 +1625,26 @@ class TestSendLaneDataExtruderIndex:
         payload = _get_sent_payload(lane)
         assert payload["namespace"] == "lane_data"
 
+    def test_key_is_the_t_command_not_the_lane_name(self):
+        """The record's "key" is now the T(n) mapping itself, not the lane
+        name -- see test_multiple_mappings_send_one_record_each for why."""
+        lane = _make_lane_for_moonraker(map_value="T2")
+        payload = _get_sent_payload(lane)
+        assert payload["key"] == "T2"
+        assert payload["value"]["lane"] == "2"
+
     def test_weight_is_included(self):
         lane = _make_lane_for_moonraker()
         payload = _get_sent_payload(lane)
         assert payload["value"]["weight"] == 750.0
 
-    def test_no_send_when_map_is_none(self):
-        lane = _make_lane_for_moonraker()
-        lane.current_map = None
+    def test_no_send_when_map_is_empty(self):
+        lane = _make_lane_for_moonraker(map_value=None)
         lane.send_lane_data()
         lane.afc.moonraker.send_lane_data.assert_not_called()
 
-    def test_no_send_when_map_has_no_T(self):
-        lane = _make_lane_for_moonraker()
-        lane.current_map = "0"
+    def test_no_send_when_map_is_none_placeholder(self):
+        lane = _make_lane_for_moonraker(map_value="NONE")
         lane.send_lane_data()
         lane.afc.moonraker.send_lane_data.assert_not_called()
 
@@ -1648,6 +1657,59 @@ class TestSendLaneDataExtruderIndex:
         # afc.moonraker is None here, so there's nothing to assert the call
         # against -- the AttributeError that not-called would otherwise
         # crash into is exactly what the guard is meant to prevent.
+
+    def test_multiple_mappings_send_one_record_each(self):
+        lane = _make_lane_for_moonraker(map_value="T0")
+        lane.map = ["T0", "T3"]
+        lane.send_lane_data()
+        calls = lane.afc.moonraker.send_lane_data.call_args_list
+        assert len(calls) == 2
+        keys = {c.args[0]["key"] for c in calls}
+        assert keys == {"T0", "T3"}
+        lane_fields = {c.args[0]["value"]["lane"] for c in calls}
+        assert lane_fields == {"0", "3"}
+
+    def test_multiple_mappings_share_same_spool_data(self):
+        lane = _make_lane_for_moonraker(map_value="T0")
+        lane.map = ["T0", "T3"]
+        lane.send_lane_data()
+        colors = {c.args[0]["value"]["color"] for c in lane.afc.moonraker.send_lane_data.call_args_list}
+        assert colors == {"#FF0000"}
+
+    def test_updates_sent_keys_after_send(self):
+        lane = _make_lane_for_moonraker(map_value="T0")
+        lane.map = ["T0", "T3"]
+        lane.send_lane_data()
+        assert lane._sent_lane_data_keys == ["T0", "T3"]
+
+    def test_removes_stale_key_no_longer_owned_by_anyone(self):
+        """A T(n) that was mapped last call but isn't anymore, and isn't in
+        any lane's own map list, gets its record removed."""
+        lane = _make_lane_for_moonraker(map_value="T0")
+        lane._sent_lane_data_keys = ["T0", "T3"]
+        lane.afc.lanes = {lane.name: lane}
+        lane.send_lane_data()
+        lane.afc.moonraker.remove_database_entry.assert_called_once_with("lane_data", "T3")
+
+    def test_does_not_remove_stale_key_reassigned_to_another_lane(self):
+        """A T(n) that moved to a different lane's own map (e.g. during a
+        swap) must not be removed -- the new owner's own send_lane_data()
+        call is responsible for that key's record."""
+        lane = _make_lane_for_moonraker(map_value="T0")
+        lane._sent_lane_data_keys = ["T0", "T3"]
+        other_lane = MagicMock()
+        other_lane.map = ["T3"]
+        lane.afc.lanes = {lane.name: lane, "lane2": other_lane}
+        lane.send_lane_data()
+        lane.afc.moonraker.remove_database_entry.assert_not_called()
+
+    def test_no_stale_removal_when_key_still_mapped(self):
+        """Covers the `key not in current_keys` half of the removal
+        condition being falsy on its own."""
+        lane = _make_lane_for_moonraker(map_value="T0")
+        lane._sent_lane_data_keys = ["T0"]
+        lane.send_lane_data()
+        lane.afc.moonraker.remove_database_entry.assert_not_called()
 
 
 class TestClearLaneDataExtruderIndex:
@@ -1667,6 +1729,12 @@ class TestClearLaneDataExtruderIndex:
         payload = _get_cleared_payload(lane)
         assert isinstance(payload["value"]["extruder_index"], int)
 
+    def test_key_is_the_t_command(self):
+        lane = _make_lane_for_moonraker(map_value="T2")
+        payload = _get_cleared_payload(lane)
+        assert payload["key"] == "T2"
+        assert payload["value"]["lane"] == "2"
+
     def test_color_is_cleared(self):
         lane = _make_lane_for_moonraker()
         payload = _get_cleared_payload(lane)
@@ -1677,9 +1745,23 @@ class TestClearLaneDataExtruderIndex:
         payload = _get_cleared_payload(lane)
         assert payload["value"]["weight"] == 0
 
-    def test_no_clear_when_map_is_none(self):
-        lane = _make_lane_for_moonraker()
-        lane.current_map = None
+    def test_clears_one_record_per_mapping(self):
+        lane = _make_lane_for_moonraker(map_value="T0")
+        lane.map = ["T0", "T3"]
+        lane.clear_lane_data()
+        calls = lane.afc.moonraker.send_lane_data.call_args_list
+        assert len(calls) == 2
+        keys = {c.args[0]["key"] for c in calls}
+        assert keys == {"T0", "T3"}
+
+    def test_updates_sent_keys_after_clear(self):
+        lane = _make_lane_for_moonraker(map_value="T0")
+        lane.map = ["T0", "T3"]
+        lane.clear_lane_data()
+        assert lane._sent_lane_data_keys == ["T0", "T3"]
+
+    def test_no_clear_when_map_is_empty(self):
+        lane = _make_lane_for_moonraker(map_value=None)
         lane.clear_lane_data()
         lane.afc.moonraker.send_lane_data.assert_not_called()
 

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -222,7 +222,9 @@ def _make_afc_lane(fullname="AFC_stepper lane1"):
     lane.short_moves_accel = 100
     lane._load_state = False
     lane.runout_lane = None
-    lane.map = "T0"
+    lane.map = ["T0"]
+    lane._map = ["T0"]
+    lane.current_map = "T0"
     lane.gcode = MagicMock()
     lane.need_purge = False
     return lane
@@ -1183,20 +1185,117 @@ class TestAFCLaneLoadEs:
 
         assert lane_a.load_es != lane_b.load_es
 
+
+# ── map_to_string ─────────────────────────────────────────────────────────────
+
+class TestMapToString:
+    def test_returns_none_when_map_is_empty(self):
+        lane = _make_afc_lane()
+        lane.map = []
+        assert lane.map_to_string() == "NONE"
+
+    def test_joins_single_entry(self):
+        lane = _make_afc_lane()
+        lane.map = ["T0"]
+        assert lane.map_to_string() == "T0"
+
+    def test_sorts_entries_naturally_low_to_high(self):
+        lane = _make_afc_lane()
+        lane.map = ["T10", "T2", "T0"]
+        assert lane.map_to_string() == "T0, T2, T10"
+
+
+# ── _map_to_string ────────────────────────────────────────────────────────────
+
+class Test_MapToString:
+    def test_joins_single_entry(self):
+        lane = _make_afc_lane()
+        lane._map = ["T0"]
+        assert lane._map_to_string() == "T0"
+
+    def test_sorts_entries_naturally_low_to_high(self):
+        lane = _make_afc_lane()
+        lane._map = ["T10", "T2", "T0"]
+        assert lane._map_to_string() == "T0, T2, T10"
+
+    def test_empty_list_returns_empty_string(self):
+        """Unlike map_to_string(), _map_to_string() has no empty-list guard
+        -- an empty list joins to "" rather than "NONE"."""
+        lane = _make_afc_lane()
+        lane._map = []
+        assert lane._map_to_string() == ""
+
+
+# ── get_status: map sorting ───────────────────────────────────────────────────
+
+def _make_lane_for_get_status(map_value):
+    """Build a lane with just enough state for get_status() to run."""
+    lane = _make_afc_lane()
+    lane.connect_done = True
+    lane.unit = "Turtle_1"
+    lane.hub = "PB1"
+    lane.afc_extruder_name = "extruder"
+    lane.buffer_name = None
+    lane.buffer_status = lambda: "None"
+    lane.index = "0"
+    lane.map = map_value
+    lane.current_map = "T0"
+    lane.prep_state = False
+    lane._selector_state = None
+    lane.tool_loaded = False
+    lane.loaded_to_hub = False
+    lane.material = ""
+    lane.remember_spool = False
+    lane.spool_id = None
+    lane.color = ""
+    lane.filament_name = ""
+    lane.multi_color = []
+    lane.weight = 0
+    lane.extruder_temp = None
+    lane.bed_temp = None
+    lane.runout_lane = None
+    lane.status = None
+    lane.dist_hub = 900
+    lane.td1_data = {}
+    lane.afc.function.get_filament_status = MagicMock(return_value="a:b")
+    return lane
+
+
+class TestGetStatusMapSorting:
+    def test_map_is_naturally_sorted_low_to_high(self):
+        lane = _make_lane_for_get_status(["T10", "T2", "T0"])
+        response = lane.get_status()
+        assert response["map"] == ["T0", "T2", "T10"]
+
+    def test_does_not_mutate_self_map_order(self):
+        """response['map'] is a sorted copy -- self.map itself must keep its
+        original order, since other code relies on map[0] being the first
+        assigned mapping, not the lowest one."""
+        lane = _make_lane_for_get_status(["T10", "T2", "T0"])
+        lane.get_status()
+        assert lane.map == ["T10", "T2", "T0"]
+
+    def test_save_to_file_uses_map_to_string_instead_of_raw_list(self):
+        lane = _make_lane_for_get_status(["T10", "T2", "T0"])
+        lane.td1_data = {"td": "", "color": "", "scan_time": ""}
+        response = lane.get_status(save_to_file=True)
+        assert response["map"] == "T0, T2, T10"
+
+
 class TestAFCLaneIndexProperty:
     def test_lane_index_property_map_none(self):
         lane = _make_afc_lane()
-        lane.map = None
+        lane.current_map = None
         assert lane.lane_index == ""
-    
+
     def test_lane_index_property_map_set(self):
         lane = _make_afc_lane()
-        lane.map = "T5"
+        lane.current_map = "T5"
         assert lane.lane_index == "5"
-    
+
     def test_lane_index_property_is_str(self):
         lane = _make_afc_lane()
-        lane.map = "T5"
+        lane.current_map = "T5"
         assert isinstance(lane.lane_index, str)
 
 class TestAFCLaneExtruderIndexProperty:
@@ -1472,7 +1571,7 @@ class TestIsNormalPrintingState:
 def _make_lane_for_moonraker(extruder_name="extruder", map_value="T0"):
     """Build a minimal AFCLane wired up for send/clear lane data tests."""
     lane = _make_afc_lane("AFC_stepper lane1")
-    lane.map = map_value
+    lane.current_map = map_value
     lane.extruder_obj = MagicMock()
     lane.extruder_obj.th_extruder_name = lane.extruder_obj.name = extruder_name
     lane.color = "#FF0000"
@@ -1535,13 +1634,13 @@ class TestSendLaneDataExtruderIndex:
 
     def test_no_send_when_map_is_none(self):
         lane = _make_lane_for_moonraker()
-        lane.map = None
+        lane.current_map = None
         lane.send_lane_data()
         lane.afc.moonraker.send_lane_data.assert_not_called()
 
     def test_no_send_when_map_has_no_T(self):
         lane = _make_lane_for_moonraker()
-        lane.map = "0"
+        lane.current_map = "0"
         lane.send_lane_data()
         lane.afc.moonraker.send_lane_data.assert_not_called()
 
@@ -1585,7 +1684,7 @@ class TestClearLaneDataExtruderIndex:
 
     def test_no_clear_when_map_is_none(self):
         lane = _make_lane_for_moonraker()
-        lane.map = None
+        lane.current_map = None
         lane.clear_lane_data()
         lane.afc.moonraker.send_lane_data.assert_not_called()
 
@@ -2541,7 +2640,7 @@ class TestPerformInfiniteRunout:
         afc.error.pause_resume.send_pause_command.assert_called_once()
         afc.save_pos.assert_called_once()
         afc.CHANGE_TOOL.assert_called_with(lane2, restore_pos=False)
-        lane.gcode.run_script_from_command.assert_called_with(f"SET_MAP LANE={lane2.name} MAP={lane.map}")
+        lane.gcode.run_script_from_command.assert_called_with(f"AFC_SWAP_MAPPING FROM={lane.name} TO={lane2.name}")
         afc.restore_pos.assert_called_once()
         afc.error.pause_resume.send_resume_command.assert_called_once()
         lane.unit_obj.lane_not_ready.assert_called_with(lane)

--- a/tests/test_AFC_spool.py
+++ b/tests/test_AFC_spool.py
@@ -315,6 +315,26 @@ class TestSetMap:
 # ── cmd_AFC_SWAP_MAPPING ────────────────────────────────────────────────────────
 
 class TestAfcSwapMapping:
+    def test_from_equals_to_raises_and_does_not_swap(self):
+        spool = _make_spool()
+        lane1 = _make_lane("lane1")
+        lane1.map = ["T0"]
+        lane1.current_map = "T0"
+        spool.afc.lanes = {"lane1": lane1}
+        gcmd = _make_gcmd(FROM="lane1", TO="lane1")
+        with pytest.raises(Exception, match=r"FROM\(lane1\) TO\(lane1\) values are the same, not swapping\."):
+            spool.cmd_AFC_SWAP_MAPPING(gcmd)
+        assert lane1.map == ["T0"]
+        assert lane1.current_map == "T0"
+
+    def test_from_equals_to_case_insensitive_raises(self):
+        spool = _make_spool()
+        lane1 = _make_lane("lane1")
+        spool.afc.lanes = {"lane1": lane1}
+        gcmd = _make_gcmd(FROM="Lane1", TO="lane1")
+        with pytest.raises(Exception, match=r"FROM\(Lane1\) TO\(lane1\) values are the same, not swapping\."):
+            spool.cmd_AFC_SWAP_MAPPING(gcmd)
+
     def test_from_lane_not_found_raises(self):
         spool = _make_spool()
         spool.afc.lanes = {"lane2": _make_lane("lane2")}
@@ -629,6 +649,22 @@ class TestAfcEnableMultipleMapping:
         gcmd = _make_gcmd()
         spool.cmd_AFC_ENABLE_MULTIPLE_MAPPING(gcmd)
         assert spool.enable_multiple_mapping is False
+
+    def test_disable_resets_mapping(self):
+        spool = _make_spool()
+        spool.enable_multiple_mapping = True
+        spool._reset_mapping = MagicMock()
+        gcmd = _make_gcmd(ENABLE=0)
+        spool.cmd_AFC_ENABLE_MULTIPLE_MAPPING(gcmd)
+        spool._reset_mapping.assert_called_once_with()
+
+    def test_enable_does_not_reset_mapping(self):
+        spool = _make_spool()
+        spool.enable_multiple_mapping = False
+        spool._reset_mapping = MagicMock()
+        gcmd = _make_gcmd(ENABLE=1)
+        spool.cmd_AFC_ENABLE_MULTIPLE_MAPPING(gcmd)
+        spool._reset_mapping.assert_not_called()
 
 
 # ── register_commands ─────────────────────────────────────────────────────────

--- a/tests/test_AFC_spool.py
+++ b/tests/test_AFC_spool.py
@@ -7,7 +7,7 @@ Covers:
   - cmd_SET_COLOR / cmd_SET_MATERIAL / cmd_SET_WEIGHT: attribute updates
   - cmd_SET_SPOOL_ID: spoolman interaction
   - cmd_SET_RUNOUT: runout lane assignment
-  - cmd_RESET_AFC_MAPPING: clears mappings
+  - cmd_AFC_RESET_MAPPING: clears mappings
 """
 
 from __future__ import annotations
@@ -435,7 +435,7 @@ class TestAfcAddMapping:
         spool = _make_spool()
         spool.enable_multiple_mapping = False
         gcmd = _make_gcmd(LANE="lane1", MAPPING="T1")
-        with pytest.raises(Exception, match="enable multiple mapping needs to be enabled"):
+        with pytest.raises(Exception, match="Enable multiple mapping needs to be enabled"):
             spool.cmd_AFC_ADD_MAPPING(gcmd)
 
     def test_raises_when_lane_not_found(self):
@@ -525,7 +525,7 @@ class TestAfcRemoveMapping:
         spool = _make_spool()
         spool.enable_multiple_mapping = False
         gcmd = _make_gcmd(MAPPING="T1")
-        with pytest.raises(Exception, match="enable multiple mapping needs to be enabled"):
+        with pytest.raises(Exception, match="Enable multiple mapping needs to be enabled"):
             spool.cmd_AFC_REMOVE_MAPPING(gcmd)
 
     def test_removes_existing_mapping(self):
@@ -1020,7 +1020,7 @@ class TestSetRunout:
         assert spool.logger.messages == [("error", "Unknown runout lane: no_such_lane")]
 
 
-# ── cmd_RESET_AFC_MAPPING ─────────────────────────────────────────────────────
+# ── cmd_AFC_RESET_MAPPING ─────────────────────────────────────────────────────
 
 class TestResetAFCMapping:
     def _make_reset_gcmd(self, runout="yes"):
@@ -1040,7 +1040,7 @@ class TestResetAFCMapping:
         spool.afc.lanes = {"lane1": lane1}
         spool.afc.units = {}  # no units, loop skips mapping reassignment
         gcmd = self._make_reset_gcmd()
-        spool.cmd_RESET_AFC_MAPPING(gcmd)
+        spool.cmd_AFC_RESET_MAPPING(gcmd)
         spool.afc.save_vars.assert_called()
 
     def test_reset_clears_runout_lanes(self):
@@ -1050,7 +1050,7 @@ class TestResetAFCMapping:
         spool.afc.lanes = {"lane1": lane1}
         spool.afc.units = {}
         gcmd = self._make_reset_gcmd(runout="yes")
-        spool.cmd_RESET_AFC_MAPPING(gcmd)
+        spool.cmd_AFC_RESET_MAPPING(gcmd)
         assert lane1.runout_lane is None
 
     def test_reset_skips_runout_when_no(self):
@@ -1060,7 +1060,7 @@ class TestResetAFCMapping:
         spool.afc.lanes = {"lane1": lane1}
         spool.afc.units = {}
         gcmd = self._make_reset_gcmd(runout="no")
-        spool.cmd_RESET_AFC_MAPPING(gcmd)
+        spool.cmd_AFC_RESET_MAPPING(gcmd)
         assert lane1.runout_lane == "lane2"  # not cleared
 
     def test_reset_reassigns_map_without_manual_mapping(self):
@@ -1077,7 +1077,7 @@ class TestResetAFCMapping:
         unit.lanes = {"lane1": unit_lane}
         spool.afc.units = {"unit_1": unit}
         gcmd = self._make_reset_gcmd()
-        spool.cmd_RESET_AFC_MAPPING(gcmd)
+        spool.cmd_AFC_RESET_MAPPING(gcmd)
         # tool_cmds and the unit's lane.current_map must have been updated
         assert spool.afc.tool_cmds.get("T0") == "lane1"
         assert unit_lane.current_map == "T0"
@@ -1096,7 +1096,7 @@ class TestResetAFCMapping:
         spool.afc.lanes = {"lane1": lane1, "lane2": lane2}
         spool.afc.units = {}  # isolates existing_cmds construction/sort from the reassignment loop
         gcmd = self._make_reset_gcmd()
-        spool.cmd_RESET_AFC_MAPPING(gcmd)
+        spool.cmd_AFC_RESET_MAPPING(gcmd)
         info_msgs = [m for lvl, m in spool.logger.messages if lvl == "info"]
         # "T0" is never consumed since afc.units is empty, so it also shows
         # up in the leftover-mappings cleanup message, which now logs before
@@ -1120,7 +1120,7 @@ class TestResetAFCMapping:
         unit.lanes = {"lane1": unit_lane}
         spool.afc.units = {"unit_1": unit}
         gcmd = self._make_reset_gcmd()
-        spool.cmd_RESET_AFC_MAPPING(gcmd)
+        spool.cmd_AFC_RESET_MAPPING(gcmd)
         # The manually assigned T0 should be applied
         assert spool.afc.tool_cmds.get("T0") == "lane1"
 
@@ -1138,7 +1138,7 @@ class TestResetAFCMapping:
         unit.lanes = {"lane3": lane3, "lane4": lane4}
         spool.afc.units = {"unit2": unit}
         gcmd = self._make_reset_gcmd()
-        spool.cmd_RESET_AFC_MAPPING(gcmd)
+        spool.cmd_AFC_RESET_MAPPING(gcmd)
         assert spool.afc.tool_cmds.get("T0") == "lane3"
         assert spool.afc.tool_cmds.get("T1") == "lane4"
         assert lane3.current_map == "T0"
@@ -1160,7 +1160,7 @@ class TestResetAFCMapping:
         unit.lanes = {"lane1": lane1, "lane2": lane2}
         spool.afc.units = {"unit1": unit}
         gcmd = self._make_reset_gcmd()
-        spool.cmd_RESET_AFC_MAPPING(gcmd)
+        spool.cmd_AFC_RESET_MAPPING(gcmd)
         assert spool.afc.tool_cmds.get("T1") == "lane2"
         spool.function.register_tool_macro.assert_called_once_with("lane2", "T1")
 
@@ -1176,7 +1176,7 @@ class TestResetAFCMapping:
         unit.lanes = {"lane1": lane1}
         spool.afc.units = {"unit1": unit}
         gcmd = self._make_reset_gcmd()
-        spool.cmd_RESET_AFC_MAPPING(gcmd)
+        spool.cmd_AFC_RESET_MAPPING(gcmd)
         spool.function.register_tool_macro.assert_not_called()
 
     def test_reset_registers_newly_manually_assigned_command(self):
@@ -1191,7 +1191,7 @@ class TestResetAFCMapping:
         unit.lanes = {"lane1": lane1}
         spool.afc.units = {"unit1": unit}
         gcmd = self._make_reset_gcmd()
-        spool.cmd_RESET_AFC_MAPPING(gcmd)
+        spool.cmd_AFC_RESET_MAPPING(gcmd)
         assert spool.afc.tool_cmds.get("T7") == "lane1"
         spool.function.register_tool_macro.assert_called_once_with("lane1", "T7")
 
@@ -1208,7 +1208,7 @@ class TestResetAFCMapping:
         unit.lanes = {"lane1": lane1, "lane2": lane2, "lane3": lane3}
         spool.afc.units = {"unit1": unit}
         gcmd = self._make_reset_gcmd()
-        spool.cmd_RESET_AFC_MAPPING(gcmd)
+        spool.cmd_AFC_RESET_MAPPING(gcmd)
         assert spool.afc.tool_cmds.get("T0") == "lane1"
         assert spool.afc.tool_cmds.get("T1") == "lane2"
         assert spool.afc.tool_cmds.get("T2") == "lane3"
@@ -1224,7 +1224,7 @@ class TestResetAFCMapping:
         unit.lanes = {"lane1": lane1}
         spool.afc.units = {"unit1": unit}
         gcmd = self._make_reset_gcmd()
-        spool.cmd_RESET_AFC_MAPPING(gcmd)
+        spool.cmd_AFC_RESET_MAPPING(gcmd)
         assert lane1.map == ["T0"]
         assert spool.gcode._commands.get("T5") is None and "T5" in spool.gcode._commands
         assert "T5" not in spool.afc.tool_cmds
@@ -1295,7 +1295,7 @@ class TestHandleConnect:
         spool = AFCSpool(config)
         spool.register_commands(afc)
         spool.handle_connect()
-        assert "RESET_AFC_MAPPING" in afc.gcode._commands
+        assert "AFC_RESET_MAPPING" in afc.gcode._commands
         assert "SET_NEXT_SPOOL_ID" in afc.gcode._commands
 
 

--- a/tests/test_AFC_spool.py
+++ b/tests/test_AFC_spool.py
@@ -1063,10 +1063,12 @@ class TestResetAFCMapping:
         spool.cmd_RESET_AFC_MAPPING(gcmd)
         info_msgs = [m for lvl, m in spool.logger.messages if lvl == "info"]
         # "T0" is never consumed since afc.units is empty, so it also shows
-        # up in the trailing "leftover mappings" cleanup message.
+        # up in the leftover-mappings cleanup message, which now logs before
+        # the final "reset" message since it must run before the
+        # send_lane_data() pass for tool_cmds to be fully consistent.
         assert info_msgs == [
-            "Tool mappings reset and runout lanes reset",
             "T0 remain, removing these mappings",
+            "Tool mappings reset and runout lanes reset",
         ]
 
     def test_reset_uses_manual_map_when_set(self):
@@ -1085,6 +1087,111 @@ class TestResetAFCMapping:
         spool.cmd_RESET_AFC_MAPPING(gcmd)
         # The manually assigned T0 should be applied
         assert spool.afc.tool_cmds.get("T0") == "lane1"
+
+    def test_reset_renumbers_sequentially_after_unit_removed(self):
+        """Simulates a unit having been removed: the 2 remaining lanes still
+        carry their old (now-gapped) T4/T5 numbers from when more lanes
+        existed. Reset must renumber them down to a clean T0/T1 sequence
+        instead of recycling the old high numbers, and unregister the old
+        numbers since no lane claims them anymore."""
+        spool = _make_spool()
+        lane3 = self._make_lane_for_reset("lane3", "T4")
+        lane4 = self._make_lane_for_reset("lane4", "T5")
+        spool.afc.lanes = {"lane3": lane3, "lane4": lane4}
+        unit = MagicMock()
+        unit.lanes = {"lane3": lane3, "lane4": lane4}
+        spool.afc.units = {"unit2": unit}
+        gcmd = self._make_reset_gcmd()
+        spool.cmd_RESET_AFC_MAPPING(gcmd)
+        assert spool.afc.tool_cmds.get("T0") == "lane3"
+        assert spool.afc.tool_cmds.get("T1") == "lane4"
+        assert lane3.current_map == "T0"
+        assert lane4.current_map == "T1"
+        assert spool.gcode._commands.get("T4") is None and "T4" in spool.gcode._commands
+        assert spool.gcode._commands.get("T5") is None and "T5" in spool.gcode._commands
+        assert "T4" not in spool.afc.tool_cmds
+        assert "T5" not in spool.afc.tool_cmds
+
+    def test_reset_registers_newly_assigned_auto_command(self):
+        """A unit was added, so this lane's auto-assigned number (T1) was
+        never in use before and has no gcode handler registered yet."""
+        spool = _make_spool()
+        lane1 = self._make_lane_for_reset("lane1", "T0")
+        lane2 = self._make_lane_for_reset("lane2", "NONE")
+        lane2.map = []
+        spool.afc.lanes = {"lane1": lane1, "lane2": lane2}
+        unit = MagicMock()
+        unit.lanes = {"lane1": lane1, "lane2": lane2}
+        spool.afc.units = {"unit1": unit}
+        gcmd = self._make_reset_gcmd()
+        spool.cmd_RESET_AFC_MAPPING(gcmd)
+        assert spool.afc.tool_cmds.get("T1") == "lane2"
+        spool.function.register_tool_macro.assert_called_once_with("lane2", "T1")
+
+    def test_reset_does_not_reregister_command_already_in_use(self):
+        """Covers the `map_cmd not in previously_used_cmds` condition being
+        falsy on its own: a command that already existed before the reset
+        (recycled onto the same or a different lane) must not be
+        re-registered -- proven independently of the newly-added case above."""
+        spool = _make_spool()
+        lane1 = self._make_lane_for_reset("lane1", "T0")
+        spool.afc.lanes = {"lane1": lane1}
+        unit = MagicMock()
+        unit.lanes = {"lane1": lane1}
+        spool.afc.units = {"unit1": unit}
+        gcmd = self._make_reset_gcmd()
+        spool.cmd_RESET_AFC_MAPPING(gcmd)
+        spool.function.register_tool_macro.assert_not_called()
+
+    def test_reset_registers_newly_manually_assigned_command(self):
+        """A manual mapping (config `map:` value) that's never been used
+        before also needs registering, not just auto-assigned ones."""
+        spool = _make_spool()
+        lane1 = self._make_lane_for_reset("lane1", "NONE")
+        lane1.map = []
+        lane1._map = ["T7"]
+        spool.afc.lanes = {"lane1": lane1}
+        unit = MagicMock()
+        unit.lanes = {"lane1": lane1}
+        spool.afc.units = {"unit1": unit}
+        gcmd = self._make_reset_gcmd()
+        spool.cmd_RESET_AFC_MAPPING(gcmd)
+        assert spool.afc.tool_cmds.get("T7") == "lane1"
+        spool.function.register_tool_macro.assert_called_once_with("lane1", "T7")
+
+    def test_reset_skips_manually_assigned_number_for_auto_lanes(self):
+        """A manual mapping in the middle of the sequence (T1) must not be
+        reused by an auto-assigned lane -- the auto lanes get T0 and T2."""
+        spool = _make_spool()
+        lane1 = self._make_lane_for_reset("lane1", "T0")
+        lane2 = self._make_lane_for_reset("lane2", "T1")
+        lane2._map = ["T1"]  # manually assigned
+        lane3 = self._make_lane_for_reset("lane3", "T2")
+        spool.afc.lanes = {"lane1": lane1, "lane2": lane2, "lane3": lane3}
+        unit = MagicMock()
+        unit.lanes = {"lane1": lane1, "lane2": lane2, "lane3": lane3}
+        spool.afc.units = {"unit1": unit}
+        gcmd = self._make_reset_gcmd()
+        spool.cmd_RESET_AFC_MAPPING(gcmd)
+        assert spool.afc.tool_cmds.get("T0") == "lane1"
+        assert spool.afc.tool_cmds.get("T1") == "lane2"
+        assert spool.afc.tool_cmds.get("T2") == "lane3"
+
+    def test_reset_removes_multimapping_virtual_tool_extras(self):
+        """A lane with 2 T(n)'s mapped (multimapping) collapses back to 1 on
+        reset; the extra T(n) no longer assigned to any lane is removed."""
+        spool = _make_spool()
+        lane1 = self._make_lane_for_reset("lane1", "T0")
+        lane1.map = ["T0", "T5"]  # T5 is a virtual-tool extra
+        spool.afc.lanes = {"lane1": lane1}
+        unit = MagicMock()
+        unit.lanes = {"lane1": lane1}
+        spool.afc.units = {"unit1": unit}
+        gcmd = self._make_reset_gcmd()
+        spool.cmd_RESET_AFC_MAPPING(gcmd)
+        assert lane1.map == ["T0"]
+        assert spool.gcode._commands.get("T5") is None and "T5" in spool.gcode._commands
+        assert "T5" not in spool.afc.tool_cmds
 
 
 # ── cmd_SET_NEXT_SPOOL_ID ─────────────────────────────────────────────────────

--- a/tests/test_AFC_spool.py
+++ b/tests/test_AFC_spool.py
@@ -1353,6 +1353,9 @@ class TestSetSpoolID:
         return spool
 
     def test_no_spoolman_not_remember_spool_clears_values(self):
+        """Covers the `spoolman is not None` half of the combined condition
+        being falsy on its own -- _make_spool()'s afc.moonraker defaults to
+        set, so this proves moonraker alone isn't enough either."""
         spool = _make_spool()
         lane = _make_lane()
         lane.remember_spool = False
@@ -1367,6 +1370,18 @@ class TestSetSpoolID:
         spool.clear_values = MagicMock()
         spool.set_spoolID(lane, "")
         spool.clear_values.assert_not_called()
+
+    def test_spoolman_set_but_no_moonraker_clears_values(self):
+        """Covers the `moonraker is not None` half of the combined condition
+        being falsy on its own, with spoolman still set -- proves spoolman
+        alone isn't enough to enter the lookup branch."""
+        spool = self._make_spool_with_spoolman()
+        spool.afc.moonraker = None
+        lane = _make_lane()
+        lane.remember_spool = False
+        spool.clear_values = MagicMock()
+        spool.set_spoolID(lane, "42")
+        spool.clear_values.assert_called_once_with(lane)
 
     def test_valid_spool_id_sets_lane_attributes(self):
         spool = self._make_spool_with_spoolman()

--- a/tests/test_AFC_spool.py
+++ b/tests/test_AFC_spool.py
@@ -15,16 +15,14 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 import pytest
 
-from extras.AFC_spool import AFCSpool
+from extras.AFC_spool import AFCSpool, load_config
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 def _make_spool():
-    """Build an AFCSpool instance bypassing __init__."""
-    spool = AFCSpool.__new__(AFCSpool)
-
-    from tests.conftest import MockAFC, MockPrinter, MockLogger, MockGcode
+    """Build an AFCSpool instance through the real __init__."""
+    from tests.conftest import MockAFC, MockConfig, MockPrinter, MockLogger, MockGcode
 
     afc = MockAFC()
     printer = MockPrinter(afc=afc)
@@ -36,15 +34,17 @@ def _make_spool():
     afc.lanes = {}
     afc.units = {}
 
-    spool.printer = printer
+    config = MockConfig(name="AFC_Spool", printer=printer)
+    spool = AFCSpool(config)
+
     spool.afc = afc
     spool.error = afc.error
     spool.reactor = afc.reactor
     spool.gcode = afc.gcode
     spool.logger = afc.logger
     spool.disable_weight_check = False
-    spool.next_spool_id = None
-    spool.SPOOLMAN_REMOTE_METHOD = 'spoolman_set_active_spool'
+    spool.enable_multiple_mapping = afc.enable_multiple_mapping
+    spool.function = afc.function
 
     return spool
 
@@ -52,7 +52,9 @@ def _make_spool():
 def _make_lane(name="lane1", extruder_name="extruder", extruder_index=0):
     lane = MagicMock()
     lane.name = name
-    lane.map = None
+    lane.map = []
+    lane._map = []
+    lane.current_map = None
     lane.color = ""
     lane.material = ""
     lane.weight = 0
@@ -68,18 +70,52 @@ def _make_lane(name="lane1", extruder_name="extruder", extruder_index=0):
 
 
 def _make_gcmd(**kwargs):
-    """Build a gcmd mock that returns values from kwargs."""
-    gcmd = MagicMock()
-    gcmd.get = lambda key, default=None: kwargs.get(key, default)
-    def _get_float(key, default=0.0, **kw):
-        val = kwargs.get(key, default)
-        return float(val) if val is not None else None
-    gcmd.get_float = _get_float
-    def _get_int(key, default=0, **kw):
-        val = kwargs.get(key, default)
-        return int(val) if val is not None else None
-    gcmd.get_int = _get_int
-    return gcmd
+    """Build a gcmd mock that returns values from kwargs.
+
+    Backed by MockGCodeCommand, so a key with no default supplied by the
+    caller under test (e.g. gcmd.get('LANE') with no second argument) raises
+    gcmd.error(...) exactly like real Klipper -- it does not silently
+    return None the way a lambda-based mock would.
+    """
+    from tests.conftest import MockGCodeCommand
+    return MockGCodeCommand(params=kwargs)
+
+
+# ── __init__ ─────────────────────────────────────────────────────────────────
+
+class TestAFCSpoolInit:
+    def _make_config(self):
+        from tests.conftest import MockAFC, MockConfig, MockPrinter
+
+        afc = MockAFC()
+        printer = MockPrinter(afc=afc)
+        config = MockConfig(name="AFC_Spool", printer=printer)
+        return config, printer
+
+    def test_stores_printer_from_config(self):
+        config, printer = self._make_config()
+        spool = AFCSpool(config)
+        assert spool.printer is printer
+
+    def test_sets_spoolman_remote_method(self):
+        config, _ = self._make_config()
+        spool = AFCSpool(config)
+        assert spool.SPOOLMAN_REMOTE_METHOD == "spoolman_set_active_spool"
+
+    def test_print_task_config_obj_starts_none(self):
+        config, _ = self._make_config()
+        spool = AFCSpool(config)
+        assert spool.print_task_config_obj is None
+
+    def test_next_spool_id_starts_none(self):
+        config, _ = self._make_config()
+        spool = AFCSpool(config)
+        assert spool.next_spool_id is None
+
+    def test_registers_klippy_connect_handler_to_handle_connect(self):
+        config, printer = self._make_config()
+        spool = AFCSpool(config)
+        assert printer._event_handlers["klippy:connect"] == [spool.handle_connect]
 
 
 # ── cmd_SET_MAP ────────────────────────────────────────────────────────────────
@@ -88,50 +124,565 @@ class TestSetMap:
     def test_set_map_assigns_lane_mapping(self):
         spool = _make_spool()
         lane1 = _make_lane("lane1")
+        lane1.map = ["T1"]
+        lane1.current_map = "T1"
         lane2 = _make_lane("lane2")
-        lane2.map = "T0"
+        lane2.map = ["T0"]
+        lane2.current_map = "T0"
         # T0 is currently mapped to lane2; we want to remap it to lane1
         spool.afc.tool_cmds = {"T0": "lane2"}
         spool.afc.lanes = {"lane1": lane1, "lane2": lane2}
         gcmd = _make_gcmd(LANE="lane1", MAP="T0")
         spool.cmd_SET_MAP(gcmd)
-        assert lane1.map == "T0"
+        assert lane1.current_map == "T0"
         assert spool.afc.tool_cmds.get("T0") == "lane1"
+        assert lane2.map == ["T1"]
+        assert spool.afc.tool_cmds.get("T1") == "lane2"
 
     def test_set_map_invalid_lane_logs_error(self):
         spool = _make_spool()
         spool.afc.lanes = {}
         gcmd = _make_gcmd(LANE="nonexistent", MAP="T1")
         spool.cmd_SET_MAP(gcmd)
-        # Should log an error about invalid lane
-        error_msgs = [m for lvl, m in spool.logger.messages if lvl == "error"]
-        assert len(error_msgs) > 0
+        assert spool.logger.messages == [("error", "Invalid map command: T1")]
 
-    def test_no_lane_param_logs_info(self):
-        """Covers lines 66-68: lane is None → log info + return."""
+    def test_no_lane_param_raises(self):
+        """No default is passed to gcmd.get('LANE'), so a missing LANE
+        parameter is expected to raise via Klipper's own required-parameter
+        handling, not a hand-rolled None check."""
         spool = _make_spool()
-        gcmd = _make_gcmd()  # no LANE key → returns None
-        spool.cmd_SET_MAP(gcmd)
-        info_msgs = [m for lvl, m in spool.logger.messages if lvl == "info"]
-        assert any("LANE" in m for m in info_msgs)
+        gcmd = _make_gcmd(MAP="T0")  # no LANE key
+        with pytest.raises(Exception, match="missing LANE"):
+            spool.cmd_SET_MAP(gcmd)
 
-    def test_no_map_param_logs_info(self):
-        """Covers lines 72-74: map_cmd is None → log info + return."""
+    def test_no_map_param_raises(self):
+        """Same as above, for the MAP parameter."""
         spool = _make_spool()
-        gcmd = _make_gcmd(LANE="lane1")  # no MAP key → returns None
+        gcmd = _make_gcmd(LANE="lane1")  # no MAP key
+        with pytest.raises(Exception, match="missing MAP"):
+            spool.cmd_SET_MAP(gcmd)
+
+    def test_map_already_assigned_to_lane_logs_info_and_returns(self):
+        """MAP already resolves to the requested lane (sw_lane is cur_lane)
+        -> logs info and returns without touching any state."""
+        spool = _make_spool()
+        lane1 = _make_lane("lane1")
+        lane1.map = ["T0"]
+        lane1.current_map = "T0"
+        spool.afc.lanes = {"lane1": lane1}
+        spool.afc.tool_cmds = {"T0": "lane1"}
+        gcmd = _make_gcmd(LANE="lane1", MAP="T0")
         spool.cmd_SET_MAP(gcmd)
-        info_msgs = [m for lvl, m in spool.logger.messages if lvl == "info"]
-        assert any("MAP" in m for m in info_msgs)
+        assert spool.logger.messages == [
+            ("debug", "lane to switch is lane1"),
+            ("info", "T0 is already mapped to lane1"),
+        ]
+        assert lane1.map == ["T0"]
+
+    def test_single_mapping_swap_leaves_sw_lane_current_map_empty_when_map_empty(self):
+        """sw_lane.map[0] if sw_lane.map else "" -- covers the falsy branch:
+        cur_lane.map is empty, so after the swap sw_lane.map is also empty
+        and current_map must fall back to ""."""
+        spool = _make_spool()
+        lane1 = _make_lane("lane1")
+        lane1.map = []
+        lane1.current_map = ""
+        lane2 = _make_lane("lane2")
+        lane2.map = ["T0"]
+        lane2.current_map = "T0"
+        spool.afc.lanes = {"lane1": lane1, "lane2": lane2}
+        spool.afc.tool_cmds = {"T0": "lane2"}
+        gcmd = _make_gcmd(LANE="lane1", MAP="T0")
+        spool.cmd_SET_MAP(gcmd)
+        assert lane2.map == []
+        assert lane2.current_map == ""
+
+    def test_single_mapping_swap_skips_none_placeholder_in_tool_cmds(self):
+        """Covers the "NONE" continue branch in both tool_cmds rebuild loops
+        for the enable_multiple_mapping=False path."""
+        spool = _make_spool()
+        lane1 = _make_lane("lane1")
+        lane1.map = ["NONE"]
+        lane1.current_map = None
+        lane2 = _make_lane("lane2")
+        lane2.map = ["T0"]
+        lane2.current_map = "T0"
+        spool.afc.lanes = {"lane1": lane1, "lane2": lane2}
+        spool.afc.tool_cmds = {"T0": "lane2"}
+        gcmd = _make_gcmd(LANE="lane1", MAP="T0")
+        spool.cmd_SET_MAP(gcmd)
+        assert "NONE" not in spool.afc.tool_cmds
+        assert spool.afc.tool_cmds["T0"] == "lane1"
 
     def test_lane_not_in_lanes_with_valid_tool_cmd_logs_info(self):
-        """Covers lines 84-86: MAP in tool_cmds, lane not in lanes → log info + return."""
+        """MAP in tool_cmds, lane not in lanes → log info + return."""
         spool = _make_spool()
         spool.afc.tool_cmds = {"T0": "lane2"}
         spool.afc.lanes = {}  # lane1 not present
         gcmd = _make_gcmd(LANE="lane1", MAP="T0")
         spool.cmd_SET_MAP(gcmd)
-        info_msgs = [m for lvl, m in spool.logger.messages if lvl == "info"]
-        assert any("lane1" in m for m in info_msgs)
+        assert spool.logger.messages == [
+            ("debug", "lane to switch is lane2"),
+            ("info", "lane1 Unknown"),
+        ]
+
+    def test_switch_lane_missing_logs_info_and_returns(self):
+        """tool_cmds points MAP at a lane name that isn't in afc.lanes (e.g.
+        stale save data) -> logs info and returns without touching state."""
+        spool = _make_spool()
+        lane1 = _make_lane("lane1")
+        spool.afc.tool_cmds = {"T0": "ghost_lane"}
+        spool.afc.lanes = {"lane1": lane1}
+        gcmd = _make_gcmd(LANE="lane1", MAP="T0")
+        spool.cmd_SET_MAP(gcmd)
+        assert spool.logger.messages == [
+            ("debug", "lane to switch is ghost_lane"),
+            ("info", "ghost_lane is not found when swapping mapping."),
+        ]
+        # Nothing was mutated -- tool_cmds still points at the stale lane
+        assert spool.afc.tool_cmds["T0"] == "ghost_lane"
+        assert lane1.map == []
+
+    def test_multiple_mapping_moves_single_map_cmd_between_lanes(self):
+        """enable_multiple_mapping=True: MAP is popped out of sw_lane's list
+        and appended to cur_lane's list, rather than swapping the full list
+        (the enable_multiple_mapping=False behavior covered above)."""
+        spool = _make_spool()
+        spool.enable_multiple_mapping = True
+        lane1 = _make_lane("lane1")
+        lane1.map = ["T2"]
+        lane2 = _make_lane("lane2")
+        lane2.map = ["T0", "T1"]
+        lane2.current_map = "T1"
+        spool.afc.tool_cmds = {"T0": "lane2", "T1": "lane2"}
+        spool.afc.lanes = {"lane1": lane1, "lane2": lane2}
+        gcmd = _make_gcmd(LANE="lane1", MAP="T0")
+        spool.cmd_SET_MAP(gcmd)
+        # Only T0 moved -- T1 (sw_lane's other mapping) is untouched
+        assert lane2.map == ["T1"]
+        assert lane1.map == ["T2", "T0"]
+        assert spool.afc.tool_cmds["T0"] == "lane1"
+
+    def test_multiple_mapping_clears_sw_lane_current_map_when_it_matches(self):
+        """sw_lane.current_map == map_cmd -> cleared, since the tool that was
+        actively loaded on sw_lane is the one being moved away."""
+        spool = _make_spool()
+        spool.enable_multiple_mapping = True
+        lane1 = _make_lane("lane1")
+        lane1.map = []
+        lane2 = _make_lane("lane2")
+        lane2.map = ["T0"]
+        lane2.current_map = "T0"
+        spool.afc.tool_cmds = {"T0": "lane2"}
+        spool.afc.lanes = {"lane1": lane1, "lane2": lane2}
+        gcmd = _make_gcmd(LANE="lane1", MAP="T0")
+        spool.cmd_SET_MAP(gcmd)
+        assert lane2.current_map == ""
+
+    def test_multiple_mapping_leaves_sw_lane_current_map_when_it_differs(self):
+        """sw_lane.current_map != map_cmd -> left untouched (the tool being
+        moved away wasn't the one actively loaded on sw_lane)."""
+        spool = _make_spool()
+        spool.enable_multiple_mapping = True
+        lane1 = _make_lane("lane1")
+        lane1.map = []
+        lane2 = _make_lane("lane2")
+        lane2.map = ["T0", "T1"]
+        lane2.current_map = "T1"
+        spool.afc.tool_cmds = {"T0": "lane2", "T1": "lane2"}
+        spool.afc.lanes = {"lane1": lane1, "lane2": lane2}
+        gcmd = _make_gcmd(LANE="lane1", MAP="T0")
+        spool.cmd_SET_MAP(gcmd)
+        assert lane2.current_map == "T1"
+
+    def test_multiple_mapping_filters_none_placeholder_from_cur_lane(self):
+        """cur_lane starting with the "NONE" placeholder must lose it once a
+        real mapping is added, rather than keeping ["NONE", "T0"]."""
+        spool = _make_spool()
+        spool.enable_multiple_mapping = True
+        lane1 = _make_lane("lane1")
+        lane1.map = ["NONE"]
+        lane2 = _make_lane("lane2")
+        lane2.map = ["T0"]
+        lane2.current_map = "T0"
+        spool.afc.tool_cmds = {"T0": "lane2"}
+        spool.afc.lanes = {"lane1": lane1, "lane2": lane2}
+        gcmd = _make_gcmd(LANE="lane1", MAP="T0")
+        spool.cmd_SET_MAP(gcmd)
+        assert lane1.map == ["T0"]
+
+
+# ── cmd_AFC_SWAP_MAPPING ────────────────────────────────────────────────────────
+
+class TestAfcSwapMapping:
+    def test_from_lane_not_found_raises(self):
+        spool = _make_spool()
+        spool.afc.lanes = {"lane2": _make_lane("lane2")}
+        gcmd = _make_gcmd(FROM="lane1", TO="lane2")
+        with pytest.raises(Exception, match="Swapping from lane1 not found"):
+            spool.cmd_AFC_SWAP_MAPPING(gcmd)
+
+    def test_to_lane_not_found_raises(self):
+        spool = _make_spool()
+        spool.afc.lanes = {"lane1": _make_lane("lane1")}
+        gcmd = _make_gcmd(FROM="lane1", TO="lane2")
+        with pytest.raises(Exception, match="Swapping to lane2 not found"):
+            spool.cmd_AFC_SWAP_MAPPING(gcmd)
+
+    def test_swap_exchanges_map_and_current_map(self):
+        spool = _make_spool()
+        lane1 = _make_lane("lane1")
+        lane1.map = ["T0"]
+        lane1.current_map = "T0"
+        lane2 = _make_lane("lane2")
+        lane2.map = ["T1", "T2"]
+        lane2.current_map = "T1"
+        spool.afc.lanes = {"lane1": lane1, "lane2": lane2}
+        gcmd = _make_gcmd(FROM="lane1", TO="lane2")
+        spool.cmd_AFC_SWAP_MAPPING(gcmd)
+        assert lane1.map == ["T1", "T2"]
+        assert lane1.current_map == "T1"
+        assert lane2.map == ["T0"]
+        assert lane2.current_map == "T0"
+
+    def test_swap_updates_tool_cmds_to_lane_names(self):
+        spool = _make_spool()
+        lane1 = _make_lane("lane1")
+        lane1.map = ["T0"]
+        lane1.current_map = "T0"
+        lane2 = _make_lane("lane2")
+        lane2.map = ["T1", "T2"]
+        lane2.current_map = "T1"
+        spool.afc.lanes = {"lane1": lane1, "lane2": lane2}
+        spool.afc.tool_cmds = {"T0": "lane1", "T1": "lane2", "T2": "lane2"}
+        gcmd = _make_gcmd(FROM="lane1", TO="lane2")
+        spool.cmd_AFC_SWAP_MAPPING(gcmd)
+        assert spool.afc.tool_cmds["T1"] == "lane1"
+        assert spool.afc.tool_cmds["T2"] == "lane1"
+        assert spool.afc.tool_cmds["T0"] == "lane2"
+
+    def test_swap_skips_none_placeholder_in_tool_cmds(self):
+        """A lane with no real mapping carries map=["NONE"]; that
+        placeholder must not be written into tool_cmds."""
+        spool = _make_spool()
+        lane1 = _make_lane("lane1")
+        lane1.map = ["NONE"]
+        lane1.current_map = None
+        lane2 = _make_lane("lane2")
+        lane2.map = ["T1"]
+        lane2.current_map = "T1"
+        spool.afc.lanes = {"lane1": lane1, "lane2": lane2}
+        spool.afc.tool_cmds = {"T1": "lane2"}
+        gcmd = _make_gcmd(FROM="lane1", TO="lane2")
+        spool.cmd_AFC_SWAP_MAPPING(gcmd)
+        assert "NONE" not in spool.afc.tool_cmds
+
+    def test_swap_skips_none_placeholder_landing_on_from_lane(self):
+        """Same guard as above, but exercised for the FROM lane's post-swap
+        list (i.e. the "NONE" placeholder originated from the TO lane)."""
+        spool = _make_spool()
+        lane1 = _make_lane("lane1")
+        lane1.map = ["T1"]
+        lane1.current_map = "T1"
+        lane2 = _make_lane("lane2")
+        lane2.map = ["NONE"]
+        lane2.current_map = None
+        spool.afc.lanes = {"lane1": lane1, "lane2": lane2}
+        spool.afc.tool_cmds = {"T1": "lane1"}
+        gcmd = _make_gcmd(FROM="lane1", TO="lane2")
+        spool.cmd_AFC_SWAP_MAPPING(gcmd)
+        assert "NONE" not in spool.afc.tool_cmds
+        assert spool.afc.tool_cmds["T1"] == "lane2"
+
+    def test_swap_sends_lane_data_for_both_lanes_and_saves(self):
+        spool = _make_spool()
+        lane1 = _make_lane("lane1")
+        lane1.map = ["T0"]
+        lane2 = _make_lane("lane2")
+        lane2.map = ["T1"]
+        spool.afc.lanes = {"lane1": lane1, "lane2": lane2}
+        gcmd = _make_gcmd(FROM="lane1", TO="lane2")
+        spool.cmd_AFC_SWAP_MAPPING(gcmd)
+        lane1.send_lane_data.assert_called_once()
+        lane2.send_lane_data.assert_called_once()
+        spool.afc.save_vars.assert_called_once()
+
+
+# ── cmd_AFC_ADD_MAPPING ─────────────────────────────────────────────────────────
+
+class TestAfcAddMapping:
+    def test_raises_when_multiple_mapping_disabled(self):
+        spool = _make_spool()
+        spool.enable_multiple_mapping = False
+        gcmd = _make_gcmd(LANE="lane1", MAPPING="T1")
+        with pytest.raises(Exception, match="enable multiple mapping needs to be enabled"):
+            spool.cmd_AFC_ADD_MAPPING(gcmd)
+
+    def test_raises_when_lane_not_found(self):
+        spool = _make_spool()
+        spool.enable_multiple_mapping = True
+        spool.afc.lanes = {}
+        gcmd = _make_gcmd(LANE="lane1", MAPPING="T1")
+        with pytest.raises(Exception, match="lane1 is not a valid lane"):
+            spool.cmd_AFC_ADD_MAPPING(gcmd)
+
+    def test_adds_single_mapping(self):
+        spool = _make_spool()
+        spool.enable_multiple_mapping = True
+        lane1 = _make_lane("lane1")
+        lane1.map = ["T0"]
+        spool.afc.lanes = {"lane1": lane1}
+        spool.afc.tool_cmds = {"T0": "lane1"}
+        gcmd = _make_gcmd(LANE="lane1", MAPPING="T1")
+        spool.cmd_AFC_ADD_MAPPING(gcmd)
+        assert spool.afc.tool_cmds["T1"] == "lane1"
+        assert lane1.map == ["T0", "T1"]
+        spool.function.register_tool_macro.assert_called_once_with("lane1", "T1")
+        lane1.send_lane_data.assert_called_once()
+        spool.afc.save_vars.assert_called_once()
+
+    def test_adds_comma_separated_multiple_mappings(self):
+        spool = _make_spool()
+        spool.enable_multiple_mapping = True
+        lane1 = _make_lane("lane1")
+        lane1.map = ["T0"]
+        spool.afc.lanes = {"lane1": lane1}
+        spool.afc.tool_cmds = {"T0": "lane1"}
+        gcmd = _make_gcmd(LANE="lane1", MAPPING="T1,T2")
+        spool.cmd_AFC_ADD_MAPPING(gcmd)
+        assert spool.afc.tool_cmds["T1"] == "lane1"
+        assert spool.afc.tool_cmds["T2"] == "lane1"
+        assert lane1.map == ["T0", "T1", "T2"]
+
+    def test_mapping_is_uppercased(self):
+        spool = _make_spool()
+        spool.enable_multiple_mapping = True
+        lane1 = _make_lane("lane1")
+        lane1.map = []
+        spool.afc.lanes = {"lane1": lane1}
+        spool.afc.tool_cmds = {}
+        gcmd = _make_gcmd(LANE="lane1", MAPPING="t1")
+        spool.cmd_AFC_ADD_MAPPING(gcmd)
+        assert "T1" in spool.afc.tool_cmds
+        assert "t1" not in spool.afc.tool_cmds
+
+    def test_skips_and_logs_error_when_mapping_already_exists(self):
+        spool = _make_spool()
+        spool.enable_multiple_mapping = True
+        lane1 = _make_lane("lane1")
+        lane1.map = ["T0"]
+        spool.afc.lanes = {"lane1": lane1}
+        spool.afc.tool_cmds = {"T0": "lane1", "T1": "lane2"}
+        gcmd = _make_gcmd(LANE="lane1", MAPPING="T1")
+        spool.cmd_AFC_ADD_MAPPING(gcmd)
+        # Existing mapping is untouched, not stolen from lane2
+        assert spool.afc.tool_cmds["T1"] == "lane2"
+        assert lane1.map == ["T0"]
+        spool.afc.error.AFC_error.assert_called_once_with(
+            "Cannot map T1 to lane1, as mapping already exists.", False
+        )
+
+    def test_skips_and_logs_error_when_mapping_is_not_t_number_format(self):
+        spool = _make_spool()
+        spool.enable_multiple_mapping = True
+        lane1 = _make_lane("lane1")
+        lane1.map = ["T0"]
+        spool.afc.lanes = {"lane1": lane1}
+        spool.afc.tool_cmds = {"T0": "lane1"}
+        gcmd = _make_gcmd(LANE="lane1", MAPPING="CUSTOM_LANE")
+        spool.cmd_AFC_ADD_MAPPING(gcmd)
+        assert "CUSTOM_LANE" not in spool.afc.tool_cmds
+        assert lane1.map == ["T0"]
+        spool.afc.error.AFC_error.assert_called_once_with(
+            "'CUSTOM_LANE' is not a valid mapping, expect T(n) format.", False
+        )
+
+
+# ── cmd_AFC_REMOVE_MAPPING ───────────────────────────────────────────────────────
+
+class TestAfcRemoveMapping:
+    def test_raises_when_multiple_mapping_disabled(self):
+        spool = _make_spool()
+        spool.enable_multiple_mapping = False
+        gcmd = _make_gcmd(MAPPING="T1")
+        with pytest.raises(Exception, match="enable multiple mapping needs to be enabled"):
+            spool.cmd_AFC_REMOVE_MAPPING(gcmd)
+
+    def test_removes_existing_mapping(self):
+        spool = _make_spool()
+        spool.enable_multiple_mapping = True
+        lane1 = _make_lane("lane1")
+        lane1.map = ["T0", "T1"]
+        spool.afc.lanes = {"lane1": lane1}
+        spool.afc.tool_cmds = {"T0": "lane1", "T1": "lane1"}
+        gcmd = _make_gcmd(MAPPING="T1")
+        spool.cmd_AFC_REMOVE_MAPPING(gcmd)
+        assert "T1" not in spool.afc.tool_cmds
+        assert lane1.map == ["T0"]
+        lane1.send_lane_data.assert_called_once()
+        # MockGcode.register_command records into _commands rather than being a Mock
+        assert spool.gcode._commands.get("T1") is None
+        assert "T1" in spool.gcode._commands
+        spool.afc.save_vars.assert_called_once()
+
+    def test_removing_active_mapping_falls_back_to_next_remaining_entry(self):
+        """lane_obj.current_map == m -> current_map is refreshed to the
+        lane's next remaining mapping."""
+        spool = _make_spool()
+        spool.enable_multiple_mapping = True
+        lane1 = _make_lane("lane1")
+        lane1.map = ["T0", "T1"]
+        lane1.current_map = "T1"
+        spool.afc.lanes = {"lane1": lane1}
+        spool.afc.tool_cmds = {"T0": "lane1", "T1": "lane1"}
+        gcmd = _make_gcmd(MAPPING="T1")
+        spool.cmd_AFC_REMOVE_MAPPING(gcmd)
+        assert lane1.current_map == "T0"
+
+    def test_removing_active_mapping_falls_back_to_empty_when_no_mappings_remain(self):
+        spool = _make_spool()
+        spool.enable_multiple_mapping = True
+        lane1 = _make_lane("lane1")
+        lane1.map = ["T0"]
+        lane1.current_map = "T0"
+        spool.afc.lanes = {"lane1": lane1}
+        spool.afc.tool_cmds = {"T0": "lane1"}
+        gcmd = _make_gcmd(MAPPING="T0")
+        spool.cmd_AFC_REMOVE_MAPPING(gcmd)
+        assert lane1.current_map == ""
+
+    def test_removing_inactive_mapping_leaves_current_map_unchanged(self):
+        spool = _make_spool()
+        spool.enable_multiple_mapping = True
+        lane1 = _make_lane("lane1")
+        lane1.map = ["T0", "T1"]
+        lane1.current_map = "T0"
+        spool.afc.lanes = {"lane1": lane1}
+        spool.afc.tool_cmds = {"T0": "lane1", "T1": "lane1"}
+        gcmd = _make_gcmd(MAPPING="T1")
+        spool.cmd_AFC_REMOVE_MAPPING(gcmd)
+        assert lane1.current_map == "T0"
+
+    def test_removes_multiple_comma_separated_mappings(self):
+        spool = _make_spool()
+        spool.enable_multiple_mapping = True
+        lane1 = _make_lane("lane1")
+        lane1.map = ["T0", "T1", "T2"]
+        spool.afc.lanes = {"lane1": lane1}
+        spool.afc.tool_cmds = {"T0": "lane1", "T1": "lane1", "T2": "lane1"}
+        gcmd = _make_gcmd(MAPPING="T1,T2")
+        spool.cmd_AFC_REMOVE_MAPPING(gcmd)
+        assert "T1" not in spool.afc.tool_cmds
+        assert "T2" not in spool.afc.tool_cmds
+        assert lane1.map == ["T0"]
+
+    def test_logs_error_and_skips_unregister_for_nonexistent_mapping(self):
+        spool = _make_spool()
+        spool.enable_multiple_mapping = True
+        spool.afc.tool_cmds = {}
+        gcmd = _make_gcmd(MAPPING="T9")
+        spool.cmd_AFC_REMOVE_MAPPING(gcmd)
+        spool.afc.error.AFC_error.assert_called_once_with("Mapping T9 does not exist", False)
+        assert "T9" not in spool.gcode._commands
+
+    def test_missing_lane_object_still_unregisters_command(self):
+        """tool_cmds can reference a lane name that's no longer in afc.lanes;
+        the gcode command should still be torn down."""
+        spool = _make_spool()
+        spool.enable_multiple_mapping = True
+        spool.afc.lanes = {}
+        spool.afc.tool_cmds = {"T1": "missing_lane"}
+        gcmd = _make_gcmd(MAPPING="T1")
+        spool.cmd_AFC_REMOVE_MAPPING(gcmd)
+        assert "T1" not in spool.afc.tool_cmds
+        assert spool.gcode._commands.get("T1") is None
+        assert "T1" in spool.gcode._commands
+
+
+# ── cmd_AFC_ENABLE_MULTIPLE_MAPPING ─────────────────────────────────────────────
+
+class TestAfcEnableMultipleMapping:
+    def test_enable_sets_flag_true(self):
+        spool = _make_spool()
+        spool.enable_multiple_mapping = False
+        gcmd = _make_gcmd(ENABLE=1)
+        spool.cmd_AFC_ENABLE_MULTIPLE_MAPPING(gcmd)
+        assert spool.enable_multiple_mapping is True
+        spool.function.ConfigRewrite.assert_called_once_with(
+            "AFC", "enable_multiple_mapping", True
+        )
+
+    def test_disable_sets_flag_false(self):
+        spool = _make_spool()
+        spool.enable_multiple_mapping = True
+        gcmd = _make_gcmd(ENABLE=0)
+        spool.cmd_AFC_ENABLE_MULTIPLE_MAPPING(gcmd)
+        assert spool.enable_multiple_mapping is False
+        spool.function.ConfigRewrite.assert_called_once_with(
+            "AFC", "enable_multiple_mapping", False
+        )
+
+    def test_default_enable_value_is_disable(self):
+        """Covers ENABLE defaulting to 0 when the param is omitted."""
+        spool = _make_spool()
+        spool.enable_multiple_mapping = True
+        gcmd = _make_gcmd()
+        spool.cmd_AFC_ENABLE_MULTIPLE_MAPPING(gcmd)
+        assert spool.enable_multiple_mapping is False
+
+
+# ── register_commands ─────────────────────────────────────────────────────────
+
+def _make_spool_for_register_commands(show_macros=True):
+    """Build an AFCSpool through the real __init__, ready for register_commands()."""
+    from tests.conftest import MockAFC, MockConfig, MockPrinter
+
+    afc = MockAFC()
+    afc.show_macros = show_macros
+    printer = MockPrinter(afc=afc)
+    config = MockConfig(name="AFC_Spool", printer=printer)
+    spool = AFCSpool(config)
+    return spool, afc
+
+
+class TestRegisterCommands:
+    def test_stores_afc_function_and_enable_multiple_mapping(self):
+        spool, afc = _make_spool_for_register_commands()
+        afc.enable_multiple_mapping = True
+        spool.register_commands(afc)
+        assert spool.afc is afc
+        assert spool.function is afc.function
+        assert spool.enable_multiple_mapping is True
+
+    def test_afc_swap_mapping_registered_without_show_macros(self):
+        """AFC_SWAP_MAPPING is an internal command invoked by
+        _perform_infinite_runout, not a user-facing macro, so it must always
+        register with show_macros=False regardless of afc.show_macros."""
+        spool, afc = _make_spool_for_register_commands(show_macros=True)
+        spool.register_commands(afc)
+        calls = afc.function.register_commands.call_args_list
+        swap_call = next(c for c in calls if c.args[1] == "AFC_SWAP_MAPPING")
+        assert swap_call.args[0] is False
+
+    def test_add_and_remove_mapping_use_show_macros_true(self):
+        spool, afc = _make_spool_for_register_commands(show_macros=True)
+        spool.register_commands(afc)
+        calls = afc.function.register_commands.call_args_list
+        names = {c.args[1]: c.args[0] for c in calls}
+        assert names["AFC_ADD_MAPPING"] is True
+        assert names["AFC_REMOVE_MAPPING"] is True
+        assert names["AFC_ENABLE_MULTIPLE_MAPPING"] is True
+
+    def test_add_and_remove_mapping_use_show_macros_false(self):
+        """Proves afc.show_macros is actually threaded through rather than
+        hardcoded, by driving it to the opposite value from the true case."""
+        spool, afc = _make_spool_for_register_commands(show_macros=False)
+        spool.register_commands(afc)
+        calls = afc.function.register_commands.call_args_list
+        names = {c.args[1]: c.args[0] for c in calls}
+        assert names["AFC_ADD_MAPPING"] is False
+        assert names["AFC_REMOVE_MAPPING"] is False
+        assert names["AFC_ENABLE_MULTIPLE_MAPPING"] is False
 
 
 # ── cmd_SET_COLOR ──────────────────────────────────────────────────────────────
@@ -193,21 +744,19 @@ class TestSetColor:
         spool.afc.save_vars.assert_called()
 
     def test_no_lane_param_logs_info(self):
-        """Covers lines 117-119: lane is None → log info + return."""
+        """lane is None → log info + return."""
         spool = _make_spool()
         gcmd = _make_gcmd()  # no LANE key
         spool.cmd_SET_COLOR(gcmd)
-        info_msgs = [m for lvl, m in spool.logger.messages if lvl == "info"]
-        assert any("LANE" in m for m in info_msgs)
+        assert spool.logger.messages == [("info", "No LANE Defined")]
 
     def test_lane_not_in_lanes_logs_info(self):
-        """Covers lines 121-123: lane not in lanes dict → log info + return."""
+        """lane not in lanes dict → log info + return."""
         spool = _make_spool()
         spool.afc.lanes = {}
         gcmd = _make_gcmd(LANE="ghost", COLOR="FF0000")
         spool.cmd_SET_COLOR(gcmd)
-        info_msgs = [m for lvl, m in spool.logger.messages if lvl == "info"]
-        assert any("ghost" in m for m in info_msgs)
+        assert spool.logger.messages == [("info", "ghost Unknown")]
 
 
 # ── cmd_SET_MATERIAL ───────────────────────────────────────────────────────────
@@ -233,24 +782,22 @@ class TestSetMaterial:
         spool.afc.save_vars.assert_called()
 
     def test_no_lane_param_logs_info(self):
-        """Covers lines 185-187: lane is None → log info + return."""
+        """lane is None → log info + return."""
         spool = _make_spool()
         gcmd = _make_gcmd()  # no LANE key
         spool.cmd_SET_MATERIAL(gcmd)
-        info_msgs = [m for lvl, m in spool.logger.messages if lvl == "info"]
-        assert any("LANE" in m for m in info_msgs)
+        assert spool.logger.messages == [("info", "No LANE Defined")]
 
     def test_lane_not_in_lanes_logs_info(self):
-        """Covers lines 188-190: lane not in lanes → log info + return."""
+        """lane not in lanes → log info + return."""
         spool = _make_spool()
         spool.afc.lanes = {}
         gcmd = _make_gcmd(LANE="ghost", MATERIAL="PLA")
         spool.cmd_SET_MATERIAL(gcmd)
-        info_msgs = [m for lvl, m in spool.logger.messages if lvl == "info"]
-        assert any("ghost" in m for m in info_msgs)
+        assert spool.logger.messages == [("info", "ghost Unknown")]
 
     def test_with_density_sets_filament_density(self):
-        """Covers lines 200-201: density is not None → sets cur_lane.filament_density."""
+        """density is not None → sets cur_lane.filament_density."""
         spool = _make_spool()
         lane = _make_lane("lane1")
         spool.afc.lanes = {"lane1": lane}
@@ -283,16 +830,14 @@ class TestSetWeight:
         spool.afc.lanes = {}
         gcmd = _make_gcmd(LANE="missing", WEIGHT=100)
         spool.cmd_SET_WEIGHT(gcmd)
-        info_msgs = [m for lvl, m in spool.logger.messages if lvl == "info"]
-        assert len(info_msgs) > 0
+        assert spool.logger.messages == [("info", "missing Unknown")]
 
     def test_no_lane_param_logs_info(self):
-        """Covers lines 146-148: lane is None → log info + return."""
+        """lane is None → log info + return."""
         spool = _make_spool()
         gcmd = _make_gcmd()  # no LANE key
         spool.cmd_SET_WEIGHT(gcmd)
-        info_msgs = [m for lvl, m in spool.logger.messages if lvl == "info"]
-        assert any("LANE" in m for m in info_msgs)
+        assert spool.logger.messages == [("info", "No LANE Defined")]
 
 
 # ── cmd_AFC_SET_SPOOL_TEMP ─────────────────────────────────────────────────────
@@ -339,17 +884,16 @@ class TestAFCSetSpoolTemp:
         spool = _make_spool()
         gcmd = _make_gcmd()
         spool.cmd_AFC_SET_SPOOL_TEMP(gcmd)
-        info_msgs = [m for lvl, m in spool.logger.messages if lvl == "info"]
-        assert any("LANE" in m for m in info_msgs)
-
+        assert spool.logger.messages == [
+            ("info", "No LANE parameter provided, please specify a valid LANE parameter.")
+        ]
 
     def test_unknown_lane_logs_info(self):
         spool = _make_spool()
         spool.afc.lanes = {}
         gcmd = _make_gcmd(LANE="ghost", BED_TEMP=60, EXTRUDER_TEMP=210)
         spool.cmd_AFC_SET_SPOOL_TEMP(gcmd)
-        info_msgs = [m for lvl, m in spool.logger.messages if lvl == "info"]
-        assert any("ghost" in m for m in info_msgs)
+        assert spool.logger.messages == [("info", "ghost Unknown")]
 
 
 # ── cmd_SET_RUNOUT ─────────────────────────────────────────────────────────────
@@ -375,31 +919,30 @@ class TestSetRunout:
         spool.afc.save_vars.assert_called()
 
     def test_no_lane_param_logs_info(self):
-        """Covers lines 373-375: lane is None → log info + return."""
+        """lane is None → log info + return."""
         spool = _make_spool()
         gcmd = _make_gcmd()  # no LANE key
         spool.cmd_SET_RUNOUT(gcmd)
-        info_msgs = [m for lvl, m in spool.logger.messages if lvl == "info"]
-        assert any("LANE" in m for m in info_msgs)
+        assert spool.logger.messages == [("info", "No LANE Defined")]
 
     def test_lane_equals_runout_logs_error(self):
-        """Covers lines 379-381: lane == runout → log error + return."""
+        """lane == runout → log error + return."""
         spool = _make_spool()
         lane1 = _make_lane("lane1")
         spool.afc.lanes = {"lane1": lane1}
         gcmd = _make_gcmd(LANE="lane1", RUNOUT="lane1")
         spool.cmd_SET_RUNOUT(gcmd)
-        error_msgs = [m for lvl, m in spool.logger.messages if lvl == "error"]
-        assert any("lane1" in m for m in error_msgs)
+        assert spool.logger.messages == [
+            ("error", "Lane(lane1) and runout(lane1) cannot be the same")
+        ]
 
     def test_lane_not_in_lanes_logs_error(self):
-        """Covers lines 383-385: lane not in lanes → log error + return."""
+        """lane not in lanes → log error + return."""
         spool = _make_spool()
         spool.afc.lanes = {}
         gcmd = _make_gcmd(LANE="ghost", RUNOUT="lane2")
         spool.cmd_SET_RUNOUT(gcmd)
-        error_msgs = [m for lvl, m in spool.logger.messages if lvl == "error"]
-        assert any("ghost" in m for m in error_msgs)
+        assert spool.logger.messages == [("error", "Unknown lane: ghost")]
 
     def test_set_runout_none_clears_runout_lane(self):
         """RUNOUT='NONE' (uppercase) → runout_lane set to None."""
@@ -432,29 +975,26 @@ class TestSetRunout:
         assert lane1.runout_lane is None
 
     def test_runout_not_in_lanes_logs_error(self):
-        """Covers lines 387-389: runout != 'NONE' but not in lanes → log error + return."""
+        """runout != 'NONE' but not in lanes → log error + return."""
         spool = _make_spool()
         lane1 = _make_lane("lane1")
         spool.afc.lanes = {"lane1": lane1}
         gcmd = _make_gcmd(LANE="lane1", RUNOUT="no_such_lane")
         spool.cmd_SET_RUNOUT(gcmd)
-        error_msgs = [m for lvl, m in spool.logger.messages if lvl == "error"]
-        assert any("no_such_lane" in m for m in error_msgs)
+        assert spool.logger.messages == [("error", "Unknown runout lane: no_such_lane")]
 
 
 # ── cmd_RESET_AFC_MAPPING ─────────────────────────────────────────────────────
 
 class TestResetAFCMapping:
     def _make_reset_gcmd(self, runout="yes"):
-        gcmd = MagicMock()
-        gcmd.get = lambda key, default=None: runout if key == "RUNOUT" else default
-        return gcmd
+        return _make_gcmd(RUNOUT=runout)
 
     def _make_lane_for_reset(self, name, map_cmd="T0"):
-        """Lane mock with explicit _map=None and map=map_cmd."""
+        """Lane mock with explicit _map=[] (not manually assigned) and map=[map_cmd]."""
         lane = _make_lane(name)
-        lane.map = map_cmd
-        lane._map = None  # not manually assigned
+        lane.map = [map_cmd]
+        lane._map = []  # not manually assigned
         lane.runout_lane = None
         return lane
 
@@ -488,33 +1028,56 @@ class TestResetAFCMapping:
         assert lane1.runout_lane == "lane2"  # not cleared
 
     def test_reset_reassigns_map_without_manual_mapping(self):
-        """Covers lines 422-431 else branch: lane._map=None → pops from existing_cmds."""
+        """lane._map=[] → pops from existing_cmds."""
         spool = _make_spool()
         # Set up a lane in afc.lanes used to build existing_cmds
         lane1 = self._make_lane_for_reset("lane1", "T0")
         spool.afc.lanes = {"lane1": lane1}
-        # Unit whose lane also has _map=None (else branch)
+        # Unit whose lane also has _map=[] (else branch)
         unit_lane = MagicMock()
         unit_lane.name = "lane1"
-        unit_lane._map = None
+        unit_lane._map = []
         unit = MagicMock()
         unit.lanes = {"lane1": unit_lane}
         spool.afc.units = {"unit_1": unit}
         gcmd = self._make_reset_gcmd()
         spool.cmd_RESET_AFC_MAPPING(gcmd)
-        # tool_cmds and lane.map must have been updated
+        # tool_cmds and the unit's lane.current_map must have been updated
         assert spool.afc.tool_cmds.get("T0") == "lane1"
-        assert spool.afc.lanes["lane1"].map == "T0"
+        assert unit_lane.current_map == "T0"
 
-    def test_reset_uses_manual_map_when_set(self):
-        """Covers lines 425-427 if branch: lane._map is not None → uses it directly."""
+    def test_reset_excludes_none_placeholder_from_existing_cmds(self):
+        """"NONE" entries in lane.map must be filtered out by value, not
+        object identity -- lane.map values loaded from config/saved vars are
+        never the same string object as a "NONE" literal in the source, so
+        an identity check silently fails to filter them. Left unfiltered,
+        "NONE" also has no digit chars, so the numeric sort right after would
+        raise ValueError -- this call must complete without raising."""
         spool = _make_spool()
         lane1 = self._make_lane_for_reset("lane1", "T0")
-        lane1._map = "T0"  # manually assigned
+        none_placeholder = "".join(["N", "O", "N", "E"])
+        lane2 = self._make_lane_for_reset("lane2", none_placeholder)
+        spool.afc.lanes = {"lane1": lane1, "lane2": lane2}
+        spool.afc.units = {}  # isolates existing_cmds construction/sort from the reassignment loop
+        gcmd = self._make_reset_gcmd()
+        spool.cmd_RESET_AFC_MAPPING(gcmd)
+        info_msgs = [m for lvl, m in spool.logger.messages if lvl == "info"]
+        # "T0" is never consumed since afc.units is empty, so it also shows
+        # up in the trailing "leftover mappings" cleanup message.
+        assert info_msgs == [
+            "Tool mappings reset and runout lanes reset",
+            "T0 remain, removing these mappings",
+        ]
+
+    def test_reset_uses_manual_map_when_set(self):
+        """lane._map is not empty → uses it directly."""
+        spool = _make_spool()
+        lane1 = self._make_lane_for_reset("lane1", "T0")
+        lane1._map = ["T0"]  # manually assigned
         spool.afc.lanes = {"lane1": lane1}
         unit_lane = MagicMock()
         unit_lane.name = "lane1"
-        unit_lane._map = "T0"  # manual assignment
+        unit_lane._map = ["T0"]  # manual assignment
         unit = MagicMock()
         unit.lanes = {"lane1": unit_lane}
         spool.afc.units = {"unit_1": unit}
@@ -534,16 +1097,18 @@ class TestSetNextSpoolId:
         assert spool.next_spool_id == 42
 
     def test_invalid_spool_id_logs_error_and_clears(self):
-        """Covers lines 466-468: ValueError → log error, next_spool_id stays None."""
+        """ValueError → log error, next_spool_id stays None."""
         spool = _make_spool()
         gcmd = _make_gcmd(SPOOL_ID="not_a_number")
         spool.cmd_SET_NEXT_SPOOL_ID(gcmd)
-        error_msgs = [m for lvl, m in spool.logger.messages if lvl == "error"]
-        assert len(error_msgs) > 0
+        assert spool.logger.messages == [
+            ("error", "Invalid spool ID: not_a_number"),
+            ("info", "Spool ID set for next load: 'None'"),
+        ]
         assert spool.next_spool_id is None
 
     def test_empty_spool_id_clears_next(self):
-        """Covers lines 469-470: SpoolID='' → next_spool_id set to None."""
+        """SpoolID='' → next_spool_id set to None."""
         spool = _make_spool()
         spool.next_spool_id = 99
         gcmd = _make_gcmd()  # no SPOOL_ID key → default ''
@@ -551,38 +1116,41 @@ class TestSetNextSpoolId:
         assert spool.next_spool_id is None
 
     def test_overwrites_existing_spool_id_logs_overwrite(self):
-        """Covers lines 471-472: previous_id is set → log overwrite info message."""
+        """previous_id is set → log overwrite info message."""
         spool = _make_spool()
         spool.next_spool_id = 10  # existing
         gcmd = _make_gcmd(SPOOL_ID=20)
         spool.cmd_SET_NEXT_SPOOL_ID(gcmd)
         assert spool.next_spool_id == 20
-        info_msgs = [m for lvl, m in spool.logger.messages if lvl == "info"]
-        assert any("10" in m for m in info_msgs)
+        assert spool.logger.messages == [
+            ("info", "Spool ID '10' being overwritten for next load: '20'")
+        ]
 
 
 # ── handle_connect / register_lane_macros ─────────────────────────────────────
 
 class TestHandleConnect:
     def test_handle_connect_stores_afc_references(self):
-        from tests.conftest import MockAFC, MockPrinter
+        from tests.conftest import MockAFC, MockConfig, MockPrinter
         afc = MockAFC()
         printer = MockPrinter(afc=afc)
-        spool = AFCSpool.__new__(AFCSpool)
-        spool.printer = printer
-        spool.next_spool_id = None
+        config = MockConfig(name="AFC_Spool", printer=printer)
+        spool = AFCSpool(config)
+        # register_commands() is what normally sets self.afc, ahead of the
+        # klippy:connect event that triggers handle_connect()
+        spool.register_commands(afc)
         spool.handle_connect()
         assert spool.afc is afc
         assert spool.gcode is afc.gcode
         assert spool.logger is afc.logger
 
     def test_handle_connect_registers_commands(self):
-        from tests.conftest import MockAFC, MockPrinter
+        from tests.conftest import MockAFC, MockConfig, MockPrinter
         afc = MockAFC()
         printer = MockPrinter(afc=afc)
-        spool = AFCSpool.__new__(AFCSpool)
-        spool.printer = printer
-        spool.next_spool_id = None
+        config = MockConfig(name="AFC_Spool", printer=printer)
+        spool = AFCSpool(config)
+        spool.register_commands(afc)
         spool.handle_connect()
         assert "RESET_AFC_MAPPING" in afc.gcode._commands
         assert "SET_NEXT_SPOOL_ID" in afc.gcode._commands
@@ -644,8 +1212,13 @@ class TestSetActiveSpool:
         spool.afc.spoolman = MagicMock()
         spool.printer.lookup_object = MagicMock(return_value=None)
         spool.set_active_spool(7)
-        error_msgs = [m for lvl, m in spool.logger.messages if lvl == "error"]
-        assert any("Error trying to set active spool" in m for m in error_msgs)
+        assert spool.logger.messages == [
+            (
+                "error",
+                "Error trying to set active spool \n"
+                "'NoneType' object has no attribute 'call_remote_method'",
+            )
+        ]
 
 
 # ── _get_filament_values ──────────────────────────────────────────────────────
@@ -929,7 +1502,7 @@ class TestSetSpoolID:
         assert lane.extruder_temp is None
 
     def test_exception_in_get_spool_calls_afc_error(self):
-        """Covers lines 346-348: exception in get_spool → AFC_error called."""
+        """exception in get_spool → AFC_error called."""
         spool = self._make_spool_with_spoolman()
         lane = _make_lane()
         lane.remember_spool = False
@@ -940,7 +1513,7 @@ class TestSetSpoolID:
         spool.afc.error.AFC_error.assert_called()
 
     def test_empty_spool_id_with_spoolman_not_remember_spool_clears_values(self):
-        """Covers lines 348-349: spoolman not None + SpoolID='' + not remember_spool → clear_values."""
+        """spoolman not None + SpoolID='' + not remember_spool → clear_values."""
         spool = self._make_spool_with_spoolman()
         lane = _make_lane()
         lane.remember_spool = False
@@ -1021,26 +1594,24 @@ class TestCmdSetSpoolID:
         spool.set_spoolID.assert_called_once_with(lane1, '')
 
     def test_no_lane_param_logs_info(self):
-        """Covers lines 239-241: spoolman not None + lane=None → log info + return."""
+        """spoolman not None + lane=None → log info + return."""
         spool = _make_spool()
         spool.afc.spoolman = MagicMock()
         gcmd = _make_gcmd()  # no LANE key
         spool.cmd_SET_SPOOL_ID(gcmd)
-        info_msgs = [m for lvl, m in spool.logger.messages if lvl == "info"]
-        assert any("LANE" in m for m in info_msgs)
+        assert spool.logger.messages == [("info", "No LANE Defined")]
 
     def test_lane_not_in_lanes_logs_info(self):
-        """Covers lines 243-245: spoolman not None + lane not in lanes → log info + return."""
+        """spoolman not None + lane not in lanes → log info + return."""
         spool = _make_spool()
         spool.afc.spoolman = MagicMock()
         spool.afc.lanes = {}
         gcmd = _make_gcmd(LANE="ghost", SPOOL_ID="7")
         spool.cmd_SET_SPOOL_ID(gcmd)
-        info_msgs = [m for lvl, m in spool.logger.messages if lvl == "info"]
-        assert any("ghost" in m for m in info_msgs)
+        assert spool.logger.messages == [("info", "ghost Unknown")]
 
     def test_calls_set_active_spool_when_lane_is_current(self):
-        """Covers lines 264-265: cur_lane.name == afc.current → set_active_spool called."""
+        """cur_lane.name == afc.current → set_active_spool called."""
         spool = _make_spool()
         spool.afc.spoolman = MagicMock()
         lane1 = _make_lane("lane1")
@@ -1172,8 +1743,14 @@ class TestSetSnapmakerFilamentParams:
         spool.printer = MagicMock()
         spool.printer.update_snapmaker_config_file.side_effect = RuntimeError("Creating error")
         spool.set_snapmaker_filament_params(lane)
-        error_msgs = [m for lvl, m in spool.logger.messages if lvl == "error"]
-        assert any("Error when trying to update colors for snapmaker print_task_config" in m for m in error_msgs)
+        levels = [lvl for lvl, _ in spool.logger.messages]
+        # The debug entry is traceback.format_exc(), whose exact text is
+        # environment-dependent (file paths/line numbers) so only its
+        # presence is checked; the error message is asserted verbatim.
+        assert levels == ["error", "debug"]
+        assert spool.logger.messages[0] == (
+            "error", "Error when trying to update colors for snapmaker print_task_config"
+        )
     
     def test_snapmaker_printer_extruder_update_called(self):
         from tests.conftest import _make_print_task_config
@@ -1402,4 +1979,28 @@ class TestSetSnapmakerFilamentParams:
         assert print_task_config["filament_color_multi"][extruder_num]["mode"] == 1
         assert print_task_config["filament_color_multi"][extruder_num]["nums"] == 3
         assert print_task_config["filament_color_multi"][extruder_num]["colors"] == ["123456", "589465", "725893"]
+
+
+# ── load_config ──────────────────────────────────────────────────────────────
+
+class TestLoadConfig:
+    def test_returns_afc_spool_instance(self):
+        from tests.conftest import MockAFC, MockConfig, MockPrinter
+
+        afc = MockAFC()
+        printer = MockPrinter(afc=afc)
+        config = MockConfig(name="AFC_Spool", printer=printer)
+        result = load_config(config)
+        assert isinstance(result, AFCSpool)
+
+    def test_registers_klippy_connect_handler(self):
+        """Proves load_config actually wires the real constructor through,
+        not just that some AFCSpool-shaped object comes back."""
+        from tests.conftest import MockAFC, MockConfig, MockPrinter
+
+        afc = MockAFC()
+        printer = MockPrinter(afc=afc)
+        config = MockConfig(name="AFC_Spool", printer=printer)
+        load_config(config)
+        assert printer._event_handlers.get("klippy:connect")
     

--- a/tests/test_AFC_utils.py
+++ b/tests/test_AFC_utils.py
@@ -22,6 +22,7 @@ from extras.AFC_utils import (
     VirtualRunoutHelper, VirtualFilamentSensor, AFC_PrintFileMetaData,
     natural_sort_key,
 )
+from tests.conftest import MockGCodeCommand
 
 
 # ── natural_sort_key ────────────────────────────────────────────────────────
@@ -1048,7 +1049,7 @@ class TestVirtualFilamentSensor:
         printer = self._make_printer_with_add_object()
         sensor = VirtualFilamentSensor(printer, "FPS1_expanded", logger=MagicMock())
         sensor.runout_helper.note_filament_present(100.0, True)
-        gcmd = MagicMock()
+        gcmd = MockGCodeCommand()
         sensor.cmd_QUERY_FILAMENT_SENSOR(gcmd)
         gcmd.respond_info.assert_called_once_with(
             "Filament Sensor FPS1_expanded: filament detected")
@@ -1056,7 +1057,7 @@ class TestVirtualFilamentSensor:
     def test_cmd_query_filament_sensor_reports_not_detected(self):
         printer = self._make_printer_with_add_object()
         sensor = VirtualFilamentSensor(printer, "FPS1_expanded", logger=MagicMock())
-        gcmd = MagicMock()
+        gcmd = MockGCodeCommand()
         sensor.cmd_QUERY_FILAMENT_SENSOR(gcmd)
         gcmd.respond_info.assert_called_once_with(
             "Filament Sensor FPS1_expanded: filament not detected")
@@ -1064,8 +1065,7 @@ class TestVirtualFilamentSensor:
     def test_cmd_set_filament_sensor_enables(self):
         printer = self._make_printer_with_add_object()
         sensor = VirtualFilamentSensor(printer, "FPS1_expanded", logger=MagicMock())
-        gcmd = MagicMock()
-        gcmd.get_int = MagicMock(return_value=1)
+        gcmd = MockGCodeCommand(params={"ENABLE": 1})
         sensor.cmd_SET_FILAMENT_SENSOR(gcmd)
         gcmd.get_int.assert_called_once_with("ENABLE", 1, minval=0, maxval=1)
         assert sensor.runout_helper.sensor_enabled is True
@@ -1074,7 +1074,6 @@ class TestVirtualFilamentSensor:
         printer = self._make_printer_with_add_object()
         sensor = VirtualFilamentSensor(printer, "FPS1_expanded", logger=MagicMock())
         sensor.runout_helper.sensor_enabled = True
-        gcmd = MagicMock()
-        gcmd.get_int = MagicMock(return_value=0)
+        gcmd = MockGCodeCommand(params={"ENABLE": 0})
         sensor.cmd_SET_FILAMENT_SENSOR(gcmd)
         assert sensor.runout_helper.sensor_enabled is False

--- a/tests/test_AFC_utils.py
+++ b/tests/test_AFC_utils.py
@@ -20,7 +20,31 @@ import pytest
 from extras.AFC_utils import (
     check_and_return, section_in_config, DebounceButton, AFC_moonraker,
     VirtualRunoutHelper, VirtualFilamentSensor, AFC_PrintFileMetaData,
+    natural_sort_key,
 )
+
+
+# ── natural_sort_key ────────────────────────────────────────────────────────
+
+class TestNaturalSortKey:
+    def test_sorts_t_macros_numerically_not_lexicographically(self):
+        items = ["T10", "T2", "T1", "T0"]
+        assert sorted(items, key=natural_sort_key) == ["T0", "T1", "T2", "T10"]
+
+    def test_digit_chunk_compares_as_int(self):
+        """Covers the digit branch of the inline conditional: "T10" and "T2"
+        share the same non-digit prefix, so only the int comparison of the
+        digit chunk decides the order."""
+        assert natural_sort_key("T2") < natural_sort_key("T10")
+
+    def test_non_digit_chunk_compares_as_lowercased_string(self):
+        """Covers the non-digit branch: differing prefixes are compared as
+        lowercased strings before any digit chunk is reached."""
+        assert natural_sort_key("ALPHA") < natural_sort_key("beta")
+
+    def test_placeholder_sorts_with_string_entries(self):
+        items = ["T1", "NONE", "T0"]
+        assert sorted(items, key=natural_sort_key) == ["NONE", "T0", "T1"]
 
 
 # ── check_and_return ──────────────────────────────────────────────────────────

--- a/tests/test_AFC_vivid.py
+++ b/tests/test_AFC_vivid.py
@@ -233,8 +233,8 @@ class TestCmdAfcSelectLane:
         lane = _make_lane("lane1")
         unit.afc.lanes = {"lane1": lane}
         unit.select_lane = MagicMock(return_value=(True, 15.0))
-        gcmd = MagicMock()
-        gcmd.get.return_value = "lane1"
+        from tests.conftest import MockGCodeCommand
+        gcmd = MockGCodeCommand(params={"LANE": "lane1"})
         unit.cmd_AFC_SELECT_LANE(gcmd)
         unit.select_lane.assert_called_once_with(lane)
 
@@ -243,8 +243,8 @@ class TestCmdAfcSelectLane:
         lane = _make_lane("lane1")
         unit.afc.lanes = {"lane1": lane}
         unit.select_lane = MagicMock(return_value=(True, 15.0))
-        gcmd = MagicMock()
-        gcmd.get.return_value = "lane1"
+        from tests.conftest import MockGCodeCommand
+        gcmd = MockGCodeCommand(params={"LANE": "lane1"})
         unit.cmd_AFC_SELECT_LANE(gcmd)
         info_msgs = [m for lvl, m in unit.logger.messages if lvl == "info"]
         assert any("lane1" in m for m in info_msgs)
@@ -254,8 +254,8 @@ class TestCmdAfcSelectLane:
         lane = _make_lane("lane1")
         unit.afc.lanes = {"lane1": lane}
         unit.select_lane = MagicMock(return_value=(False, 0))
-        gcmd = MagicMock()
-        gcmd.get.return_value = "lane1"
+        from tests.conftest import MockGCodeCommand
+        gcmd = MockGCodeCommand(params={"LANE": "lane1"})
         unit.cmd_AFC_SELECT_LANE(gcmd)
         error_msgs = [m for lvl, m in unit.logger.messages if lvl == "error"]
         assert any("lane1" in m for m in error_msgs)
@@ -263,8 +263,8 @@ class TestCmdAfcSelectLane:
     def test_calls_gcmd_error_when_lane_not_found(self):
         unit = _make_vivid()
         unit.afc.lanes = {}
-        gcmd = MagicMock()
-        gcmd.get.return_value = "missing_lane"
+        from tests.conftest import MockGCodeCommand
+        gcmd = MockGCodeCommand(params={"LANE": "missing_lane"})
         unit.cmd_AFC_SELECT_LANE(gcmd)
         gcmd.error.assert_called()
 


### PR DESCRIPTION
## Major Changes in this PR
- Added ability to map multiple T(n) commands to a single lane, Closes #605
- Added ability to add new T(n) maps to create virtual tools
- Added the following macros to support virtual tools: `AFC_ADD_MAPPING`, `AFC_REMOVE_MAPPING`
- Added `AFC_ENABLE_MULTIPLE_MAPPING` to enable the use of mapping multiple tools and virtual tools. If `enable_multiple_mapping` variable is not set then mapping works like it currently did before this PR.
- Added `AFC_SWAP_MAPPING` to easily swap all T(n) mappings between two lanes
- Lane data had to be updated to use T(n) as the key instead of `lane` since this would have not worked correctly with the multi-mapping per lane.
- Breaking change - `RESET_AFC_MAPPING` has been changed to `AFC_RESET_MAPPING`
- Fixed `AFC_RESET_MAPPING` to reset back to single mapping and remove extra T(n) macro, also fixes #657

With claudes help, unit tests were added/updated and typing was fixed only in AFC_spool.py

Docs PR: https://github.com/AFCProject/Documentation/pull/26

## Notes to Code Reviewers
Bulk of the work is in AFC_spool.py, but still needed changes throughout the codebase since map is in multiple places.

## How the changes in this PR are tested
- Verified that if a users runs one of the new macros that raising an gcmd error while printing does not crash the print
- Verified that AFC_SWAP_MAPPING worked correctly during a infinite runout, video below shows this (swap happens around 1:22 mark). This test also shows that mapping multiple T(n) macros work correctly and AFC keep a 4 color print to 1 color because of the mapping.

https://github.com/user-attachments/assets/8c2ea4e9-2be4-4db0-aae6-70f5bbae4f81

- Running through `AFC_ADD_MAPPING`, `AFC_REMOVE_MAPPING`, `AFC_ENABLE_MULTIPLE_MAPPING` and `RESET_AFC_MAPPING` macros

https://github.com/user-attachments/assets/28b012bb-ca43-426e-9937-21d373c5f264

- How lane_data endpoint looks now:
<img width="364" height="418" alt="image" src="https://github.com/user-attachments/assets/77593ad9-8393-4ef7-814a-6e5b218988df" />


## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to pr-review channel requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for multiple tool-to-lane mappings, including add, remove, swap, and reset commands.
  * Automatically registers and updates tool commands when mappings change.
  * Synchronizes per-mapping lane and spool information with Moonraker.
  * Supports automatic mapping transfers during infinite-spool operation.

* **Bug Fixes**
  * Corrected tool numbering after lane moves and improved handling of missing or invalid mappings.
  * Improved mapping restoration, temperature handling, and load/unload recovery.
  * Renamed the mapping reset command to `AFC_RESET_MAPPING`.

* **Chores**
  * Updated AFC to version 1.2.5 and refreshed documentation metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->