### PR TITLE
Publish vendor, filament name and initial weight in lane_data (#808)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   turns the feature on (existing single-mapping behavior is unchanged until enabled).
 - Added `AFC_SWAP_MAPPING` macro to swap T(n) mappings between two lanes. Infinite spool runout now
   uses this to move a lane's mappings to the runout lane automatically.
+- `lane_data` records now carry `vendor_name`, `name` and `initial_weight`, and a lane's status reports
+  `spool_vendor`. AFC already fetched all three during a Spoolman lookup but never published them, so
+  anything reading `lane_data` could see a lane's material but not its brand. A slicer can now match a
+  lane to a brand-specific filament preset instead of falling back to the generic preset for that
+  material type (#808).
 
 ### Fixed
 - `AFC_RESET_MAPPING` now renumbers T(n) mappings sequentially instead of reusing old numbers, so

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -1900,6 +1900,8 @@ class AFCLane:
                 "value": {
                     "color"          : self.color,
                     "material"       : self.material,
+                    "vendor_name"    : self.spool_vendor,
+                    "name"           : self.filament_name,
                     "bed_temp"       : self.bed_temp,
                     "nozzle_temp"    : self.extruder_temp,
                     "scan_time"      : scan_time,
@@ -1907,7 +1909,8 @@ class AFCLane:
                     "lane"           : key.replace("T", ""),
                     "extruder_index" : self.lane_extruder_index,
                     "spool_id"       : self.spool_id,
-                    "weight"         : self.weight
+                    "weight"         : self.weight,
+                    "initial_weight" : self.espooler.espooler_values.full_weight
                 }
             }
             self.afc.moonraker.send_lane_data(lane_data)
@@ -1933,6 +1936,8 @@ class AFCLane:
                 "value": {
                     "color"          : "",
                     "material"       : "",
+                    "vendor_name"    : "",
+                    "name"           : "",
                     "bed_temp"       : "",
                     "nozzle_temp"    : "",
                     "scan_time"      : "",
@@ -1940,7 +1945,8 @@ class AFCLane:
                     "lane"           : key.replace("T", ""),
                     "extruder_index" : self.lane_extruder_index,
                     "spool_id"       : None,
-                    "weight"         : 0
+                    "weight"         : 0,
+                    "initial_weight" : 0
                 }
             }
             self.afc.moonraker.send_lane_data(lane_data)
@@ -2382,6 +2388,7 @@ class AFCLane:
         response["color"]=self.color
         if not save_to_file:
             response["filament_name"] = self.filament_name
+            response["spool_vendor"] = self.spool_vendor
             response["multi_color_hexes"] = self.multi_color
             response["initial_weight"] = self.espooler.espooler_values.full_weight
 

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -1248,6 +1248,7 @@ def _make_lane_for_get_status(map_value):
     lane.spool_id = None
     lane.color = ""
     lane.filament_name = ""
+    lane.spool_vendor = ""
     lane.multi_color = []
     lane.weight = 0
     lane.extruder_temp = None
@@ -1579,6 +1580,9 @@ def _make_lane_for_moonraker(extruder_name="extruder", map_value="T0"):
     lane.td1_data = {"scan_time": "1.23", "td": "0.95"}
     lane.spool_id = "abc123"
     lane.weight = 750.0
+    lane.spool_vendor = "Overture"
+    lane.filament_name = "Overture Gray ASA"
+    lane.espooler.espooler_values.full_weight = 1000
     return lane
 
 
@@ -1594,6 +1598,30 @@ def _get_cleared_payload(lane):
     lane.clear_lane_data()
     lane.afc.moonraker.send_lane_data.assert_called_once()
     return lane.afc.moonraker.send_lane_data.call_args[0][0]
+
+
+class TestGetStatusSpoolVendor:
+    def test_spool_vendor_reported(self):
+        lane = _make_lane_for_get_status(["T0"])
+        lane.spool_vendor = "Overture"
+        response = lane.get_status()
+        assert response["spool_vendor"] == "Overture"
+
+    def test_spool_vendor_tracks_the_attribute(self):
+        lane = _make_lane_for_get_status(["T0"])
+        lane.spool_vendor = ""
+        response = lane.get_status()
+        assert response["spool_vendor"] == ""
+
+    def test_spool_vendor_omitted_when_saving_to_file(self):
+        """Vendor is re-fetched from Spoolman, so it is not persisted -- the
+        same treatment filament_name already gets."""
+        lane = _make_lane_for_get_status(["T0"])
+        lane.spool_vendor = "Overture"
+        lane.td1_data = {"td": "", "color": "", "scan_time": ""}
+        response = lane.get_status(save_to_file=True)
+        assert "spool_vendor" not in response
+        assert "filament_name" not in response
 
 
 class TestSendLaneDataExtruderIndex:
@@ -1637,6 +1665,37 @@ class TestSendLaneDataExtruderIndex:
         lane = _make_lane_for_moonraker()
         payload = _get_sent_payload(lane)
         assert payload["value"]["weight"] == 750.0
+
+    def test_vendor_published_as_vendor_name(self):
+        """`lane_data` is a shared namespace with an established key for this
+        value, so the record uses that key rather than the lane attribute's."""
+        lane = _make_lane_for_moonraker()
+        payload = _get_sent_payload(lane)
+        assert payload["value"]["vendor_name"] == "Overture"
+        assert "spool_vendor" not in payload["value"]
+        assert "vendor" not in payload["value"]
+
+    def test_filament_name_published_as_name(self):
+        """Same shared-namespace key rule as the vendor above."""
+        lane = _make_lane_for_moonraker()
+        payload = _get_sent_payload(lane)
+        assert payload["value"]["name"] == "Overture Gray ASA"
+        assert "filament_name" not in payload["value"]
+
+    def test_initial_weight_is_included(self):
+        lane = _make_lane_for_moonraker()
+        payload = _get_sent_payload(lane)
+        assert payload["value"]["initial_weight"] == 1000
+
+    def test_vendor_and_name_empty_for_unlinked_lane(self):
+        """A lane with no Spoolman link publishes the keys as empty strings
+        rather than omitting them."""
+        lane = _make_lane_for_moonraker()
+        lane.spool_vendor = ""
+        lane.filament_name = ""
+        payload = _get_sent_payload(lane)
+        assert payload["value"]["vendor_name"] == ""
+        assert payload["value"]["name"] == ""
 
     def test_no_send_when_map_is_empty(self):
         lane = _make_lane_for_moonraker(map_value=None)
@@ -1744,6 +1803,19 @@ class TestClearLaneDataExtruderIndex:
         lane = _make_lane_for_moonraker()
         payload = _get_cleared_payload(lane)
         assert payload["value"]["weight"] == 0
+
+    def test_vendor_and_name_are_cleared(self):
+        """Cleared independently of the lane attributes, which AFC_spool resets
+        after the push rather than before it."""
+        lane = _make_lane_for_moonraker()
+        payload = _get_cleared_payload(lane)
+        assert payload["value"]["vendor_name"] == ""
+        assert payload["value"]["name"] == ""
+
+    def test_initial_weight_is_cleared(self):
+        lane = _make_lane_for_moonraker()
+        payload = _get_cleared_payload(lane)
+        assert payload["value"]["initial_weight"] == 0
 
     def test_clears_one_record_per_mapping(self):
         lane = _make_lane_for_moonraker(map_value="T0")


### PR DESCRIPTION
## Major Changes in this PR

Closes #808.

`lane_data` is what slicers and UIs read, but it could not describe a spool's brand, so a
consumer could see that a lane held PLA and nothing about whose PLA it was. AFC already
fetches vendor, filament name and initial weight during a Spoolman lookup and attaches them
to the lane; they were just never published.

- `send_lane_data` now emits `vendor_name`, `name` and `initial_weight`
- `clear_lane_data` clears them alongside the fields it already reset
- `get_status` gains `spool_vendor`, the only one of the three that was missing from the
  live status dict

The `lane_data` keys are the ones already established for that shared namespace,
`vendor_name` and `name`, per your note on #808. `get_status` reports the vendor under
this class's own attribute name, `spool_vendor`, alongside the `filament_name` and
`initial_weight` already there.

Second commit is forward compatibility for the multi-tool mapping work. Both lane_data
methods guarded on `"T" in self.map`, which is a substring test that only holds while
`map` is a single string. When `map` becomes a mapping, that turns into a key-membership
test, returns False, and publishing stops with no error anywhere. `lane_index` has the
same assumption one level down (`self.map.replace(...)`), so fixing only the guard would
move the failure from a silent stop to an `AttributeError` inside the record itself.
`tool_mappings()` normalizes both forms and the guards and `lane_index` route through it.

Outer key naming is untouched here. Moving records to `T<n>` keys is your change and I
did not want to guess at its semantics. Same for `tool_mappings()` - happy to drop it in
favour of whatever #832 lands with, once that merges.

## Notes to Code Reviewers

- The string branch of `tool_mappings()` deliberately keeps the original `"T" in map`
  substring test instead of tightening it to `startswith`, so existing single-string
  configs behave exactly as they do today.
- A multi-tool lane collapses to the lowest-numbered tool for `lane_index`, sorted
  numerically so `T9` beats `T10`. There is a test pinning that, since a lexical sort
  gets it backwards.
- For a `map` with no `T` in it, `lane_index` used to return the raw string and now returns `""`. It is unreachable in production, since its only two consumers are the lane_data records and both sit behind the tool-mapping guard. Pinned with a test either way.
- `tool_mappings()` is public in case it is useful to the mapping work.
- The test fixture change is not cosmetic: `_make_afc_lane` builds lanes via
  `AFCLane.__new__`, so `spool_vendor` never existed on a test lane and the new
  publish raised `AttributeError` in 8 existing tests until the helper set it.
- Unrelated, but you may want to look at it: `./run-tests.sh --klippy` exits 0 while
  printing `X`. `--kalico` on its own correctly exits 1, so it is the combined runner
  swallowing the status. Anything gating on that exit code reads red as green.

## How the changes in this PR are tested

- `ruff check .` clean
- `python -m pytest tests/` - 3316 passing
- Branch coverage (`--cov=extras --cov-branch`) on every added or changed line, with no
  partial branches in the new code
- `./run-tests.sh --klippy` - klipper passes. kalico fails `afc_htlf_commands` and
  `afc_psf_buffer_commands`, which are pre-existing: I ran the same two against a clean
  worktree at `origin/DEV` and they fail there identically.
- Not yet exercised end to end against a printer with a multi-tool lane, since the
  mapping change that produces one is not in `DEV` yet.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)

- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to pr-review channel requesting review (no, I talked to JimmyJon directly)
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

---

Disclosure per AI_USAGE_POLICY.md: drafted with Claude, then reviewed, tested and edited
by me... you know, Preston.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lane data now supports lanes mapped to multiple tools and reports the lowest-numbered tool.
  * Lane information includes vendor, filament name, and initial spool weight.
  * Lane status now displays spool vendor details.
  * Clearing lane data removes associated vendor, filament, and weight information.

* **Documentation**
  * Added a changelog entry documenting updated lane metadata, spool vendor reporting, and multi-tool support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
